### PR TITLE
[Minor] Compilation error with __has_attribuute operator

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -375,8 +375,12 @@ typedef off_t goffset;
 #  endif
 #elif defined(__GNUC__)
 /* GCC based */
-#  if __has_attribute(__no_sanitize_address__)
-#    define RSPAMD_NO_SANITIZE __attribute__((no_sanitize_address))
+#  if defined(__has_attribute)
+#    if __has_attribute(__no_sanitize_address__)
+#      define RSPAMD_NO_SANITIZE __attribute__((no_sanitize_address))
+#    else
+#      define RSPAMD_NO_SANITIZE
+#    endif
 #  else
 #    define RSPAMD_NO_SANITIZE
 #  endif


### PR DESCRIPTION
GCC recommands to add alternative to __has_attribute operator:

https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html

Without this alternative, the project doesn't build with some GCC version.
In other way, the alternative is written i other part of rspamd like mem_pool.h