### PR TITLE
[Minor] Log should not depend on config

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -3855,7 +3855,6 @@ start_controller_worker (struct rspamd_worker *worker)
 
 	rspamd_stat_close ();
 	rspamd_http_router_free (ctx->http);
-	rspamd_log_close (worker->srv->logger);
 
 	if (ctx->cached_password.len > 0) {
 		m = (gpointer)ctx->cached_password.begin;
@@ -3870,6 +3869,7 @@ start_controller_worker (struct rspamd_worker *worker)
 	g_hash_table_unref (ctx->plugins);
 	g_hash_table_unref (ctx->custom_commands);
 	REF_RELEASE (ctx->cfg);
+	rspamd_log_close (worker->srv->logger, TRUE);
 
 	exit (EXIT_SUCCESS);
 }

--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -3017,8 +3017,6 @@ start_fuzzy (struct rspamd_worker *worker)
 		g_array_free (ctx->updates_pending, TRUE);
 	}
 
-	rspamd_log_close (worker->srv->logger);
-
 	if (ctx->peer_fd != -1) {
 		if (worker->index == 0) {
 			event_del (&ctx->peer_ev);
@@ -3031,6 +3029,8 @@ start_fuzzy (struct rspamd_worker *worker)
 	}
 
 	REF_RELEASE (ctx->cfg);
+
+	rspamd_log_close (worker->srv->logger, TRUE);
 
 	exit (EXIT_SUCCESS);
 }

--- a/src/libserver/worker_util.c
+++ b/src/libserver/worker_util.c
@@ -647,7 +647,7 @@ rspamd_fork_worker (struct rspamd_main *rspamd_main,
 		}
 
 		/* Do silent log reopen to avoid collisions */
-		rspamd_log_close (rspamd_main->logger);
+		rspamd_log_close (rspamd_main->logger, FALSE);
 
 
 		if (rspamd_main->cfg->log_silent_workers) {
@@ -771,7 +771,7 @@ rspamd_hard_terminate (struct rspamd_main *rspamd_main)
 
 	msg_err_main ("shutting down Rspamd due to fatal error");
 
-	rspamd_log_close (rspamd_main->logger);
+	rspamd_log_close (rspamd_main->logger, TRUE);
 	exit (EXIT_FAILURE);
 }
 

--- a/src/libutil/logger.h
+++ b/src/libutil/logger.h
@@ -40,7 +40,7 @@ gint rspamd_log_open (rspamd_logger_t *logger);
 /**
  * Close log file or destroy other structures
  */
-void rspamd_log_close (rspamd_logger_t *logger);
+void rspamd_log_close (rspamd_logger_t *logger, gboolean termination);
 
 /**
  * Close and open log again
@@ -55,7 +55,7 @@ gint rspamd_log_open_priv (rspamd_logger_t *logger, uid_t uid, gid_t gid);
 /**
  * Close log file or destroy other structures for privileged processes
  */
-void rspamd_log_close_priv (rspamd_logger_t *logger, uid_t uid, gid_t gid);
+void rspamd_log_close_priv (rspamd_logger_t *logger, gboolean termination, uid_t uid, gid_t gid);
 
 /**
  * Close and open log again for privileged processes

--- a/src/log_helper.c
+++ b/src/log_helper.c
@@ -227,8 +227,8 @@ start_log_helper (struct rspamd_worker *worker)
 	close (ctx->pair[0]);
 	rspamd_worker_block_signals ();
 
-	rspamd_log_close (worker->srv->logger);
 	REF_RELEASE (ctx->cfg);
+	rspamd_log_close (worker->srv->logger, TRUE);
 
 	exit (EXIT_SUCCESS);
 }

--- a/src/lua_worker.c
+++ b/src/lua_worker.c
@@ -412,8 +412,9 @@ start_lua_worker (struct rspamd_worker *worker)
 		luaL_unref (L, LUA_REGISTRYINDEX, ctx->cbref_fin);
 	}
 
-	rspamd_log_close (worker->srv->logger);
 	REF_RELEASE (ctx->cfg);
+	rspamd_log_close (worker->srv->logger, TRUE);
+
 	exit (EXIT_SUCCESS);
 }
 

--- a/src/rspamadm/rspamadm.c
+++ b/src/rspamadm/rspamadm.c
@@ -498,8 +498,8 @@ main (gint argc, gchar **argv, gchar **env)
 		cmd->run (0, NULL, cmd);
 	}
 
-	rspamd_log_close (rspamd_main->logger);
 	REF_RELEASE (rspamd_main->cfg);
+	rspamd_log_close (rspamd_main->logger, TRUE);
 	g_free (rspamd_main);
 	g_ptr_array_free (all_commands, TRUE);
 

--- a/src/rspamd.c
+++ b/src/rspamd.c
@@ -294,6 +294,7 @@ reread_config (struct rspamd_main *rspamd_main)
 				TRUE)) {
 		rspamd_main->cfg = old_cfg;
 		rspamd_log_close_priv (rspamd_main->logger,
+					FALSE,
 					rspamd_main->workers_uid,
 					rspamd_main->workers_gid);
 		rspamd_set_logger (rspamd_main->cfg, g_quark_try_string ("main"),
@@ -972,6 +973,7 @@ rspamd_hup_handler (gint signo, short what, gpointer arg)
 			" is restarting");
 	g_hash_table_foreach (rspamd_main->workers, kill_old_workers, NULL);
 	rspamd_log_close_priv (rspamd_main->logger,
+				FALSE,
 				rspamd_main->workers_uid,
 				rspamd_main->workers_gid);
 	reread_config (rspamd_main);
@@ -1288,8 +1290,8 @@ main (gint argc, gchar **argv, gchar **env)
 		exit (EXIT_SUCCESS);
 	}
 
-	rspamd_log_close_priv (rspamd_main->logger, rspamd_main->workers_uid,
-			rspamd_main->workers_gid);
+	rspamd_log_close_priv (rspamd_main->logger, FALSE,
+			rspamd_main->workers_uid, rspamd_main->workers_gid);
 
 	if (config_test || dump_cache) {
 		if (!load_rspamd_config (rspamd_main, rspamd_main->cfg, FALSE, 0,
@@ -1516,8 +1518,8 @@ main (gint argc, gchar **argv, gchar **env)
 
 	msg_info_main ("terminating...");
 
-	rspamd_log_close (rspamd_main->logger);
 	REF_RELEASE (rspamd_main->cfg);
+	rspamd_log_close (rspamd_main->logger, TRUE);
 	g_hash_table_unref (rspamd_main->spairs);
 	g_hash_table_unref (rspamd_main->workers);
 	rspamd_mempool_delete (rspamd_main->server_pool);

--- a/src/rspamd_proxy.c
+++ b/src/rspamd_proxy.c
@@ -2211,14 +2211,13 @@ start_rspamd_proxy (struct rspamd_worker *worker) {
 	event_base_loop (ctx->ev_base, 0);
 	rspamd_worker_block_signals ();
 
-	rspamd_log_close (worker->srv->logger);
-
 	if (ctx->has_self_scan) {
 		rspamd_stat_close ();
 	}
 
 	rspamd_keypair_cache_destroy (ctx->keys_cache);
 	REF_RELEASE (ctx->cfg);
+	rspamd_log_close (worker->srv->logger, TRUE);
 
 	exit (EXIT_SUCCESS);
 }

--- a/src/worker.c
+++ b/src/worker.c
@@ -691,9 +691,9 @@ start_worker (struct rspamd_worker *worker)
 	rspamd_worker_block_signals ();
 
 	rspamd_stat_close ();
-	rspamd_log_close (worker->srv->logger);
 	rspamd_keypair_cache_destroy (ctx->keys_cache);
 	REF_RELEASE (ctx->cfg);
+	rspamd_log_close (worker->srv->logger, TRUE);
 
 	exit (EXIT_SUCCESS);
 }


### PR DESCRIPTION
When config is being closed, some destructors could be called, and that dtors could write into log. Hence, it is better to terminate config and only then close log. And log should not refer disposed config