### PR TITLE
leaving original symbols if DNSWL composite rules are triggered

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -85,16 +85,19 @@ composites {
         expression = "RECEIVED_PBL & -RCVD_VIA_SMTP_AUTH";
         description = "Relayed through ZEN PBL IP without sufficient authentication (possible indicating an open relay)";
         score = 2.0;
+        policy = "leave";
     }
     RCVD_DKIM_ARC_DNSWL_MED {
         expression = "(R_DKIM_ALLOW | ARC_ALLOW ) & RCVD_IN_DNSWL_MED";
         description = "Sufficiently DKIM/ARC signed and received from IP with medium trust at DNSWL";
         score = -1.5;
+        policy = "leave";
     }
     RCVD_DKIM_ARC_DNSWL_HI {
         expression = "(R_DKIM_ALLOW | ARC_ALLOW ) & RCVD_IN_DNSWL_HI";
         description = "Sufficiently DKIM/ARC signed and received from IP with high trust at DNSWL";
         score = -3.5;
+        policy = "leave";
     }
 
     .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/composites.conf"


### PR DESCRIPTION
Without policy = "leave", rspamd replaces the original symbols
in log and message header (if enabled), which makes debugging more
hard and is not used in this case.