### PR TITLE
Add composite symbols reference to conf/composites.conf

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -12,7 +12,8 @@
 # '$LOCAL_CONFDIR/local.d/file.conf' - to add your options or rewrite defaults
 # '$LOCAL_CONFDIR/override.d/file.conf' - to override the defaults
 #
-# See https://rspamd.com/doc/tutorials/writing_rules.html for details
+# See https://rspamd.com/doc/tutorials/writing_rules.html and
+# https://rspamd.com/doc/configuration/composites.html for details
 
 composites {
 


### PR DESCRIPTION
Adding another reference to the [composite symbols](https://rspamd.com/doc/configuration/composites.html) in the `conf/composites.conf`.