### PR TITLE
Run gdb on core dump

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,6 +48,12 @@ pipeline:
       - set +e
       - ./rspamd-test -p /rspamd/lua; EXIT_CODE=$?
       - set -e
+      # shell sets exit status of a process that terminated by a signal to '128 + signal-number'
+      - >
+        if [ $EXIT_CODE -gt 128 ];
+        then gdb -c /var/tmp/*.rspamd-test.core ./rspamd-test -ex "set pagination 0" -ex "thread apply all bt full" --batch;
+        exit $EXIT_CODE;
+        fi
       # luacov-coveralls reads luacov.stats.out written by rspamd-test using luacov module
       # and writes json report for coveralls.io service
       - luacov-coveralls -o /rspamd/build/unit_test_lua.json --dryrun

--- a/.drone.yml
+++ b/.drone.yml
@@ -52,9 +52,9 @@ pipeline:
       # shell sets exit status of a process terminated by a signal to '128 + signal-number'
       # if rspamd-test was terminated by a signal it should be SIGSEGV or SIGABRT, try to examine core
       - >
-        if [ $EXIT_CODE -gt 128 ];
-        then gdb -c /var/tmp/*.rspamd-test.core ./rspamd-test -ex "set pagination 0" -ex "thread apply all bt full" --batch;
-        exit $EXIT_CODE;
+        if [ $EXIT_CODE -gt 128 ]; then
+        	gdb -c /var/tmp/*.rspamd-test.core ./rspamd-test -ex "set pagination 0" -ex "thread apply all bt full" --batch;
+        	exit $EXIT_CODE;
         fi
       # luacov-coveralls reads luacov.stats.out written by rspamd-test using luacov module
       # and writes json report for coveralls.io service

--- a/.drone.yml
+++ b/.drone.yml
@@ -42,6 +42,7 @@ pipeline:
     group: tests
     commands:
       - test "$(id -un)" = nobody
+      - ulimit -c unlimited
       # rspamd-test and functional test both use luacov.stats.out file and should be started from
       # different directories (if started in parallel)
       - cd /rspamd/build/test

--- a/.drone.yml
+++ b/.drone.yml
@@ -49,7 +49,8 @@ pipeline:
       - set +e
       - ./rspamd-test -p /rspamd/lua; EXIT_CODE=$?
       - set -e
-      # shell sets exit status of a process that terminated by a signal to '128 + signal-number'
+      # shell sets exit status of a process terminated by a signal to '128 + signal-number'
+      # if rspamd-test was terminated by a signal it should be SIGSEGV or SIGABRT, try to examine core
       - >
         if [ $EXIT_CODE -gt 128 ];
         then gdb -c /var/tmp/*.rspamd-test.core ./rspamd-test -ex "set pagination 0" -ex "thread apply all bt full" --batch;


### PR DESCRIPTION
Note: exit code > 128 doesn't indicate that core dump was actually written, but anyway if rspamd-test was terminated by a signal script can fail - there is no need to gather coverage.