### PR TITLE
[Minor] mime_types: remove .tmp from bad_extensions

### DIFF
--- a/src/plugins/lua/mime_types.lua
+++ b/src/plugins/lua/mime_types.lua
@@ -142,7 +142,6 @@ local settings = {
     scf = 2,
     shs = 2,
     theme = 2,
-    tmp = 2,
     url = 2,
     vbp = 2,
     vsmacros = 2,


### PR DESCRIPTION
as it is not potentially harmful

Just a note: M$ Office documents are archives and some of them may contain *.tmp files
(as well as other actually potentially dangerous extensions).