### PR TITLE
[fix] add support ElasticSearch>=7 for elastic module

### DIFF
--- a/src/plugins/lua/elastic.lua
+++ b/src/plugins/lua/elastic.lua
@@ -71,7 +71,7 @@ local function elastic_send_data(task)
   local tbl = {}
   for _,value in pairs(rows) do
     table.insert(tbl, '{ "index" : { "_index" : "'..es_index..
-        '", "_type" : "logs" ,"pipeline": "rspamd-geoip"} }')
+        '", "_type" : "_doc" ,"pipeline": "rspamd-geoip"} }')
     table.insert(tbl, ucl.to_format(value, 'json-compact'))
   end
 


### PR DESCRIPTION
Since version 7.x of ElasticSearch, logs type is not supported.

Close #3324