### PR TITLE
Fix typo in symbol description.

### DIFF
--- a/conf/metrics.conf
+++ b/conf/metrics.conf
@@ -548,7 +548,7 @@ metric {
     }
     symbol {
         weight = 0.0;
-        description = "SPF verification soft-failed";
+        description = "DKIM verification soft-failed";
         name = "R_DKIM_TEMPFAIL";
     }
     symbol {


### PR DESCRIPTION
Typo in conf/metrics.conf
