### PR TITLE
cyrptobox: work with OpenSSL-1.1

### DIFF
--- a/src/libcryptobox/cryptobox.c
+++ b/src/libcryptobox/cryptobox.c
@@ -374,7 +374,7 @@ rspamd_cryptobox_init (void)
 	ctx->blake2_impl = blake2b_load ();
 	ctx->ed25519_impl = ed25519_load ();
 	ctx->base64_impl = base64_load ();
-#ifdef HAVE_USABLE_OPENSSL
+#if defined(HAVE_USABLE_OPENSSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
 	ERR_load_EC_strings ();
 	ERR_load_RAND_strings ();
 	ERR_load_EVP_strings ();


### PR DESCRIPTION
ERR_load_EC_strings and friends don't need to be called with
OpenSSL-1.1. Infact, on some platforms it causes a cyclic init
which stops rspamd from working entirely.

Luckily OpenSSL-1.1 should load these string automatically so we
can avoid calling them.