### PR TITLE
also query resolved IPs against Spamhaus ZEN

### DIFF
--- a/conf/modules.d/surbl.conf
+++ b/conf/modules.d/surbl.conf
@@ -87,12 +87,15 @@ EOD;
             }
         }
 
-        "SBL_URIBL" {
-            suffix = "sbl.spamhaus.org";
+        "SPAMHAUS_ZEN_URIBL" {
+            suffix = "zen.spamhaus.org";
             resolve_ip = true;
             ips {
                 URIBL_SBL = "127.0.0.2";
                 URIBL_SBL_CSS = "127.0.0.3";
+                URIBL_XBL = ["127.0.0.4", "127.0.0.5", "127.0.0.6", "127.0.0.7"];
+                URIBL_PBL = ["127.0.0.10", "127.0.0.11"];
+                URIBL_DROP = "127.0.0.9";
             }
         }
 

--- a/conf/scores.d/surbl_group.conf
+++ b/conf/scores.d/surbl_group.conf
@@ -163,7 +163,7 @@ symbols = {
         description = "A domain listed in the mail is listed in Spamhaus XBL URIBL";
     }
     "URIBL_PBL" {
-        weight = 0.1;
+        weight = 0.01;
         description = "A domain listed in the mail is listed in Spamhaus PBL URIBL";
     }
     "URIBL_DROP" {

--- a/conf/scores.d/surbl_group.conf
+++ b/conf/scores.d/surbl_group.conf
@@ -152,26 +152,26 @@ symbols = {
     }
     "URIBL_SBL" {
         weight = 6.5;
-        description = "A domain in the mail resolves to an IP listed in Spamhaus SBL";
+        description = "A domain in the message body resolves to an IP listed in Spamhaus SBL";
     }
     "URIBL_SBL_CSS" {
         weight = 6.5;
-        description = "A domain in the mail resolves to an IP listed in Spamhaus SBL CSS";
+        description = "A domain in the message body resolves to an IP listed in Spamhaus SBL CSS";
     }
     "URIBL_XBL" {
         weight = 6.5;
-        description = "A domain in the mail resolves to an IP listed in Spamhaus XBL";
+        description = "A domain in the message body resolves to an IP listed in Spamhaus XBL";
     }
     "URIBL_PBL" {
         weight = 0.01;
-        description = "A domain in the mail resolves to an IP listed in Spamhaus PBL";
+        description = "A domain in the message body resolves to an IP listed in Spamhaus PBL";
     }
     "URIBL_DROP" {
         weight = 8.0;
-        description = "A domain in the mail resolves to an IP listed in Spamhaus DROP";
+        description = "A domain in the message body resolves to an IP listed in Spamhaus DROP";
     }
     "RBL_SARBL_BAD" {
         weight = 2.5;
-        description = "A domain in the mail is blacklisted in SARBL";
+        description = "A domain in the message body is blacklisted in SARBL";
    }
 }

--- a/conf/scores.d/surbl_group.conf
+++ b/conf/scores.d/surbl_group.conf
@@ -152,26 +152,26 @@ symbols = {
     }
     "URIBL_SBL" {
         weight = 6.5;
-        description = "A domain listed in the mail is listed in Spamhaus SBL URIBL";
+        description = "A domain in the mail resolves to an IP listed in Spamhaus SBL";
     }
     "URIBL_SBL_CSS" {
         weight = 6.5;
-        description = "A domain listed in the mail is listed in Spamhaus SBL CSS URIBL";
+        description = "A domain in the mail resolves to an IP listed in Spamhaus SBL CSS";
     }
     "URIBL_XBL" {
         weight = 6.5;
-        description = "A domain listed in the mail is listed in Spamhaus XBL URIBL";
+        description = "A domain in the mail resolves to an IP listed in Spamhaus XBL";
     }
     "URIBL_PBL" {
         weight = 0.01;
-        description = "A domain listed in the mail is listed in Spamhaus PBL URIBL";
+        description = "A domain in the mail resolves to an IP listed in Spamhaus PBL";
     }
     "URIBL_DROP" {
         weight = 8.0;
-        description = "A domain listed in the mail is listed in Spamhaus DROP URIBL";
+        description = "A domain in the mail resolves to an IP listed in Spamhaus DROP";
     }
     "RBL_SARBL_BAD" {
         weight = 2.5;
-        description = "A domain listed in the mail is blacklisted in SARBL";
+        description = "A domain in the mail is blacklisted in SARBL";
    }
 }

--- a/conf/scores.d/surbl_group.conf
+++ b/conf/scores.d/surbl_group.conf
@@ -146,17 +146,29 @@ symbols = {
         description = "uribl.com grey url";
         one_shot = true;
     }
-    "SBL_URIBL" {
+    "SPAMHAUS_ZEN_URIBL" {
         weight = 0.0;
-        description = "SBL URIBL: Filtered result";
+        description = "Spamhaus ZEN URIBL: Filtered result";
     }
     "URIBL_SBL" {
         weight = 6.5;
-        description = "Spamhaus SBL URIBL";
+        description = "A domain listed in the mail is listed in Spamhaus SBL URIBL";
     }
     "URIBL_SBL_CSS" {
         weight = 6.5;
-        description = "Spamhaus SBL CSS URIBL";
+        description = "A domain listed in the mail is listed in Spamhaus SBL CSS URIBL";
+    }
+    "URIBL_XBL" {
+        weight = 6.5;
+        description = "A domain listed in the mail is listed in Spamhaus XBL URIBL";
+    }
+    "URIBL_PBL" {
+        weight = 0.1;
+        description = "A domain listed in the mail is listed in Spamhaus PBL URIBL";
+    }
+    "URIBL_DROP" {
+        weight = 8.0;
+        description = "A domain listed in the mail is listed in Spamhaus DROP URIBL";
     }
     "RBL_SARBL_BAD" {
         weight = 2.5;


### PR DESCRIPTION
Currently, resolved IP addresses of a domain are "only" checked against Spamhaus SBL. Since it might be useful to know if an IP address is listed in PBL, XBL, or even DROP, these are added here.

To gather full results, `zen.spamhaus.org` must be used instead of `sbl.spamhaus.org`.