### PR TITLE
Add undocumented interval change on add_periodic to documentation

### DIFF
--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -578,7 +578,7 @@ rspamd_config:add_on_load(function(cfg, ev_base)
 	rspamd_config:add_periodic(ev_base, 1.0, function(cfg, ev_base)
 		local logger = require "rspamd_logger"
 		logger.infox(cfg, "periodic function")
-		return true -- if return false, then the periodic event is removed
+		return true -- if return numeric, a new interval is set. if return false, then the periodic event is removed
 	end)
 end)
  */


### PR DESCRIPTION
You are able to re-register the interval for the periodic function by returning a numerical value. This updates the documentation to include this.