### PR TITLE
[Minor] Make socket non-blocking before connect()

### DIFF
--- a/contrib/hiredis/net.c
+++ b/contrib/hiredis/net.c
@@ -367,8 +367,6 @@ addrretry:
                 goto error;
             }
         }
-        if (blocking && redisSetBlocking(c,1) != REDIS_OK)
-            goto error;
         if (redisSetTcpNoDelay(c) != REDIS_OK)
             goto error;
         if (connect(s,p->ai_addr,p->ai_addrlen) == -1) {
@@ -393,6 +391,8 @@ addrretry:
         rv = REDIS_OK;
         goto end;
     }
+    if (blocking && redisSetBlocking(c,1) != REDIS_OK)
+        goto error;
     if (p == NULL) {
         char buf[128];
         snprintf(buf,sizeof(buf),"Can't create socket: %s",strerror(errno));

--- a/contrib/hiredis/net.c
+++ b/contrib/hiredis/net.c
@@ -367,6 +367,10 @@ addrretry:
                 goto error;
             }
         }
+        if (blocking && redisSetBlocking(c,1) != REDIS_OK)
+            goto error;
+        if (redisSetTcpNoDelay(c) != REDIS_OK)
+            goto error;
         if (connect(s,p->ai_addr,p->ai_addrlen) == -1) {
             if (errno == EHOSTUNREACH) {
                 redisContextCloseFd(c);
@@ -384,10 +388,6 @@ addrretry:
                     goto error;
             }
         }
-        if (blocking && redisSetBlocking(c,1) != REDIS_OK)
-            goto error;
-        if (redisSetTcpNoDelay(c) != REDIS_OK)
-            goto error;
 
         c->flags |= REDIS_CONNECTED;
         rv = REDIS_OK;


### PR DESCRIPTION
    Otherwise, in the case of error, socket may become invalid
    and we will get an incorrect error, i.e. "setsockopt(TCP_NODELAY): Invalid argument"
    instead of "Connection refused"