### PR TITLE
[Minor] Fixes for p0f plugin

### DIFF
--- a/lualib/lua_scanners/p0f.lua
+++ b/lualib/lua_scanners/p0f.lua
@@ -117,7 +117,7 @@ local function p0f_check(task, ip, rule)
 
       data = parse_p0f_response(data)
 
-      if rule.redis_params then
+      if rule.redis_params and data then
         local key = rule.prefix .. ip:to_string()
         local ret = lua_redis.redis_make_request(task,
           rule.redis_params,

--- a/src/plugins/lua/milter_headers.lua
+++ b/src/plugins/lua/milter_headers.lua
@@ -422,11 +422,11 @@ local function milter_headers(task)
 
     local os_string, link_type, uptime_min, distance =
       task:get_mempool():get_variable('os_fingerprint',
-        'string, string, int, int');
+        'string, string, double, double');
 
     if not os_string then return end
 
-    local value = string.format('%s, (up: %u min), (distance %i, link: %s)',
+    local value = string.format('%s, (up: %i min), (distance %i, link: %s)',
       os_string, uptime_min, distance, link_type)
 
     if settings.routines['x-os-fingerprint'].remove then
@@ -434,7 +434,7 @@ local function milter_headers(task)
         = settings.routines['x-os-fingerprint'].remove
     end
 
-    add_header(settings.routines['x-os-fingerprint'].header, value)
+    add_header('x-os-fingerprint', value)
   end
 
   routines['x-spam-status'] = function()


### PR DESCRIPTION
- Skip cache when p0f failed with error or missing record (was causing error message `wrong number of arguments for 'setex' command` in the log)
- Fixed incorrect parameter for `add_header()` function in x-os-fingerprint header routine. Routine name should've been passed instead of full header name.
- _(in the same commit as above)_ Use `double` instead of `int` when unpacking integers from mempool in x-os-fingerprint routine.