### PR TITLE
[Minor] fix compilation without replxx

### DIFF
--- a/src/rspamadm/lua_repl.c
+++ b/src/rspamadm/lua_repl.c
@@ -610,9 +610,11 @@ static void
 rspamadm_lua_run_repl (lua_State *L, bool is_batch)
 {
 	gchar *input;
+#ifdef WITH_LUA_REPL
 	gboolean is_multiline = FALSE;
 	GString *tb = NULL;
 	gsize i;
+#endif
 
 	for (;;) {
 #ifndef WITH_LUA_REPL
@@ -1004,10 +1006,14 @@ rspamadm_lua (gint argc, gchar **argv, const struct rspamadm_command *cmd)
 	rx_instance = replxx_init ();
 #endif
 	if (!batch) {
+#ifdef WITH_LUA_REPL
 		replxx_set_max_history_size (rx_instance, max_history);
 		replxx_history_load (rx_instance, histfile);
+#endif
 		rspamadm_lua_run_repl (L, false);
+#ifdef WITH_LUA_REPL
 		replxx_history_save (rx_instance, histfile);
+#endif
 	} else {
 		rspamadm_lua_run_repl (L, true);
 	}


### PR DESCRIPTION
../src/rspamadm/lua_repl.c: In function ‘rspamadm_lua_run_repl’:
../src/rspamadm/lua_repl.c:615:8: warning: unused variable ‘i’ [-Wunused-variable]
  615 |  gsize i;
      |        ^
../src/rspamadm/lua_repl.c:614:11: warning: unused variable ‘tb’ [-Wunused-variable]
  614 |  GString *tb = NULL;
      |           ^~
../src/rspamadm/lua_repl.c:613:11: warning: unused variable ‘is_multiline’ [-Wunused-variable]
  613 |  gboolean is_multiline = FALSE;
      |           ^~~~~~~~~~~~
../src/rspamadm/lua_repl.c: In function ‘rspamadm_lua’:
../src/rspamadm/lua_repl.c:1007:3: warning: implicit declaration of function ‘replxx_set_max_history_size’ [-Wimplicit-function-declaration]
 1007 |   replxx_set_max_history_size (rx_instance, max_history);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/rspamadm/lua_repl.c:1007:32: error: ‘rx_instance’ undeclared (first use in this function)
 1007 |   replxx_set_max_history_size (rx_instance, max_history);
      |                                ^~~~~~~~~~~
../src/rspamadm/lua_repl.c:1007:32: note: each undeclared identifier is reported only once for each function it appears in
../src/rspamadm/lua_repl.c:1008:3: warning: implicit declaration of function ‘replxx_history_load’ [-Wimplicit-function-declaration]
 1008 |   replxx_history_load (rx_instance, histfile);
      |   ^~~~~~~~~~~~~~~~~~~
../src/rspamadm/lua_repl.c:1010:3: warning: implicit declaration of function ‘replxx_history_save’ [-Wimplicit-function-declaration]
 1010 |   replxx_history_save (rx_instance, histfile);
      |   ^~~~~~~~~~~~~~~~~~~