### PR TITLE
[Minor] lua_scanners - use pattern for FAIL symbol

### DIFF
--- a/conf/modules.d/antivirus.conf
+++ b/conf/modules.d/antivirus.conf
@@ -45,6 +45,10 @@ antivirus {
       # symbol_name = "pattern";
       JUST_EICAR = '^Eicar-Test-Signature$';
     }
+    patterns_fail {
+      # symbol_name = "pattern";
+      #CLAM_PROTOCOL_ERROR = '^unhandled response';
+    }
     # `whitelist` points to a map of IP addresses. Mail from these addresses is not scanned.
     whitelist = "/etc/rspamd/antivirus.wl";
   }

--- a/lualib/lua_scanners/dcc.lua
+++ b/lualib/lua_scanners/dcc.lua
@@ -115,8 +115,7 @@ local function dcc_check(task, content, digest, rule)
         else
           rspamd_logger.errx(task, '%s: failed to scan, maximum retransmits '..
             'exceed', rule.log_prefix)
-          task:insert_result(rule['symbol_fail'], 0.0, 'failed to scan and '..
-            'retransmits exceed')
+          common.yield_result(task, rule, 'failed to scan and retransmits exceed', 0.0, 'fail')
         end
       end
 
@@ -221,9 +220,7 @@ local function dcc_check(task, content, digest, rule)
           else
             -- Unknown result
             rspamd_logger.warnx(task, '%s: result error: %1', rule.log_prefix, result);
-            task:insert_result(rule.symbol_fail,
-                0.0,
-                'error: ' .. result)
+            common.yield_result(task, rule, 'error: ' .. result, 0.0, 'fail')
           end
         end
       end

--- a/lualib/lua_scanners/fprot.lua
+++ b/lualib/lua_scanners/fprot.lua
@@ -118,8 +118,7 @@ local function fprot_check(task, content, digest, rule)
           rspamd_logger.errx(task,
               '%s [%s]: failed to scan, maximum retransmits exceed',
               rule['symbol'], rule['type'])
-          task:insert_result(rule['symbol_fail'], 0.0,
-              'failed to scan and retransmits exceed')
+          common.yield_result(task, rule, 'failed to scan and retransmits exceed', 0.0, 'fail')
         end
       else
         upstream:ok()

--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -137,12 +137,12 @@ local function icap_check(task, content, digest, rule)
           ICAP/1.0 500 Server error
         ]]--
         rspamd_logger.errx(task, '%s: ICAP ERROR: %s', rule.log_prefix, icap_headers.icap)
-        task:insert_result(rule.symbol_fail, 0.0, icap_headers.icap)
+        common.yield_result(task, rule, icap_headers.icap, 0.0, 'fail')
         return false
       else
         rspamd_logger.errx(task, '%s: unhandled response |%s|',
           rule.log_prefix, string.gsub(result, "\r\n", ", "))
-        task:insert_result(rule.symbol_fail, 0.0, 'unhandled icap response: ' .. icap_headers.icap)
+        common.yield_result(task, rule, 'unhandled icap response: ' .. icap_headers.icap, 0.0, 'fail')
       end
     end
 
@@ -162,12 +162,12 @@ local function icap_check(task, content, digest, rule)
         else
           rspamd_logger.errx(task, '%s: RESPMOD method not advertised: Methods: %s',
             rule.log_prefix, icap_headers['Methods'])
-          task:insert_result(rule.symbol_fail, 0.0, 'NO RESPMOD')
+          common.yield_result(task, rule, 'NO RESPMOD', 0.0, 'fail')
         end
       else
         rspamd_logger.errx(task, '%s: OPTIONS query failed: %s',
           rule.log_prefix, icap_headers.icap)
-        task:insert_result(rule.symbol_fail, 0.0, 'OPTIONS query failed')
+        common.yield_result(task, rule, 'OPTIONS query failed', 0.0, 'fail')
       end
     end
 
@@ -206,7 +206,7 @@ local function icap_check(task, content, digest, rule)
         else
           rspamd_logger.errx(task, '%s: failed to scan, maximum retransmits '..
             'exceed - err: %s', rule.log_prefix, error)
-          task:insert_result(rule.symbol_fail, 0.0, 'failed - err: ' .. error)
+          common.yield_result(task, rule, 'failed - err: ' .. error, 0.0, 'fail')
         end
       end
 

--- a/lualib/lua_scanners/kaspersky_av.lua
+++ b/lualib/lua_scanners/kaspersky_av.lua
@@ -138,8 +138,7 @@ local function kaspersky_check(task, content, digest, rule)
           rspamd_logger.errx(task,
               '%s [%s]: failed to scan, maximum retransmits exceed',
               rule['symbol'], rule['type'])
-          task:insert_result(rule['symbol_fail'], 0.0,
-              'failed to scan and retransmits exceed')
+          common.yield_result(task, rule, 'failed to scan and retransmits exceed', 0.0, 'fail')
         end
 
       else
@@ -159,7 +158,7 @@ local function kaspersky_check(task, content, digest, rule)
             cached = vname
           else
             rspamd_logger.errx(task, 'unhandled response: %s', data)
-            task:insert_result(rule['symbol_fail'], 0.0, 'unhandled response')
+            common.yield_result(task, rule, 'unhandled response', 0.0, 'fail')
           end
         end
         if cached then

--- a/lualib/lua_scanners/savapi.lua
+++ b/lualib/lua_scanners/savapi.lua
@@ -160,6 +160,7 @@ local function savapi_check(task, content, digest, rule)
           if not virus then
             rspamd_logger.errx(task, "%s: virus result unparseable: %s",
                 rule['type'], result)
+            common.yield_result(task, rule, 'virus result unparseable: ' .. result, 0.0, 'fail')
             return
           end
         end
@@ -185,6 +186,7 @@ local function savapi_check(task, content, digest, rule)
       else
         rspamd_logger.errx(task, '%s: invalid product id %s', rule['type'],
             rule['product_id'])
+        common.yield_result(task, rule, 'invalid product id: ' .. result, 0.0, 'fail')
         conn:add_write(savapi_fin_cb, 'QUIT\n')
       end
     end
@@ -222,7 +224,7 @@ local function savapi_check(task, content, digest, rule)
           })
         else
           rspamd_logger.errx(task, '%s [%s]: failed to scan, maximum retransmits exceed', rule['symbol'], rule['type'])
-          task:insert_result(rule['symbol_fail'], 0.0, 'failed to scan and retransmits exceed')
+          common.yield_result(task, rule, 'failed to scan and retransmits exceed', 0.0, 'fail')
         end
       else
         upstream:ok()

--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -108,6 +108,7 @@ local function add_antivirus_rule(sym, opts)
   end
 
   rule.patterns = common.create_regex_table(opts.patterns or {})
+  rule.patterns_fail = common.create_regex_table(opts.patterns_fail or {})
 
   if opts.whitelist then
     rule.whitelist = rspamd_config:add_hash_map(opts.whitelist)

--- a/src/plugins/lua/external_services.lua
+++ b/src/plugins/lua/external_services.lua
@@ -148,6 +148,7 @@ local function add_scanner_rule(sym, opts)
   end
 
   rule.patterns = common.create_regex_table(opts.patterns or {})
+  rule.patterns_fail = common.create_regex_table(opts.patterns_fail or {})
 
   rule.mime_parts_filter_regex = common.create_regex_table(opts.mime_parts_filter_regex or {})
 


### PR DESCRIPTION
With using patterns also for SYMBOL_FAIL it is possible to handle some error messages with composites or force actions or set a weight.

Maybe to soft reject mails not scanned by a specific virus scanner or reject encrypted attachments.