### PR TITLE
[Minor] --var doesn't work

### DIFF
--- a/src/rspamd.c
+++ b/src/rspamd.c
@@ -148,6 +148,11 @@ rspamd_parse_var (const gchar *option_name,
 		v = g_strdup (t + 1);
 		*t = '\0';
 
+		if (ucl_vars == NULL) {
+			ucl_vars = g_hash_table_new_full (rspamd_strcase_hash,
+					rspamd_strcase_equal, g_free, g_free);
+		}
+
 		g_hash_table_insert (ucl_vars, k, v);
 	}
 	else {


### PR DESCRIPTION
We can add varaibels on the command line after argument or using --var parameter.
When --var is used, an assertion is triggered:

```
./rspamd.install/bin/rspamd --var LOGDIR=/tmp/
(rspamd:7171): GLib-CRITICAL **: g_hash_table_insert_internal: assertion 'hash_table != NULL' failed
```
The hash table is not initialized, because the table is initialized after
the argument parser.

This patch initialize the hash table on demand.

**Note**: the patch is tested on 1.9 version and not on master, because I can't compile the master branch. The code is easy, I guess the right behavior.

**Note**: I suggest to backport the patch on 1.9 version