### PR TITLE
Fix analysis table / oletools pattern

### DIFF
--- a/lualib/lua_scanners/oletools.lua
+++ b/lualib/lua_scanners/oletools.lua
@@ -291,7 +291,7 @@ local function oletools_check(task, content, digest, rule)
           lua_util.debugm(N, task, '%s: analysis_keyword_table: %s', rule.log_prefix, analysis_keyword_table)
           lua_util.debugm(N, task, '%s: analysis_cat_table: %s', rule.log_prefix, analysis_cat_table)
 
-          if rule.extended == false and analysis_cat_table.autoexec == 'A' and analysis_cat_table.suspicious == 'S' then
+          if rule.extended == false and analysis_cat_table[2] == 'A' and analysis_cat_table[3] == 'S' then
             -- use single string as virus name
             local threat = 'AutoExec + Suspicious (' .. table.concat(analysis_keyword_table, ',') .. ')'
             lua_util.debugm(rule.name, task, '%s: threat result: %s', rule.log_prefix, threat)
@@ -309,7 +309,7 @@ local function oletools_check(task, content, digest, rule)
             common.yield_result(task, rule, analysis_keyword_table, rule.default_score)
             common.save_cache(task, digest, rule, analysis_keyword_table, rule.default_score)
 
-          elseif analysis_cat_table.macro_exist == '-' and #analysis_keyword_table == 0 then
+          elseif analysis_cat_table[1] == '-' and #analysis_keyword_table == 0 then
             common.save_cache(task, digest, rule, 'OK')
             common.log_clean(task, rule, 'No macro found')
 

--- a/lualib/lua_scanners/oletools.lua
+++ b/lualib/lua_scanners/oletools.lua
@@ -171,15 +171,15 @@ local function oletools_check(task, content, digest, rule)
 
           -- M=Macros, A=Auto-executable, S=Suspicious keywords, I=IOCs,
           -- H=Hex strings, B=Base64 strings, D=Dridex strings, V=VBA strings
-          local analysis_cat_table = {
-            macro_exist = '-',
-            autoexec = '-',
-            suspicious = '-',
-            iocs = '-',
-            hex = '-',
-            base64 = '-',
-            dridex = '-',
-            vba = '-'
+	  local analysis_cat_table = {
+            [1] = '-',
+            [2] = '-',
+            [3] = '-',
+            [4] = '-',
+            [5] = '-',
+            [6] = '-',
+            [7] = '-',
+            [8] = '-'
           }
           local analysis_keyword_table = {}
 
@@ -247,7 +247,7 @@ local function oletools_check(task, content, digest, rule)
 
               elseif #v.macros > 0 then
 
-                analysis_cat_table.macro_exist = 'M'
+                analysis_cat_table[1] = 'M'
 
                 lua_util.debugm(rule.name, task,
                     '%s: filename: %s', rule.log_prefix, result[2]['file'])
@@ -263,25 +263,25 @@ local function oletools_check(task, content, digest, rule)
                   lua_util.debugm(rule.name, task, '%s: threat found - type: %s, keyword: %s, '..
                       'description: %s', rule.log_prefix, a.type, a.keyword, a.description)
                   if a.type == 'AutoExec' then
-                    analysis_cat_table.autoexec = 'A'
+                    analysis_cat_table[2] = 'A'
                     table.insert(analysis_keyword_table, a.keyword)
                   elseif a.type == 'Suspicious' then
                     if rule.extended == true or
                       (a.keyword ~= 'Base64 Strings' and a.keyword ~= 'Hex Strings')
                     then
-                      analysis_cat_table.suspicious = 'S'
+                      analysis_cat_table[3] = 'S'
                       table.insert(analysis_keyword_table, a.keyword)
                     end
                   elseif a.type == 'IOC' then
-                    analysis_cat_table.iocs = 'I'
+                    analysis_cat_table[4] = 'I'
                   elseif a.type == 'Hex strings' then
-                    analysis_cat_table.hex = 'H'
+                    analysis_cat_table[5] = 'H'
                   elseif a.type == 'Base64 strings' then
-                    analysis_cat_table.base64 = 'B'
+                    analysis_cat_table[6] = 'B'
                   elseif a.type == 'Dridex strings' then
-                    analysis_cat_table.dridex = 'D'
+                    analysis_cat_table[7] = 'D'
                   elseif a.type == 'VBA strings' then
-                    analysis_cat_table.vba = 'V'
+                    analysis_cat_table[8] = 'V'
                   end
                 end
               end


### PR DESCRIPTION
I think after rework of oletools with PR #3368 the extended oletools mode and pattern config can't be used any more.

the return analysis_cat_table is empty when using string values in tables and table.concat