### PR TITLE
Revert "[Fix] Fix hiredis stupidity" and use the hiredis api as intended

### DIFF
--- a/contrib/hiredis/async.c
+++ b/contrib/hiredis/async.c
@@ -129,7 +129,6 @@ static redisAsyncContext *redisAsyncInitialize(redisContext *c) {
 
     ac->onConnect = NULL;
     ac->onDisconnect = NULL;
-    ac->disconnectCbdata = NULL;
 
     ac->replies.head = NULL;
     ac->replies.tail = NULL;
@@ -216,10 +215,9 @@ int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn
     return REDIS_ERR;
 }
 
-int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn, void *cbdata) {
+int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn) {
     if (ac->onDisconnect == NULL) {
         ac->onDisconnect = fn;
-        ac->disconnectCbdata = cbdata;
         return REDIS_OK;
     }
     return REDIS_ERR;
@@ -308,10 +306,10 @@ static void __redisAsyncFree(redisAsyncContext *ac) {
      * this context, the status will always be REDIS_OK. */
     if (ac->onDisconnect && (c->flags & REDIS_CONNECTED)) {
         if (c->flags & REDIS_FREEING) {
-            ac->onDisconnect(ac,REDIS_OK,ac->disconnectCbdata);
+            ac->onDisconnect(ac,REDIS_OK);
         } else {
             c->flags |= REDIS_FREEING;
-            ac->onDisconnect(ac,(ac->err == 0) ? REDIS_OK : REDIS_ERR,ac->disconnectCbdata);
+            ac->onDisconnect(ac,(ac->err == 0) ? REDIS_OK : REDIS_ERR);
         }
     }
 

--- a/contrib/hiredis/async.h
+++ b/contrib/hiredis/async.h
@@ -54,7 +54,7 @@ typedef struct redisCallbackList {
 } redisCallbackList;
 
 /* Connection callback prototypes */
-typedef void (redisDisconnectCallback)(const struct redisAsyncContext*, int status, void *cbdata);
+typedef void (redisDisconnectCallback)(const struct redisAsyncContext*, int status);
 typedef void (redisConnectCallback)(const struct redisAsyncContext*, int status);
 
 /* Context for an async connection to Redis */
@@ -85,8 +85,6 @@ typedef struct redisAsyncContext {
     /* Called when either the connection is terminated due to an error or per
      * user request. The status is set accordingly (REDIS_OK, REDIS_ERR). */
     redisDisconnectCallback *onDisconnect;
-    /* Hiredis is just brain-damaged here, need to fix it */
-    void *disconnectCbdata;
 
     /* Called when the first write event was received. */
     redisConnectCallback *onConnect;
@@ -109,7 +107,7 @@ redisAsyncContext *redisAsyncConnectBindWithReuse(const char *ip, int port,
                                                   const char *source_addr);
 redisAsyncContext *redisAsyncConnectUnix(const char *path);
 int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn);
-int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn, void *cbdata);
+int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn);
 void redisAsyncDisconnect(redisAsyncContext *ac);
 void redisAsyncFree(redisAsyncContext *ac);
 


### PR DESCRIPTION
This reverts commit b05b9bf904edce75c17e63982d5e0a82dd3e9064.

Async hiredis allows to pass user specific data to the callback function via `data` element of `struct redisAsyncContext` (see https://github.com/rspamd/rspamd/blob/192c6b791d1c2b42861df6526c663f1d0814ee84/contrib/hiredis/async.h#L69-L70). I would suggest to use it as intended and revert your changes. This change makes the rspamd compatible with upstream hiredis.