### PR TITLE
[Fix] Fix lua_ip_equal logic

### DIFF
--- a/src/lua/lua_ip.c
+++ b/src/lua/lua_ip.c
@@ -490,7 +490,7 @@ lua_ip_equal (lua_State *L)
 	gboolean res = FALSE;
 
 	if (ip1 && ip2 && ip1->addr && ip2->addr) {
-		res = rspamd_inet_address_compare (ip1->addr, ip2->addr, TRUE);
+		res = rspamd_inet_address_compare (ip1->addr, ip2->addr, TRUE) == 0;
 	}
 
 	lua_pushboolean (L, res);


### PR DESCRIPTION
rspamd_inet_address_compare() seems to return a <0 / =0 / >0 valua à la strcmp(). Or am I mistaken?