### PR TITLE
[Test] Don't use deprecated RobotFramework syntax

### DIFF
--- a/test/functional/cases/120_fuzzy/lib.robot
+++ b/test/functional/cases/120_fuzzy/lib.robot
@@ -62,7 +62,7 @@ Fuzzy Fuzzy Test
   [Arguments]  ${message}
   Run Keyword If  ${RSPAMD_FUZZY_ADD_${message}} != 1  Fail  "Fuzzy Add was not run"
   @{path_info} =  Path Splitter  ${message}
-  @{fuzzy_files} =  List Files In Directory  @{pathinfo}[0]  pattern=@{pathinfo}[1].fuzzy*  absolute=1
+  @{fuzzy_files} =  List Files In Directory  ${pathinfo}[0]  pattern=${pathinfo}[1].fuzzy*  absolute=1
   FOR  ${i}  IN  @{fuzzy_files}
     ${result} =  Scan Message With Rspamc  ${i}
     Check Rspamc  ${result}  ${FLAG1_SYMBOL}

--- a/test/functional/cases/121_json/lib.robot
+++ b/test/functional/cases/121_json/lib.robot
@@ -4,19 +4,19 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 *** Keywords ***
 Stat Test
   @{result} =  HTTP  GET  ${LOCAL_ADDR}  ${PORT_CONTROLLER}  /stat
-  Check JSON  @{result}[1]
-  Should Be Equal As Integers  @{result}[0]  200
+  Check JSON  ${result}[1]
+  Should Be Equal As Integers  ${result}[0]  200
 
 History Test
   [Arguments]  ${rspamc_expected_result}
   ${result} =  Scan Message With Rspamc  ${MESSAGE}
   Check Rspamc  ${result}  ${rspamc_expected_result}
   @{result} =  HTTP  GET  ${LOCAL_ADDR}  ${PORT_CONTROLLER}  /history
-  Check JSON  @{result}[1]
-  Should Be Equal As Integers  @{result}[0]  200
+  Check JSON  ${result}[1]
+  Should Be Equal As Integers  ${result}[0]  200
 
 Scan Test
   ${content} =  Get File  ${MESSAGE}
   @{result} =  HTTP  POST  ${LOCAL_ADDR}  ${PORT_NORMAL}  /check  ${content}
-  Check JSON  @{result}[1]
-  Should Be Equal As Integers  @{result}[0]  200
+  Check JSON  ${result}[1]
+  Should Be Equal As Integers  ${result}[0]  200

--- a/test/functional/cases/140_proxy.robot
+++ b/test/functional/cases/140_proxy.robot
@@ -34,13 +34,13 @@ RSPAMC Legacy Protocol
 *** Keywords ***
 Proxy Setup
   &{d} =  Run Rspamd  CONFIG=${TESTDIR}/configs/lua_test.conf
-  Set Suite Variable  ${SLAVE_LOGPOS}  &{d}[RSPAMD_LOGPOS]
-  Set Suite Variable  ${SLAVE_PID}  &{d}[RSPAMD_PID]
-  Set Suite Variable  ${SLAVE_TMPDIR}  &{d}[TMPDIR]
+  Set Suite Variable  ${SLAVE_LOGPOS}  ${d}[RSPAMD_LOGPOS]
+  Set Suite Variable  ${SLAVE_PID}  ${d}[RSPAMD_PID]
+  Set Suite Variable  ${SLAVE_TMPDIR}  ${d}[TMPDIR]
   &{d} =  Run Rspamd  CONFIG=${TESTDIR}/configs/proxy.conf
-  Set Suite Variable  ${PROXY_LOGPOS}  &{d}[RSPAMD_LOGPOS]
-  Set Suite Variable  ${PROXY_PID}  &{d}[RSPAMD_PID]
-  Set Suite Variable  ${PROXY_TMPDIR}  &{d}[TMPDIR]
+  Set Suite Variable  ${PROXY_LOGPOS}  ${d}[RSPAMD_LOGPOS]
+  Set Suite Variable  ${PROXY_PID}  ${d}[RSPAMD_PID]
+  Set Suite Variable  ${PROXY_TMPDIR}  ${d}[TMPDIR]
 
 Proxy Teardown
   Shutdown Process With Children  ${PROXY_PID}

--- a/test/functional/cases/210_clickhouse/001_migration.robot
+++ b/test/functional/cases/210_clickhouse/001_migration.robot
@@ -79,7 +79,7 @@ Prepare rspamd
     &{d} =    Run Rspamd    CONFIG=${TESTDIR}/configs/clickhouse.conf    TMPDIR=${TMPDIR}
     ${keys} =    Get Dictionary Keys    ${d}
     FOR    ${i}    IN    @{keys}
-        Run Keyword If    '${RSPAMD_SCOPE}' == 'Suite'    Set Suite Variable    ${${i}}    &{d}[${i}]
-        ...    ELSE IF    '${RSPAMD_SCOPE}' == 'Test'     Set Test Variable     ${${i}}    &{d}[${i}]
+        Run Keyword If    '${RSPAMD_SCOPE}' == 'Suite'    Set Suite Variable    ${${i}}    ${d}[${i}]
+        ...    ELSE IF    '${RSPAMD_SCOPE}' == 'Test'     Set Test Variable     ${${i}}    ${d}[${i}]
         ...    ELSE    Fail    'RSPAMD_SCOPE must be Test or Suite'
     END

--- a/test/functional/lib/rspamd.robot
+++ b/test/functional/lib/rspamd.robot
@@ -6,8 +6,8 @@ Library         Process
 *** Keywords ***
 Check Controller Errors
   @{result} =  HTTP  GET  ${LOCAL_ADDR}  ${PORT_CONTROLLER}  /errors
-  Should Be Equal As Integers  @{result}[0]  200
-  Log  @{result}[1]
+  Should Be Equal As Integers  ${result}[0]  200
+  Log  ${result}[1]
 
 Check Pidfile
   [Arguments]  ${pidfile}  ${timeout}=1 min
@@ -22,7 +22,7 @@ Check Rspamc
   ${has_rc} =  Evaluate  'rc' in $kwargs
   ${inverse} =  Evaluate  'inverse' in $kwargs
   ${re} =  Evaluate  're' in $kwargs
-  ${rc} =  Set Variable If  ${has_rc} == True  &{kwargs}[rc]  0
+  ${rc} =  Set Variable If  ${has_rc} == True  ${kwargs}[rc]  0
   FOR  ${i}  IN  @{args}
     Run Keyword If  ${re} == True  Check Rspamc Match Regexp  ${result.stdout}  ${i}  ${inverse}
     ...  ELSE  Check Rspamc Match String  ${result.stdout}  ${i}  ${inverse}
@@ -63,8 +63,8 @@ Generic Setup
   &{d} =  Run Rspamd  @{vargs}  &{kwargs}
   ${keys} =  Get Dictionary Keys  ${d}
   FOR  ${i}  IN  @{keys}
-    Run Keyword If  '${RSPAMD_SCOPE}' == 'Suite'  Set Suite Variable  ${${i}}  &{d}[${i}]
-    ...  ELSE IF  '${RSPAMD_SCOPE}' == 'Test'  Set Test Variable  ${${i}}  &{d}[${i}]
+    Run Keyword If  '${RSPAMD_SCOPE}' == 'Suite'  Set Suite Variable  ${${i}}  ${d}[${i}]
+    ...  ELSE IF  '${RSPAMD_SCOPE}' == 'Test'  Set Test Variable  ${${i}}  ${d}[${i}]
     ...  ELSE  Fail  'RSPAMD_SCOPE must be Test or Suite'
   END
 
@@ -152,9 +152,9 @@ Run Rspamd
   [Arguments]  @{vargs}  &{kwargs}
   ${has_CONFIG} =  Evaluate  'CONFIG' in $kwargs
   ${has_TMPDIR} =  Evaluate  'TMPDIR' in $kwargs
-  ${CONFIG} =  Set Variable If  '${has_CONFIG}' == 'True'  &{kwargs}[CONFIG]  ${CONFIG}
+  ${CONFIG} =  Set Variable If  '${has_CONFIG}' == 'True'  ${kwargs}[CONFIG]  ${CONFIG}
   &{d} =  Create Dictionary
-  ${tmpdir} =  Run Keyword If  '${has_TMPDIR}' == 'True'  Set Variable  &{kwargs}[TMPDIR]
+  ${tmpdir} =  Run Keyword If  '${has_TMPDIR}' == 'True'  Set Variable  ${kwargs}[TMPDIR]
   ...  ELSE  Make Temporary Directory
   Set Directory Ownership  ${tmpdir}  ${RSPAMD_USER}  ${RSPAMD_GROUP}
   ${template} =  Get File  ${CONFIG}
@@ -192,9 +192,9 @@ Sync Fuzzy Storage
   ${len} =  Get Length  ${vargs}
   ${result} =  Run Keyword If  $len == 0  Run Process  ${RSPAMADM}  control  -s
   ...  ${TMPDIR}/rspamd.sock  fuzzy_sync
-  ...  ELSE  Run Process  ${RSPAMADM}  control  -s  @{vargs}[0]/rspamd.sock
+  ...  ELSE  Run Process  ${RSPAMADM}  control  -s  ${vargs}[0]/rspamd.sock
   ...  fuzzy_sync
   Log  ${result.stdout}
   Run Keyword If  $len == 0  Follow Rspamd Log
-  ...  ELSE  Custom Follow Rspamd Log  @{vargs}[0]/rspamd.log  @{vargs}[1]  @{vargs}[2]  @{vargs}[3]
+  ...  ELSE  Custom Follow Rspamd Log  ${vargs}[0]/rspamd.log  ${vargs}[1]  ${vargs}[2]  ${vargs}[3]
   Sleep  0.1s  Try give fuzzy storage time to sync


### PR DESCRIPTION
With the contemporary version of Robot Framework it's printing a lot of warnings:
```
[ WARN ] Accessing variable items using '&{kwargs}[CONFIG]' syntax is deprecated. Use '${kwargs}[CONFIG]' instead.
[ WARN ] Accessing variable items using '@{result}[0]' syntax is deprecated. Use '${result}[0]' instead.
```
This patch makes the warnings go away.