### PR TITLE
[Fix] ip_score - respect check_authed and check_local settings

### DIFF
--- a/src/plugins/lua/ip_score.lua
+++ b/src/plugins/lua/ip_score.lua
@@ -314,8 +314,12 @@ local ip_score_check = function(task)
     return cmd, args
   end
 
-  if task:get_user() or (ip and ip:is_local()) then
-    rspamd_logger.infox(task, "skip IP Score for local networks and authorized users")
+  if task:get_user() and not check_authed then
+    rspamd_logger.infox(task, "skip IP Score for authorized users")
+    return
+  end
+  if ip and ip:is_local() and not check_local then
+    rspamd_logger.infox(task, "skip IP Score for local networks")
     return
   end
   if ip:is_valid() then
@@ -355,7 +359,7 @@ end
 
 -- Configuration options
 local configure_ip_score_module = function()
-  local opts = rspamd_config:get_all_opt('options')
+  local opts = rspamd_config:get_all_opt(N)
   if type(opts) == 'table' then
     if type(opts['check_authed']) == 'boolean' then
       check_authed = opts['check_authed']
@@ -364,7 +368,6 @@ local configure_ip_score_module = function()
       check_local = opts['check_local']
     end
   end
-  opts = rspamd_config:get_all_opt('ip_score')
   if not opts then return end
   for k,v in pairs(opts) do
     options[k] = v


### PR DESCRIPTION
check_authed  and check_local wasn't overwritten by options set in the config file.