### PR TITLE
also trigger DNSWL score rule in case mails are properly ARC signed

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -86,14 +86,14 @@ composites {
         description = "Relayed through ZEN PBL IP without sufficient authentication (possible indicating an open relay)";
         score = 2.0;
     }
-    RCVD_DKIM_DNSWL_MED {
-        expression = "R_DKIM_ALLOW & RCVD_IN_DNSWL_MED";
-        description = "Sufficiently DKIM signed and received from IP with medium trust at DNSWL";
+    RCVD_DKIM_ARC_DNSWL_MED {
+        expression = "(R_DKIM_ALLOW | ARC_ALLOW ) & RCVD_IN_DNSWL_MED";
+        description = "Sufficiently DKIM/ARC signed and received from IP with medium trust at DNSWL";
         score = -1.5;
     }
-    RCVD_DKIM_DNSWL_HI {
-        expression = "R_DKIM_ALLOW & RCVD_IN_DNSWL_HI";
-        description = "Sufficiently DKIM signed and received from IP with high trust at DNSWL";
+    RCVD_DKIM_ARC_DNSWL_HI {
+        expression = "(R_DKIM_ALLOW | ARC_ALLOW ) & RCVD_IN_DNSWL_HI";
+        description = "Sufficiently DKIM/ARC signed and received from IP with high trust at DNSWL";
         score = -3.5;
     }
 


### PR DESCRIPTION
The first version of the extended DNSWL score composite rules only triggered in case a mail is properly DKIM signed. They should also do in case it is ARC signed.