### PR TITLE
Fix maillist checks to catch Google Groups.

### DIFF
--- a/src/plugins/lua/maillist.lua
+++ b/src/plugins/lua/maillist.lua
@@ -256,7 +256,9 @@ local function check_generic_list_headers(task)
 
   if has_subscribe and has_unsubscribe then
     score = score + 0.25
-  elseif (has_subscribe or has_unsubscribe) then
+  elseif (has_unsubscribe) then
+    score = score - 0.25
+  elseif (has_subscribe) then
     score = score - 0.75
   end
 


### PR DESCRIPTION
Mails from Google Groups don't have the List-Subscribe header. As a result their score from check_generic_list_headers will be reduced to 0.625 and additional tests (check_ml_googlegroup) need a score of > 1 to process.

```
maillist; maillist.lua:209: has header List-Id, score = 0
maillist; maillist.lua:215: has header Precedence: list, score = 0.75
maillist; maillist.lua:222: has header List-Archive, score = 1
maillist; maillist.lua:232: has header List-Help, score = 1.125
maillist; maillist.lua:245: has header List-Unsubscribe, score = 1.25
maillist; maillist.lua:263: final maillist score 0.625
```

As a result of the change lists will still be penalized for not having List-Subscribe, but not as harshly. Google Groups will now qualify with a score of 1.125.

```
maillist; maillist.lua:209: has header List-Id, score = 0
maillist; maillist.lua:215: has header Precedence: list, score = 0.75
maillist; maillist.lua:222: has header List-Archive, score = 1
maillist; maillist.lua:232: has header List-Help, score = 1.125
maillist; maillist.lua:245: has header List-Unsubscribe, score = 1.25
maillist; maillist.lua:271: final maillist score 1.125
```