### PR TITLE
adjust Spamhaus group name for received IPs

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -35,7 +35,7 @@ rbl {
             }
         }
 
-        spamhaus_xbl {
+        spamhaus_received {
             symbol = "RECEIVED_SPAMHAUS";
             rbl = "zen.spamhaus.org";
             ipv6 = true;


### PR DESCRIPTION
This changes the RBL group name from `spamhaus_xbl` to `spamhaus_received` which describes better what the group actually does.

Just some cleanup... :-)