### PR TITLE
Added message/rfc822 to mime_types.inc

### DIFF
--- a/conf/mime_types.inc
+++ b/conf/mime_types.inc
@@ -1352,6 +1352,7 @@ message/global-headers 0
 message/http 0
 message/imdn+xml 0
 message/news 0
+message/rfc822 0
 message/s-http 0
 message/sip 0
 message/sipfrag 0


### PR DESCRIPTION
message/rfc822 is the mimetype if you forward an email as attachment (.eml)