### PR TITLE
[Feature] Export url visible part to lua and add new url flag

### DIFF
--- a/src/libserver/html.c
+++ b/src/libserver/html.c
@@ -2373,6 +2373,12 @@ rspamd_html_check_displayed_url (rspamd_mempool_t *pool,
 		return;
 	}
 
+	gint visible_part_len = dest->len - href_offset;
+	url->visible_part = rspamd_mempool_alloc0(pool, visible_part_len +1);
+	url->visible_partlen = visible_part_len;
+	gchar *visible_part = g_strndup(dest->data + href_offset, visible_part_len);
+	g_stpcpy(url->visible_part, visible_part);
+
 	rspamd_html_url_is_phished (pool, url,
 			dest->data + href_offset,
 			dest->len - href_offset,

--- a/src/libserver/html.c
+++ b/src/libserver/html.c
@@ -2384,6 +2384,9 @@ rspamd_html_check_displayed_url (rspamd_mempool_t *pool,
 			dest->len - href_offset,
 			&url_found, &displayed_url);
 
+	if (url_found) {
+		url->flags |= RSPAMD_URL_FLAG_DISPLAY_URL;
+	}
 	if (exceptions && url_found) {
 		ex = rspamd_mempool_alloc (pool,
 				sizeof (*ex));

--- a/src/libserver/url.h
+++ b/src/libserver/url.h
@@ -48,6 +48,7 @@ struct rspamd_url {
 	gchar *fragment;
 	gchar *surbl;
 	gchar *tld;
+	gchar *visible_part;
 
 	struct rspamd_url *phished_url;
 
@@ -61,6 +62,7 @@ struct rspamd_url {
 	guint tldlen;
 	guint urllen;
 	guint rawlen;
+	guint visible_partlen;
 
 	enum rspamd_url_flags flags;
 	guint count;

--- a/src/libserver/url.h
+++ b/src/libserver/url.h
@@ -28,6 +28,7 @@ enum rspamd_url_flags {
 	RSPAMD_URL_FLAG_SCHEMALESS = 1 << 15,
 	RSPAMD_URL_FLAG_UNNORMALISED = 1 << 16,
 	RSPAMD_URL_FLAG_ZW_SPACES = 1 << 17,
+	RSPAMD_URL_FLAG_DISPLAY_URL = 1 << 18,
 };
 
 struct rspamd_url_tag {

--- a/src/lua/lua_url.c
+++ b/src/lua/lua_url.c
@@ -63,6 +63,7 @@ LUA_FUNCTION_DEF (url, get_tag);
 LUA_FUNCTION_DEF (url, get_count);
 LUA_FUNCTION_DEF (url, get_tags);
 LUA_FUNCTION_DEF (url, add_tag);
+LUA_FUNCTION_DEF (url, get_visible);
 LUA_FUNCTION_DEF (url, create);
 LUA_FUNCTION_DEF (url, init);
 LUA_FUNCTION_DEF (url, all);
@@ -89,6 +90,7 @@ static const struct luaL_reg urllib_m[] = {
 	LUA_INTERFACE_DEF (url, get_tag),
 	LUA_INTERFACE_DEF (url, get_tags),
 	LUA_INTERFACE_DEF (url, add_tag),
+	LUA_INTERFACE_DEF (url, get_visible),
 	LUA_INTERFACE_DEF (url, get_count),
 	LUA_INTERFACE_DEF (url, get_flags),
 	{"get_redirected", lua_url_get_phished},
@@ -648,6 +650,27 @@ lua_url_get_count (lua_State *L)
 	}
 
 	return 1;
+}
+
+ /***
+* @method url:get_visible()
+* Get visible part of the url with html tags stripped
+* @return {string} url string
+*/
+static gint
+lua_url_get_visible (lua_State *L)
+{
+	LUA_TRACE_POINT;
+	struct rspamd_lua_url *url = lua_check_url (L, 1);
+
+	if (url != NULL) {
+		lua_pushlstring (L, url->url->visible_part, url->url->visible_partlen);
+	}
+	else {
+		lua_pushnil (L);
+	}
+
+return 1;
 }
 
 /***

--- a/src/lua/lua_url.c
+++ b/src/lua/lua_url.c
@@ -901,6 +901,7 @@ lua_url_all (lua_State *L)
  * - `schemaless`: URL has no schema
  * - `unnormalised`: URL has some unicode unnormalities
  * - `zw_spaces`: URL has some zero width spaces
+ * - `url_displayed`: URL has some other url-like string in visible part
  * @return {table} URL flags
  */
 #define PUSH_FLAG(fl, name) do { \
@@ -941,6 +942,7 @@ lua_url_get_flags (lua_State *L)
 		PUSH_FLAG (RSPAMD_URL_FLAG_SCHEMALESS, "schemaless");
 		PUSH_FLAG (RSPAMD_URL_FLAG_UNNORMALISED, "unnormalised");
 		PUSH_FLAG (RSPAMD_URL_FLAG_ZW_SPACES, "zw_spaces");
+		PUSH_FLAG (RSPAMD_URL_FLAG_DISPLAY_URL, "url_displayed");
 	}
 	else {
 		return luaL_error (L, "invalid arguments");


### PR DESCRIPTION
Hello everyone!
I crafted some code allowing me to export visible part of each link to lua modules for further processing. I have no idea if there is other way to get such information there.
I added also new flag for url structure which inform whether visible part is something looking similar to url address. Difference between my flag and PHISHED is that, my flag does not require visible url to be in different domain.
I'll be very happy to see Your comments.

Regards!