### PR TITLE
Allow setting static domain for ARC signatures

### DIFF
--- a/lualib/lua_dkim_tools.lua
+++ b/lualib/lua_dkim_tools.lua
@@ -135,6 +135,8 @@ local function prepare_dkim_signing(N, task, settings)
       return udom
     elseif settings[dtype] == 'recipient' then
       return tdom
+    else
+      return settings[dtype]:lower()
     end
   end
 


### PR DESCRIPTION
ARC draft places no requirements on the domains used for the AMS header field signatures, so we can use any domain whose keys we have. 

Because I use ARC to seal incomming external emails, the `use_domain_sign_inbound="recipient"` should be sufficient. In case the server manage multiple domains, some of which do not use DKIM, I need to set static domain name (and key) to be able to seal emails for them with static domain `use_domain_sign_inbound="domain.tld"`.
