### PR TITLE
[Fix] Segmentation fault in contrib/lua-lpeg/lpvm.c on ppc64el

### DIFF
--- a/contrib/lua-lpeg/lptypes.h
+++ b/contrib/lua-lpeg/lptypes.h
@@ -152,7 +152,7 @@ typedef struct Charset {
 #define testchar(st,c)	(((int)(st)[((c) >> 3)] & (1 << ((c) & 7))))
 
 /* Special workaround for luajit */
-#if defined(WITH_LUAJIT) && !(defined(_X86_) || defined(__x86_64__) || defined(__i386__))
+#if defined(WITH_LUAJIT) && !(defined(_X86_) || defined(__x86_64__) || defined(__i386__) || defined(__powerpc__))
 # define LPEG_LUD_WORKAROUND 1
 void * lpeg_allocate_mem_low(size_t sz);
 void lpeg_free_mem_low(void *p);


### PR DESCRIPTION
This disables a workaround only intended for aarch64 if the target
architecture is powerpc.

Issue: #3365