### PR TITLE
[Minor] Fix parsing DMARC records containing upper-case letters

### DIFF
--- a/src/plugins/lua/dmarc.lua
+++ b/src/plugins/lua/dmarc.lua
@@ -178,6 +178,23 @@ end
 
 local dmarc_grammar = gen_dmarc_grammar()
 
+local function dmarc_key_value_case(elts)
+  if type(elts) ~= "table" then
+    return elts
+  end
+  local result = {}
+  for k, v in pairs(elts) do
+    k = k:lower()
+    if k ~= "v" then
+      v = v:lower()
+    end
+
+    result[k] = v
+  end
+
+  return result
+end
+
 local function dmarc_report(task, spf_ok, dkim_ok, disposition,
     sampled_out, hfromdom, spfdom, dres, spf_result)
   local ip = task:get_from_ip()
@@ -228,6 +245,8 @@ local function dmarc_check_record(task, record, is_tld)
       record, is_tld, elts)
 
   if elts then
+    elts = dmarc_key_value_case(elts)
+
     local dkim_pol = elts['adkim']
     if dkim_pol then
       if dkim_pol == 's' then
@@ -1129,7 +1148,7 @@ if opts['reporting'] == true then
                 failed_policy = true
               elseif elts then
                 found_policy = true
-                policy = elts
+                policy = dmarc_key_value_case(elts)
               end
             end
             if not found_policy then


### PR DESCRIPTION
According to a post on dmarc.org [Link](https://dmarc.org/2016/07/common-problems-with-dmarc-records/),  the string “DMARC” is the only portion of the DMARC policy record that is case-sensitive, but it is not uncommon for people reading the specification to miss this fact.

It seems that this happened when the DMARC plugin was developed and I hereby fixed this issue.