### PR TITLE
fix preprocessor syntax as 1.8.2 fails to compile

### DIFF
--- a/src/libutil/mem_pool.h
+++ b/src/libutil/mem_pool.h
@@ -25,18 +25,18 @@ struct f_str_s;
 #  if __has_attribute(alloc_size)
 #    define RSPAMD_ATTR_ALLOC_SIZE(pos) __attribute__((alloc_size(pos)))
 #  else
-#    #define RSPAMD_ATTR_ALLOC_SIZE(pos)
+#    define RSPAMD_ATTR_ALLOC_SIZE(pos)
 #  endif
 
 #  if __has_attribute(assume_aligned)
 #    define RSPAMD_ATTR_ALLOC_ALIGN(al) __attribute__((assume_aligned(al)))
 #  else
-#    #define RSPAMD_ATTR_ALLOC_ALIGN(al)
+#    define RSPAMD_ATTR_ALLOC_ALIGN(al)
 #  endif
 #  if __has_attribute(returns_nonnull)
 #    define RSPAMD_ATTR_RETURNS_NONNUL __attribute__((returns_nonnull))
 #  else
-#    #define RSPAMD_ATTR_RETURNS_NONNUL
+#    define RSPAMD_ATTR_RETURNS_NONNUL
 #  endif
 #else
 #define RSPAMD_ATTR_ALLOC_SIZE(pos)


### PR DESCRIPTION
due to a syntax error in preprocessor directives I'm unable to compile 1.8.2:
```
BUILDSTDERR: In file included from /builddir/build/BUILD/rspamd-1.8.2/contrib/lc-btrie/btrie.c:311:0:
BUILDSTDERR: /builddir/build/BUILD/rspamd-1.8.2/src/libutil/mem_pool.h:28:6: error: invalid preprocessing directive ##
BUILDSTDERR:  #    #define RSPAMD_ATTR_ALLOC_SIZE(pos)
BUILDSTDERR:       ^
BUILDSTDERR: /builddir/build/BUILD/rspamd-1.8.2/src/libutil/mem_pool.h:34:6: error: invalid preprocessing directive ##
BUILDSTDERR:  #    #define RSPAMD_ATTR_ALLOC_ALIGN(al)
BUILDSTDERR:       ^
BUILDSTDERR: /builddir/build/BUILD/rspamd-1.8.2/src/libutil/mem_pool.h:39:6: error: invalid preprocessing directive ##
BUILDSTDERR:  #    #define RSPAMD_ATTR_RETURNS_NONNUL
```
This PR removes the extra pound sign.