### PR TITLE
[Minor] Fix typos in p0f plugin

### DIFF
--- a/conf/modules.d/p0f.conf
+++ b/conf/modules.d/p0f.conf
@@ -18,7 +18,7 @@ p0f {
   enabled = false;
 
   # Path to the unix socket that p0f listens on
-  socket = '/tmp/p0f.sock';
+  socket = '/var/run/p0f.sock';
 
   # Connection timeout
   timeout = 5s;

--- a/lualib/lua_scanners/p0f.lua
+++ b/lualib/lua_scanners/p0f.lua
@@ -51,10 +51,10 @@ local function p0f_check(task, ip, rule)
   local function trim(...)
     local vars = {...}
 
-    for k in pairs(vars) do
+    for k, v in ipairs(vars) do
       -- skip numbers, trim only strings
       if tonumber(vars[k]) == nil then
-        vars[k] = string.gsub(vars[k], '[^%w-_\\.\\(\\) ]', '')
+        vars[k] = string.gsub(v, '[^%w-_\\.\\(\\) ]', '')
       end
     end
 
@@ -71,7 +71,7 @@ local function p0f_check(task, ip, rule)
     data = tostring(data)
 
     -- API response must be 232 bytes long
-    if (#data < 232) then
+    if #data ~= 232 then
       rspamd_logger.errx(task, 'malformed response from p0f on %s, %s bytes',
         rule.socket, #data)
 
@@ -112,7 +112,6 @@ local function p0f_check(task, ip, rule)
       local function redis_set_cb(redis_set_err)
         if redis_set_err then
           rspamd_logger.errx(task, 'redis received an error: %s', redis_set_err)
-          return
         end
       end
 
@@ -156,7 +155,7 @@ local function p0f_check(task, ip, rule)
   end
 
   local ret = nil
-  if rule.redis_prams then
+  if rule.redis_params then
     local key = rule.prefix .. ip:to_string()
     ret = lua_redis.redis_make_request(task,
       rule.redis_params,

--- a/src/plugins/lua/p0f.lua
+++ b/src/plugins/lua/p0f.lua
@@ -33,7 +33,7 @@ p0f {
   enabled = true
 
   # Path to the unix socket that p0f listens on
-  socket = '/tmp/p0f.sock';
+  socket = '/var/run/p0f.sock';
 
   # Connection timeout
   timeout = 5s;

--- a/test/functional/cases/161_p0f.robot
+++ b/test/functional/cases/161_p0f.robot
@@ -27,39 +27,58 @@ p0f HIT
   Run Dummy p0f  ${P0F_SOCKET}  windows
   ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.2
   Check Rspamc  ${result}  P0F  inverse=1
+  Check Rspamc  ${result}  P0F_FAIL  inverse=1
   Check Rspamc  ${result}  ETHER
   Check Rspamc  ${result}  DISTGE10
   Check Rspamc  ${result}  WINDOWS
   Shutdown p0f
-  
-p0f NOREDIS
-  Shutdown Process With Children  ${REDIS_PID}
+
+p0f MISS CACHE
   Run Dummy p0f
   ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.3
+  Check Rspamc  ${result}  WINDOWS  inverse=1
+  Shutdown p0f
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.3
+  Check Rspamc  ${result}  WINDOWS  inverse=1
+  Check Rspamc  ${result}  P0F_FAIL  inverse=1
+
+p0f HIT CACHE
+  Run Dummy p0f  ${P0F_SOCKET}  windows
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.4
+  Check Rspamc  ${result}  WINDOWS
+  Shutdown p0f
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.4
+  Check Rspamc  ${result}  WINDOWS
+  Check Rspamc  ${result}  P0F_FAIL  inverse=1
+
+p0f NO REDIS
+  Shutdown Process With Children  ${REDIS_PID}
+  Run Dummy p0f
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.5
   Check Rspamc  ${result}  P0F
   Check Rspamc  ${result}  ETHER
   Check Rspamc  ${result}  DISTGE10
   Check Rspamc  ${result}  P0F_FAIL  inverse=1
   Shutdown p0f
 
-p0f NOMATCH
+p0f NO MATCH
   Run Dummy p0f  ${P0F_SOCKET}  windows  no_match
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.4
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.6
   Check Rspamc  ${result}  P0F  inverse=1
   Check Rspamc  ${result}  WINDOWS  inverse=1
   Shutdown p0f
 
-p0f BADQUERY
+p0f BAD QUERY
   Run Dummy p0f  ${P0F_SOCKET}  windows  bad_query
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.5
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.7
   Check Rspamc  ${result}  P0F_FAIL
   Check Rspamc  ${result}  Malformed Query
   Check Rspamc  ${result}  WINDOWS  inverse=1
   Shutdown p0f
 
-p0f FAILURE
-  Run Dummy p0f  ${P0F_SOCKET}  windows  fail
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.6
+p0f BAD RESPONSE
+  Run Dummy p0f  ${P0F_SOCKET}  windows  bad_response
+  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.8
   Check Rspamc  ${result}  P0F_FAIL
   Check Rspamc  ${result}  Malformed Response
   Check Rspamc  ${result}  WINDOWS  inverse=1

--- a/test/functional/util/dummy_p0f.py
+++ b/test/functional/util/dummy_p0f.py
@@ -28,23 +28,23 @@ class MyStreamHandler(socketserver.BaseRequestHandler):
 
         self.data = self.request.recv(21).strip()
 
-        if self.server.p0f_status == 'fail':
+        if self.server.p0f_status == 'bad_response':
             response = 0
         else:
             response = struct.pack(
                 "IbIIIIIIIhbb32s32s32s32s32s32s",
-                0x50304602,                       # magic        
+                0x50304602,                       # magic
                 S[self.server.p0f_status],        # status
                 1568493408,                       # first_seen
                 1568493408,                       # last_seen
                 1,                                # total_conn
                 1,                                # uptime_min
-                4,                                # up_mod_days        
+                4,                                # up_mod_days
                 1568493408,                       # last_nat
                 1568493408,                       # last_chg
                 10,                               # distance
                 0,                                # bad_sw
-                0,                                # os_match_q    
+                0,                                # os_match_q
                 OS[self.server.p0f_os][0],        # os_name
                 OS[self.server.p0f_os][1],        # os_flavor
                 '',                               # http_name
@@ -61,7 +61,7 @@ def cleanup(SOCK):
         try:
             os.unlink(SOCK)
         except OSError:
-            logging.warning("Could not unlink socket %s", SOCK)
+            print "Could not unlink socket: " + SOCK
 
 if __name__ == "__main__":
     SOCK = '/tmp/p0f.sock'


### PR DESCRIPTION
This PR fixes a couple of problems with p0f plugin, that I've noticed during it's usage in small-scale production environment.

Major one being typo on [line 159](https://github.com/denpaforks/rspamd/blob/master/lualib/lua_scanners/p0f.lua#L159) of `./lualib/lua_scanners/p0f.lua` (redis_prams instead of redis_params) which prevented redis cache from ever being used. I've included test cases for cached results to make sure that everything works correctly now.

I've also changed default socket location to `/var/run/p0f.sock` as per @moisseev recommendation in #3037.
