### PR TITLE
fix return code of rspamc

### DIFF
--- a/src/client/rspamc.c
+++ b/src/client/rspamc.c
@@ -2024,5 +2024,5 @@ main (gint argc, gchar **argv, gchar **env)
 	}
 
 	/* Mix retcode (return from Rspamd side) and ret (return from subprocess) */
-	return ret ^ retcode;
+	return ret | retcode;
 }


### PR DESCRIPTION
It'll set the return code to EXIT_FAILURE if one of the parties (rspamd side or sub process) or both are failing.