### PR TITLE
[Fix] Support listening on systemd sockets by name

### DIFF
--- a/src/libserver/cfg_utils.c
+++ b/src/libserver/cfg_utils.c
@@ -98,7 +98,7 @@ rspamd_parse_bind_line (struct rspamd_config *cfg,
 	const gchar *str)
 {
 	struct rspamd_worker_bind_conf *cnf;
-	gchar *err;
+	const gchar *fdname;
 	gboolean ret = TRUE;
 
 	if (str == NULL) {
@@ -112,11 +112,13 @@ rspamd_parse_bind_line (struct rspamd_config *cfg,
 
 	if (g_ascii_strncasecmp (str, "systemd:", sizeof ("systemd:") - 1) == 0) {
 		/* The actual socket will be passed by systemd environment */
+		fdname = str + sizeof ("systemd:") - 1;
 		cnf->is_systemd = TRUE;
-		cnf->cnt = strtoul (str + sizeof ("systemd:") - 1, &err, 10);
-		cnf->addrs = g_ptr_array_new ();
+		cnf->addrs = g_ptr_array_new_full (1, g_free);
 
-		if (err == NULL || *err == '\0') {
+		if (fdname[0]) {
+			g_ptr_array_add (cnf->addrs, g_strdup (fdname));
+			cnf->cnt = cnf->addrs->len;
 			cnf->name = g_strdup (str);
 			LL_PREPEND (cf->bind_conf, cnf);
 		}


### PR DESCRIPTION
* Add support for looking up sockets by the systemd socket name, e.g.
  `systemd:rspamd-proxy.socket` or the name from `FileDescriptorName`.
  https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html
* Replace EOVERFLOW error code to avoid confusing error messages.

Fixes: #2035
___
Tested with various combinations (and with ASAN/UBSAN):
- `systemd:control`
- `systemd:0`, `systemd:control`
- `systemd:-1` (bad)
- `systemd:1` (bad)
- `systemd:invalid` (bad)
- `systemd:control`, `systemd:proxy`
