### PR TITLE
Send Content-Type header in Vault create request

### DIFF
--- a/lualib/rspamadm/vault.lua
+++ b/lualib/rspamadm/vault.lua
@@ -290,6 +290,7 @@ local function create_and_push_key(opts, domain, existing)
     url = uri,
     method = 'put',
     headers = {
+      ['Content-Type'] = 'application/json',
       ['X-Vault-Token'] = opts.token
     },
     body = {
@@ -493,6 +494,7 @@ local function roll_handler(opts, domain)
     url = uri,
     method = 'put',
     headers = {
+      ['Content-Type'] = 'application/json',
       ['X-Vault-Token'] = opts.token
     },
     body = {


### PR DESCRIPTION
I noticed this while building a dummy Vault-like backend.