### PR TITLE
[Feature] Additional attributes for force_actions rules

### DIFF
--- a/src/plugins/lua/force_actions.lua
+++ b/src/plugins/lua/force_actions.lua
@@ -152,6 +152,7 @@ local function configure_module()
         local raction = lua_util.list_to_hash(sett.require_action)
         local honor = lua_util.list_to_hash(sett.honor_action)
         local check_local = sett.check_local
+        local group = sett.group
         local cb, atoms = gen_cb(expr, action, rspamd_config:get_mempool(),
           message, subject, raction, honor, lim, least, check_local)
         if cb and atoms then
@@ -163,6 +164,9 @@ local function configure_module()
             t.type = 'normal'
           end
           t.name = 'FORCE_ACTION_' .. name
+          if type(group) == 'string' then
+            t.group = group
+          end
           t.callback = cb
           t.flags = 'empty'
           rspamd_config:register_symbol(t)


### PR DESCRIPTION
Two additional attributes for the rules of the force_action plugin. I hope you will find this useful.

### Attribute check_local (boolean)
**true** The rule is only enabled for local IPs.
**false** The rule is only enabled for non-local IPs.
If the option is **absent**, the rule is always enabled.

My use-case is to reject ougoing virus mails with a forced action, but let incoming virus mails pass as they get quarantined by a subsequent milter.

### Attribute group (string)
Set the group of the symbol which is registered for the rule.