### PR TITLE
Fix not logging DMARC reporting addresses

### DIFF
--- a/src/plugins/lua/dmarc.lua
+++ b/src/plugins/lua/dmarc.lua
@@ -975,7 +975,7 @@ if opts['reporting'] == true then
           reporting_addr[report_settings.additional_address] = true
         end
         rspamd_logger.infox(ev_base, 'sending report for %s <%s>',
-            reporting_domain, table.concat(reporting_addr, ','))
+            reporting_domain, reporting_addr)
         local dmarc_xml = dmarc_report_xml()
         local dmarc_push_cb
         dmarc_push_cb = function(err, data)


### PR DESCRIPTION
When sending DMARC reports, the reporting addresses are not being included in the logs. For example:

> <>; lua; dmarc.lua:977: sending report for googlemail.com <>

`table.concat` is being used to build a string containing the email addresses. However,  `reporting_addr` uses the email addresses as keys, so `table.concat` won't produce any output.

This pull request adds a temporary table to use for concatenating the email addresses into the log message.