### PR TITLE
[Minor] Fixed error reported by ASAN: do not try using already pop-ed…

### DIFF
--- a/src/lua/lua_tcp.c
+++ b/src/lua/lua_tcp.c
@@ -485,6 +485,7 @@ lua_tcp_maybe_free (struct lua_tcp_cbdata *cbd)
 		if (cbd->w) {
 			rspamd_session_watcher_pop (cbd->session, cbd->w);
 		}
+		cbd->w = NULL;
 
 		if (cbd->async_ev) {
 			rspamd_session_remove_event (cbd->session, lua_tcp_void_finalyser, cbd);
@@ -496,6 +497,7 @@ lua_tcp_maybe_free (struct lua_tcp_cbdata *cbd)
 		if (cbd->w) {
 			rspamd_session_watcher_pop (cbd->session, cbd->w);
 		}
+		cbd->w = NULL;
 
 		if (cbd->async_ev) {
 			rspamd_session_remove_event (cbd->session, lua_tcp_fin, cbd);


### PR DESCRIPTION
… watcher

The watcher is pop-ed once session is over but reference to the structure remains in Lua and then being removed from lua dtor.
In this case we try to pop it second time. Bad.