### PR TITLE
[Fix] 'R' flag is for all headers regexp

### DIFF
--- a/src/libmime/mime_expressions.c
+++ b/src/libmime/mime_expressions.c
@@ -380,7 +380,7 @@ rspamd_mime_expr_parse_regexp_atom (rspamd_mempool_t * pool, const gchar *line,
 			p++;
 			break;
 		case 'R':
-			result->type = RSPAMD_RE_RAWHEADER;
+			result->type = RSPAMD_RE_ALLHEADER;
 			p++;
 			break;
 		case 'B':


### PR DESCRIPTION
According to the documentation R flag is for regexp which applied for
all headers (unencoded):
https://rspamd.com/doc/modules/regexp.html#regular-expressions