### PR TITLE
cmake: remove unused ENABLE_OPENBLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,6 @@ OPTION(ENABLE_UTILS        "Build rspamd internal utils [default: OFF]" OFF)
 OPTION(ENABLE_LIBUNWIND    "Use libunwind to print crash traces [default: OFF]" OFF)
 OPTION(ENABLE_LUA_TRACE    "Trace all Lua C API invocations [default: OFF]" OFF)
 OPTION(ENABLE_LUA_REPL     "Enables Lua repl (requires C++11 compiler) [default: ON]" ON)
-OPTION(ENABLE_BLAS         "Enables libopenblas support [default: OFF]" OFF)
 
 ############################# INCLUDE SECTION #############################################
 

--- a/cmake/Openblas.cmake
+++ b/cmake/Openblas.cmake
@@ -1,4 +1,4 @@
-option (ENABLE_OPENBLAS    "Enable openblas for fast neural network processing [default: OFF]" OFF)
+option (ENABLE_BLAS    "Enable openblas for fast neural network processing [default: OFF]" OFF)
 
 IF(ENABLE_BLAS MATCHES "ON")
     ProcessPackage(BLAS OPTIONAL_INCLUDE LIBRARY openblas blas


### PR DESCRIPTION
Remove `ENABLE_OPENBLAS` option because it is not used to check if the openblas should be used currently, but `ENABLE_BLAS` from `CMakeLists.txt` is.

Hopefully, I didn't missed anything. I believe this commit may avoid future confusion in configuration phase.
