### PR TITLE
Appease lintian by stating that public-domain is a public domain.

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -53,6 +53,7 @@ Files: contrib/libottery/chacha_crovetz.c
 Copyright: Ted Krovetz <ted@krovetz.net>
            D. J. Bernstein
 License: public-domain
+ Public domain.
 
 Files: contrib/xxhash/xxhash.*
 Copyright: 2012-2013, Yann Collet.


### PR DESCRIPTION
Update debian/copyright (similar to a change in 0.6 branch)
