### PR TITLE
workers.conf: controller listen to localhost instead of 127.0.0.1

### DIFF
--- a/conf/workers.conf
+++ b/conf/workers.conf
@@ -9,7 +9,7 @@ worker {
 }
 worker {
     type = "controller";
-    bind_socket = "127.0.0.1:11334";
+    bind_socket = "localhost:11334";
     count = 1;
 }
 worker {


### PR DESCRIPTION
the rspamc controller default host is "localhost" and using by default 127.0.0.1 for rspamd controller is an issue on hosts using IPv6 as "localhost".
