### PR TITLE
[Minor] Clickhouse: fix log

### DIFF
--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -381,7 +381,7 @@ local function clickhouse_send_data(task, ev_base, why, gen_rows, cust_rows)
   local upstream = settings.upstream:get_upstream_round_robin()
   local ip_addr = upstream:get_addr():to_string(true)
   rspamd_logger.infox(log_object, "trying to send %s rows to clickhouse server %s; started as %s",
-      nrows, ip_addr, why)
+      #gen_rows + #cust_rows, ip_addr, why)
 
   local function gen_success_cb(what, how_many)
     return function (_, _)


### PR DESCRIPTION
Fix log message, which was broken in c9e6e26319c08a0e440a9e27b9bf3743e32ad70b
nrows is 0 when clickhouse_send_data is called.