### PR TITLE
Clickhouse

### DIFF
--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -459,11 +459,11 @@ local function clickhouse_collect(task)
     end
   end
 
-  local mime_rcpt = {}
+  local mime_recipients = {}
   if task:has_recipients('mime') then
     local recipients = task:get_recipients({'mime','orig'})
     for _, rcpt in ipairs(recipients) do
-      table.insert(mime_rcpt, rcpt['user'] .. '@' .. rcpt['domain']:lower())
+      table.insert(mime_recipients, rcpt['user'] .. '@' .. rcpt['domain']:lower())
     end
   end
 
@@ -674,7 +674,7 @@ local function clickhouse_collect(task)
     subject,
     digest,
     fields.spf,
-    mime_rcpt,
+    mime_recipients,
     message_id,
     scan_real,
     scan_virtual,

--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -91,7 +91,7 @@ local clickhouse_schema = {[[
 CREATE TABLE rspamd
 (
     Date Date COMMENT 'Date (used for partitioning)',
-    TS DateTime COMMENT 'Date and time of request start (UTC)',
+    TS DateTime COMMENT 'Date and time of the request start (UTC)',
     From String COMMENT 'Domain part of the return address (RFC5321.MailFrom)',
     MimeFrom String COMMENT 'Domain part of the address in From: header (RFC5322.From)',
     IP String COMMENT 'SMTP client IP as provided by MTA or from Received: header',
@@ -110,10 +110,10 @@ CREATE TABLE rspamd
     Action Enum8('reject' = 0, 'rewrite subject' = 1, 'add header' = 2, 'greylist' = 3, 'no action' = 4, 'soft reject' = 5, 'custom' = 6) DEFAULT 'no action' COMMENT 'Action returned for the message; if action is not predefined actual action will be in `CustomAction` field',
     CustomAction LowCardinality(String) COMMENT 'Action string for custom action',
     FromUser String COMMENT 'Local part of the return address (RFC5321.MailFrom)',
-    MimeUser String COMMENT 'Local part of address in From: header (RFC5322.From)',
+    MimeUser String COMMENT 'Local part of the address in From: header (RFC5322.From)',
     RcptUser String COMMENT '[Deprecated] Local part of the first envelope recipient (RFC5321.RcptTo)',
     RcptDomain String COMMENT '[Deprecated] Domain part of the first envelope recipient (RFC5321.RcptTo)',
-    SMTPRecipients Array(String) COMMENT 'List of envelope recipient (RFC5321.RcptTo)',
+    SMTPRecipients Array(String) COMMENT 'List of envelope recipients (RFC5321.RcptTo)',
     MimeRecipients Array(String) COMMENT 'List of recipients from headers (RFC5322.To/.CC/.BCC)',
     MessageId String COMMENT 'Message-ID header',
     ListId String COMMENT 'List-Id header',
@@ -134,12 +134,12 @@ CREATE TABLE rspamd
     ScanTimeReal UInt32 COMMENT 'Request time in milliseconds',
     ScanTimeVirtual UInt32,
     AuthUser String COMMENT 'Username for authenticated SMTP client',
-    SettingsId LowCardinality(String) COMMENT 'ID for settings profile',
-    Digest FixedString(32) COMMENT 'Deprecated, no longer stored',
+    SettingsId LowCardinality(String) COMMENT 'ID for the settings profile',
+    Digest FixedString(32) COMMENT '[Deprecated]',
     SMTPFrom ALIAS if(From = '', '', concat(FromUser, '@', From)) COMMENT 'Return address (RFC5321.MailFrom)',
-    SMTPRcpt ALIAS SMTPRecipients[1] COMMENT 'First recipient (RFC5321.RcptTo)',
+    SMTPRcpt ALIAS SMTPRecipients[1] COMMENT 'The first envelope recipient (RFC5321.RcptTo)',
     MIMEFrom ALIAS if(MimeFrom = '', '', concat(MimeUser, '@', MimeFrom)) COMMENT 'Address in From: header (RFC5322.From)',
-    MIMERcpt ALIAS MimeRecipients[1] COMMENT 'First recipients from headers (RFC5322.To/.CC/.BCC)'
+    MIMERcpt ALIAS MimeRecipients[1] COMMENT 'The first recipient from headers (RFC5322.To/.CC/.BCC)'
 ) ENGINE = MergeTree()
 PARTITION BY toMonday(Date)
 ORDER BY TS

--- a/test/functional/cases/210_clickhouse/001_migration.robot
+++ b/test/functional/cases/210_clickhouse/001_migration.robot
@@ -33,7 +33,10 @@ Migration
     Column should exist    rspamd    Symbols.Scores
     Column should exist    rspamd    Attachments.Digest
     Column should exist    rspamd    Symbols.Scores
-    Schema version should be    6
+    # Added in schema version 7
+    Column should exist    rspamd    Helo
+    Column should exist    rspamd    SMTPRecipients
+    Schema version should be    7
 
 Retention
     Upload new schema        ${TESTDIR}/data/schema_2/schema.sql


### PR DESCRIPTION
Log more data to ClickHouse.
Unfortunately it is not easy to migrate from storing only first recipient to storing all recipients in an array without loosing current data, so for some time we probably have to log first recipient twice - in an array and in RcptUser/RcptDomain columns.