### PR TITLE
Update rbl.conf

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -167,6 +167,7 @@ rbl {
       }
     }
     MSBL_EBL {
+      ignore_whitelist = true;
       ignore_defaults = true;
       rbl = "ebl.msbl.org";
       emails_domainonly = false;


### PR DESCRIPTION
MSBL list a lot of gmail dropboxes, but these are being excluded from the checks due to gmail.com being whitelisted. Same happens for other freemail providers.

Ignoring the whitelist in this case should be safe enough.