### PR TITLE
make sure blocklist.de-rule for Received IPs only triggers once

### DIFF
--- a/conf/scores.d/rbl_group.conf
+++ b/conf/scores.d/rbl_group.conf
@@ -168,5 +168,6 @@ symbols = {
     "RECEIVED_BLOCKLISTDE" {
         weight = 3.0;
         description = "Received address is listed in Blocklist (https://www.blocklist.de/)";
+        one_shot = true;
     }
 }


### PR DESCRIPTION
Add forgotten `one_shot = true;`  line for blocklist.de-rule which looks at `Received` addresses.

Sorry about that.