### PR TITLE
[Test] Settings: empty symbols_enabled / groups_enabled

### DIFF
--- a/test/functional/cases/108_settings.robot
+++ b/test/functional/cases/108_settings.robot
@@ -18,6 +18,15 @@ ${HAM_MESSAGE}      ${TESTDIR}/messages/ham.eml
 ${RSPAMD_SCOPE}  Suite
 ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
+*** Keywords ***
+Check Everything Disabled
+  [Arguments]  ${result}
+  Check Rspamc  ${result}  Action: no action
+  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL
+  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Should Not Contain  ${result.stdout}  SIMPLE_POST
+  Should Not Contain  ${result.stdout}  BAYES_SPAM
+
 *** Test Cases ***
 NO SETTINGS SPAM
   ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}
@@ -34,6 +43,22 @@ NO SETTINGS HAM
   Should Contain  ${result.stdout}  SIMPLE_PRE
   Should Contain  ${result.stdout}  SIMPLE_POST
   Should Contain  ${result.stdout}  BAYES_HAM
+
+EMPTY SYMBOLS ENABLED - STATIC
+  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}  -i  5.5.5.5
+  Check Everything Disabled  ${result}
+
+EMPTY GROUPS ENABLED - STATIC
+  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}  -i  5.5.5.6
+  Check Everything Disabled  ${result}
+
+EMPTY SYMBOLS ENABLED - SETTINGS-ID
+  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}  --header  Settings-Id=empty_symbols_enabled
+  Check Everything Disabled  ${result}
+
+EMPTY GROUPS ENABLED - SETTINGS-ID
+  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}  --header  Settings-Id=empty_groups_enabled
+  Check Everything Disabled  ${result}
 
 ENABLE SYMBOL - NORMAL
   ${result} =  Scan Message With Rspamc  ${HAM_MESSAGE}  --header  Settings={symbols_enabled = ["SIMPLE_TEST"]}

--- a/test/functional/configs/settings.conf
+++ b/test/functional/configs/settings.conf
@@ -66,6 +66,20 @@ settings {
       }
     }
   }
+
+  empty_symbols_enabled {
+    ip = "5.5.5.5";
+    apply {
+      symbols_enabled = [];
+    }
+  }
+
+  empty_groups_enabled {
+    ip = "5.5.5.6";
+    apply {
+      groups_enabled = [];
+    }
+  }
 }
 
 classifier {


### PR DESCRIPTION
Is it worth fixing I wonder? This works in legacy settings (when contents of `apply` block is wrapped in `default`) but not otherwise. However not clear if it particularly should work; there are other ways to solve the problems which may cause people to reach for this -& maybe no-one really does.