### PR TITLE
make rspamd_http_message_find_header case-insensitive

### DIFF
--- a/src/libutil/http.c
+++ b/src/libutil/http.c
@@ -1155,7 +1155,7 @@ rspamd_http_message_find_header (struct rspamd_http_message *msg,
 		LL_FOREACH (msg->headers, hdr)
 		{
 			if (hdr->name->len == slen) {
-				if (memcmp (hdr->name->str, name, slen) == 0) {
+				if (g_ascii_strncasecmp(hdr->name->str, name, slen) == 0) {
 					res = hdr->value->str;
 					break;
 				}


### PR DESCRIPTION
according to RFC 2616, http headers supposed to be case insensitive. My nginx lower cased the headers, so it breaks the web-gui.
