### PR TITLE
ARC signing instead of DKIM signing.

### DIFF
--- a/conf/modules.d/arc.conf
+++ b/conf/modules.d/arc.conf
@@ -47,7 +47,7 @@ arc {
   symbol_sign = "ARC_SIGNED";
   # Whether to fallback to global config
   try_fallback = true;
-  # Domain to use for DKIM signing: can be "header", "envelope" or "recipient"
+  # Domain to use for ARC signing: can be "header", "envelope" or "recipient"
   use_domain = "recipient";
   # Whether to normalise domains to eSLD
   use_esld = true;


### PR DESCRIPTION
The original commit:
198dca66a ARC signing instead of DKIM signing.
was unintended "reverted" in:
3288513eb [Config] Reasonable default settings for ARC