### PR TITLE
[Minor] Cherry-pick a fix for replxx to build with gcc10

### DIFF
--- a/contrib/replxx/src/io.cxx
+++ b/contrib/replxx/src/io.cxx
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <array>
+#include <stdexcept>
 
 #ifdef _WIN32
 


### PR DESCRIPTION
723d9c84869511dfb5e63f5c3d3372ac38114713 in replxx's git.

Building rspamd with gcc10 errors out with "'runtime_error' is not a
member of 'std'" otherwise.