### PR TITLE
Update packaging versions

### DIFF
--- a/centos/rspamd.spec
+++ b/centos/rspamd.spec
@@ -8,7 +8,7 @@
 %define rspamd_wwwdir   %{_datadir}/rspamd/www
 
 Name:           rspamd
-Version:        1.1.0
+Version:        2.4
 Release: 1
 Summary:        Rapid spam filtering system
 Group:          System Environment/Daemons

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,40 +1,5 @@
-rspamd (1.0.2) unstable; urgency=low
+rspamd (2.4) unstable; urgency=low
 
   * New release.
 
- -- Mikhail Gusarov <dottedmag@debian.org>  Thu, 17 Sep 2015 15:17:32 +0100
-
-rspamd (0.9.4) unstable; urgency=low
-
-  * New release:
-    - Fix Build-Depends to let buildd pick up lua 5.1 on architectures
-      without luajit (Closes: #785800)
-
- -- Mikhail Gusarov <dottedmag@debian.org>  Thu, 21 May 2015 09:26:18 +0200
-
-rspamd (0.9.3) unstable; urgency=low
-
-  * New release:
-    - Use lua 5.1 if luajit is not available.
-
- -- Mikhail Gusarov <dottedmag@debian.org>  Tue, 19 May 2015 15:25:54 +0200
-
-rspamd (0.9.1) unstable; urgency=low
-
-  * New release.
-
- -- Mikhail Gusarov <dottedmag@debian.org>  Sun, 17 May 2015 17:46:32 +0200
-
-rspamd (0.8.3) unstable; urgency=low
-
-  * New release.
-  * systemd socket-activated service.
-  * Bump Standards-Version, no changes required.
-
- -- Mikhail Gusarov <dottedmag@debian.org>  Sun, 08 Mar 2015 22:38:55 +0100
-
-rspamd (0.6.9) unstable; urgency=low
-
-  * Initial release (Closes: #683746)
-
- -- Mikhail Gusarov <dottedmag@debian.org>  Sun, 23 Mar 2014 19:04:13 +0100
+ -- Vsevolod Stakhov <vsevolod@highsecure.ru>  Fri, 14 Feb 2020 23:10:27 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: rspamd
 Section: mail
 Priority: extra
-Maintainer: Mikhail Gusarov <dottedmag@debian.org>
+Maintainer: Vsevolod Stakhov <vsevolod@highsecure.ru>
 Build-Depends: cmake,
                debhelper (>= 10),
                libcurl4-openssl-dev,
@@ -21,7 +21,7 @@ Build-Depends: cmake,
                zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: https://rspamd.com
-Vcs-Git: git://github.com/vstakhov/rspamd.git
+Vcs-Git: https://github.com/vstakhov/rspamd.git
 Vcs-Browser: https://github.com/vstakhov/rspamd
 
 Package: rspamd

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Update the version after a new release.
+version=$1
+if ! [[ "$version" =~ ^[0-9]+.[0-9]+$ ]]; then
+    echo "Usage: $0 <major>.<minor>"
+    exit 1
+fi
+
+read major minor <<< "${version/./ }"
+sed -e "s/^\\(SET(RSPAMD_VERSION_MAJOR \\)[0-9]*)/\\1$major)/" \
+    -e "s/^\\(SET(RSPAMD_VERSION_MINOR \\)[0-9]*)/\\1$minor)/" \
+    -i CMakeLists.txt
+sed -e "1s/([0-9.]*)/($version)/" -i debian/changelog
+sed -e "s/^\\(Version: *\\)[0-9.]*$/\\1$version/" -i centos/rspamd.spec


### PR DESCRIPTION
Two more changes to reduce the patching necessary in rspamd_build.sh, and to ensure that `dpkg-buildpackage -b -us -uc` produces a package with a recent version number to make upgrading easier.

CC @sbadia (the current Debian maintainer)
___
[Minor] Update Debian and RPM package versions

* Add script that can be used after tagging to update versions.
* Example (for this commit): `./set-version.sh 2.4`
* Clear Debian changelog, this information is not updated anyway.

[Minor] debian/control: Update Vcs-Git URL and maintainer

* Let Vcs-Git point to a secure transport.
* Use Vsevolod's email address as maintainer to avoid having to patch
  this file in rspamd_build.sh. Mikhail is not the current maintainer of
  the Debian package anyway.

[Minor] use quilt for debian/source/format

* Match the build scripts and main Debian packaging.
* This allows for a separate debian/ directory in debian.tar.gz, see
  https://www.debian.org/doc/manuals/maint-guide/dother.en.html#sourcef
