### PR TITLE
Added "text/calendar" as a legal mimetype for .ics files. 

### DIFF
--- a/src/plugins/lua/mime_types.lua
+++ b/src/plugins/lua/mime_types.lua
@@ -376,7 +376,7 @@ local full_extensions_map = {
   {"hxx", "text/plain"},
   {"i", "text/plain"},
   {"ico", "image/x-icon"},
-  {"ics", "application/octet-stream"},
+  {"ics", {"text/calendar", "application/octet-stream"}},
   {"idl", "text/plain"},
   {"ief", "image/ief"},
   {"iii", "application/x-iphone"},


### PR DESCRIPTION
Files are failing this test, and "text/calendar" seems to be the correct one from https://tools.ietf.org/html/rfc5545