### PR TITLE
[Test] Added key to run specific lua-test

### DIFF
--- a/test/rspamd_lua_test.c
+++ b/test/rspamd_lua_test.c
@@ -24,6 +24,8 @@
 #endif
 
 static const char *lua_src = BUILDROOT "/test/lua/tests.lua";
+extern gchar *lua_test;
+extern struct rspamd_main *rspamd_main;
 
 static int
 traceback (lua_State *L)
@@ -61,6 +63,8 @@ rspamd_lua_test_func (void)
 	glob_t globbuf;
 	gint i, len;
 
+	rspamd_lua_set_globals (rspamd_main->cfg, L, NULL);
+
 	rspamd_printf ("Starting lua tests\n");
 
 	if ((rp = realpath (lua_src, rp_buf)) == NULL) {
@@ -90,11 +94,27 @@ rspamd_lua_test_func (void)
 	pattern = g_malloc (len);
 	rspamd_snprintf (pattern, len, "%s/unit/%s", dir, "*.lua");
 
+	gint lua_test_len = 0;
+	gint inserted_file = 1;
+	gint path_start;
+	if (lua_test) {
+		lua_test_len = strlen (lua_test);
+	}
 	if (glob (pattern, GLOB_DOOFFS, NULL, &globbuf) == 0) {
 		for (i = 0; i < (gint)globbuf.gl_pathc; i++) {
-			lua_pushinteger (L, i + 1);
+			if (lua_test) {
+				path_start = strlen (globbuf.gl_pathv[i]) - lua_test_len;
+				if (path_start < 0 ||
+						strncmp (globbuf.gl_pathv[i] + path_start, lua_test, lua_test_len) != 0) {
+					continue;
+				}
+			}
+
+			lua_pushinteger (L, inserted_file);
 			lua_pushstring (L, globbuf.gl_pathv[i]);
 			lua_settable (L, -3);
+
+			inserted_file ++;
 		}
 		globfree (&globbuf);
 		g_free (pattern);

--- a/test/rspamd_test_suite.c
+++ b/test/rspamd_test_suite.c
@@ -7,10 +7,22 @@ struct rspamd_main             *rspamd_main = NULL;
 struct event_base              *base = NULL;
 worker_t *workers[] = { NULL };
 
+gchar *lua_test = NULL;
+gboolean verbose = FALSE;
+
+static GOptionEntry entries[] =
+{
+	{ "test", 't', 0, G_OPTION_ARG_STRING, &lua_test,
+	  "Lua test to run (i.e. selectors.lua)", NULL },
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};
+
 int
 main (int argc, char **argv)
 {
 	struct rspamd_config *cfg;
+	GOptionContext *context;
+	GError *error = NULL;
 
 	rspamd_main = (struct rspamd_main *)g_malloc (sizeof (struct rspamd_main));
 	memset (rspamd_main, 0, sizeof (struct rspamd_main));
@@ -26,6 +38,15 @@ main (int argc, char **argv)
 	(void)rspamd_log_open (rspamd_main->logger);
 
 	g_test_init (&argc, &argv, NULL);
+
+	context = g_option_context_new ("- run rspamd test");
+	g_option_context_add_main_entries (context, entries, NULL);
+
+	if (!g_option_context_parse (context, &argc, &argv, &error)) {
+		fprintf (stderr, "option parsing failed: %s\n", error->message);
+		g_option_context_free (context);
+		exit (1);
+	}
 
 	cfg->libs_ctx = rspamd_init_libs ();
 


### PR DESCRIPTION
example:
$ ./test/rspamd-test -p /rspamd/lua -t selectors.lua

no way to run two test suites atm