### PR TITLE
Two minor bugfixes

### DIFF
--- a/src/plugins/lua/dmarc.lua
+++ b/src/plugins/lua/dmarc.lua
@@ -1382,6 +1382,13 @@ rspamd_config:register_symbol({
   type = 'virtual'
 })
 rspamd_config:register_symbol({
+  name = dmarc_symbols['badpolicy'],
+  parent = id,
+  group = 'policies',
+  groups = {'dmarc'},
+  type = 'virtual'
+})
+rspamd_config:register_symbol({
   name = dmarc_symbols['na'],
   parent = id,
   group = 'policies',

--- a/src/plugins/lua/force_actions.lua
+++ b/src/plugins/lua/force_actions.lua
@@ -164,9 +164,9 @@ local function configure_module()
               rspamd_config:register_dependency(t.name, a)
             end
             rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> with dependencies [%3]',
-                name, expr, table.concat(atoms, ','))
+                t.name, expr, table.concat(atoms, ','))
           else
-            rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> as postfilter', name, expr)
+            rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> as postfilter', t.name, expr)
           end
         end
       end


### PR DESCRIPTION
Dear maintainers

Today I have found two minor issues, one in the force_actions and another in the dmarc plugin.

**force_actions**
The plugin registers a symbol for every configured rule with its name prefixed with 'FORCE_ACTION_'.
The issue is that the prefix is not printed in the log messages which is misleading.

**dmarc**
It appears that the symbol DMARC_BAD_POLICY has been forgotten to register. This causes rspamd to warn about it if someone creates a forced action based on this symbol:
_cannot find dependency on symbol DMARC_BAD_POLICY for symbol FORCE_ACTION_DMARC_BAD_POLICY_