### PR TITLE
some housekeeping of composite rulesets

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -114,6 +114,11 @@ composites {
         description = "Spammy message with detailled sender but generic recipient";
         score = 0.5;
     }
+    HAS_ANON_DOMAIN {
+        expression = "HAS_GUC_PROXY_URI | URIBL_RED | DBL_ABUSE_REDIR";
+        description = "Contains one or more domains trying to disguise owner/destination";
+        score = 0.5;
+    }
 
     .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/composites.conf"
     .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/composites.conf"

--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -68,7 +68,7 @@ composites {
         expression = "MAILER_1C_8 & (FROM_EXCESS_BASE64 | MIME_BASE64_TEXT | SUBJ_EXCESS_BASE64 | TO_EXCESS_BASE64)";
     }
     HACKED_WP_PHISHING {
-        expression = "HAS_X_POS & HAS_WP_URI & PHISHING";
+        expression = "(HAS_X_POS | HAS_PHPMAILER_SIG) & HAS_WP_URI & (PHISHING | DBL_PHISH | PHISHED_OPENPHISH | PHISHED_PHISHTANK)";
         description = "Phish message sent by hacked Wordpress instance";
         policy = "leave";
     }
@@ -105,7 +105,7 @@ composites {
         score = 1.0;
     }
     PHISH_EMOTION {
-        expression = "(HACKED_WP_PHISHING | DBL_PHISH | PHISHED_OPENPHISH | PHISHED_PHISHTANK) & (SUBJECT_ENDS_QUESTION | SUBJECT_ENDS_EXCLAIM)";
+        expression = "(PHISHING | DBL_PHISH | PHISHED_OPENPHISH | PHISHED_PHISHTANK) & (SUBJECT_ENDS_QUESTION | SUBJECT_ENDS_EXCLAIM)";
         description = "Phish message with subject trying to address users emotion";
         score = 2.0;
     }

--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -46,11 +46,13 @@ composites {
     }
     RBL_SPAMHAUS_XBL_ANY {
         expression = "RBL_SPAMHAUS_XBL & RECEIVED_SPAMHAUS_XBL";
+        description = "Message was relayed through at least one hop listed in Spamhaus XBL";
     }
     AUTH_NA {
         expression = "R_DKIM_NA & R_SPF_NA & DMARC_NA";
         score = 1.0;
         policy = "remove_weight";
+        description = "Authenticating message via SPF/DKIM/DMARC not possible";
     }
     DKIM_MIXED {
         expression = "-R_DKIM_ALLOW & (R_DKIM_DNSFAIL | R_DKIM_PERMFAIL | R_DKIM_REJECT)"


### PR DESCRIPTION
- Some missing descriptions were added
- Improved reliability of hacked Wordprass rule
- Removed redundant symbol in `PHISH_EMOTION`
- Add rule for domains trying to stay anonymous (is it possible to include the redirector domains to this?)