### PR TITLE
Remove prev form when clicking outside the modal

### DIFF
--- a/interface/js/app/config.js
+++ b/interface/js/app/config.js
@@ -203,8 +203,8 @@ define(["jquery"],
                 return false;
             });
             // close modal without saving
-            $("[data-dismiss=\"modal\"]").on("click", function () {
-                $("#modalBody form").hide();
+            $("#modalDialog").on('hidden.bs.modal', function () {
+              $("#modalBody form").remove();
             });
             // @save forms from modal
             function saveMap(server) {


### PR DESCRIPTION
1. Function is triggered by click on close button **and** by clicking anywhere outside the modal to close it.
2. Form is being removed instead of hidden.