### PR TITLE
add support ES>=6.7 for elasctic module

### DIFF
--- a/src/plugins/lua/elastic.lua
+++ b/src/plugins/lua/elastic.lua
@@ -53,6 +53,7 @@ local settings = {
   password = nil,
   no_ssl_verify = false,
   max_fail = 3,
+  ingest_module = false,
 }
 
 local function read_file(path)
@@ -234,8 +235,7 @@ local opts = rspamd_config:get_all_opt('elastic')
 local function check_elastic_server(cfg, ev_base, _)
   local upstream = settings.upstream:get_upstream_round_robin()
   local ip_addr = upstream:get_addr():to_string(true)
-
-  local plugins_url = connect_prefix .. ip_addr .. '/_nodes/plugins'
+  local plugins_url = connect_prefix .. ip_addr .. '/_nodes/' .. ingest_geoip_type
   local function http_callback(err, code, body, _)
     if code == 200 then
       local parser = ucl.parser()
@@ -444,6 +444,12 @@ if redis_params and opts then
   else
     if settings.use_https then
       connect_prefix = 'https://'
+    end
+
+    if settings.ingest_module then
+      ingest_geoip_type = 'modules'
+    else
+      ingest_geoip_type = 'plugins'
     end
 
     settings.upstream = upstream_list.create(rspamd_config,


### PR DESCRIPTION
Since version 6.7.0 of ElasticSearch, the ingest-geoip plugin is a module integrated into the solution.

Instead of detecting the version of ElasticSearch I added the configuration parameter ingest_module which is false by default for ElasticSearch versions < 6.7.0 and true for versions >= 6.7.0