### PR TITLE
[Minor] Penalize EXE files in RAR archives

### DIFF
--- a/conf/scores.d/mime_types_group.conf
+++ b/conf/scores.d/mime_types_group.conf
@@ -43,6 +43,11 @@ symbols = {
         description = "Encrypted archive in a message";
         one_shot = true;
     }
+    "MIME_EXE_IN_GEN_SPLIT_RAR" {
+        weight = 5.0;
+        description = "EXE file in RAR archive with generic split extension (e.g. .001)";
+        one_shot = true;
+    }
     "MIME_ARCHIVE_IN_ARCHIVE" {
         weight = 5.0;
         description = "Archive within another archive";


### PR DESCRIPTION
that have generic split file extensions (e.g. .001)