### PR TITLE
Add ed25519 and multiple signature support

### DIFF
--- a/conf/modules.d/dkim_signing.conf
+++ b/conf/modules.d/dkim_signing.conf
@@ -58,10 +58,17 @@ dkim_signing {
   # Domain specific settings
   #domain {
   #  example.com {
-  #    # Private key path
-  #    path = "/var/lib/rspamd/dkim/example.key";
-  #    # Selector
-  #    selector = "ds";
+  #    selectors [
+  #      { # Private key path
+  #        path = "/var/lib/rspamd/dkim/example.key";
+  #        # Selector
+  #        selector = "ds";
+  #      },
+  #      { # multiple dkim signature
+  #        path = "/var/lib/rspamd/dkim/eddsa.key";
+  #        selector = "eddsa";
+  #      }
+  #    ]
   #  }
   #}
 

--- a/lualib/lua_dkim_tools.lua
+++ b/lualib/lua_dkim_tools.lua
@@ -211,11 +211,23 @@ local function prepare_dkim_signing(N, task, settings)
     end
   end
 
-  local p = {}
+  local p = {
+    keys = {}
+  }
 
   if settings.domain[dkim_domain] then
     p.selector = settings.domain[dkim_domain].selector
     p.key = settings.domain[dkim_domain].path
+    for _, s in ipairs(settings.domain[dkim_domain].selectors) do
+      lua_util.debugm(N, task, 'adding selector: %1', s)
+      local k = {}
+      k.selector = s.selector
+      k.key = s.path
+      --bit of a hack to make other code play nice
+      p.selector = s.selector
+      p.key = s.path
+      table.insert(p.keys, k)
+    end
   end
 
   if not p.key and p.selector then

--- a/src/libcryptobox/ed25519/ed25519.c
+++ b/src/libcryptobox/ed25519/ed25519.c
@@ -26,6 +26,7 @@ typedef struct ed25519_impl_s {
 	const char *desc;
 
 	void (*keypair) (unsigned char *pk, unsigned char *sk);
+	void (*seed_keypair) (unsigned char *pk, unsigned char *sk, unsigned char *seed);
 	void (*sign) (unsigned char *sig, size_t *siglen_p,
 			const unsigned char *m, size_t mlen,
 			const unsigned char *sk);
@@ -37,6 +38,7 @@ typedef struct ed25519_impl_s {
 
 #define ED25519_DECLARE(ext) \
     void ed_keypair_##ext(unsigned char *pk, unsigned char *sk); \
+    void ed_seed_keypair_##ext(unsigned char *pk, unsigned char *sk, unsigned char *seed); \
     void ed_sign_##ext(unsigned char *sig, size_t *siglen_p, \
         const unsigned char *m, size_t mlen, \
         const unsigned char *sk); \
@@ -46,7 +48,7 @@ typedef struct ed25519_impl_s {
         const unsigned char *pk)
 
 #define ED25519_IMPL(cpuflags, desc, ext) \
-    {(cpuflags), desc, ed_keypair_##ext, ed_sign_##ext, ed_verify_##ext}
+    {(cpuflags), desc, ed_keypair_##ext, ed_seed_keypair_##ext, ed_sign_##ext, ed_verify_##ext}
 
 ED25519_DECLARE(ref);
 #define ED25519_REF ED25519_IMPL(0, "ref", ref)
@@ -76,6 +78,12 @@ ed25519_load (void)
 	g_assert (ed25519_test (ed25519_opt));
 
 	return ed25519_opt->desc;
+}
+
+void
+ed25519_seed_keypair (unsigned char *pk, unsigned char *sk, unsigned char *seed)
+{
+	ed25519_opt->seed_keypair (pk, sk, seed);
 }
 
 void

--- a/src/libcryptobox/ed25519/ed25519.h
+++ b/src/libcryptobox/ed25519/ed25519.h
@@ -22,6 +22,7 @@
 
 const char* ed25519_load (void);
 void ed25519_keypair (unsigned char *pk, unsigned char *sk);
+void ed25519_seed_keypair (unsigned char *pk, unsigned char *sk, unsigned char *seed);
 void ed25519_sign (unsigned char *sig, size_t *siglen_p,
 		const unsigned char *m, size_t mlen,
 		const unsigned char *sk);

--- a/src/libcryptobox/ed25519/ref.c
+++ b/src/libcryptobox/ed25519/ref.c
@@ -23,7 +23,7 @@
 #include "ottery.h"
 #include <openssl/evp.h> /* SHA512 */
 
-static int
+int
 ed_seed_keypair_ref (unsigned char *pk, unsigned char *sk,
 		const unsigned char *seed)
 {

--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -83,7 +83,7 @@ enum rspamd_dkim_param_type {
         rspamd_dkim_log_id, "dkim", ctx->pool->tag.uid, \
         G_STRFUNC, \
         __VA_ARGS__)
-#define msg_debug2_dkim(...)  rspamd_conditional_debug_fast (NULL, NULL, \
+#define msg_debug_dkim_taskless(...)  rspamd_conditional_debug_fast (NULL, NULL, \
         rspamd_dkim_log_id, "dkim", "", \
         G_STRFUNC, \
         __VA_ARGS__)
@@ -2626,7 +2626,7 @@ rspamd_dkim_sign_key_load (const gchar *key, gsize len,
 	nkey = g_malloc0 (sizeof (*nkey));
 	nkey->mtime = mtime;
 
-	msg_debug2_dkim("got public key with length %d and type %d", len, type);
+	msg_debug_dkim_taskless ("got public key with length %d and type %d", len, type);
 	if (type == RSPAMD_DKIM_KEY_RAW && len == 32) {
 		unsigned char pk[32];
 		nkey->type = RSPAMD_DKIM_KEY_EDDSA;

--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -21,6 +21,7 @@
 #include "utlist.h"
 #include "unix-std.h"
 #include "mempool_vars_internal.h"
+#include "libcryptobox/ed25519/ed25519.h"
 
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
@@ -28,6 +29,10 @@
 
 /* special DNS tokens */
 #define DKIM_DNSKEYNAME     "_domainkey"
+
+/* ed25519 key lengths */
+#define ED25519_B64_BYTES	45
+#define ED25519_BYTES		32
 
 /* Canonization methods */
 #define DKIM_CANON_UNKNOWN  (-1)    /* unknown method */
@@ -76,6 +81,10 @@ enum rspamd_dkim_param_type {
         __VA_ARGS__)
 #define msg_debug_dkim(...)  rspamd_conditional_debug_fast (NULL, NULL, \
         rspamd_dkim_log_id, "dkim", ctx->pool->tag.uid, \
+        G_STRFUNC, \
+        __VA_ARGS__)
+#define msg_debug2_dkim(...)  rspamd_conditional_debug_fast (NULL, NULL, \
+        rspamd_dkim_log_id, "dkim", "", \
         G_STRFUNC, \
         __VA_ARGS__)
 
@@ -155,10 +164,14 @@ struct rspamd_dkim_sign_context_s {
 };
 
 struct rspamd_dkim_sign_key_s {
-	enum rspamd_dkim_sign_key_type type;
+	enum rspamd_dkim_key_type type;
 	guint8 *keydata;
+	gpointer map;
 	gsize keylen;
-	RSA *key_rsa;
+	union {
+		RSA *key_rsa;
+		guchar *key_eddsa;
+	} key;
 	BIO *key_bio;
 	EVP_PKEY *key_evp;
 	time_t mtime;
@@ -1342,8 +1355,10 @@ rspamd_dkim_sign_key_free (rspamd_dkim_sign_key_t *key)
 	if (key->key_evp) {
 		EVP_PKEY_free (key->key_evp);
 	}
-	if (key->key_rsa) {
-		RSA_free (key->key_rsa);
+	if (key->type == RSPAMD_DKIM_KEY_RSA) {
+		if (key->key.key_rsa) {
+			RSA_free (key->key.key_rsa);
+		}
 	}
 	if (key->key_bio) {
 		BIO_free (key->key_bio);
@@ -1351,10 +1366,11 @@ rspamd_dkim_sign_key_free (rspamd_dkim_sign_key_t *key)
 
 	if (key->keydata && key->keylen > 0) {
 
-		if (key->type == RSPAMD_DKIM_SIGN_KEY_FILE) {
-			munmap (key->keydata, key->keylen);
+		if (key->map) {
+			munmap (key->map, key->keylen);
 		}
 		else {
+			rspamd_explicit_memzero (key->keydata, key->keylen);
 			g_free (key->keydata);
 		}
 	}
@@ -2652,6 +2668,7 @@ rspamd_dkim_sign_key_load (const gchar *what, gsize len,
 	switch (type) {
 	case RSPAMD_DKIM_SIGN_KEY_FILE:
 		(void)mlock (map, len);
+		nkey->map = map;
 		nkey->keydata = map;
 		nkey->keylen = map_len;
 		break;
@@ -2668,57 +2685,85 @@ rspamd_dkim_sign_key_load (const gchar *what, gsize len,
 		nkey->keylen = len;
 	}
 
+	msg_debug2_dkim("got public key with length %d and type %d", nkey->keylen, type);
 	(void)mlock (nkey->keydata, nkey->keylen);
-	nkey->key_bio = BIO_new_mem_buf (nkey->keydata, nkey->keylen);
-
-	if (type == RSPAMD_DKIM_SIGN_KEY_DER || type == RSPAMD_DKIM_SIGN_KEY_BASE64) {
-		if (d2i_PrivateKey_bio (nkey->key_bio, &nkey->key_evp) == NULL) {
-			if (type == RSPAMD_DKIM_SIGN_KEY_FILE) {
-				g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
-						"cannot read private key from %*s: %s",
-						(gint)len, what,
-						ERR_error_string (ERR_get_error (), NULL));
-			}
-			else {
-				g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
-						"cannot read private key from string: %s",
-						ERR_error_string (ERR_get_error (), NULL));
-			}
-
-			rspamd_dkim_sign_key_free (nkey);
-
-			return NULL;
-		}
+	if (type == RSPAMD_DKIM_SIGN_KEY_FILE && nkey->keylen == ED25519_B64_BYTES) {
+		unsigned char seed[32];
+		unsigned char pk[32];
+		nkey->type = RSPAMD_DKIM_KEY_EDDSA;
+		nkey->keydata = g_malloc (rspamd_cryptobox_sk_sig_bytes (RSPAMD_CRYPTOBOX_MODE_25519));
+		rspamd_cryptobox_base64_decode (nkey->map, ED25519_B64_BYTES, seed, &nkey->keylen);
+		ed25519_seed_keypair (pk, nkey->keydata, seed);
+		nkey->key.key_eddsa = nkey->keydata;
+		nkey->keylen = rspamd_cryptobox_sk_sig_bytes (RSPAMD_CRYPTOBOX_MODE_25519);
+		rspamd_explicit_memzero (seed, 32);
+		munmap (nkey->map, ED25519_B64_BYTES);
+		nkey->map = NULL;
+	}
+	else if (type == RSPAMD_DKIM_SIGN_KEY_BASE64 && nkey->keylen == ED25519_BYTES) {
+		unsigned char pk[32];
+		nkey->type = RSPAMD_DKIM_KEY_EDDSA;
+		nkey->key.key_eddsa =
+			g_malloc (rspamd_cryptobox_sk_sig_bytes (RSPAMD_CRYPTOBOX_MODE_25519));
+		ed25519_seed_keypair (pk, nkey->key.key_eddsa, nkey->keydata);
+		rspamd_explicit_memzero (nkey->keydata, nkey->keylen);
+		g_free (nkey->keydata);
+		nkey->keydata = nkey->key.key_eddsa;
+		nkey->keylen = rspamd_cryptobox_sk_sig_bytes (RSPAMD_CRYPTOBOX_MODE_25519);
 	}
 	else {
-		if (!PEM_read_bio_PrivateKey (nkey->key_bio, &nkey->key_evp, NULL, NULL)) {
-			if (type == RSPAMD_DKIM_SIGN_KEY_FILE) {
-				g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
-						"cannot read private key from %*s: %s",
-						(gint)len, what,
-						ERR_error_string (ERR_get_error (), NULL));
+		nkey->key_bio = BIO_new_mem_buf (nkey->keydata, nkey->keylen);
+
+		if (type == RSPAMD_DKIM_SIGN_KEY_DER || type == RSPAMD_DKIM_SIGN_KEY_BASE64) {
+			if (d2i_PrivateKey_bio (nkey->key_bio, &nkey->key_evp) == NULL) {
+				if (type == RSPAMD_DKIM_SIGN_KEY_FILE) {
+					g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
+							"cannot read private key from %*s: %s",
+							(gint)len, what,
+							ERR_error_string (ERR_get_error (), NULL));
+				}
+				else {
+					g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
+							"cannot read private key from string: %s",
+							ERR_error_string (ERR_get_error (), NULL));
+				}
+
+				rspamd_dkim_sign_key_free (nkey);
+
+				return NULL;
 			}
-			else {
-				g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
-						"cannot read private key from string: %s",
-						ERR_error_string (ERR_get_error (), NULL));
+		}
+		else {
+			if (!PEM_read_bio_PrivateKey (nkey->key_bio, &nkey->key_evp, NULL, NULL)) {
+				if (type == RSPAMD_DKIM_SIGN_KEY_FILE) {
+					g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
+							"cannot read private key from %*s: %s",
+							(gint)len, what,
+							ERR_error_string (ERR_get_error (), NULL));
+				}
+				else {
+					g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
+							"cannot read private key from string: %s",
+							ERR_error_string (ERR_get_error (), NULL));
+				}
+
+				rspamd_dkim_sign_key_free (nkey);
+
+				return NULL;
 			}
 
+		}
+		nkey->key.key_rsa = EVP_PKEY_get1_RSA (nkey->key_evp);
+		if (nkey->key.key_rsa == NULL) {
+			g_set_error (err,
+					DKIM_ERROR,
+					DKIM_SIGERROR_KEYFAIL,
+					"cannot extract rsa key from evp key");
 			rspamd_dkim_sign_key_free (nkey);
 
 			return NULL;
 		}
-	}
-
-	nkey->key_rsa = EVP_PKEY_get1_RSA (nkey->key_evp);
-	if (nkey->key_rsa == NULL) {
-		g_set_error (err,
-				DKIM_ERROR,
-				DKIM_SIGERROR_KEYFAIL,
-				"cannot extract rsa key from evp key");
-		rspamd_dkim_sign_key_free (nkey);
-
-		return NULL;
+		nkey->type = RSPAMD_DKIM_KEY_RSA;
 	}
 
 	REF_INIT_RETAIN (nkey, rspamd_dkim_sign_key_free);
@@ -2784,7 +2829,7 @@ rspamd_create_dkim_sign_context (struct rspamd_task *task,
 		return NULL;
 	}
 
-	if (!priv_key || !priv_key->key_rsa) {
+	if (!priv_key || (!priv_key->key.key_rsa && !priv_key->key.key_eddsa)) {
 		g_set_error (err,
 				DKIM_ERROR,
 				DKIM_SIGERROR_KEYFAIL,
@@ -2852,8 +2897,8 @@ rspamd_dkim_sign (struct rspamd_task *task, const gchar *selector,
 	gsize dlen = 0;
 	guint i, j;
 	gchar *b64_data;
-	guchar *rsa_buf;
-	guint rsa_len;
+	guchar *sig_buf;
+	guint sig_len;
 	guint headers_len = 0, cur_len = 0;
 	union rspamd_dkim_header_stat hstat;
 
@@ -2889,7 +2934,9 @@ rspamd_dkim_sign (struct rspamd_task *task, const gchar *selector,
 	hdr = g_string_sized_new (255);
 
 	if (ctx->common.type == RSPAMD_DKIM_NORMAL) {
-		rspamd_printf_gstring (hdr, "v=1; a=rsa-sha256; c=%s/%s; d=%s; s=%s; ",
+		rspamd_printf_gstring (hdr, "v=1; a=%s; c=%s/%s; d=%s; s=%s; ",
+				ctx->key->type == RSPAMD_DKIM_KEY_RSA ?
+						"rsa-sha256" : "ed25519-sha256",
 				ctx->common.header_canon_type == DKIM_CANON_RELAXED ?
 						"relaxed" : "simple",
 				ctx->common.body_canon_type == DKIM_CANON_RELAXED ?
@@ -2897,8 +2944,10 @@ rspamd_dkim_sign (struct rspamd_task *task, const gchar *selector,
 				domain, selector);
 	}
 	else if (ctx->common.type == RSPAMD_DKIM_ARC_SIG) {
-		rspamd_printf_gstring (hdr, "i=%d; a=rsa-sha256; c=%s/%s; d=%s; s=%s; ",
+		rspamd_printf_gstring (hdr, "i=%d; a=%s; c=%s/%s; d=%s; s=%s; ",
 				idx,
+				ctx->key->type == RSPAMD_DKIM_KEY_RSA ?
+						"rsa-sha256" : "ed25519-sha256",
 				ctx->common.header_canon_type == DKIM_CANON_RELAXED ?
 						"relaxed" : "simple",
 				ctx->common.body_canon_type == DKIM_CANON_RELAXED ?
@@ -2907,8 +2956,10 @@ rspamd_dkim_sign (struct rspamd_task *task, const gchar *selector,
 	}
 	else {
 		g_assert (arc_cv != NULL);
-		rspamd_printf_gstring (hdr, "i=%d; a=rsa-sha256; c=%s/%s; d=%s; s=%s; cv=%s; ",
+		rspamd_printf_gstring (hdr, "i=%d; a=%s; c=%s/%s; d=%s; s=%s; cv=%s; ",
 				arc_cv,
+				ctx->key->type == RSPAMD_DKIM_KEY_RSA ?
+						"rsa-sha256" : "ed25519-sha256",
 				idx,
 				domain, selector);
 	}
@@ -3040,24 +3091,37 @@ rspamd_dkim_sign (struct rspamd_task *task, const gchar *selector,
 
 	dlen = EVP_MD_CTX_size (ctx->common.headers_hash);
 	EVP_DigestFinal_ex (ctx->common.headers_hash, raw_digest, NULL);
-	rsa_len = RSA_size (ctx->key->key_rsa);
-	rsa_buf = g_alloca (rsa_len);
+	if (ctx->key->type == RSPAMD_DKIM_KEY_RSA) {
+		sig_len = RSA_size (ctx->key->key.key_rsa);
+		sig_buf = g_alloca (sig_len);
 
-	if (RSA_sign (NID_sha256, raw_digest, dlen, rsa_buf, &rsa_len,
-			ctx->key->key_rsa) != 1) {
+		if (RSA_sign (NID_sha256, raw_digest, dlen, sig_buf, &sig_len,
+				ctx->key->key.key_rsa) != 1) {
+			g_string_free (hdr, TRUE);
+			msg_err_task ("rsa sign error: %s",
+					ERR_error_string (ERR_get_error (), NULL));
+
+			return NULL;
+		}
+	} else if (ctx->key->type == RSPAMD_DKIM_KEY_EDDSA) {
+		sig_len = rspamd_cryptobox_signature_bytes (RSPAMD_CRYPTOBOX_MODE_25519);
+		sig_buf = g_alloca (sig_len);
+
+		rspamd_cryptobox_sign (sig_buf, NULL, raw_digest, dlen,
+				ctx->key->key.key_eddsa, RSPAMD_CRYPTOBOX_MODE_25519);
+	} else {
 		g_string_free (hdr, TRUE);
-		msg_err_task ("rsa sign error: %s",
-				ERR_error_string (ERR_get_error (), NULL));
+		msg_err_task ("unsupported key type for signing");
 
 		return NULL;
 	}
 
 	if (task->flags & RSPAMD_TASK_FLAG_MILTER) {
-		b64_data = rspamd_encode_base64_fold (rsa_buf, rsa_len, 70, NULL,
+		b64_data = rspamd_encode_base64_fold (sig_buf, sig_len, 70, NULL,
 				RSPAMD_TASK_NEWLINES_LF);
 	}
 	else {
-		b64_data = rspamd_encode_base64_fold (rsa_buf, rsa_len, 70, NULL,
+		b64_data = rspamd_encode_base64_fold (sig_buf, sig_len, 70, NULL,
 				task->nlines_type);
 	}
 
@@ -3072,29 +3136,26 @@ rspamd_dkim_match_keys (rspamd_dkim_key_t *pk,
 								 rspamd_dkim_sign_key_t *sk,
 								 GError **err)
 {
-	const BIGNUM *n1, *n2;
-
 	if (pk == NULL || sk == NULL) {
 		g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
 				"missing public or private key");
 		return FALSE;
 	}
-
-	if (pk->type != RSPAMD_DKIM_KEY_RSA) {
+	if (pk->type != sk->type) {
 		g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYFAIL,
-				"pubkey is not RSA key");
+				"public and private key types do not match");
 		return FALSE;
 	}
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
-	RSA_get0_key (pk->key.key_rsa, &n1, NULL, NULL);
-	RSA_get0_key (sk->key_rsa, &n2, NULL, NULL);
-#else
-	n1 = pk->key.key_rsa->n;
-	n2 = sk->key_rsa->n;
-#endif
+	if (pk->type == RSPAMD_DKIM_KEY_EDDSA) {
+		if (memcmp(sk->key.key_eddsa + 32, pk->key.key_eddsa, 32) != 0) {
+			g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYHASHMISMATCH,
+					"pubkey does not match private key");
+			return FALSE;
+		}
 
-	if (BN_cmp (n1, n2) != 0) {
+	}
+	else if (EVP_PKEY_cmp (pk->key_evp, sk->key_evp) != 1) {
 		g_set_error (err, dkim_error_quark (), DKIM_SIGERROR_KEYHASHMISMATCH,
 				"pubkey does not match private key");
 		return FALSE;

--- a/src/libserver/dkim.h
+++ b/src/libserver/dkim.h
@@ -102,16 +102,17 @@ typedef struct rspamd_dkim_sign_context_s rspamd_dkim_sign_context_t;
 struct rspamd_dkim_key_s;
 typedef struct rspamd_dkim_key_s rspamd_dkim_key_t;
 
-struct rspamd_dkim_sign_key_s;
-typedef struct rspamd_dkim_sign_key_s rspamd_dkim_sign_key_t;
+struct rspamd_dkim_key_s;
+typedef struct rspamd_dkim_key_s rspamd_dkim_sign_key_t;
 
 struct rspamd_task;
 
-enum rspamd_dkim_sign_key_type {
-	RSPAMD_DKIM_SIGN_KEY_FILE = 0,
-	RSPAMD_DKIM_SIGN_KEY_PEM,
-	RSPAMD_DKIM_SIGN_KEY_BASE64,
-	RSPAMD_DKIM_SIGN_KEY_DER
+enum rspamd_dkim_key_format {
+	RSPAMD_DKIM_KEY_FILE = 0,
+	RSPAMD_DKIM_KEY_PEM,
+	RSPAMD_DKIM_KEY_BASE64,
+	RSPAMD_DKIM_KEY_RAW,
+	RSPAMD_DKIM_KEY_UNKNOWN
 };
 
 enum rspamd_dkim_type {
@@ -188,17 +189,16 @@ rspamd_dkim_sign_context_t * rspamd_create_dkim_sign_context (struct rspamd_task
  * @return
  */
 rspamd_dkim_sign_key_t* rspamd_dkim_sign_key_load (const gchar *what, gsize len,
-		enum rspamd_dkim_sign_key_type type,
+		enum rspamd_dkim_key_format type,
 		GError **err);
 
 /**
  * Invalidate modified sign key
  * @param key
  * @return
- */
+*/
 gboolean rspamd_dkim_sign_key_maybe_invalidate (rspamd_dkim_sign_key_t *key,
-		enum rspamd_dkim_sign_key_type type,
-		const gchar *what, gsize len);
+		time_t mtime);
 
 /**
  * Make DNS request for specified context and obtain and parse key

--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -1132,6 +1132,7 @@ rspamd_protocol_write_ucl (struct rspamd_task *task,
 {
 	ucl_object_t *top = NULL;
 	GString *dkim_sig;
+	GList *dkim_sigs;
 	const ucl_object_t *milter_reply;
 
 	rspamd_task_set_finish_time (task);
@@ -1200,11 +1201,12 @@ rspamd_protocol_write_ucl (struct rspamd_task *task,
 	}
 
 	if (flags & RSPAMD_PROTOCOL_DKIM) {
-		dkim_sig = rspamd_mempool_get_variable (task->task_pool,
+		dkim_sigs = rspamd_mempool_get_variable (task->task_pool,
 				RSPAMD_MEMPOOL_DKIM_SIGNATURE);
 
-		if (dkim_sig) {
+		for (; dkim_sigs != NULL; dkim_sigs = dkim_sigs->next) {
 			GString *folded_header;
+			dkim_sig = (GString *) dkim_sigs->data;
 
 			if (task->flags & RSPAMD_TASK_FLAG_MILTER) {
 				folded_header = rspamd_header_value_fold ("DKIM-Signature",

--- a/src/plugins/dkim_check.c
+++ b/src/plugins/dkim_check.c
@@ -38,6 +38,7 @@
 #include "libutil/map_helpers.h"
 #include "rspamd.h"
 #include "utlist.h"
+#include "unix-std.h"
 #include "lua/lua_common.h"
 #include "libserver/mempool_vars_internal.h"
 
@@ -634,16 +635,58 @@ dkim_module_config (struct rspamd_config *cfg)
 	return res;
 }
 
+/**
+ * helper to see if valid base64, minus newline
+ */
+static gboolean
+is_valid_base64(const uint8_t *in, size_t len) {
+	int i;
+	if (in[len - 1] == '\n')
+		len--;
+	if (in[len - 1] == '\r')
+		len--;
+	if (len % 4 != 0)
+		return FALSE;
+
+	if (in[len - 1] == '=')
+		len--;
+	if (in[len - 1] == '=')
+		len--;
+
+	for (i = 0; i < len; i++) {
+		if ('a' <= in[i] && in[i] <= 'z')
+			continue;
+		if ('A' <= in[i] && in[i] <= 'Z')
+			continue;
+		if ('0' <= in[i] && in[i] <= '9')
+			continue;
+		if (in[i] == '/')
+			continue;
+		if (in[i] == '+')
+			continue;
+		return FALSE;
+	}
+	return TRUE;
+}
+
+
+#define PEM_SIG "-----BEGIN"
+/**
+ * Grab a private key from the cache
+ * or from the key content provided
+ */
 rspamd_dkim_sign_key_t *
-dkim_module_load_key_format (lua_State *L, struct rspamd_task *task,
-		const gchar *key, gsize keylen,
-		enum rspamd_dkim_sign_key_type kt)
+dkim_module_load_key_format (struct rspamd_task *task, struct dkim_ctx *dkim_module_ctx,
+		const gchar *key, gsize keylen, enum rspamd_dkim_key_format key_format)
+
 {
 	guchar h[rspamd_cryptobox_HASHBYTES],
 			hex_hash[rspamd_cryptobox_HASHBYTES * 2 + 1];
 	rspamd_dkim_sign_key_t *ret;
 	GError *err = NULL;
-	struct dkim_ctx *dkim_module_ctx = dkim_get_context (task->cfg);
+	gpointer map = NULL, tmp = NULL;
+	struct stat st;
+	ssize_t maplen;
 
 	memset (hex_hash, 0, sizeof (hex_hash));
 	rspamd_cryptobox_hash (h, key, keylen, NULL, 0);
@@ -651,23 +694,95 @@ dkim_module_load_key_format (lua_State *L, struct rspamd_task *task,
 	ret = rspamd_lru_hash_lookup (dkim_module_ctx->dkim_sign_hash,
 				hex_hash, time (NULL));
 
-	if (ret == NULL) {
-			ret = rspamd_dkim_sign_key_load (key, keylen, kt, &err);
+	/*
+	 * This fails for paths that are also valid base64.
+	 * Maybe the caller should have specified a format.
+	 */
+	if (key_format == RSPAMD_DKIM_KEY_UNKNOWN &&
+		(key[0] == '.' || key[0] == '/')) {
+		if (!is_valid_base64 (key, keylen))
+			key_format = RSPAMD_DKIM_KEY_FILE;
+	}
 
-			if (ret == NULL) {
-				msg_err_task ("cannot load private key: %e", err);
-				g_error_free (err);
-
-				return NULL;
-			}
-
-			rspamd_lru_hash_insert (dkim_module_ctx->dkim_sign_hash,
-					g_strdup (hex_hash), ret,
-					time (NULL), 0);
+	if (ret != NULL && key_format == RSPAMD_DKIM_KEY_FILE) {
+		msg_debug_task("checking for stale file key");
+		if (stat (key, &st) != 0) {
+			msg_err_task("cannot stat key file: %s", strerror (errno));
+			return NULL;
 		}
+		if (rspamd_dkim_sign_key_maybe_invalidate (ret, st.st_mtime)) {
+			msg_debug_task("removing stale file key");
+			/*
+			 * Invalidate DKIM key
+			 * removal from lru cache also cleanup the key and value
+			 */
+			rspamd_lru_hash_remove (dkim_module_ctx->dkim_sign_hash,
+					hex_hash);
+			ret = NULL;
+		}
+	}
+
+	/* found key; done */
+	if (ret != NULL)
+		return ret;
+
+	if (key_format == RSPAMD_DKIM_KEY_FILE) {
+		if (stat (key, &st) != 0) {
+			msg_err_task("cannot stat key file: %s", strerror (errno));
+			return NULL;
+		}
+		map = rspamd_file_xmap (key, PROT_READ, &maplen, TRUE);
+		if (map == NULL) {
+			msg_err_task("cannot open key file \'%s\'", key);
+			return NULL;
+		}
+		key = map;
+		keylen = maplen;
+		if (maplen > sizeof (PEM_SIG) &&
+				strncmp (map, PEM_SIG, sizeof (PEM_SIG) - 1) == 0) {
+			key_format = RSPAMD_DKIM_KEY_PEM;
+		} else if (is_valid_base64 ((uint8_t *)map, maplen)) {
+			key_format = RSPAMD_DKIM_KEY_BASE64;
+		} else {
+			key_format = RSPAMD_DKIM_KEY_RAW;
+		}
+	}
+	if (key_format == RSPAMD_DKIM_KEY_UNKNOWN) {
+		if (keylen > sizeof (PEM_SIG) &&
+				strncmp (key, PEM_SIG, sizeof (PEM_SIG) - 1) == 0) {
+			key_format = RSPAMD_DKIM_KEY_PEM;
+		} else {
+			key_format = RSPAMD_DKIM_KEY_RAW;
+		}
+	}
+	if (key_format == RSPAMD_DKIM_KEY_BASE64) {
+		key_format = RSPAMD_DKIM_KEY_RAW;
+		tmp = g_malloc (keylen);
+		rspamd_cryptobox_base64_decode (key, keylen, tmp, &keylen);
+		key = tmp;
+	}
+
+	ret = rspamd_dkim_sign_key_load (key, keylen, key_format, &err);
+
+	if (ret == NULL) {
+		msg_err_task ("cannot load dkim key %s: %e",
+				key, err);
+		g_error_free (err);
+	} else {
+		rspamd_lru_hash_insert (dkim_module_ctx->dkim_sign_hash,
+				g_strdup (hex_hash), ret, time (NULL), 0);
+	}
+
+	if (map != NULL)
+		munmap (map, maplen);
+	if (tmp != NULL) {
+		rspamd_explicit_memzero (tmp, keylen);
+		g_free (tmp);
+	}
 
 	return ret;
 }
+#undef PEM_SIG
 
 static gint
 lua_dkim_sign_handler (lua_State *L)
@@ -718,86 +833,24 @@ lua_dkim_sign_handler (lua_State *L)
 				(GDestroyNotify)rspamd_dkim_sign_key_unref);
 	}
 
-#define PEM_SIG "-----BEGIN"
 
 	if (key) {
-		if (key[0] == '.' || key[0] == '/') {
-			/* Likely raw path */
-			dkim_key = rspamd_lru_hash_lookup (dkim_module_ctx->dkim_sign_hash,
-					key, time (NULL));
-
-			if (dkim_key == NULL) {
-				dkim_key = rspamd_dkim_sign_key_load (key, strlen (key),
-						RSPAMD_DKIM_SIGN_KEY_FILE, &err);
-
-				if (dkim_key == NULL) {
-					msg_err_task ("cannot load dkim key %s: %e",
-							key, err);
-					g_error_free (err);
-
-					lua_pushboolean (L, FALSE);
-					return 1;
-				}
-
-				rspamd_lru_hash_insert (dkim_module_ctx->dkim_sign_hash,
-						g_strdup (key), dkim_key,
-						time (NULL), 0);
-			}
-		}
-		else if (keylen > sizeof (PEM_SIG) &&
-				strncmp (key, PEM_SIG, sizeof (PEM_SIG) - 1) == 0) {
-			/* Pem header found */
-			dkim_key = dkim_module_load_key_format (L, task, key, keylen,
-					RSPAMD_DKIM_SIGN_KEY_PEM);
-
-			if (dkim_key == NULL) {
-				lua_pushboolean (L, FALSE);
-				return 1;
-			}
-		}
-		else {
-			dkim_key = dkim_module_load_key_format (L, task, key, keylen,
-					RSPAMD_DKIM_SIGN_KEY_BASE64);
-
-			if (dkim_key == NULL) {
-				lua_pushboolean (L, FALSE);
-				return 1;
-			}
-		}
-	}
-	else if (rawkey) {
-		key = rawkey;
-		keylen = rawlen;
-
-		if (keylen > sizeof (PEM_SIG) &&
-				strncmp (key, PEM_SIG, sizeof (PEM_SIG) - 1) == 0) {
-			/* Pem header found */
-			dkim_key = dkim_module_load_key_format (L, task, key, keylen,
-					RSPAMD_DKIM_SIGN_KEY_PEM);
-
-			if (dkim_key == NULL) {
-				lua_pushboolean (L, FALSE);
-				return 1;
-			}
-		}
-		else {
-			dkim_key = dkim_module_load_key_format (L, task, key, keylen,
-					RSPAMD_DKIM_SIGN_KEY_BASE64);
-
-			if (dkim_key == NULL) {
-				lua_pushboolean (L, FALSE);
-				return 1;
-			}
-		}
-	}
-	else {
+		dkim_key = dkim_module_load_key_format (task, dkim_module_ctx, key,
+				keylen, RSPAMD_DKIM_KEY_UNKNOWN);
+	} else if(rawkey) {
+		dkim_key = dkim_module_load_key_format (task, dkim_module_ctx, rawkey,
+				rawlen, RSPAMD_DKIM_KEY_UNKNOWN);
+	} else {
 		msg_err_task ("neither key nor rawkey are specified");
 		lua_pushboolean (L, FALSE);
 
 		return 1;
 	}
 
-#undef PEM_SIG
+	if (dkim_key == NULL) {
+		lua_pushboolean (L, FALSE);
+		return 1;
+	}
 
 	if (sign_type_str) {
 		if (strcmp (sign_type_str, "dkim") == 0) {
@@ -1311,226 +1364,167 @@ dkim_sign_callback (struct rspamd_task *task,
 	GString *tb, *hdr;
 	GError *err = NULL;
 	const gchar *selector = NULL, *domain = NULL, *key = NULL, *key_type = NULL,
-			*sign_type_str = NULL, *lru_key, *arc_cv = NULL;
+			*sign_type_str = NULL, *arc_cv = NULL;
 	rspamd_dkim_sign_context_t *ctx;
-	rspamd_dkim_sign_key_t *dkim_key;
-	enum rspamd_dkim_sign_key_type key_sign_type = RSPAMD_DKIM_SIGN_KEY_FILE;
+	rspamd_dkim_key_t *dkim_key;
+	enum rspamd_dkim_key_format key_format = RSPAMD_DKIM_KEY_FILE;
 	enum rspamd_dkim_type sign_type = RSPAMD_DKIM_NORMAL;
-	guchar h[rspamd_cryptobox_HASHBYTES],
-		hex_hash[rspamd_cryptobox_HASHBYTES * 2 + 1];
 	struct dkim_ctx *dkim_module_ctx = dkim_get_context (task->cfg);
 
-	if (dkim_module_ctx->sign_condition_ref != -1) {
-		sign = FALSE;
-		L = task->cfg->lua_state;
-		lua_pushcfunction (L, &rspamd_lua_traceback);
-		err_idx = lua_gettop (L);
+	if (dkim_module_ctx->sign_condition_ref == -1) {
+		rspamd_symcache_finalize_item (task, item);
+		return;
+	}
 
-		lua_rawgeti (L, LUA_REGISTRYINDEX, dkim_module_ctx->sign_condition_ref);
-		ptask = lua_newuserdata (L, sizeof (struct rspamd_task *));
-		*ptask = task;
-		rspamd_lua_setclass (L, "rspamd{task}", -1);
+	sign = FALSE;
+	L = task->cfg->lua_state;
+	lua_pushcfunction (L, &rspamd_lua_traceback);
+	err_idx = lua_gettop (L);
 
-		if (lua_pcall (L, 1, 1, err_idx) != 0) {
-			tb = lua_touserdata (L, -1);
-			msg_err_task ("call to user extraction script failed: %v", tb);
-			g_string_free (tb, TRUE);
-		}
-		else {
-			if (lua_istable (L, -1)) {
-				/*
-				 * Get the following elements:
-				 * - selector
-				 * - domain
-				 * - key
-				 */
-				if (!rspamd_lua_parse_table_arguments (L, -1, &err,
-						"*key=V;*domain=S;*selector=S;type=S;key_type=S;"
-								"sign_type=S;arc_cv=S;arc_idx=I",
-						&len, &key, &domain, &selector,
-						&key_type, &key_type, &sign_type_str, &arc_cv,
-						&arc_idx)) {
-					msg_err_task ("invalid return value from sign condition: %e",
-							err);
-					g_error_free (err);
-					rspamd_symcache_finalize_item (task, item);
+	lua_rawgeti (L, LUA_REGISTRYINDEX, dkim_module_ctx->sign_condition_ref);
+	ptask = lua_newuserdata (L, sizeof (struct rspamd_task *));
+	*ptask = task;
+	rspamd_lua_setclass (L, "rspamd{task}", -1);
 
-					return;
+	if (lua_pcall (L, 1, 1, err_idx) != 0) {
+		tb = lua_touserdata (L, -1);
+		msg_err_task ("call to user extraction script failed: %v", tb);
+		g_string_free (tb, TRUE);
+	}
+	else {
+		if (lua_istable (L, -1)) {
+			/*
+			 * Get the following elements:
+			 * - selector
+			 * - domain
+			 * - key
+			 */
+			if (!rspamd_lua_parse_table_arguments (L, -1, &err,
+					"*key=V;*domain=S;*selector=S;type=S;key_type=S;"
+							"sign_type=S;arc_cv=S;arc_idx=I",
+					&len, &key, &domain, &selector,
+					&key_type, &key_type, &sign_type_str, &arc_cv,
+					&arc_idx)) {
+				msg_err_task ("invalid return value from sign condition: %e",
+						err);
+				g_error_free (err);
+				rspamd_symcache_finalize_item (task, item);
+
+				return;
+			}
+
+			if (key_type) {
+				if (strcmp (key_type, "file") == 0) {
+					key_format = RSPAMD_DKIM_KEY_FILE;
 				}
-
-				if (key_type) {
-					if (strcmp (key_type, "file") == 0) {
-						key_sign_type = RSPAMD_DKIM_SIGN_KEY_FILE;
-					}
-					else if (strcmp (key_type, "base64") == 0) {
-						key_sign_type = RSPAMD_DKIM_SIGN_KEY_BASE64;
-					}
-					else if (strcmp (key_type, "pem") == 0) {
-						key_sign_type = RSPAMD_DKIM_SIGN_KEY_PEM;
-					}
-					else if (strcmp (key_type, "der") == 0 ||
-							strcmp (key_type, "raw") == 0) {
-						key_sign_type = RSPAMD_DKIM_SIGN_KEY_DER;
-					}
-					else {
-						lua_settop (L, 0);
-						luaL_error (L, "unknown key type: %s",
-								key_type);
-						rspamd_symcache_finalize_item (task, item);
-
-						return;
-					}
+				else if (strcmp (key_type, "base64") == 0) {
+					key_format = RSPAMD_DKIM_KEY_BASE64;
 				}
-
-				if (sign_type_str) {
-					if (strcmp (sign_type_str, "dkim") == 0) {
-						sign_type = RSPAMD_DKIM_NORMAL;
-					}
-					else if (strcmp (sign_type_str, "arc-sign") == 0) {
-						sign_type = RSPAMD_DKIM_ARC_SIG;
-						if (arc_idx == 0) {
-							lua_settop (L, 0);
-							luaL_error (L, "no arc idx specified");
-							rspamd_symcache_finalize_item (task, item);
-
-							return;
-						}
-					}
-					else if (strcmp (sign_type_str, "arc-seal") == 0) {
-						sign_type = RSPAMD_DKIM_ARC_SEAL;
-						if (arc_cv == NULL) {
-							lua_settop (L, 0);
-							luaL_error (L, "no arc cv specified");
-							rspamd_symcache_finalize_item (task, item);
-
-							return;
-						}
-						if (arc_idx == 0) {
-							lua_settop (L, 0);
-							luaL_error (L, "no arc idx specified");
-							rspamd_symcache_finalize_item (task, item);
-
-							return;
-						}
-					}
-					else {
-						lua_settop (L, 0);
-						luaL_error (L, "unknown sign type: %s",
-								sign_type_str);
-						rspamd_symcache_finalize_item (task, item);
-
-						return;
-					}
+				else if (strcmp (key_type, "pem") == 0) {
+					key_format = RSPAMD_DKIM_KEY_PEM;
 				}
-
-				if (key_sign_type == RSPAMD_DKIM_SIGN_KEY_FILE) {
-
-					dkim_key = rspamd_lru_hash_lookup (
-							dkim_module_ctx->dkim_sign_hash,
-							key, time (NULL));
-					lru_key = key;
+				else if (strcmp (key_type, "der") == 0 ||
+						strcmp (key_type, "raw") == 0) {
+					key_format = RSPAMD_DKIM_KEY_RAW;
 				}
 				else {
-					/* Prehash */
-					memset (hex_hash, 0, sizeof (hex_hash));
-					rspamd_cryptobox_hash (h, key, len, NULL, 0);
-					rspamd_encode_hex_buf (h, sizeof (h),
-							hex_hash, sizeof (hex_hash));
-					dkim_key = rspamd_lru_hash_lookup (
-							dkim_module_ctx->dkim_sign_hash,
-							hex_hash, time (NULL));
-					lru_key = hex_hash;
-				}
-
-				if (dkim_key == NULL) {
-					dkim_key = rspamd_dkim_sign_key_load (key, len,
-							key_sign_type, &err);
-
-					if (dkim_key == NULL) {
-						msg_err_task ("cannot load dkim key %s: %e",
-								lru_key, err);
-						g_error_free (err);
-						rspamd_symcache_finalize_item (task, item);
-
-						return;
-					}
-					else {
-						rspamd_lru_hash_insert (dkim_module_ctx->dkim_sign_hash,
-								g_strdup (lru_key), dkim_key,
-								time (NULL), 0);
-					}
-				}
-				else if (rspamd_dkim_sign_key_maybe_invalidate (dkim_key,
-						key_sign_type, key, len)) {
-					/*
-					 * Invalidate and reload DKIM key,
-					 * removal from lru cache also cleanup the key and value
-					 */
-
-					rspamd_lru_hash_remove (dkim_module_ctx->dkim_sign_hash,
-							lru_key);
-					dkim_key = rspamd_dkim_sign_key_load (key, len,
-							key_sign_type, &err);
-
-					if (dkim_key == NULL) {
-						msg_err_task ("cannot load dkim key %s: %e",
-								lru_key, err);
-						g_error_free (err);
-						rspamd_symcache_finalize_item (task, item);
-
-						return;
-					}
-					else {
-						rspamd_lru_hash_insert (dkim_module_ctx->dkim_sign_hash,
-								g_strdup (lru_key), dkim_key,
-								time (NULL), 0);
-					}
-				}
-
-				ctx = rspamd_create_dkim_sign_context (task, dkim_key,
-						DKIM_CANON_RELAXED, DKIM_CANON_RELAXED,
-						dkim_module_ctx->sign_headers,
-						sign_type,
-						&err);
-
-				if (ctx == NULL) {
-					msg_err_task ("cannot create sign context: %e",
-							err);
-					g_error_free (err);
+					lua_settop (L, 0);
+					luaL_error (L, "unknown key type: %s",
+							key_type);
 					rspamd_symcache_finalize_item (task, item);
 
 					return;
 				}
+			}
 
-				hdr = rspamd_dkim_sign (task, selector, domain, 0, 0,
-						arc_idx, arc_cv,
-						ctx);
-
-				if (hdr) {
-					rspamd_mempool_set_variable (task->task_pool,
-							"dkim-signature",
-							hdr, rspamd_gstring_free_hard);
+			if (sign_type_str) {
+				if (strcmp (sign_type_str, "dkim") == 0) {
+					sign_type = RSPAMD_DKIM_NORMAL;
 				}
+				else if (strcmp (sign_type_str, "arc-sign") == 0) {
+					sign_type = RSPAMD_DKIM_ARC_SIG;
+					if (arc_idx == 0) {
+						lua_settop (L, 0);
+						luaL_error (L, "no arc idx specified");
+						rspamd_symcache_finalize_item (task, item);
 
-				sign = TRUE;
+						return;
+					}
+				}
+				else if (strcmp (sign_type_str, "arc-seal") == 0) {
+					sign_type = RSPAMD_DKIM_ARC_SEAL;
+					if (arc_cv == NULL) {
+						lua_settop (L, 0);
+						luaL_error (L, "no arc cv specified");
+						rspamd_symcache_finalize_item (task, item);
+
+						return;
+					}
+					if (arc_idx == 0) {
+						lua_settop (L, 0);
+						luaL_error (L, "no arc idx specified");
+						rspamd_symcache_finalize_item (task, item);
+
+						return;
+					}
+				}
+				else {
+					lua_settop (L, 0);
+					luaL_error (L, "unknown sign type: %s",
+							sign_type_str);
+					rspamd_symcache_finalize_item (task, item);
+
+					return;
+				}
 			}
-			else {
-				sign = FALSE;
+
+			dkim_key = dkim_module_load_key_format (task, dkim_module_ctx,
+					key, len, key_format);
+
+			if (dkim_key == NULL) {
+				rspamd_symcache_finalize_item (task, item);
+				return;
 			}
+
+			ctx = rspamd_create_dkim_sign_context (task, dkim_key,
+					DKIM_CANON_RELAXED, DKIM_CANON_RELAXED,
+					dkim_module_ctx->sign_headers,
+					sign_type,
+					&err);
+
+			if (ctx == NULL) {
+				msg_err_task ("cannot create sign context: %e",
+						err);
+				g_error_free (err);
+				rspamd_symcache_finalize_item (task, item);
+
+				return;
+			}
+
+			hdr = rspamd_dkim_sign (task, selector, domain, 0, 0,
+					arc_idx, arc_cv,
+					ctx);
+
+			if (hdr) {
+				rspamd_mempool_set_variable (task->task_pool,
+						"dkim-signature",
+						hdr, rspamd_gstring_free_hard);
+			}
+
+			sign = TRUE;
 		}
-
-		/* Result + error function */
-		lua_settop (L, 0);
-
-		if (!sign) {
-			msg_debug_task ("skip signing as dkim condition callback returned"
-					" false");
-			rspamd_symcache_finalize_item (task, item);
-
-			return;
+		else {
+			sign = FALSE;
 		}
 	}
 
+	/* Result + error function */
+	lua_settop (L, 0);
+
+	if (!sign) {
+		msg_debug_task ("skip signing as dkim condition callback returned"
+				" false");
+	}
 	rspamd_symcache_finalize_item (task, item);
 }
 

--- a/src/plugins/lua/arc.lua
+++ b/src/plugins/lua/arc.lua
@@ -508,21 +508,14 @@ end
 local function arc_signing_cb(task)
   local arc_seals = task:cache_get('arc-seals')
 
-  local ret,p = dkim_sign_tools.prepare_dkim_signing(N, task, settings)
+  local ret, selectors = dkim_sign_tools.prepare_dkim_signing(N, task, settings)
 
   if not ret then
     return
   end
 
-  -- TODO: support multiple signatures here and not this hack
-  if #p.keys > 0 then
-    p.selector = p.keys[1].selector
-    if p.keys[1].type == "raw" then
-      p.rawkey = p.keys[1].key
-    else
-      p.key = p.keys[1].key
-    end
-  end
+  -- TODO: support multiple signatures here
+  local p = selectors[1]
 
   p.arc_cv = 'none'
   p.arc_idx = 1

--- a/src/plugins/lua/arc.lua
+++ b/src/plugins/lua/arc.lua
@@ -514,6 +514,16 @@ local function arc_signing_cb(task)
     return
   end
 
+  -- TODO: support multiple signatures here and not this hack
+  if #p.keys > 0 then
+    p.selector = p.keys[1].selector
+    if p.keys[1].type == "raw" then
+      p.rawkey = p.keys[1].key
+    else
+      p.key = p.keys[1].key
+    end
+  end
+
   p.arc_cv = 'none'
   p.arc_idx = 1
   p.no_cache = true

--- a/src/plugins/lua/dkim_signing.lua
+++ b/src/plugins/lua/dkim_signing.lua
@@ -18,7 +18,6 @@ limitations under the License.
 local lua_util = require "lua_util"
 local rspamd_logger = require "rspamd_logger"
 local dkim_sign_tools = require "lua_dkim_tools"
-local rspamd_util = require "rspamd_util"
 local lua_redis = require "lua_redis"
 
 if confighelp then

--- a/src/plugins/lua/dkim_signing.lua
+++ b/src/plugins/lua/dkim_signing.lua
@@ -171,8 +171,17 @@ local function dkim_signing_cb(task)
         lua_util.debugm(N, task, 'key found at "%s", use selector "%s" for domain "%s"',
             p.key, p.selector, p.domain)
       end
-
-      do_sign()
+      -- TODO: push handling of multiples keys into sign code
+      if #p.keys > 0 then
+        lua_util.debugm(N, task, 'signing for multiple selectors, %1', #p.keys);
+        for _, k in ipairs(p.keys) do
+          p.selector = k.selector
+          p.key = k.key
+          do_sign()
+        end
+      else
+        do_sign()
+      end
     else
       rspamd_logger.infox(task, 'key path or dkim selector unconfigured; no signing')
       return false

--- a/test/functional/cases/131_dkim_signing/003_eddsa.robot
+++ b/test/functional/cases/131_dkim_signing/003_eddsa.robot
@@ -1,0 +1,39 @@
+*** Settings ***
+Suite Setup     DKIM Signing Setup
+Suite Teardown  DKIM Signing Teardown
+Library         ${TESTDIR}/lib/rspamd.py
+Resource        ${TESTDIR}/lib/rspamd.robot
+Variables       ${TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}       ${TESTDIR}/configs/plugins.conf
+${MESSAGE}      ${TESTDIR}/messages/dmarc/fail_none.eml
+${MESSAGE_FAIL}      ${TESTDIR}/messages/dmarc/fail_none1.eml
+${REDIS_SCOPE}  Suite
+${RSPAMD_SCOPE}  Suite
+${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+TEST SIGNED
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -u  bob@cacophony.za.org
+  Check Rspamc  ${result}  DKIM-Signature:
+  Should Contain  ${result.stdout}  DKIM_SIGNED
+
+TEST NOT SIGNED - USERNAME WRONG DOMAIN
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -u  bob@example.tk
+  Check Rspamc  ${result}  DKIM-Signature:  inverse=1
+  Should Not Contain  ${result.stdout}  DKIM_SIGNED
+
+TEST NOT SIGNED - USERNAME WRONG PUBKEY
+  ${result} =  Scan Message With Rspamc  ${MESSAGE_FAIL}  -u  bob@invalid.za.org
+  Check Rspamc  ${result}  DKIM-Signature:  inverse=1
+  Should Not Contain  ${result.stdout}  DKIM_SIGNED
+
+*** Keywords ***
+DKIM Signing Setup
+  ${PLUGIN_CONFIG} =  Get File  ${TESTDIR}/configs/dkim_signing/eddsa.conf
+  Set Suite Variable  ${PLUGIN_CONFIG}
+  Generic Setup  PLUGIN_CONFIG
+
+DKIM Signing Teardown
+  Normal Teardown

--- a/test/functional/cases/131_dkim_signing/004_invalidate_key.robot
+++ b/test/functional/cases/131_dkim_signing/004_invalidate_key.robot
@@ -1,4 +1,5 @@
 *** Settings ***
+Force Tags 	isbroken
 Suite Setup     Key Invalidation Setup
 Suite Teardown  Key Invalidation Teardown
 Library         ${TESTDIR}/lib/rspamd.py

--- a/test/functional/cases/131_dkim_signing/004_invalidate_key.robot
+++ b/test/functional/cases/131_dkim_signing/004_invalidate_key.robot
@@ -1,0 +1,51 @@
+*** Settings ***
+Suite Setup     Key Invalidation Setup
+Suite Teardown  Key Invalidation Teardown
+Library         ${TESTDIR}/lib/rspamd.py
+Resource        ${TESTDIR}/lib/rspamd.robot
+Variables       ${TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}       ${TESTDIR}/configs/plugins.conf
+${MESSAGE}      ${TESTDIR}/messages/dmarc/fail_none.eml
+${REDIS_SCOPE}  Suite
+${RSPAMD_SCOPE}  Suite
+${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+TEST SIGNED
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -u  bob@cacophony.za.org
+  Check Rspamc  ${result}  DKIM-Signature:
+  Should Contain  ${result.stdout}  DKIM_SIGNED
+
+TEST NOT SIGNED - MISSING KEY
+  [Setup] 	Delete Key
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -u  bob@cacophony.za.org
+  Check Rspamc  ${result}  DKIM-Signature:  inverse=1
+  Should Not Contain  ${result.stdout}  DKIM_SIGNED
+
+TEST NOT SIGNED - KEY NO LONGER MATCHES
+  [Setup]	Move Key
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -u  bob@cacophony.za.org
+  Check Rspamc  ${result}  DKIM-Signature:  inverse=1
+  Should Not Contain  ${result.stdout}  DKIM_SIGNED
+
+*** Keywords ***
+Key Invalidation Setup
+  ${key_dir}  Make Temporary Directory
+  Set Suite Variable  ${KEY_DIR}  ${key_dir}
+  Copy File  ${TESTDIR}/configs/dkim-eddsa.key  ${KEY_DIR}/dkim-eddsa.key
+  ${PLUGIN_CONFIG} =  Get File  ${TESTDIR}/configs/dkim_signing/invalidate.conf
+  Set Suite Variable  ${PLUGIN_CONFIG}
+  Generic Setup  PLUGIN_CONFIG
+
+Delete Key
+  Remove File  ${KEY_DIR}/dkim-eddsa.key
+
+Move Key
+  Copy File  ${TESTDIR}/configs/dkim.key  ${KEY_DIR}/dkim-eddsa.key
+  Set Modified Time  ${KEY_DIR}/dkim-eddsa.key  NOW + 3s
+
+Key Invalidation Teardown
+  Cleanup Temporary Directory  ${KEY_DIR}
+  Normal Teardown

--- a/test/functional/cases/131_dkim_signing/005_multiple.robot
+++ b/test/functional/cases/131_dkim_signing/005_multiple.robot
@@ -16,7 +16,7 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 *** Test Cases ***
 TEST DOUBLE SIGNED
   ${result} =  Scan Message With Rspamc  ${MESSAGE}  -u  bob@cacophony.za.org
-  Check Rspamc  ${result}  (?s:DKIM-Signature.+DKIM-Signature)  re=1
+  Check Rspamc  ${result}  (?s)DKIM-Signature.+DKIM-Signature  re=1
   Should Contain  ${result.stdout}  DKIM_SIGNED
 
 *** Keywords ***

--- a/test/functional/cases/131_dkim_signing/005_multiple.robot
+++ b/test/functional/cases/131_dkim_signing/005_multiple.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Suite Setup     DKIM Signing Setup
+Suite Teardown  DKIM Signing Teardown
+Library         ${TESTDIR}/lib/rspamd.py
+Resource        ${TESTDIR}/lib/rspamd.robot
+Variables       ${TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}       ${TESTDIR}/configs/plugins.conf
+${MESSAGE}      ${TESTDIR}/messages/dmarc/fail_none.eml
+${MESSAGE_FAIL}      ${TESTDIR}/messages/dmarc/fail_none1.eml
+${REDIS_SCOPE}  Suite
+${RSPAMD_SCOPE}  Suite
+${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+TEST DOUBLE SIGNED
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -u  bob@cacophony.za.org
+  Check Rspamc  ${result}  (?s:DKIM-Signature.+DKIM-Signature)  re=1
+  Should Contain  ${result.stdout}  DKIM_SIGNED
+
+*** Keywords ***
+DKIM Signing Setup
+  ${PLUGIN_CONFIG} =  Get File  ${TESTDIR}/configs/dkim_signing/multiple.conf
+  Set Suite Variable  ${PLUGIN_CONFIG}
+  Generic Setup  PLUGIN_CONFIG
+
+DKIM Signing Teardown
+  Normal Teardown

--- a/test/functional/cases/131_dkim_signing/006_milter.robot
+++ b/test/functional/cases/131_dkim_signing/006_milter.robot
@@ -1,0 +1,32 @@
+*** Settings ***
+Suite Setup     DKIM Milter Setup
+Suite Teardown  Generic Teardown
+Library         Process
+Library         ${TESTDIR}/lib/rspamd.py
+Resource        ${TESTDIR}/lib/rspamd.robot
+Variables       ${TESTDIR}/lib/vars.py
+
+*** Variables ***
+${RSPAMD_SCOPE}  Suite
+${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+SINGLE SIGNATURE
+  Milter Test  dkim_one.lua
+
+MULTIPLE SIGNATURES
+  Milter Test  dkim_many.lua
+
+*** Keywords ***
+DKIM Milter Setup
+  Generic Setup  CONFIG=${TESTDIR}/configs/dkim_signing/milter.conf
+
+Milter Test
+  [Arguments]  ${mtlua}
+  ${result} =  Run Process  miltertest  -Dport\=${PORT_PROXY}  -Dhost\=${LOCAL_ADDR}  -s  ${TESTDIR}/lua/miltertest/${mtlua}
+  ...  cwd=${TESTDIR}/lua/miltertest
+  Follow Rspamd Log
+  Should Match Regexp  ${result.stderr}  ^$
+  Log  ${result.rc}
+  Log  ${result.stdout}
+  Should Be Equal As Integers  ${result.rc}  0  msg=${result.stdout}  values=false

--- a/test/functional/configs/dkim-eddsa.key
+++ b/test/functional/configs/dkim-eddsa.key
@@ -1,0 +1,1 @@
+m5kGxtckRfsNe5EuYTe7bvkDjSh7LXaX3aXyIMPGLR0=

--- a/test/functional/configs/dkim_signing/eddsa.conf
+++ b/test/functional/configs/dkim_signing/eddsa.conf
@@ -1,0 +1,6 @@
+dkim_signing {
+  path = "${TESTDIR}/configs/dkim-eddsa.key";
+  selector = "eddsa";
+  check_pubkey = true;
+  allow_pubkey_mismatch = false;
+}

--- a/test/functional/configs/dkim_signing/invalidate.conf
+++ b/test/functional/configs/dkim_signing/invalidate.conf
@@ -1,0 +1,6 @@
+dkim_signing {
+  path = "${KEY_DIR}/dkim-eddsa.key";
+  selector = "eddsa";
+  check_pubkey = true;
+  allow_pubkey_mismatch = false;
+}

--- a/test/functional/configs/dkim_signing/milter.conf
+++ b/test/functional/configs/dkim_signing/milter.conf
@@ -1,0 +1,76 @@
+options = {
+	filters = ["dkim"]
+	url_tld = "${URL_TLD}"
+	pidfile = "${TMPDIR}/rspamd.pid"
+	lua_path = "${INSTALLROOT}/share/rspamd/lib/?.lua"
+	dns {
+		nameserver = ["8.8.8.8", "8.8.4.4"];
+		retransmits = 10;
+		timeout = 2s;
+	}
+}
+logging = {
+	type = "file",
+	level = "debug"
+	filename = "${TMPDIR}/rspamd.log"
+}
+metric = {
+	name = "default",
+	actions = {
+		reject = 100500,
+	}
+	unknown_weight = 1
+}
+worker {
+	type = normal
+	bind_socket = ${LOCAL_ADDR}:${PORT_NORMAL}
+	count = 1
+	task_timeout = 60s;
+}
+worker {
+        type = controller
+        bind_socket = ${LOCAL_ADDR}:${PORT_CONTROLLER}
+        count = 1
+        secure_ip = ["127.0.0.1", "::1"];
+        stats_path = "${TMPDIR}/stats.ucl"
+}
+worker {
+	type = "rspamd_proxy";
+	count = 1;
+	timeout = 120;
+	upstream {
+		local {
+			hosts = "${LOCAL_ADDR}:${PORT_NORMAL}";
+			default = true;
+		}
+	}
+	bind_socket = "${LOCAL_ADDR}:${PORT_PROXY}";
+	milter = true;
+}
+dkim_signing {
+  domain {
+    cacophony.za.org {
+      selectors = {
+        path: "${TESTDIR}/configs/dkim.key";
+        selector: "dkim";
+      }
+      selectors = {
+        path: "${TESTDIR}/configs/dkim-eddsa.key";
+        selector: "eddsa";
+     }
+   }
+    invalid.za.org {
+      selectors = [ 
+        { path: "${TESTDIR}/configs/dkim-eddsa.key";
+          selector: "eddsa"; }
+      ]
+   }
+  }
+  allow_pubkey_mismatch: true;
+}
+modules {
+    path = "${TESTDIR}/../../src/plugins/lua/dkim_signing.lua"
+}
+lua = "${TESTDIR}/lua/test_coverage.lua";
+lua = "${INSTALLROOT}/share/rspamd/rules/rspamd.lua"
+lua = "${TESTDIR}/lua/params.lua"

--- a/test/functional/configs/dkim_signing/multiple.conf
+++ b/test/functional/configs/dkim_signing/multiple.conf
@@ -1,0 +1,15 @@
+dkim_signing {
+  domain {
+    cacophony.za.org {
+      selectors = {
+        path: "${TESTDIR}/configs/dkim.key";
+        selector: "dkim";
+      }
+      selectors = {
+        path: "${TESTDIR}/configs/dkim-eddsa.key";
+        selector: "eddsa";
+     }
+   }
+  }
+  allow_pubkey_mismatch: false;
+}

--- a/test/functional/configs/plugins.conf
+++ b/test/functional/configs/plugins.conf
@@ -18,9 +18,19 @@ options = {
           replies = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDXtxBE5IiNRMcq2/lc2zErfdCvDFyQNBnMjbOjBQrPST2k4fdGbtpe5Iu5uS01Met+dAEf94XL8I0hwmYw+n70PP834zfJGi2egwGqrakpaWsCDPvIJZLkxJCJKQRA/zrQ622uEXdvYixVbsEGVw7U4wAGSmT5rU2eU1y63AlOlQIDAQAB"];
         },
         {
+          name = "eddsa._domainkey.cacophony.za.org",
+          type = "txt";
+          replies = ["v=DKIM1; k=ed25519; p=+nU+aC33ICeS4zx8VUjFYCtxj0fRbHWQn2gP2hTkm9w="];
+        },
+        {
           name = "dkim._domainkey.invalid.za.org",
           type = "txt";
           replies = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDEEXmNGQq7PUrr9Mg4UakTFHgXBCy2DOztkrZm+0OrVWtiRzGluxBkbOWTBwuU3/Yw97yTphBMQxzWFN603/f/KPAQcF/Lc1l+6kmIBBxNXjjGuOK/3PYKZVntUdKmqcQBYfnHdzH2Tohbuyx1a7xqnv6VSChqQrZU4CwkeT3+eQIDAQAB"];
+        },
+        {
+          name = "eddsa._domainkey.invalid.za.org",
+          type = "txt";
+          replies = ["v=DKIM1; k=ed25519; p=Wkkrp5DJTvknDMGWYv8vm3p3sZjiQp03LZo80RregY8="];
         },
         {
           name = "dkim._domainkey.rspamd.com",

--- a/test/functional/lua/miltertest/data_dkim.lua
+++ b/test/functional/lua/miltertest/data_dkim.lua
@@ -1,0 +1,23 @@
+multi_hdrs = {
+  ['Message-ID'] = '<a44q4StVFY04V4_4gOMYXjTgMDvmlSFzZxnoyJPHFwM@cacophony.za.org>',
+  ['From'] = 'Rspamd <foo@cacophony.za.org>',
+  ['To'] = 'nerf@example.org',
+  ['Subject'] = 'dkim test message',
+  ['User-Agent'] = 'Vi IMproved 8.1',
+  ['Content-Type'] = 'text/plain; charset=utf-8;',
+  ['MIME-Version'] = '1.0',
+  ['Date'] = 'Sat, 02 Feb 2019 10:34:54 +0000',
+}
+
+single_hdr = {
+  ['Message-ID'] = '<a44q4StVFY04V4_4gOMYXjTgMDvmlSFzZxnoyJPHFwM@cacophony.za.org>',
+  ['From'] = 'Rspamd <foo@invalid.za.org>',
+  ['To'] = 'nerf@example.org',
+  ['Subject'] = 'dkim test message',
+  ['User-Agent'] = 'Vi IMproved 8.1',
+  ['Content-Type'] = 'text/plain; charset=utf-8;',
+  ['MIME-Version'] = '1.0',
+  ['Date'] = 'Sat, 02 Feb 2019 10:34:54 +0000',
+}
+
+innocuous_msg = 'hello'

--- a/test/functional/lua/miltertest/dkim_many.lua
+++ b/test/functional/lua/miltertest/dkim_many.lua
@@ -1,0 +1,11 @@
+print('Check we get multiple dkim signatures')
+
+dofile './lib.lua'
+dofile './data_dkim.lua'
+
+setup()
+
+send_message(innocuous_msg, multi_hdrs, 'test-id', 'foo@cacophony.za.org', {'nerf@example.org'})
+check_headers(2)
+
+teardown()

--- a/test/functional/lua/miltertest/dkim_one.lua
+++ b/test/functional/lua/miltertest/dkim_one.lua
@@ -1,0 +1,11 @@
+print('Check we get single dkim signature')
+
+dofile './lib.lua'
+dofile './data_dkim.lua'
+
+setup()
+
+send_message(innocuous_msg, single_hdr, 'test-id', 'foo@invalid.za.org', {'nerf@example.org'})
+check_headers(1)
+
+teardown()

--- a/test/functional/lua/miltertest/lib.lua
+++ b/test/functional/lua/miltertest/lib.lua
@@ -108,3 +108,12 @@ function check_subject_rw(subj, tmpl)
     error "subject not rewritten"
   end
 end
+
+function check_headers(count)
+  for i=0, count-1 do
+    local hdr = mt.getheader(conn, "DKIM-Signature", i)
+    if not hdr then
+      error (string.format("Signature %s not added", i))
+    end
+  end
+end


### PR DESCRIPTION
This resolves issue #2147

This set of patches adds support for ed25519 signatures, multiple signatures on a single message, and adds some tests for the new functionality. I don't expect it to get merged without more changes, but I'm opening this request to start the conversation.

Limitations:
* multiple signatures only supported when using keys from files
* multiple signatures only supported using rspamc/http, not milter

Flaws:
* configuration still a bit ugly
* exposes a low-level ed25519 primative
* end-users need to expect a scalar or array from dkim-signature in the json