### PR TITLE
Fix owner when creating folder /run/rspamd in Debian init script

### DIFF
--- a/debian/rspamd.init
+++ b/debian/rspamd.init
@@ -40,7 +40,8 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	mkdir -m 755 _rspamd:_rspamd -p /run/rspamd
+	mkdir -m 755 -p /run/rspamd
+	chown _rspamd:_rspamd /run/rspamd
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
 		|| return 1
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \


### PR DESCRIPTION
In Debian init script, when creating /run/rspamd, owner is not set correctly and a folder "_rspamd:_rspamd" is created.
