### PR TITLE
[Minor] Dkim_signing: correct is_skip_sign logic

### DIFF
--- a/lualib/lua_dkim_tools.lua
+++ b/lualib/lua_dkim_tools.lua
@@ -211,9 +211,9 @@ local function prepare_dkim_signing(N, task, settings)
   end
 
   local function is_skip_sign()
-    return (settings.sign_networks and not is_sign_networks) and
-        (settings.auth_only and not is_authed) and
-        (settings.sign_local and not is_local)
+    return not (settings.sign_networks and is_sign_networks) and
+        not (settings.auth_only and is_authed) and
+        not (settings.sign_local and is_local)
   end
 
   if hdom then


### PR DESCRIPTION
If any of "sign_networks", "auth_only", or "sign_local" are disabled,
then it should not automatically proceed with signing if the enabled
conditions all fail. For example, if only the auth_only setting is
enabled, and is_authed is false, then signing should be skipped.

An earlier check luckily prevents this correctness issue from being
exploitable ("ignoring unauthenticated mail"), but fix the logic anyway.