### PR TITLE
Improve tests

### DIFF
--- a/test/functional/cases/100_general.robot
+++ b/test/functional/cases/100_general.robot
@@ -13,8 +13,8 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 GTUBE
-  ${result} =  Scan Message With Rspamc  ${GTUBE}
-  Check Rspamc  ${result}  GTUBE (
+  Scan File  ${GTUBE}
+  Expect Symbol  GTUBE
 
 GTUBE - Encrypted
   ${result} =  Run Rspamc  -p  -h  ${LOCAL_ADDR}:${PORT_NORMAL}  --key  ${KEY_PUB1}
@@ -22,13 +22,13 @@ GTUBE - Encrypted
   Check Rspamc  ${result}  GTUBE (
 
 GTUBE - Scan File feature
-  ${result} =  Scan File  ${LOCAL_ADDR}  ${PORT_NORMAL}  ${GTUBE}
-  Should Contain  ${result}  GTUBE
+  Scan File By Reference  ${GTUBE}
+  Expect Symbol  GTUBE
 
 GTUBE - Scan File feature (encoded)
   ${encoded} =  Encode Filename  ${GTUBE}
-  ${result} =  Scan File  ${LOCAL_ADDR}  ${PORT_NORMAL}  ${encoded}
-  Should Contain  ${result}  GTUBE
+  Scan File By Reference  ${encoded}
+  Expect Symbol  GTUBE
 
 GTUBE - SPAMC
   ${result} =  Spamc  ${LOCAL_ADDR}  ${PORT_NORMAL}  ${GTUBE}
@@ -38,14 +38,13 @@ GTUBE - RSPAMC
   ${result} =  Rspamc  ${LOCAL_ADDR}  ${PORT_NORMAL}  ${GTUBE}
   Should Contain  ${result}  GTUBE
 
-# Broken
-#EMAILS DETECTION 1
-#  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/emails1.eml
-#  Check Rspamc  ${result}  "jim@example.net"
-#  Should Contain  ${result.stdout}  "bob@example.net"
-#  Should Contain  ${result.stdout}  "rupert@example.net"
+EMAILS DETECTION 1
+  Scan File  ${TESTDIR}/messages/emails1.eml  URL-Format=Extended
+  Expect Email  jim@example.net
+  Expect Email  bob@example.net
+  Expect Email  rupert@example.net
 
 EMAILS DETECTION ZEROFONT
-  ${result} =  Scan File  ${LOCAL_ADDR}  ${PORT_NORMAL}  ${TESTDIR}/messages/zerofont.eml
-  Should Contain  ${result}  MANY_INVISIBLE_PARTS
-  Should Contain  ${result}  ZERO_FONT
+  Scan File  ${TESTDIR}/messages/zerofont.eml
+  Expect Symbol  MANY_INVISIBLE_PARTS
+  Expect Symbol  ZERO_FONT

--- a/test/functional/cases/101_lua.robot
+++ b/test/functional/cases/101_lua.robot
@@ -16,51 +16,50 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 *** Test Cases ***
 Flags
   [Setup]  Lua Setup  ${TESTDIR}/lua/flags.lua
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
+  Scan File  ${MESSAGE}
   ${result} =  Run Rspamc  -h  ${LOCAL_ADDR}:${PORT_CONTROLLER}  stat
   Should Contain  ${result.stdout}  Messages scanned: 0
 
 Dependencies
   [Setup]  Lua Setup  ${TESTDIR}/lua/deps.lua
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  DEP10
+  Scan File  ${MESSAGE}
+  Expect Symbol  DEP10
 
 Pre and Post Filters
   [Setup]  Lua Setup  ${TESTDIR}/lua/prepostfilters.lua
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  TEST_PRE
-  Should Contain  ${result.stdout}  TEST_POST
+  Scan File  ${MESSAGE}
+  Expect Symbol  TEST_PRE
+  Expect Symbol  TEST_POST
 
 Recipient Parsing Sanity
   [Setup]  Lua Setup  ${TESTDIR}/lua/recipients.lua
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -r  rcpt1@foobar  -r  rcpt2@foobar
-  ...  -r  rcpt3@foobar  -r  rcpt4@foobar
-  Check Rspamc  ${result}  TEST_RCPT (1.00)[rcpt1@foobar,rcpt2@foobar,rcpt3@foobar,rcpt4@foobar]
+  Scan File  ${MESSAGE}  Rcpt=rcpt1@foobar,rcpt2@foobar,rcpt3@foobar,rcpt4@foobar
+  Expect Symbol With Exact Options  TEST_RCPT  rcpt1@foobar,rcpt2@foobar,rcpt3@foobar,rcpt4@foobar
 
 TLD parts
   [Setup]  TLD Setup  ${TESTDIR}/lua/tlds.lua
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  TEST_TLD (1.00)[no worry]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  TEST_TLD  no worry
 
 Hashes
   [Setup]  Lua Setup  ${TESTDIR}/lua/hashes.lua
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  TEST_HASHES (1.00)[no worry]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  TEST_HASHES  no worry
 
 Maps Key Values
   [Setup]  Lua Replace Setup  ${TESTDIR}/lua/maps_kv.lua
   [Teardown]  Lua Replace Teardown
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  RADIX_KV (1.00)[no worry]
-  Should Contain  ${result.stdout}  REGEXP_KV (1.00)[no worry]
-  Should Contain  ${result.stdout}  MAP_KV (1.00)[no worry]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  RADIX_KV  no worry
+  Expect Symbol With Exact Options  REGEXP_KV  no worry
+  Expect Symbol With Exact Options  MAP_KV  no worry
 
 Option Order
   [Setup]  Lua Replace Setup  ${TESTDIR}/lua/option_order.lua
   [Teardown]  Lua Replace Teardown
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  OPTION_ORDER (1.00)[one, two, three, 4, 5, a]
-  Should Contain  ${result.stdout}  TBL_OPTION_ORDER (1.00)[one, two, three, 4, 5, a]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  OPTION_ORDER  one  two  three  4  5  a
+  Expect Symbol With Exact Options  TBL_OPTION_ORDER  one  two  three  4  5  a
 
 *** Keywords ***
 Lua Setup

--- a/test/functional/cases/102_multimap.robot
+++ b/test/functional/cases/102_multimap.robot
@@ -26,312 +26,311 @@ ${URL_ICS}      ${TESTDIR}/messages/ics.eml
 
 *** Test Cases ***
 URL_ICS
-  ${result} =  Scan Message With Rspamc  ${URL_ICS}
-  Check Rspamc  ${result}  Urls: ["test.com"]
+  Scan File  ${URL_ICS}
+  Expect URL  test.com
 
 MAP - DNSBL HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  127.0.0.2
-  Check Rspamc  ${result}  DNSBL_MAP
+  Scan File  ${MESSAGE}  IP=127.0.0.2
+  Expect Symbol  DNSBL_MAP
 
 MAP - DNSBL MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  127.0.0.1
-  Check Rspamc  ${result}  DNSBL_MAP  inverse=1
+  Scan File  ${MESSAGE}  IP=127.0.0.1
+  Do Not Expect Symbol  DNSBL_MAP
 
 MAP - IP HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  127.0.0.1
-  Check Rspamc  ${result}  IP_MAP
+  Scan File  ${MESSAGE}  IP=127.0.0.1
+  Expect Symbol  IP_MAP
 
 MAP - IP MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  127.0.0.2
-  Check Rspamc  ${result}  IP_MAP  inverse=1
+  Scan File  ${MESSAGE}  IP=127.0.0.2
+  Do Not Expect Symbol  IP_MAP
 
 MAP - IP MASK
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  10.1.0.10
-  Check Rspamc  ${result}  IP_MAP
+  Scan File  ${MESSAGE}  IP=10.1.0.10
+  Expect Symbol  IP_MAP
 
 MAP - IP MASK MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  11.1.0.10
-  Check Rspamc  ${result}  IP_MAP  inverse=1
+  Scan File  ${MESSAGE}  IP=11.1.0.10
+  Do Not Expect Symbol  IP_MAP
 
 MAP - IP V6
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  ::1
-  Check Rspamc  ${result}  IP_MAP
+  Scan File  ${MESSAGE}  IP=::1
+  Expect Symbol  IP_MAP
 
 MAP - IP V6 MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  fe80::1
-  Check Rspamc  ${result}  IP_MAP  inverse=1
+  Scan File  ${MESSAGE}  IP=fe80::1
+  Do Not Expect Symbol  IP_MAP
 
 MAP - FROM
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  user@example.com
-  Check Rspamc  ${result}  FROM_MAP
+  Scan File  ${MESSAGE}  From=user@example.com
+  Expect Symbol  FROM_MAP
 
 MAP - COMBINED IP MASK FROM
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  10.1.0.10  --from  user@example.com
-  Check Rspamc  ${result}  COMBINED_MAP_AND
-  Check Rspamc  ${result}  COMBINED_MAP_OR
+  Scan File  ${MESSAGE}  IP=10.1.0.10  From=user@example.com
+  Expect Symbol  COMBINED_MAP_AND
+  Expect Symbol  COMBINED_MAP_OR
 
 MAP - COMBINED IP MASK ONLY
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  10.1.0.10
-  Check Rspamc  ${result}  COMBINED_MAP_AND  inverse=1
-  Check Rspamc  ${result}  COMBINED_MAP_OR
+  Scan File  ${MESSAGE}  IP=10.1.0.10
+  Do Not Expect Symbol  COMBINED_MAP_AND
+  Expect Symbol  COMBINED_MAP_OR
 
 MAP - COMBINED FROM ONLY
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  user@example.com
-  Check Rspamc  ${result}  COMBINED_MAP_AND  inverse=1
-  Check Rspamc  ${result}  COMBINED_MAP_OR
+  Scan File  ${MESSAGE}  From=user@example.com
+  Do Not Expect Symbol  COMBINED_MAP_AND
+  Expect Symbol  COMBINED_MAP_OR
 
 MAP - COMBINED MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  11.1.0.10  --from  user@other.com
-  Check Rspamc  ${result}  COMBINED_MAP_AND  inverse=1
-  Check Rspamc  ${result}  COMBINED_MAP_OR  inverse=1
+  Scan File  ${MESSAGE}  IP=11.1.0.10  From=user@other.com
+  Do Not Expect Symbol  COMBINED_MAP_AND
+  Do Not Expect Symbol  COMBINED_MAP_OR
 
 MAP - FROM MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  user@other.com
-  Check Rspamc  ${result}  FROM_MAP  inverse=1
+  Scan File  ${MESSAGE}  From=user@other.com
+  Do Not Expect Symbol  FROM_MAP
 
 MAP - FROM REGEXP
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  user123@test.com
-  Check Rspamc  ${result}  REGEXP_MAP
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  somebody@example.com
-  Check Rspamc  ${result}  REGEXP_MAP
+  Scan File  ${MESSAGE}  From=user123@test.com
+  Expect Symbol  REGEXP_MAP
+  Scan File  ${MESSAGE}  From=somebody@example.com
+  Expect Symbol  REGEXP_MAP
 
 MAP - FROM REGEXP MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  user@other.org
-  Check Rspamc  ${result}  REGEXP_MAP  inverse=1
+  Scan File  ${MESSAGE}  From=user@other.org
+  Do Not Expect Symbol  REGEXP_MAP
 
 MAP - RCPT DOMAIN HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  user@example.com
-  Check Rspamc  ${result}  RCPT_DOMAIN
+  Scan File  ${MESSAGE}  Rcpt=user@example.com
+  Expect Symbol  RCPT_DOMAIN
 
 MAP - RCPT DOMAIN MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  example.com@user
-  Check Rspamc  ${result}  RCPT_DOMAIN  inverse=1
+  Scan File  ${MESSAGE}  Rcpt=example.com@user
+  Do Not Expect Symbol  RCPT_DOMAIN
 
 MAP - RCPT USER HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  bob@example.com
-  Check Rspamc  ${result}  RCPT_USER
+  Scan File  ${MESSAGE}  Rcpt=bob@example.com
+  Expect Symbol  RCPT_USER
 
 MAP - RCPT USER MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  example.com@bob
-  Check Rspamc  ${result}  RCPT_USER  inverse=1
+  Scan File  ${MESSAGE}  From=example.com@bob
+  Do Not Expect Symbol  RCPT_USER
 
 MAP - DEPENDS HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  88.99.142.95  --from  user123@rspamd.com
-  Check Rspamc  ${result}  DEPS_MAP
+  Scan File  ${MESSAGE}  IP=88.99.142.95  From=user123@rspamd.com
+  Expect Symbol  DEPS_MAP
 
 MAP - DEPENDS MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  1.2.3.4  --from  user123@rspamd.com
-  Check Rspamc  ${result}  DEPS_MAP  inverse=1
+  Scan File  ${MESSAGE}  IP=1.2.3.4  From=user123@rspamd.com
+  Do Not Expect Symbol  DEPS_MAP
 
 MAP - MULSYM PLAIN
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  user1@example.com
-  Check Rspamc  ${result}  RCPT_MAP
+  Scan File  ${MESSAGE}  Rcpt=user1@example.com
+  Expect Symbol  RCPT_MAP
 
 MAP - MULSYM SCORE
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  user2@example.com
-  Check Rspamc  ${result}  RCPT_MAP (10.0
+  Scan File  ${MESSAGE}  Rcpt=user2@example.com
+  Expect Symbol With Score  RCPT_MAP  10.0
 
 MAP - MULSYM SYMBOL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  user3@example.com
-  Check Rspamc  ${result}  SYM1 (1.0
+  Scan File  ${MESSAGE}  Rcpt=user3@example.com
+  Expect Symbol With Score  SYM1  1.0
 
 MAP - MULSYM SYMBOL MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  user4@example.com
-  Check Rspamc  ${result}  RCPT_MAP (1.0
+  Scan File  ${MESSAGE}  Rcpt=user4@example.com
+  Expect Symbol With Score  RCPT_MAP  1.0
 
 MAP - MULSYM SYMBOL + SCORE
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  user5@example.com
-  Check Rspamc  ${result}  SYM1 (-10.1
+  Scan File  ${MESSAGE}  Rcpt=user5@example.com
+  Expect Symbol With Score  SYM1  -10.1
 
 MAP - UTF
-  ${result} =  Scan Message With Rspamc  ${UTF_MESSAGE}
-  Check Rspamc  ${result}  HEADER_MAP
+  Scan File  ${UTF_MESSAGE}
+  Expect Symbol  HEADER_MAP
 
 MAP - UTF MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  HEADER_MAP  inverse=1
+  Scan File  ${MESSAGE}
+  Do Not Expect Symbol  HEADER_MAP
 
 MAP - HOSTNAME
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  example.com
-  Check Rspamc  ${result}  HOSTNAME_MAP
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=example.com
+  Expect Symbol  HOSTNAME_MAP
 
 MAP - HOSTNAME MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  rspamd.com
-  Check Rspamc  ${result}  HOSTNAME_MAP  inverse=1
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=rspamd.com
+  Do Not Expect Symbol  HOSTNAME_MAP
 
 MAP - TOP
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  example.com.au
-  Check Rspamc  ${result}  HOSTNAME_TOP_MAP
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=example.com.au
+  Expect Symbol  HOSTNAME_TOP_MAP
 
 MAP - TOP MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  example.com.bg
-  Check Rspamc  ${result}  HOSTNAME_TOP_MAP  inverse=1
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=example.com.bg
+  Do Not Expect Symbol  HOSTNAME_TOP_MAP
 
 MAP - CDB - HOSTNAME
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  example.com
-  Check Rspamc  ${result}  CDB_HOSTNAME
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=example.com
+  Expect Symbol  CDB_HOSTNAME
 
 MAP - CDB - HOSTNAME MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  rspamd.com
-  Check Rspamc  ${result}  CDB_HOSTNAME  inverse=1
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=rspamd.com
+  Do Not Expect Symbol  CDB_HOSTNAME
 
 MAP - REDIS - HOSTNAME
   Redis HSET  hostname  redistest.example.net  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  redistest.example.net
-  Check Rspamc  ${result}  REDIS_HOSTNAME
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=redistest.example.net
+  Expect Symbol  REDIS_HOSTNAME
 
 MAP - REDIS - HOSTNAME MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  rspamd.com
-  Check Rspamc  ${result}  REDIS_HOSTNAME  inverse=1
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=rspamd.com
+  Do Not Expect Symbol  REDIS_HOSTNAME
 
 MAP - REDIS - HOSTNAME - EXPANSION - HIT
   Redis HSET  127.0.0.1.foo.com  redistest.example.net  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  redistest.example.net  --rcpt  bob@foo.com
-  Check Rspamc  ${result}  REDIS_HOSTNAME_EXPANSION
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=redistest.example.net  Rcpt=bob@foo.com
+  Expect Symbol  REDIS_HOSTNAME_EXPANSION
 
 MAP - REDIS - HOSTNAME - EXPANSION - MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1  --hostname  redistest.example.net  --rcpt  bob@bar.com
-  Check Rspamc  ${result}  REDIS_HOSTNAME_EXPANSION  inverse=1
+  Scan File  ${MESSAGE}  IP=127.0.0.1  Hostname=redistest.example.net  Rcpt=bob@bar.com
+  Do Not Expect Symbol  REDIS_HOSTNAME_EXPANSION
 
 MAP - REDIS - IP
   Redis HSET  ipaddr  127.0.0.1  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  127.0.0.1
-  Check Rspamc  ${result}  REDIS_IPADDR
+  Scan File  ${MESSAGE}  IP=127.0.0.1
+  Expect Symbol  REDIS_IPADDR
 
 MAP - REDIS - IP - MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  8.8.8.8
-  Check Rspamc  ${result}  REDIS_IPADDR  inverse=1
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Do Not Expect Symbol  REDIS_IPADDR
 
 MAP - REDIS - FROM
   Redis HSET  emailaddr  from@rspamd.tk  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  from@rspamd.tk
-  Check Rspamc  ${result}  REDIS_FROMADDR
+  Scan File  ${MESSAGE}  From=from@rspamd.tk
+  Expect Symbol  REDIS_FROMADDR
 
 MAP - REDIS - FROM MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  user@other.com
-  Check Rspamc  ${result}  REDIS_FROMADDR  inverse=1
+  Scan File  ${MESSAGE}  From=user@other.com
+  Do Not Expect Symbol  REDIS_FROMADDR
 
 MAP - REDIS - URL TLD - HIT
   Redis HSET  hostname  example.com  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${URL1}
-  Check Rspamc  ${result}  REDIS_URL_TLD
+  Scan File  ${URL1}
+  Expect Symbol  REDIS_URL_TLD
 
 MAP - REDIS - URL TLD - MISS
-  ${result} =  Scan Message With Rspamc  ${URL2}
-  Check Rspamc  ${result}  REDIS_URL_TLD  inverse=1
+  Scan File  ${URL2}
+  Do Not Expect Symbol  REDIS_URL_TLD
 
 MAP - REDIS - URL RE FULL - HIT
   Redis HSET  fullurlre  html  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${URL2}
-  Check Rspamc  ${result}  REDIS_URL_RE_FULL
+  Scan File  ${URL2}
+  Expect Symbol  REDIS_URL_RE_FULL
 
 MAP - REDIS - URL RE FULL - MISS
-  ${result} =  Scan Message With Rspamc  ${URL1}
-  Check Rspamc  ${result}  REDIS_URL_RE_FULL  inverse=1
+  Scan File  ${URL1}
+  Do Not Expect Symbol  REDIS_URL_RE_FULL
 
 MAP - REDIS - URL FULL - HIT
   Redis HSET  fullurl  https://www.example.com/foo?a=b  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${URL1}
-  Check Rspamc  ${result}  REDIS_URL_FULL
+  Scan File  ${URL1}
+  Expect Symbol  REDIS_URL_FULL
 
 MAP - REDIS - URL FULL - MISS
-  ${result} =  Scan Message With Rspamc  ${URL2}
-  Check Rspamc  ${result}  REDIS_URL_FULL  inverse=1
+  Scan File  ${URL2}
+  Do Not Expect Symbol  REDIS_URL_FULL
 
 MAP - REDIS - URL PHISHED - HIT
   Redis HSET  phishedurl  www.rspamd.com  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${URL3}
-  Check Rspamc  ${result}  REDIS_URL_PHISHED
+  Scan File  ${URL3}
+  Expect Symbol  REDIS_URL_PHISHED
 
 MAP - REDIS - URL PHISHED - MISS
-  ${result} =  Scan Message With Rspamc  ${URL4}
-  Check Rspamc  ${result}  REDIS_URL_PHISHED  inverse=1
+  Scan File  ${URL4}
+  Do Not Expect Symbol  REDIS_URL_PHISHED
 
 MAP - REDIS - URL PLAIN REGEX - HIT
   Redis HSET  urlre  www  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${URL3}
-  Check Rspamc  ${result}  REDIS_URL_RE_PLAIN
+  Scan File  ${URL3}
+  Expect Symbol  REDIS_URL_RE_PLAIN
 
 MAP - REDIS - URL PLAIN REGEX - MISS
-  ${result} =  Scan Message With Rspamc  ${URL4}
-  Check Rspamc  ${result}  REDIS_URL_RE_PLAIN  inverse=1
+  Scan File  ${URL4}
+  Do Not Expect Symbol  REDIS_URL_RE_PLAIN
 
 MAP - REDIS - URL TLD REGEX - HIT
   Redis HSET  tldre  net  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${URL5}
-  Check Rspamc  ${result}  REDIS_URL_RE_TLD
+  Scan File  ${URL5}
+  Expect Symbol  REDIS_URL_RE_TLD
 
 MAP - REDIS - URL TLD REGEX - MISS
-  ${result} =  Scan Message With Rspamc  ${URL4}
-  Check Rspamc  ${result}  REDIS_URL_RE_TLD  inverse=1
+  Scan File  ${URL4}
+  Do Not Expect Symbol  REDIS_URL_RE_TLD
 
 MAP - REDIS - URL NOFILTER - HIT
   Redis HSET  urlnofilter  www.example.net  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${URL5}
-  Check Rspamc  ${result}  REDIS_URL_NOFILTER
+  Scan File  ${URL5}
+  Expect Symbol  REDIS_URL_NOFILTER
 
 MAP - REDIS - URL NOFILTER - MISS
-  ${result} =  Scan Message With Rspamc  ${URL4}
-  Check Rspamc  ${result}  REDIS_URL_NOFILTER  inverse=1
+  Scan File  ${URL4}
+  Do Not Expect Symbol  REDIS_URL_NOFILTER
 
 MAP - REDIS - ASN - HIT
   Redis HSET  asn  15169  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  8.8.8.8
-  Check Rspamc  ${result}  REDIS_ASN
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Expect Symbol  REDIS_ASN
 
 MAP - REDIS - ASN - MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  46.228.47.114
-  Check Rspamc  ${result}  REDIS_ASN  inverse=1
+  Scan File  ${MESSAGE}  IP=46.228.47.114
+  Do Not Expect Symbol  REDIS_ASN
 
 MAP - REDIS - CC - HIT
   Redis HSET  cc  US  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  8.8.8.8
-  Check Rspamc  ${result}  REDIS_COUNTRY
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Expect Symbol  REDIS_COUNTRY
 
 MAP - REDIS - CC - MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  46.228.47.114
-  Check Rspamc  ${result}  REDIS_COUNTRY  inverse=1
+  Scan File  ${MESSAGE}  IP=46.228.47.114
+  Do Not Expect Symbol  REDIS_COUNTRY
 
 MAP - REDIS - ASN FILTERED - HIT
   Redis HSET  asn  1  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  8.8.8.8
-  Check Rspamc  ${result}  REDIS_ASN_FILTERED
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Expect Symbol  REDIS_ASN_FILTERED
 
 MAP - REDIS - ASN FILTERED - MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  46.228.47.114
-  Check Rspamc  ${result}  REDIS_ASN_FILTERED  inverse=1
+  Scan File  ${MESSAGE}  IP=46.228.47.114
+  Do Not Expect Symbol  REDIS_ASN_FILTERED
 
 MAP - RECEIVED - IP MINMAX POS - ONE
-  ${result} =  Scan Message With Rspamc  ${RCVD1}
-  Check Rspamc  ${result}  RCVD_TEST_01
-  Check Rspamc  ${result}  RCVD_TEST_02  inverse=1
+  Scan File  ${RCVD1}
+  Expect Symbol  RCVD_TEST_01
+  Do Not Expect Symbol  RCVD_TEST_02
 
 # Relies on parsing of shitty received
 #MAP - RECEIVED - IP MINMAX POS - TWO / RCVD_AUTHED_ONE HIT
-#  ${result} =  Scan Message With Rspamc  ${RCVD2}
-#  Check Rspamc  ${result}  RCVD_TEST_02
-#  Should Not Contain  ${result.stdout}  RCVD_TEST_01
-#  Should Contain  ${result.stdout}  RCVD_AUTHED_ONE
+#  Scan File  ${RCVD2}
+#  Expect Symbol  RCVD_TEST_02
+#  Do Not Expect Symbol  RCVD_TEST_01
+#  Expect Symbol  RCVD_AUTHED_ONE
 
 MAP - RECEIVED - REDIS
   Redis HSET  RCVD_TEST  2a01:7c8:aab6:26d:5054:ff:fed1:1da2  ${EMPTY}
-  ${result} =  Scan Message With Rspamc  ${RCVD1}
-  Check Rspamc  ${result}  RCVD_TEST_REDIS_01
+  Scan File  ${RCVD1}
+  Expect Symbol  RCVD_TEST_REDIS_01
 
 RCVD_AUTHED_ONE & RCVD_AUTHED_TWO - MISS
-  ${result} =  Scan Message With Rspamc  ${RCVD3}
-  Check Rspamc  ${result}  RCVD_AUTHED_  inverse=1
+  Scan File  ${RCVD3}
+  Do Not Expect Symbol  RCVD_AUTHED_ONE
+  Do Not Expect Symbol  RCVD_AUTHED_TWO
 
 RCVD_AUTHED_TWO HIT / RCVD_AUTHED_ONE MISS
-  ${result} =  Scan Message With Rspamc  ${RCVD4}
-  Check Rspamc  ${result}  RCVD_AUTHED_TWO
-  Should Not Contain  ${result.stdout}  RCVD_AUTHED_ONE
+  Scan File  ${RCVD4}
+  Expect Symbol  RCVD_AUTHED_TWO
+  Do Not Expect Symbol  RCVD_AUTHED_ONE
 
 FREEMAIL_CC
-  ${result} =  Scan Message With Rspamc  ${FREEMAIL_CC}
-  Check Rspamc  ${result}  FREEMAIL_CC (19.00)[test.com, test1.com, test2.com, test3.com, test4.com, test5.com, test6.com, test7.com, test8.com, test9.com, test10.com, test11.com, test12.com, test13.com, test14.com]
-
-
+  Scan File  ${FREEMAIL_CC}
+  Expect Symbol With Score And Exact Options  FREEMAIL_CC  19.00  test.com  test1.com  test2.com  test3.com  test4.com  test5.com  test6.com  test7.com  test8.com  test9.com  test10.com  test11.com  test12.com  test13.com  test14.com
 
 *** Keywords ***
 Multimap Setup

--- a/test/functional/cases/104_get_from.robot
+++ b/test/functional/cases/104_get_from.robot
@@ -10,44 +10,44 @@ ${CONFIG}        ${TESTDIR}/configs/lua_script.conf
 ${LUA_SCRIPT}    ${TESTDIR}/lua/get_from.lua
 ${RSPAMD_SCOPE}  Suite
 
-${SYMBOL}   GET_FROM (0.00)
-${SYMBOL1}  ${SYMBOL}\[,user@example.org,user,example.org]
-${SYMBOL2}  ${SYMBOL}\[First Last,user@example.org,user,example.org]
-${SYMBOL3}  ${SYMBOL}\[First M. Last,user@example.org,user,example.org]
+${SYMBOL}   GET_FROM
+${OPTIONS1}  ,user@example.org,user,example.org
+${OPTIONS2}  First Last,user@example.org,user,example.org
+${OPTIONS3}  First M. Last,user@example.org,user,example.org
 
 *** Test Cases ***
 task:get_from('mime') - address only
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from.eml
-  Check Rspamc  ${result}  ${SYMBOL1}
+  Scan File  ${TESTDIR}/messages/from/from.eml
+  Expect Symbol  ${SYMBOL}
 
 task:get_from('mime') - comment
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from_comment.eml
-  Check Rspamc  ${result}  ${SYMBOL1}
+  Scan File  ${TESTDIR}/messages/from/from_comment.eml
+  Expect Symbol With Exact Options  ${SYMBOL}  ${OPTIONS1}
 
 task:get_from('mime') - display name
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from_dn.eml
-  Check Rspamc  ${result}  ${SYMBOL2}
+  Scan File  ${TESTDIR}/messages/from/from_dn.eml
+  Expect Symbol With Exact Options  ${SYMBOL}  ${OPTIONS2}
 
 task:get_from('mime') - display name Base64
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from_dn_base64.eml
-  Check Rspamc  ${result}  ${SYMBOL}\[Кириллица,user@example.org,user,example.org]
+  Scan File  ${TESTDIR}/messages/from/from_dn_base64.eml
+  Expect Symbol With Exact Options  ${SYMBOL}  Кириллица,user@example.org,user,example.org
 
 task:get_from('mime') - display name and comment
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from_dn_comment.eml
-  Check Rspamc  ${result}  ${SYMBOL2}
+  Scan File  ${TESTDIR}/messages/from/from_dn_comment.eml
+  Expect Symbol With Exact Options  ${SYMBOL}  ${OPTIONS2}
 
 task:get_from('mime') - quoted display name
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from_quoted_dn.eml
-  Check Rspamc  ${result}  ${SYMBOL3}
+  Scan File  ${TESTDIR}/messages/from/from_quoted_dn.eml
+  Expect Symbol With Exact Options  ${SYMBOL}  ${OPTIONS3}
 
 task:get_from('mime') - quoted display name and comment
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from_quoted_dn_comment.eml
-  Check Rspamc  ${result}  ${SYMBOL3}
+  Scan File  ${TESTDIR}/messages/from/from_quoted_dn_comment.eml
+  Expect Symbol With Exact Options  ${SYMBOL}  ${OPTIONS3}
 
 task:get_from('mime') - quoted in the middle of DN (outer spaces)
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from_quoted_dn_middle.eml
-  Check Rspamc  ${result}  ${SYMBOL3}
+  Scan File  ${TESTDIR}/messages/from/from_quoted_dn_middle.eml
+  Expect Symbol With Exact Options  ${SYMBOL}  ${OPTIONS3}
 
 task:get_from('mime') - quoted in the middle of DN (inner spaces)
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/from/from_quoted_dn_middle_inner.eml
-  Check Rspamc  ${result}  ${SYMBOL3}
+  Scan File  ${TESTDIR}/messages/from/from_quoted_dn_middle_inner.eml
+  Expect Symbol With Exact Options  ${SYMBOL}  ${OPTIONS3}

--- a/test/functional/cases/105_mimetypes.robot
+++ b/test/functional/cases/105_mimetypes.robot
@@ -12,58 +12,58 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 Zip
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/zip.eml
-  Check Rspamc  ${result}  MIME_BAD_EXTENSION \\(\\d+\\.\\d+\\)\\[exe\\]\\n  re=1
+  Scan File  ${TESTDIR}/messages/zip.eml
+  Expect Symbol With Exact Options  MIME_BAD_EXTENSION  exe
 
 Zip Double Bad Extension
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/zip-doublebad.eml
-  Check Rspamc  ${result}  MIME_DOUBLE_BAD_EXTENSION \\(\\d+\\.\\d+\\)\\[\\.pdf\\.exe\\]\\n  re=1
+  Scan File  ${TESTDIR}/messages/zip-doublebad.eml
+  Expect Symbol With Exact Options  MIME_DOUBLE_BAD_EXTENSION  .pdf.exe
 
 Next-to-last Double Bad Extension
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/next2last-doublebad.eml
-  Check Rspamc  ${result}  MIME_DOUBLE_BAD_EXTENSION \\(\\d+\\.\\d+\\)\\[\\.scr\\.xz\\]\\n  re=1
+  Scan File  ${TESTDIR}/messages/next2last-doublebad.eml
+  Expect Symbol With Exact Options  MIME_DOUBLE_BAD_EXTENSION  .scr.xz
 
 Date is followed by Bad Extension
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/rar-date-bad-ext.eml
-  Check Rspamc  ${result}  MIME_BAD_EXTENSION \\(\\d+\\.\\d+\\)\\[scr\\]\\n  re=1
-  Should Not Contain  ${result.stdout}  MIME_DOUBLE_BAD_EXTENSION
+  Scan File  ${TESTDIR}/messages/rar-date-bad-ext.eml
+  Expect Symbol With Exact Options  MIME_BAD_EXTENSION  scr
+  Do Not Expect Symbol  MIME_DOUBLE_BAD_EXTENSION
 
 Dotted file name is followed by Bad Extension
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/bad_ext.dotted_file_name.eml
-  Check Rspamc  ${result}  MIME_BAD_EXTENSION \\(\\d+\\.\\d+\\)\\[exe\\]\\n  re=1
-  Should Not Contain  ${result.stdout}  MIME_DOUBLE_BAD_EXTENSION
+  Scan File  ${TESTDIR}/messages/bad_ext.dotted_file_name.eml
+  Expect Symbol With Exact Options  MIME_BAD_EXTENSION  exe
+  Do Not Expect Symbol  MIME_DOUBLE_BAD_EXTENSION
 
 Dotted numbers in parentheses is followed by Bad Extension
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/next2last-digits_in_parens.eml
-  Check Rspamc  ${result}  MIME_BAD_EXTENSION \\(\\d+\\.\\d+\\)\\[msi\\]\\n  re=1
-  Should Not Contain  ${result.stdout}  MIME_DOUBLE_BAD_EXTENSION
+  Scan File  ${TESTDIR}/messages/next2last-digits_in_parens.eml
+  Expect Symbol With Exact Options  MIME_BAD_EXTENSION  msi
+  Do Not Expect Symbol  MIME_DOUBLE_BAD_EXTENSION
 
 Dotted numbers in square brackets is followed by Bad Extension
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/next2last-digits_in_brackets.eml
-  Check Rspamc  ${result}  MIME_BAD_EXTENSION \\(\\d+\\.\\d+\\)\\[msi\\]\\n  re=1
-  Should Not Contain  ${result.stdout}  MIME_DOUBLE_BAD_EXTENSION
+  Scan File  ${TESTDIR}/messages/next2last-digits_in_brackets.eml
+  Expect Symbol With Exact Options  MIME_BAD_EXTENSION  msi
+  Do Not Expect Symbol  MIME_DOUBLE_BAD_EXTENSION
 
 Rar4
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/rar4.eml
-  Check Rspamc  ${result}  MIME_BAD_EXTENSION \\(\\d+\\.\\d+\\)\\[exe\\]\\n  re=1
+  Scan File  ${TESTDIR}/messages/rar4.eml
+  Expect Symbol With Exact Options  MIME_BAD_EXTENSION  exe
 
 Cloaked Archive Extension
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/f.zip.gz.eml
-  Check Rspamc  ${result}  MIME_ARCHIVE_IN_ARCHIVE \\(\\d+\\.\\d+\\)\\[\\.zip\\.gz  re=1
+  Scan File  ${TESTDIR}/messages/f.zip.gz.eml
+  Expect Symbol With Exact Options  MIME_ARCHIVE_IN_ARCHIVE  .zip.gz  zip
 
 Multipart Archive Extension
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/f.zip.001.eml
-  Should Not Contain  ${result.stdout}  MIME_ARCHIVE_IN_ARCHIVE
+  Scan File  ${TESTDIR}/messages/f.zip.001.eml
+  Do Not Expect Symbol  MIME_ARCHIVE_IN_ARCHIVE
 
 Exe file, but name in filename_whitelist
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/exe_attm.eml
-  Should Not Contain  ${result.stdout}  MIME_BAD_EXTENSION
-  Should Not Contain  ${result.stdout}  MIME_BAD_ATTACHMENT
-  Should Not Contain  ${result.stdout}  MIME_DOUBLE_BAD_EXTENSION
+  Scan File  ${TESTDIR}/messages/exe_attm.eml
+  Do Not Expect Symbol  MIME_BAD_EXTENSION
+  Do Not Expect Symbol  MIME_BAD_ATTACHMENT
+  Do Not Expect Symbol  MIME_DOUBLE_BAD_EXTENSION
 
 Empty text part should not be treat as html
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/empty-plain-text.eml
-  Should Not Contain  ${result.stdout}  FORGED_OUTLOOK_HTML
+  Scan File  ${TESTDIR}/messages/empty-plain-text.eml
+  Do Not Expect Symbol  FORGED_OUTLOOK_HTML
 
 *** Keywords ***
 MIMETypes Setup

--- a/test/functional/cases/106_mid.robot
+++ b/test/functional/cases/106_mid.robot
@@ -12,28 +12,28 @@ ${URL_TLD}       ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 MID - invalid Message-ID
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/fws_fp.eml
-  Check Rspamc  ${result}  INVALID_MSGID (1.70)
-  Should Not Contain  ${result.stdout}  MISSING_MID
-  Should Not Contain  ${result.stdout}  INVALID_MSGID_ALLOWED
+  Scan File  ${TESTDIR}/messages/fws_fp.eml
+  Expect Symbol With Score  INVALID_MSGID  1.70
+  Do Not Expect Symbol  MISSING_MID
+  Do Not Expect Symbol  INVALID_MSGID_ALLOWED
 
 MID - invalid Message-ID allowed
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/invalid_mid_allowed.eml
-  Check Rspamc  ${result}  INVALID_MSGID_ALLOWED (1.00)
-  Should Not Contain  ${result.stdout}  MISSING_MID
-  Should Not Contain  ${result.stdout}  INVALID_MSGID (
+  Scan File  ${TESTDIR}/messages/invalid_mid_allowed.eml
+  Expect Symbol With Score  INVALID_MSGID_ALLOWED  1.00
+  Do Not Expect Symbol  MISSING_MID
+  Do Not Expect Symbol  INVALID_MSGID
 
 MID - missing Message-ID
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/freemail.eml
-  Check Rspamc  ${result}  MISSING_MID (2.50)
-  Should Not Contain  ${result.stdout}  MISSING_MID_ALLOWED
-  Should Not Contain  ${result.stdout}  INVALID_MSGID
+  Scan File  ${TESTDIR}/messages/freemail.eml
+  Expect Symbol With Score  MISSING_MID  2.50
+  Do Not Expect Symbol  MISSING_MID_ALLOWED
+  Do Not Expect Symbol  INVALID_MSGID
 
 MID - missing Message-ID allowed
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/onsubdomain_pass_relaxed.eml
-  Check Rspamc  ${result}  MISSING_MID_ALLOWED (1.00)
-  Should Not Contain  ${result.stdout}  MISSING_MID (
-  Should Not Contain  ${result.stdout}  INVALID_MSGID
+  Scan File  ${TESTDIR}/messages/dmarc/onsubdomain_pass_relaxed.eml
+  Expect Symbol With Score  MISSING_MID_ALLOWED  1.00
+  Do Not Expect Symbol  MISSING_MID
+  Do Not Expect Symbol  INVALID_MSGID
 
 *** Keywords ***
 MID Setup

--- a/test/functional/cases/108_settings.robot
+++ b/test/functional/cases/108_settings.robot
@@ -20,236 +20,235 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Keywords ***
 Check Everything Disabled
-  [Arguments]  ${result}
-  Check Rspamc  ${result}  Action: no action
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  BAYES_SPAM
+  Expect Action  no action
+  Do Not Expect Symbol  SIMPLE_VIRTUAL
+  Do Not Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  BAYES_SPAM
 
 *** Test Cases ***
 NO SETTINGS SPAM
-  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}
-  Check Rspamc  ${result}  SIMPLE_TEST
-  Should Contain  ${result.stdout}  SIMPLE_VIRTUAL
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Contain  ${result.stdout}  SIMPLE_PRE
-  Should Contain  ${result.stdout}  SIMPLE_POST
-  Should Contain  ${result.stdout}  BAYES_SPAM
+  Scan File  ${SPAM_MESSAGE}
+  Expect Symbol  SIMPLE_TEST
+  Expect Symbol  SIMPLE_VIRTUAL
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Expect Symbol  SIMPLE_PRE
+  Expect Symbol  SIMPLE_POST
+  Expect Symbol  BAYES_SPAM
 
 NO SETTINGS HAM
-  ${result} =  Scan Message With Rspamc  ${HAM_MESSAGE}
-  Check Rspamc  ${result}  SIMPLE_TEST
-  Should Contain  ${result.stdout}  SIMPLE_PRE
-  Should Contain  ${result.stdout}  SIMPLE_POST
-  Should Contain  ${result.stdout}  BAYES_HAM
+  Scan File  ${HAM_MESSAGE}
+  Expect Symbol  SIMPLE_TEST
+  Expect Symbol  SIMPLE_PRE
+  Expect Symbol  SIMPLE_POST
+  Expect Symbol  BAYES_HAM
 
 EMPTY SYMBOLS ENABLED - STATIC
-  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}  -i  5.5.5.5
-  Check Everything Disabled  ${result}
+  Scan File  ${SPAM_MESSAGE}  IP=5.5.5.5
+  Check Everything Disabled
 
 EMPTY GROUPS ENABLED - STATIC
-  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}  -i  5.5.5.6
-  Check Everything Disabled  ${result}
+  Scan File  ${SPAM_MESSAGE}  IP=5.5.5.6
+  Check Everything Disabled
 
 EMPTY SYMBOLS ENABLED - SETTINGS-ID
-  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}  --header  Settings-Id=empty_symbols_enabled
-  Check Everything Disabled  ${result}
+  Scan File  ${SPAM_MESSAGE}  Settings-Id=empty_symbols_enabled
+  Check Everything Disabled
 
 EMPTY GROUPS ENABLED - SETTINGS-ID
-  ${result} =  Scan Message With Rspamc  ${SPAM_MESSAGE}  --header  Settings-Id=empty_groups_enabled
-  Check Everything Disabled  ${result}
+  Scan File  ${SPAM_MESSAGE}  Settings-Id=empty_groups_enabled
+  Check Everything Disabled
 
 ENABLE SYMBOL - NORMAL
-  ${result} =  Scan Message With Rspamc  ${HAM_MESSAGE}  --header  Settings={symbols_enabled = ["SIMPLE_TEST"]}
-  Check Rspamc  ${result}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  BAYES_HAM
+  Scan File  ${HAM_MESSAGE}  Settings={symbols_enabled = ["SIMPLE_TEST"]}
+  Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  BAYES_HAM
 
 ENABLE SYMBOL - POSTFILTER
-  ${result} =  Scan Message With Rspamc  ${HAM_MESSAGE}  --header  Settings={symbols_enabled = ["SIMPLE_TEST", "SIMPLE_POST"]}
-  Check Rspamc  ${result}  SIMPLE_TEST
-  Should Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
-  Should Not Contain  ${result.stdout}  BAYES_HAM
+  Scan File  ${HAM_MESSAGE}  Settings={symbols_enabled = ["SIMPLE_TEST", "SIMPLE_POST"]}
+  Expect Symbol  SIMPLE_TEST
+  Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  BAYES_HAM
 
 ENABLE SYMBOL - PREFILTER
-  ${result} =  Scan Message With Rspamc  ${HAM_MESSAGE}  --header  Settings={symbols_enabled = ["SIMPLE_PRE"]}
-  Check Rspamc  ${result}  SIMPLE_PRE
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  BAYES_HAM
+  Scan File  ${HAM_MESSAGE}  Settings={symbols_enabled = ["SIMPLE_PRE"]}
+  Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  BAYES_HAM
 
 ENABLE SYMBOL - CLASSIFIER
-  ${result} =  Scan Message With Rspamc  ${HAM_MESSAGE}  --header  Settings={symbols_enabled = ["BAYES_HAM", "BAYES_SPAM"]}
-  Check Rspamc  ${result}  BAYES_HAM
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
+  Scan File  ${HAM_MESSAGE}  Settings={symbols_enabled = ["BAYES_HAM", "BAYES_SPAM"]}
+  Expect Symbol  BAYES_HAM
+  Do Not Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_TEST
 
 DISABLE SYMBOL - NORMAL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_disabled = ["SIMPLE_TEST"]}
-  Check Rspamc  ${result}  SIMPLE_TEST  inverse=1
-  Should Contain  ${result.stdout}  SIMPLE_PRE
-  Should Contain  ${result.stdout}  SIMPLE_POST
+  Scan File  ${MESSAGE}  Settings={symbols_disabled = ["SIMPLE_TEST"]}
+  Do Not Expect Symbol  SIMPLE_TEST
+  Expect Symbol  SIMPLE_PRE
+  Expect Symbol  SIMPLE_POST
 
 RESCORE SYMBOL - NORMAL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={SIMPLE_TEST = 3.33}
-  Check Rspamc  ${result}  SIMPLE_TEST (3.33)
+  Scan File  ${MESSAGE}  Settings={SIMPLE_TEST = 3.33}
+  Expect Symbol With Score  SIMPLE_TEST  3.33
 
 INJECT SYMBOL - NORMAL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols = ["INJECTED_SYMBOL1", "INJECTED_SYMBOL2"]}
-  Check Rspamc  ${result}  INJECTED_SYMBOL1
-  Should Contain  ${result.stdout}  INJECTED_SYMBOL2
+  Scan File  ${MESSAGE}  Settings={symbols = ["INJECTED_SYMBOL1", "INJECTED_SYMBOL2"]}
+  Expect Symbol  INJECTED_SYMBOL1
+  Expect Symbol  INJECTED_SYMBOL2
 
 RESCORE ACTION
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={actions { reject = 1234.5; } }
-  Check Rspamc  ${result}  ${SPACE}/ 1234.50
+  Scan File  ${MESSAGE}  Settings={actions { reject = 1234.5; } }
+  Expect Required Score  1234.5
 
 DISABLE GROUP - NORMAL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={groups_disabled = ["b"]}
-  Check Rspamc  ${result}  SIMPLE_TEST  inverse=1
-  Should Contain  ${result.stdout}  SIMPLE_PRE
-  Should Contain  ${result.stdout}  SIMPLE_POST
+  Scan File  ${MESSAGE}  Settings={groups_disabled = ["b"]}
+  Do Not Expect Symbol  SIMPLE_TEST
+  Expect Symbol  SIMPLE_PRE
+  Expect Symbol  SIMPLE_POST
 
 ENABLE GROUP - NORMAL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={groups_enabled = ["b"]}
-  Check Rspamc  ${result}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
+  Scan File  ${MESSAGE}  Settings={groups_enabled = ["b"]}
+  Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  SIMPLE_POST
 
 SETTINGS ID - NORMAL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_test
-  Check Rspamc  ${result}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
+  Scan File  ${MESSAGE}  Settings-Id=id_test
+  Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  SIMPLE_POST
 
 SETTINGS ID - PRE
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_pre
-  Check Rspamc  ${result}  SIMPLE_PRE
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
+  Scan File  ${MESSAGE}  Settings-Id=id_pre
+  Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_POST
 
 SETTINGS ID - VIRTUAL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_virtual
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  Settings-Id=id_virtual
+  Expect Symbol  SIMPLE_VIRTUAL
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL GROUP
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_virtual_group
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Contain  ${result.stdout}  EXPLICIT_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  Settings-Id=id_virtual_group
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Expect Symbol With Score  EXPLICIT_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL FROM
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --from  test2@example.com
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Contain  ${result.stdout}  EXPLICIT_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  From=test2@example.com
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Expect Symbol With Score  EXPLICIT_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL USER
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --user  test@example.com
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Contain  ${result.stdout}  EXPLICIT_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  User=test@example.com
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Expect Symbol With Score  EXPLICIT_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL HOSTNAME
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --hostname  example.com
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Contain  ${result.stdout}  EXPLICIT_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  Hostname=example.com
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Expect Symbol With Score  EXPLICIT_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL SELECTOR
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  user3@example.com
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Contain  ${result.stdout}  EXPLICIT_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  Rcpt=user3@example.com
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Expect Symbol With Score  EXPLICIT_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - ANGLED RECIPIENT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --rcpt  <user3@example.com>
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Contain  ${result.stdout}  EXPLICIT_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  Rcpt=<user3@example.com>
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Expect Symbol With Score  EXPLICIT_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL HEADER MATCH
-  ${result} =  Scan Message With Rspamc  ${MESSAGE_7BIT}
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Contain  ${result.stdout}  EXPLICIT_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE_7BIT}
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Expect Symbol With Score  EXPLICIT_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL HEADER EXISTS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE_CUSTOM_HDR}
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE_CUSTOM_HDR}
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL HEADER ABSENT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE_ABSENT_MIME}
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE_ABSENT_MIME}
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL REQUEST HEADER
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Test=passed
-  Check Rspamc  ${result}  SIMPLE_VIRTUAL (10
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL1
-  Should Not Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  Test=passed
+  Expect Symbol With Score  SIMPLE_VIRTUAL  10
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL1
+  Do Not Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 SETTINGS ID - VIRTUAL DEP
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_virtual1
-  Check Rspamc  ${result}  EXPLICIT_VIRTUAL1
-  Should Contain  ${result.stdout}  DEP_VIRTUAL
-  Should Contain  ${result.stdout}  DEP_REAL
-  Should Not Contain  ${result.stdout}  SIMPLE_TEST
-  Should Not Contain  ${result.stdout}  SIMPLE_VIRTUAL
-  Should Not Contain  ${result.stdout}  SIMPLE_POST
-  Should Not Contain  ${result.stdout}  SIMPLE_PRE
+  Scan File  ${MESSAGE}  Settings-Id=id_virtual1
+  Expect Symbol  EXPLICIT_VIRTUAL1
+  Expect Symbol  DEP_VIRTUAL
+  Expect Symbol  DEP_REAL
+  Do Not Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_VIRTUAL
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  SIMPLE_PRE
 
 PRIORITY
-  ${result} =  Scan Message With Rspamc  ${MESSAGE_PRIORITY}  --header  Settings-Id=id_virtual_group  --from  user@test.com
-  Should Contain  ${result.stdout}  PRIORITY_2
+  Scan File  ${MESSAGE_PRIORITY}  Settings-Id=id_virtual_group  From=user@test.com
+  Expect Symbol  PRIORITY_2
 
 
 *** Keywords ***

--- a/test/functional/cases/109_composites.robot
+++ b/test/functional/cases/109_composites.robot
@@ -13,73 +13,75 @@ ${RSPAMD_SCOPE}  Suite
 
 *** Test Cases ***
 Composites - Score
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  ${SPACE}50.00 / 0.00
+  Scan File  ${MESSAGE}
+  Expect Score  50
+  Expect Required Score To Be Null
 
 Composites - Expressions
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  EXPRESSIONS (5.00)
-  Should Contain  ${result.stdout}  EXPRESSIONS_B (0.00)
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  EXPRESSIONS  5
+  Expect Symbol With Score  EXPRESSIONS_B  0
 
 Composites - Policy: remove_weight
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  ${SPACE}POLICY_REMOVE_WEIGHT (5.00)
-  Should Not Contain  ${result.stdout}  ${SPACE}POLICY_REMOVE_WEIGHT_A (1.00)
-  Should Contain  ${result.stdout}  ${SPACE}POLICY_REMOVE_WEIGHT_B (0.00)
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  POLICY_REMOVE_WEIGHT  5
+  Expect Symbol With Score  POLICY_REMOVE_WEIGHT_B  0
+  Do Not Expect Symbol  POLICY_REMOVE_WEIGHT_A
 
 Composites - Policy: force removing
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  ${SPACE}POLICY_FORCE_REMOVE (5.00)
-  Should Contain  ${result.stdout}  ${SPACE}POLICY_FORCE_REMOVE_A (1.00)
-  Should Not Contain  ${result.stdout}  ${SPACE}POLICY_FORCE_REMOVE_B
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  POLICY_FORCE_REMOVE  5.00
+  Expect Symbol With Score  POLICY_FORCE_REMOVE_A  1.00
+  Do Not Expect Symbol  POLICY_FORCE_REMOVE_B
 
 Composites - Policy: leave
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  ${SPACE}POLICY_LEAVE (5.00)
-  Should Not Contain  ${result.stdout}  ${SPACE}POLICY_LEAVE_A
-  Should Contain  ${result.stdout}  ${SPACE}POLICY_LEAVE_B (1.00)
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  POLICY_LEAVE  5.00
+  Do Not Expect Symbol  POLICY_LEAVE_A
+  Expect Symbol With Score  POLICY_LEAVE_B  1.00
 
 Composites - Default policy: remove_weight
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  DEFAULT_POLICY_REMOVE_WEIGHT (5.00)
-  Should Contain  ${result.stdout}  DEFAULT_POLICY_REMOVE_WEIGHT_A (0.00)
-  Should Contain  ${result.stdout}  DEFAULT_POLICY_REMOVE_WEIGHT_B (0.00)
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  DEFAULT_POLICY_REMOVE_WEIGHT  5.00
+  Expect Symbol With Score  DEFAULT_POLICY_REMOVE_WEIGHT_A  0.00
+  Expect Symbol With Score  DEFAULT_POLICY_REMOVE_WEIGHT_B  0.00
 
 Composites - Default policy: remove_symbol
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  DEFAULT_POLICY_REMOVE_SYMBOL (5.00)
-  Should Not Contain  ${result.stdout}  DEFAULT_POLICY_REMOVE_SYMBOL_
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  DEFAULT_POLICY_REMOVE_SYMBOL  5.00
+  Do Not Expect Symbol  DEFAULT_POLICY_REMOVE_SYMBOL_A
+  Do Not Expect Symbol  DEFAULT_POLICY_REMOVE_SYMBOL_B
 
 Composites - Default policy: leave
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  DEFAULT_POLICY_LEAVE (5.00)
-  Should Contain  ${result.stdout}  DEFAULT_POLICY_LEAVE_A (1.00)
-  Should Contain  ${result.stdout}  DEFAULT_POLICY_LEAVE_B (1.00)
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  DEFAULT_POLICY_LEAVE  5.00
+  Expect Symbol With Score  DEFAULT_POLICY_LEAVE_A  1.00
+  Expect Symbol With Score  DEFAULT_POLICY_LEAVE_B  1.00
 
 Composites - Symbol groups
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  SYMBOL_GROUPS (5.00)
-  Should Contain  ${result.stdout}  POSITIVE_A (-1.00)
-  Should Contain  ${result.stdout}  ANY_A (-1.00)
-  Should Contain  ${result.stdout}  NEGATIVE_B (1.00)
-  Should Not Contain  ${result.stdout}  NEGATIVE_A
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  SYMBOL_GROUPS  5.00
+  Expect Symbol With Score  POSITIVE_A  -1.00
+  Expect Symbol With Score  ANY_A  -1.00
+  Expect Symbol With Score  NEGATIVE_B  1.00
+  Do Not Expect Symbol  NEGATIVE_A
 
 Composites - Opts Plain
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header=opts:sym1
-  Check Rspamc  ${result}  SYMOPTS1 (5.00)
-  Should Not Contain  ${result.stdout}  SYMOPTS2
+  Scan File  ${MESSAGE}  opts=sym1
+  Expect Symbol With Score  SYMOPTS1  5.00
+  Do Not Expect Symbol  SYMOPTS2
 
 Composites - Opts RE Miss one
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header=opts:sym1,foo1
-  Check Rspamc  ${result}  SYMOPTS1 (5.00)
-  Should Not Contain  ${result.stdout}  SYMOPTS2
+  Scan File  ${MESSAGE}  opts=sym1,foo1
+  Expect Symbol With Score  SYMOPTS1  5.00
+  Do Not Expect Symbol  SYMOPTS2
 
 Composites - Opts RE Miss both
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header=opts:sym2
-  Should Not Contain  ${result.stdout}  SYMOPTS1
-  Should Not Contain  ${result.stdout}  SYMOPTS2
+  Scan File  ${MESSAGE}  opts=sym2
+  Do Not Expect Symbol  SYMOPTS1
+  Do Not Expect Symbol  SYMOPTS2
 
 Composites - Opts RE Hit
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header=opts:sym2,foo1
-  Check Rspamc  ${result}  SYMOPTS2 (6.00)
-  Should Not Contain  ${result.stdout}  SYMOPTS1
+  Scan File  ${MESSAGE}  opts=sym2,foo1
+  Expect Symbol With Score  SYMOPTS2  6.00
+  Do Not Expect Symbol  SYMOPTS1

--- a/test/functional/cases/110_statistics/lib.robot
+++ b/test/functional/cases/110_statistics/lib.robot
@@ -22,28 +22,28 @@ Empty Part Test
   Set Test Variable  ${MESSAGE}  ${TESTDIR}/messages/empty_part.eml
   ${result} =  Run Rspamc  -h  ${LOCAL_ADDR}:${PORT_CONTROLLER}  learn_spam  ${MESSAGE}
   Check Rspamc  ${result}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  BAYES_SPAM
+  Scan File  ${MESSAGE}
+  Expect Symbol  BAYES_SPAM
 
 Learn Test
   Set Suite Variable  ${RSPAMD_STATS_LEARNTEST}  0
   ${result} =  Run Rspamc  -h  ${LOCAL_ADDR}:${PORT_CONTROLLER}  learn_spam  ${MESSAGE_SPAM}
   ${result} =  Run Rspamc  -h  ${LOCAL_ADDR}:${PORT_CONTROLLER}  learn_ham  ${MESSAGE_HAM}
   Check Rspamc  ${result}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE_SPAM}
-  Check Rspamc  ${result}  BAYES_SPAM
-  ${result} =  Scan Message With Rspamc  ${MESSAGE_HAM}
-  Check Rspamc  ${result}  BAYES_HAM
+  Scan File  ${MESSAGE_SPAM}
+  Expect Symbol  BAYES_SPAM
+  Scan File  ${MESSAGE_HAM}
+  Expect Symbol  BAYES_HAM
   Set Suite Variable  ${RSPAMD_STATS_LEARNTEST}  1
 
 Relearn Test
   Run Keyword If  ${RSPAMD_STATS_LEARNTEST} == 0  Fail  "Learn test was not run"
   ${result} =  Run Rspamc  -h  ${LOCAL_ADDR}:${PORT_CONTROLLER}  learn_ham  ${MESSAGE_SPAM}
   Check Rspamc  ${result}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE_SPAM}
-  ${pass} =  Run Keyword And Return Status  Check Rspamc  ${result}  BAYES_HAM
+  Scan File  ${MESSAGE_SPAM}
+  ${pass} =  Run Keyword And Return Status  Expect Symbol  BAYES_HAM
   Run Keyword If  ${pass}  Pass Execution  What Me Worry
-  Should Not Contain  ${result.stdout}  BAYES_SPAM
+  Do Not Expect Symbol  BAYES_SPAM
 
 Redis Statistics Setup
   ${tmpdir} =  Make Temporary Directory

--- a/test/functional/cases/114_phishing.robot
+++ b/test/functional/cases/114_phishing.robot
@@ -15,16 +15,16 @@ ${URL_TLD}       ${TESTDIR}/../../contrib/publicsuffix/effective_tld_names.dat
 
 *** Test Cases ***
 TEST PHISHING
-  ${result} =  Scan Message With Rspamc  ${MESSAGE1}
-  Check Rspamc  ${result}  ${SPACE}PHISHING
+  Scan File  ${MESSAGE1}
+  Expect Symbol  PHISHING
 
 TEST PHISHING STRICT ONE
-  ${result} =  Scan Message With Rspamc  ${MESSAGE2}
-  Check Rspamc  ${result}  STRICT_PHISHING
+  Scan File  ${MESSAGE2}
+  Expect Symbol  STRICT_PHISHING
 
 TEST PHISHING STRICT TWO
-  ${result} =  Scan Message With Rspamc  ${MESSAGE3}
-  Check Rspamc  ${result}  STRICTER_PHISHING
+  Scan File  ${MESSAGE3}
+  Expect Symbol  STRICTER_PHISHING
 
 *** Keywords ***
 Phishing Setup

--- a/test/functional/cases/115_dmarc.robot
+++ b/test/functional/cases/115_dmarc.robot
@@ -12,80 +12,80 @@ ${URL_TLD}       ${TESTDIR}/../../contrib/publicsuffix/effective_tld_names.dat
 
 *** Test Cases ***
 DMARC NONE PASS DKIM
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/pass_none.eml
-  Check Rspamc  ${result}  DMARC_POLICY_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/pass_none.eml
+  Expect Symbol  DMARC_POLICY_ALLOW
 
 DMARC NONE PASS SPF
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/fail_none.eml
-  ...  -i  8.8.4.4  --from  foo@spf.cacophony.za.org
-  Check Rspamc  ${result}  DMARC_POLICY_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/fail_none.eml
+  ...  IP=8.8.4.4  From=foo@spf.cacophony.za.org
+  Expect Symbol  DMARC_POLICY_ALLOW
 
 DMARC NONE FAIL
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/fail_none.eml
-  Check Rspamc  ${result}  DMARC_POLICY_SOFTFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/fail_none.eml
+  Expect Symbol  DMARC_POLICY_SOFTFAIL
 
 DMARC REJECT FAIL
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/fail_reject.eml
-  Check Rspamc  ${result}  DMARC_POLICY_REJECT
+  Scan File  ${TESTDIR}/messages/dmarc/fail_reject.eml
+  Expect Symbol  DMARC_POLICY_REJECT
 
 DMARC QUARANTINE FAIL
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/fail_quarantine.eml
-  Check Rspamc  ${result}  DMARC_POLICY_QUARANTINE
+  Scan File  ${TESTDIR}/messages/dmarc/fail_quarantine.eml
+  Expect Symbol  DMARC_POLICY_QUARANTINE
 
 DMARC SP NONE FAIL
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/subdomain_fail_none.eml
-  Check Rspamc  ${result}  DMARC_POLICY_SOFTFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/subdomain_fail_none.eml
+  Expect Symbol  DMARC_POLICY_SOFTFAIL
 
 DMARC SP REJECT FAIL
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/subdomain_fail_reject.eml
-  Check Rspamc  ${result}  DMARC_POLICY_REJECT
+  Scan File  ${TESTDIR}/messages/dmarc/subdomain_fail_reject.eml
+  Expect Symbol  DMARC_POLICY_REJECT
 
 DMARC SP QUARANTINE FAIL
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/subdomain_fail_quarantine.eml
-  Check Rspamc  ${result}  DMARC_POLICY_QUARANTINE
+  Scan File  ${TESTDIR}/messages/dmarc/subdomain_fail_quarantine.eml
+  Expect Symbol  DMARC_POLICY_QUARANTINE
 
 DMARC SUBDOMAIN FAIL DKIM STRICT ALIGNMENT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/onsubdomain_fail_alignment.eml
-  Check Rspamc  ${result}  DMARC_POLICY_REJECT
+  Scan File  ${TESTDIR}/messages/dmarc/onsubdomain_fail_alignment.eml
+  Expect Symbol  DMARC_POLICY_REJECT
 
 DMARC SUBDOMAIN PASS DKIM RELAXED ALIGNMENT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/onsubdomain_pass_relaxed.eml
-  Check Rspamc  ${result}  DMARC_POLICY_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/onsubdomain_pass_relaxed.eml
+  Expect Symbol  DMARC_POLICY_ALLOW
 
 DMARC SUBDOMAIN PASS SPF STRICT ALIGNMENT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/onsubdomain_fail_alignment.eml
-  ...  -i  37.48.67.26  --from  foo@yo.mom.za.org
-  Check Rspamc  ${result}  DMARC_POLICY_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/onsubdomain_fail_alignment.eml
+  ...  IP=37.48.67.26  From=foo@yo.mom.za.org
+  Expect Symbol  DMARC_POLICY_ALLOW
 
 DMARC SUBDOMAIN FAIL SPF STRICT ALIGNMENT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/onsubdomain_fail_alignment.eml
-  ...  -i  37.48.67.26  --from  foo@mom.za.org
-  Check Rspamc  ${result}  DMARC_POLICY_REJECT
+  Scan File  ${TESTDIR}/messages/dmarc/onsubdomain_fail_alignment.eml
+  ...  IP=37.48.67.26  From=foo@mom.za.org
+  Expect Symbol  DMARC_POLICY_REJECT
 
 DMARC SUBDOMAIN PASS SPF RELAXED ALIGNMENT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/onsubdomain_fail.eml
-  ...  -i  37.48.67.26  --from  foo@mom.za.org
-  Check Rspamc  ${result}  DMARC_POLICY_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/onsubdomain_fail.eml
+  ...  IP=37.48.67.26  From=foo@mom.za.org
+  Expect Symbol  DMARC_POLICY_ALLOW
 
 DMARC DNSFAIL
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/dmarc_tmpfail.eml
-  ...  -i  37.48.67.26  --from  foo@mom.za.org
-  Check Rspamc  ${result}  DMARC_DNSFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/dmarc_tmpfail.eml
+  ...  IP=37.48.67.26  From=foo@mom.za.org
+  Expect Symbol  DMARC_DNSFAIL
 
 DMARC NA NXDOMAIN
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/utf.eml
-  ...  -i  37.48.67.26  --from  foo@mom.za.org
-  Check Rspamc  ${result}  DMARC_NA
+  Scan File  ${TESTDIR}/messages/utf.eml
+  ...  IP=37.48.67.26  From=foo@mom.za.org
+  Expect Symbol  DMARC_NA
 
 DMARC PCT ZERO REJECT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/pct_none.eml
-  ...  -i  37.48.67.26  --from  foo@mom.za.org
-  Check Rspamc  ${result}  DMARC_POLICY_QUARANTINE
+  Scan File  ${TESTDIR}/messages/dmarc/pct_none.eml
+  ...  IP=37.48.67.26  From=foo@mom.za.org
+  Expect Symbol  DMARC_POLICY_QUARANTINE
 
 DMARC PCT ZERO SP QUARANTINE
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/pct_none1.eml
-  ...  -i  37.48.67.26  --from  foo@mom.za.org
-  Check Rspamc  ${result}  DMARC_POLICY_SOFTFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/pct_none1.eml
+  ...  IP=37.48.67.26  From=foo@mom.za.org
+  Expect Symbol  DMARC_POLICY_SOFTFAIL
 
 *** Keywords ***
 DMARC Setup

--- a/test/functional/cases/116_dkim.robot
+++ b/test/functional/cases/116_dkim.robot
@@ -12,24 +12,24 @@ ${URL_TLD}       ${TESTDIR}/../../contrib/publicsuffix/effective_tld_names.dat
 
 *** Test Cases ***
 DKIM PERMFAIL NXDOMAIN
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim2.eml
-  ...  -i  37.48.67.26
-  Check Rspamc  ${result}  R_DKIM_PERMFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim2.eml
+  ...  IP=37.48.67.26
+  Expect Symbol  R_DKIM_PERMFAIL
 
 DKIM PERMFAIL BAD RECORD
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  37.48.67.26
-  Check Rspamc  ${result}  R_DKIM_PERMFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=37.48.67.26
+  Expect Symbol  R_DKIM_PERMFAIL
 
 DKIM TEMPFAIL SERVFAIL UNALIGNED
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim3.eml
-  ...  -i  37.48.67.26
-  Check Rspamc  ${result}  R_DKIM_TEMPFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim3.eml
+  ...  IP=37.48.67.26
+  Expect Symbol  R_DKIM_TEMPFAIL
 
 DKIM NA NOSIG
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/utf.eml
-  ...  -i  37.48.67.26
-  Check Rspamc  ${result}  R_DKIM_NA
+  Scan File  ${TESTDIR}/messages/utf.eml
+  ...  IP=37.48.67.26
+  Expect Symbol  R_DKIM_NA
 
 DKIM Sign
   Set Suite Variable  ${RAN_SIGNTEST}  0
@@ -41,16 +41,16 @@ DKIM Sign
 
 DKIM Self Verify
   Run Keyword If  ${RAN_SIGNTEST} == 0  Fail  "Sign test was not run"
-  ${result} =  Scan Message With Rspamc  ${SIGNED_MESSAGE}
-  Check Rspamc  ${result}  R_DKIM_ALLOW
+  Scan File  ${SIGNED_MESSAGE}
+  Expect Symbol  R_DKIM_ALLOW
 
 DKIM Verify ED25519 PASS
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/ed25519.eml
-  Check Rspamc  ${result}  R_DKIM_ALLOW
+  Scan File  ${TESTDIR}/messages/ed25519.eml
+  Expect Symbol  R_DKIM_ALLOW
 
 DKIM Verify ED25519 REJECT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/ed25519-broken.eml
-  Check Rspamc  ${result}  R_DKIM_REJECT
+  Scan File  ${TESTDIR}/messages/ed25519-broken.eml
+  Expect Symbol  R_DKIM_REJECT
 
 *** Keywords ***
 DKIM Setup

--- a/test/functional/cases/117_spf.robot
+++ b/test/functional/cases/117_spf.robot
@@ -12,129 +12,129 @@ ${URL_TLD}       ${TESTDIR}/../../contrib/publicsuffix/effective_tld_names.dat
 
 *** Test Cases ***
 SPF FAIL UNRESOLVEABLE INCLUDE
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  37.48.67.26  -F  x@fail3.org.org.za
-  Check Rspamc  ${result}  R_SPF_FAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=37.48.67.26  From=x@fail3.org.org.za
+  Expect Symbol  R_SPF_FAIL
 
 SPF DNSFAIL FAILED INCLUDE UNALIGNED
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@fail2.org.org.za
-  Check Rspamc  ${result}  R_SPF_DNSFAIL
-  Should Contain  ${result.stdout}  DMARC_POLICY_SOFTFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@fail2.org.org.za
+  Expect Symbol  R_SPF_DNSFAIL
+  Expect Symbol  DMARC_POLICY_SOFTFAIL
 
 SPF ALLOW UNRESOLVEABLE INCLUDE
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@fail3.org.org.za
-  Check Rspamc  ${result}  R_SPF_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@fail3.org.org.za
+  Expect Symbol  R_SPF_ALLOW
 
 SPF ALLOW FAILED INCLUDE
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.4.4  -F  x@fail2.org.org.za
-  Check Rspamc  ${result}  R_SPF_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.4.4  From=x@fail2.org.org.za
+  Expect Symbol  R_SPF_ALLOW
 
 SPF NA NA
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@za
-  Check Rspamc  ${result}  R_SPF_NA
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@za
+  Expect Symbol  R_SPF_NA
 
 SPF NA NOREC
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@co.za
-  Check Rspamc  ${result}  R_SPF_NA
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@co.za
+  Expect Symbol  R_SPF_NA
 
 SPF NA NXDOMAIN
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@zzzzaaaa
-  Check Rspamc  ${result}  R_SPF_NA
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@zzzzaaaa
+  Expect Symbol  R_SPF_NA
 
 SPF PERMFAIL UNRESOLVEABLE REDIRECT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@fail4.org.org.za
-  Check Rspamc  ${result}  R_SPF_PERMFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@fail4.org.org.za
+  Expect Symbol  R_SPF_PERMFAIL
 
 SPF REDIRECT NO USEABLE ELEMENTS
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@fail10.org.org.za
-  Check Rspamc  ${result}  R_SPF_PERMFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@fail10.org.org.za
+  Expect Symbol  R_SPF_PERMFAIL
 
 SPF DNSFAIL FAILED REDIRECT
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@fail1.org.org.za
-  Check Rspamc  ${result}  R_SPF_DNSFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@fail1.org.org.za
+  Expect Symbol  R_SPF_DNSFAIL
 
 SPF PERMFAIL NO USEABLE ELEMENTS
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@fail5.org.org.za
-  Check Rspamc  ${result}  R_SPF_PERMFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@fail5.org.org.za
+  Expect Symbol  R_SPF_PERMFAIL
 
 SPF FAIL
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@example.net
-  Check Rspamc  ${result}  R_SPF_FAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@example.net
+  Expect Symbol  R_SPF_FAIL
 
 SPF FAIL UNRESOLVEABLE MX
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  1.2.3.4  -F  x@fail6.org.org.za
-  Check Rspamc  ${result}  R_SPF_FAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=1.2.3.4  From=x@fail6.org.org.za
+  Expect Symbol  R_SPF_FAIL
 
 SPF FAIL UNRESOLVEABLE A
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  1.2.3.4  -F  x@fail7.org.org.za
-  Check Rspamc  ${result}  R_SPF_FAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=1.2.3.4  From=x@fail7.org.org.za
+  Expect Symbol  R_SPF_FAIL
 
 SPF DNSFAIL FAILED A
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  1.2.3.4  -F  x@fail8.org.org.za
-  Check Rspamc  ${result}  R_SPF_DNSFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=1.2.3.4  From=x@fail8.org.org.za
+  Expect Symbol  R_SPF_DNSFAIL
 
 SPF DNSFAIL FAILED MX
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  1.2.3.4  -F  x@fail9.org.org.za
-  Check Rspamc  ${result}  R_SPF_DNSFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=1.2.3.4  From=x@fail9.org.org.za
+  Expect Symbol  R_SPF_DNSFAIL
 
 SPF DNSFAIL FAILED RECORD
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  1.2.3.4  -F  x@www.dnssec-failed.org
-  Check Rspamc  ${result}  R_SPF_DNSFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=1.2.3.4  From=x@www.dnssec-failed.org
+  Expect Symbol  R_SPF_DNSFAIL
 
 SPF PASS INCLUDE
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@pass1.org.org.za
-  Check Rspamc  ${result}  R_SPF_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@pass1.org.org.za
+  Expect Symbol  R_SPF_ALLOW
 
 SPF PTRS
-  ${result} =  Scan Message With Rspamc  /dev/null
-  ...  -i  88.99.142.95  -F  foo@crazyspf.cacophony.za.org
-  Check Rspamc  ${result}  R_SPF_ALLOW
-  ${result} =  Scan Message With Rspamc  /dev/null
-  ...  -i  128.66.0.1  -F  foo@crazyspf.cacophony.za.org
-  Check Rspamc  ${result}  R_SPF_FAIL
-  ${result} =  Scan Message With Rspamc  /dev/null
-  ...  -i  209.85.216.182  -F  foo@crazyspf.cacophony.za.org
-  Check Rspamc  ${result}  R_SPF_FAIL
-  #${result} =  Scan Message With Rspamc  /dev/null
-  #...  -i  98.138.91.166  -F  foo@crazyspf.cacophony.za.org
-  #Check Rspamc  ${result}  R_SPF_ALLOW
-  #${result} =  Scan Message With Rspamc  /dev/null
-  #...  -i  98.138.91.167  -F  foo@crazyspf.cacophony.za.org
-  #Check Rspamc  ${result}  R_SPF_ALLOW
-  #${result} =  Scan Message With Rspamc  /dev/null
-  #...  -i  98.138.91.168  -F  foo@crazyspf.cacophony.za.org
-  #Check Rspamc  ${result}  R_SPF_ALLOW
+  Scan File  /dev/null
+  ...  IP=88.99.142.95  From=foo@crazyspf.cacophony.za.org
+  Expect Symbol  R_SPF_ALLOW
+  Scan File  /dev/null
+  ...  IP=128.66.0.1  From=foo@crazyspf.cacophony.za.org
+  Expect Symbol  R_SPF_FAIL
+  Scan File  /dev/null
+  ...  IP=209.85.216.182  From=foo@crazyspf.cacophony.za.org
+  Expect Symbol  R_SPF_FAIL
+  #Scan File  /dev/null
+  #...  IP=98.138.91.166  From=foo@crazyspf.cacophony.za.org
+  #Expect Symbol  R_SPF_ALLOW
+  #Scan File  /dev/null
+  #...  IP=98.138.91.167  From=foo@crazyspf.cacophony.za.org
+  #Expect Symbol  R_SPF_ALLOW
+  #Scan File  /dev/null
+  #...  IP=98.138.91.168  From=foo@crazyspf.cacophony.za.org
+  #Expect Symbol  R_SPF_ALLOW
 
 SPF PERMFAIL REDIRECT WITHOUT SPF
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim4.eml
-  ...  -i  192.0.2.1  -F  a@fail1.org.org.za
-  Check Rspamc  ${result}  R_SPF_DNSFAIL
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim4.eml
+  ...  IP=192.0.2.1  From=a@fail1.org.org.za
+  Expect Symbol  R_SPF_DNSFAIL
 
 SPF EXTERNAL RELAY
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/external_relay.eml
-  Should contain  ${result.stdout}  R_SPF_ALLOW (1.00)[+ip4:37.48.67.26]
+  Scan File  ${TESTDIR}/messages/external_relay.eml
+  Expect Symbol With Score And Exact Options  R_SPF_ALLOW  1.0  +ip4:37.48.67.26
 
 SPF UPPERCASE
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
-  ...  -i  8.8.8.8  -F  x@fail11.org.org.za
-  Check Rspamc  ${result}  R_SPF_ALLOW
+  Scan File  ${TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@fail11.org.org.za
+  Expect Symbol  R_SPF_ALLOW
 
 *** Keywords ***
 SPF Setup

--- a/test/functional/cases/120_fuzzy/lib.robot
+++ b/test/functional/cases/120_fuzzy/lib.robot
@@ -27,13 +27,13 @@ Fuzzy Skip Add Test Base
   ...  ${FLAG1_NUMBER}  fuzzy_add  ${message}
   Check Rspamc  ${result}
   Sync Fuzzy Storage
-  ${result} =  Scan Message With Rspamc  ${message}
+  Scan File  ${message}
   Create File  ${TMPDIR}/test.map
-  Should Contain  ${result.stdout}  R_TEST_FUZZY_DENIED
+  Expect Symbol  R_TEST_FUZZY_DENIED
   Append To File  ${TMPDIR}/skip_hash.map.tmp  670cfcba72a87bab689958a8af5c22593dc17c907836c7c26a74d1bb49add25adfa45a5f172e3af82c9c638e8eb5fc860c22c7e966e61a459165ef0b9e1acc89
   Hard Link  ${TMPDIR}/skip_hash.map.tmp  ${TMPDIR}/skip_hash.map
-  ${result} =  Scan Message With Rspamc  ${message}
-  Check Rspamc  ${result}  R_TEST_FUZZY_DENIED  inverse=1
+  Scan File  ${message}
+  Do Not Expect Symbol  R_TEST_FUZZY_DENIED
 
 Fuzzy Add Test
   [Arguments]  ${message}
@@ -42,8 +42,8 @@ Fuzzy Add Test
   ...  ${FLAG1_NUMBER}  fuzzy_add  ${message}
   Check Rspamc  ${result}
   Sync Fuzzy Storage
-  ${result} =  Scan Message With Rspamc  ${message}
-  Check Rspamc  ${result}  ${FLAG1_SYMBOL}
+  Scan File  ${message}
+  Expect Symbol  ${FLAG1_SYMBOL}
   Set Suite Variable  ${RSPAMD_FUZZY_ADD_${message}}  1
 
 Fuzzy Delete Test
@@ -53,9 +53,8 @@ Fuzzy Delete Test
   ...  ${message}
   Check Rspamc  ${result}
   Sync Fuzzy Storage
-  ${result} =  Scan Message With Rspamc  ${message}
-  Should Not Contain  ${result.stdout}  ${FLAG1_SYMBOL}
-  Should Be Equal As Integers  ${result.rc}  0
+  Scan File  ${message}
+  Do Not Expect Symbol  ${FLAG1_SYMBOL}
 
 Fuzzy Fuzzy Test
   [Arguments]  ${message}
@@ -63,14 +62,14 @@ Fuzzy Fuzzy Test
   @{path_info} =  Path Splitter  ${message}
   @{fuzzy_files} =  List Files In Directory  ${pathinfo}[0]  pattern=${pathinfo}[1].fuzzy*  absolute=1
   FOR  ${i}  IN  @{fuzzy_files}
-    ${result} =  Scan Message With Rspamc  ${i}
-    Check Rspamc  ${result}  ${FLAG1_SYMBOL}
+    Scan File  ${i}
+    Expect Symbol  ${FLAG1_SYMBOL}
   END
 
 Fuzzy Miss Test
   [Arguments]  ${message}
-  ${result} =  Scan Message With Rspamc  ${message}
-  Check Rspamc  ${result}  ${FLAG1_SYMBOL}  inverse=1
+  Scan File  ${message}
+  Do Not Expect Symbol  ${FLAG1_SYMBOL}
 
 Fuzzy Overwrite Test
   [Arguments]  ${message}
@@ -81,10 +80,9 @@ Fuzzy Overwrite Test
     Check Rspamc  ${result}
   END
   Sync Fuzzy Storage
-  ${result} =  Scan Message With Rspamc  ${message}
-  Should Not Contain  ${result.stdout}  ${FLAG1_SYMBOL}
-  Should Contain  ${result.stdout}  ${FLAG2_SYMBOL}
-  Should Be Equal As Integers  ${result.rc}  0
+  Scan File  ${message}
+  Do Not Expect Symbol  ${FLAG1_SYMBOL}
+  Expect Symbol  ${FLAG2_SYMBOL}
 
 Fuzzy Setup Encrypted
   [Arguments]  ${algorithm}

--- a/test/functional/cases/123_whitelist.robot
+++ b/test/functional/cases/123_whitelist.robot
@@ -20,68 +20,62 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 WHITELISTS
-  ${result} =  Scan Message With Rspamc  ${M_DMARC_OK}  -i  8.8.4.4  -F  foo@spf.cacophony.za.org
-  Check Rspamc  ${result}  WHITELIST_DKIM (-
-  Should Contain  ${result.stdout}  STRICT_DMARC (-
-  Should Contain  ${result.stdout}  WHITELIST_SPF_DKIM (-
-  Should Contain  ${result.stdout}  WHITELIST_DDS (-
-  Should Contain  ${result.stdout}  WHITELIST_DMARC (-
-  Should Contain  ${result.stdout}  WHITELIST_DMARC_DKIM (-
-  Should Contain  ${result.stdout}  WHITELIST_SPF (-
-  Should Not Contain  ${result.stdout}  BLACKLIST_SPF (
-  Should Not Contain  ${result.stdout}  BLACKLIST_DKIM (
-  Should Not Contain  ${result.stdout}  BLACKLIST_DMARC (
+  Scan File  ${M_DMARC_OK}  IP=8.8.4.4  From=foo@spf.cacophony.za.org
+  Expect Symbol With Score  WHITELIST_DKIM  -1
+  Expect Symbol With Score  STRICT_DMARC  -3
+  Expect Symbol With Score  WHITELIST_SPF_DKIM  -3
+  Expect Symbol With Score  WHITELIST_DDS  -3
+  Expect Symbol With Score  WHITELIST_DMARC  -2
+  Expect Symbol With Score  WHITELIST_DMARC_DKIM  -2
+  Expect Symbol With Score  WHITELIST_SPF  -1
+  Do Not Expect Symbol  BLACKLIST_SPF
+  Do Not Expect Symbol  BLACKLIST_DKIM
+  Do Not Expect Symbol  BLACKLIST_DMARC
 
 BLACKLIST SHOULD FIRE IF ANY CONSTRAINT FAILED
-  ${result} =  Scan Message With Rspamc  ${M_DMARC_OK}  -i  9.8.4.4  -F  foo@spf.cacophony.za.org
-  Check Rspamc  ${result}  BLACKLIST_DDS (3
-  Should Not Contain  ${result.stdout}  WHITELIST_DDS (
-  Should Not Contain  ${result.stdout}  WHITELIST_SPF (
+  Scan File  ${M_DMARC_OK}  IP=9.8.4.4  From=foo@spf.cacophony.za.org
+  Expect Symbol With Score  BLACKLIST_DDS  3
+  Do Not Expect Symbol  WHITELIST_DDS
+  Do Not Expect Symbol  WHITELIST_SPF
 
 BLACKLISTS
-  ${result} =  Scan Message With Rspamc  ${M_DMARC_BAD}  -i  9.8.4.4  -F  foo@cacophony.za.org
-  Check Rspamc  ${result}  BLACKLIST_SPF (3
-  Should Contain  ${result.stdout}  BLACKLIST_SPF (3
-  Should Contain  ${result.stdout}  STRICT_DMARC (3
-  Should Contain  ${result.stdout}  BLACKLIST_DDS (3
-  Should Contain  ${result.stdout}  BLACKLIST_DMARC (2
-  Should Not Contain  ${result.stdout}  WHITELIST_DDS (
-  Should Not Contain  ${result.stdout}  WHITELIST_SPF (
-  Should Not Contain  ${result.stdout}  WHITELIST_DKIM (
-  Should Not Contain  ${result.stdout}  WHITELIST_DMARC (
-  Should Not Contain  ${result.stdout}  WHITELIST_DMARC_DKIM (
+  Scan File  ${M_DMARC_BAD}  IP=9.8.4.4  From=foo@cacophony.za.org
+  Expect Symbol With Score  BLACKLIST_SPF  3
+  Expect Symbol With Score  BLACKLIST_SPF  3
+  Expect Symbol With Score  STRICT_DMARC  3
+  Expect Symbol With Score  BLACKLIST_DDS  3
+  Expect Symbol With Score  BLACKLIST_DMARC  2
+  Do Not Expect Symbol  WHITELIST_DDS
+  Do Not Expect Symbol  WHITELIST_SPF
+  Do Not Expect Symbol  WHITELIST_DKIM
+  Do Not Expect Symbol  WHITELIST_DMARC
+  Do Not Expect Symbol  WHITELIST_DMARC_DKIM
 
-WHITELIST_WL_ONLY
-  ${result} =  Scan Message With Rspamc  ${M_DKIM_RSPAMD_OK}
-  Check Rspamc  ${result}  WHITELIST_DKIM (-2
-  Should Not Contain  ${result.stdout}  BLACKLIST_DKIM (
+WHITELIST_WL_ONLY - VALID SPF AND VALID DKIM
+  Scan File  ${M_DKIM_RSPAMD_OK}
+  Expect Symbol With Score  WHITELIST_DKIM  -2
+  Do Not Expect Symbol  BLACKLIST_DKIM
+  Expect Symbol With Score  R_SPF_ALLOW  1
+  Expect Symbol With Score  R_DKIM_ALLOW  1
+  Expect Symbol With Score  WHITELIST_SPF_DKIM  -6
 
-BLACKLISTS_WL_ONLY
-  ${result} =  Scan Message With Rspamc  ${M_DKIM_RSPAMD_BAD}
-  Check Rspamc  ${result}  DKIM_REJECT (
-  Should Not Contain  ${result.stdout}  WHITELIST_DKIM (
-  Should Not Contain  ${result.stdout}  BLACKLIST_DKIM (
-
-VALID SPF and VALID DKIM
-  ${result} =  Scan Message With Rspamc  ${M_DKIM_RSPAMD_OK}
-  Should Contain  ${result.stdout}  R_SPF_ALLOW (
-  Should Contain  ${result.stdout}  R_DKIM_ALLOW (
-  Should Contain  ${result.stdout}  WHITELIST_SPF_DKIM (
-
-VALID SPF and NOT VALID DKIM
-  ${result} =  Scan Message With Rspamc  ${M_DKIM_RSPAMD_BAD}
-  Should Contain  ${result.stdout}  R_SPF_ALLOW (
-  Should Contain  ${result.stdout}  R_DKIM_REJECT (
-  Should Not Contain  ${result.stdout}  WHITELIST_SPF_DKIM (
-  Should Not Contain  ${result.stdout}  R_DKIM_ALLOW (
+BLACKLISTS_WL_ONLY - VALID SPF AND INVALID DKIM
+  Scan File  ${M_DKIM_RSPAMD_BAD}
+  Expect Symbol With Score  R_DKIM_REJECT  1
+  Do Not Expect Symbol  WHITELIST_DKIM
+  Do Not Expect Symbol  BLACKLIST_DKIM
+  Expect Symbol With Score  R_SPF_ALLOW  1
+  Expect Symbol With Score  R_DKIM_REJECT  1
+  Do Not Expect Symbol  WHITELIST_SPF_DKIM
+  Do Not Expect Symbol  R_DKIM_ALLOW
 
 VALID SPF and NO DKIM
-  ${result} =  Scan Message With Rspamc  ${M_NO_DKIM_VALID_SPF}
-  Should Contain  ${result.stdout}  R_SPF_ALLOW (
-  Should Contain  ${result.stdout}  R_DKIM_NA (
-  Should Not Contain  ${result.stdout}  R_DKIM_REJECT (
-  Should Not Contain  ${result.stdout}  WHITELIST_SPF_DKIM (
-  Should Not Contain  ${result.stdout}  R_DKIM_ALLOW (
+  Scan File  ${M_NO_DKIM_VALID_SPF}
+  Expect Symbol With Score  R_SPF_ALLOW  1
+  Expect Symbol With Score  R_DKIM_NA  1
+  Do Not Expect Symbol  R_DKIM_REJECT
+  Do Not Expect Symbol  WHITELIST_SPF_DKIM
+  Do Not Expect Symbol  R_DKIM_ALLOW
 
 *** Keywords ***
 Whitelist Setup

--- a/test/functional/cases/125_map_reload.robot
+++ b/test/functional/cases/125_map_reload.robot
@@ -14,8 +14,8 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 CHECK HIT AND MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  MAP_SET_HIT_AND_MISS (1.00)[example.com]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score And Exact Options  MAP_SET_HIT_AND_MISS  1  example.com
 
 WRITE NEW MAP
   ${TMP_FILE} =  Make Temporary File
@@ -24,8 +24,8 @@ WRITE NEW MAP
 
 CHECK HIT AND MISS AFTER RELOAD
   Sleep  1s  Wait for map reload
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  MAP_SET_HIT_AND_MISS (1.00)[rspamd.com]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score And Exact Options  MAP_SET_HIT_AND_MISS  1  rspamd.com
 
 *** Keywords ***
 Map Reload Setup

--- a/test/functional/cases/135_spamassassin.robot
+++ b/test/functional/cases/135_spamassassin.robot
@@ -11,51 +11,27 @@ ${RSPAMD_SCOPE}  Suite
 ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
-Freemail Scan
-  ${FREEMAIL_RESULT} =  Scan Message With Rspamc  ${TESTDIR}/messages/freemail.eml
-  ...  --from  faked.asdfjisiwosp372@outlook.com
-  Set Suite Variable  ${FREEMAIL_RESULT}  ${FREEMAIL_RESULT}
-  Check Rspamc  ${FREEMAIL_RESULT}  ${EMPTY}
+FREEMAIL
+  Scan File  ${TESTDIR}/messages/freemail.eml
+  ...  From=faked.asdfjisiwosp372@outlook.com
+  Expect Symbol  FREEMAIL_FROM
+  Expect Symbol  FREEMAIL_ENVFROM_END_DIGIT
+  Expect Symbol  FREEMAIL_SUBJECT
+  Expect Symbol  TEST_META4
 
-Freemail From
-  Should Contain  ${FREEMAIL_RESULT.stdout}  FREEMAIL_FROM
+WLBL WHITELIST
+  Scan File  ${TESTDIR}/messages/bad_message.eml
+  Expect Symbol  USER_IN_WHITELIST
+  Expect Symbol  USER_IN_WHITELIST_TO
+  Do Not Expect Symbol  USER_IN_BLACKLIST_TO
+  Do Not Expect Symbol  USER_IN_BLACKLIST
 
-Freemail From Enddigit
-  Should Contain  ${FREEMAIL_RESULT.stdout}  FREEMAIL_ENVFROM_END_DIGIT
-
-Freemail Subject
-  Should Contain  ${FREEMAIL_RESULT.stdout}  FREEMAIL_SUBJECT
-
-Metas
-  Should Contain  ${FREEMAIL_RESULT.stdout}  TEST_META4
-
-WLBL From Whitelist
-  ${BAD_MESSAGE_RESULT} =  Scan Message With Rspamc  ${TESTDIR}/messages/bad_message.eml
-  Set Suite Variable  ${BAD_MESSAGE_RESULT}  ${BAD_MESSAGE_RESULT}
-  Check Rspamc  ${BAD_MESSAGE_RESULT}  USER_IN_WHITELIST (
-
-WLBL To Whitelist
-  Should Contain  ${BAD_MESSAGE_RESULT.stdout}  USER_IN_WHITELIST_TO
-
-WLBL To Blacklist Miss
-  Should Not Contain  ${BAD_MESSAGE_RESULT.stdout}  USER_IN_BLACKLIST_TO
-
-WLBL From Blacklist Miss
-  Should Not Contain  ${BAD_MESSAGE_RESULT.stdout}  USER_IN_BLACKLIST (
-
-WLBL From Blacklist
-  ${UTF_RESULT} =  Scan Message With Rspamc  ${TESTDIR}/messages/utf.eml
-  Set Suite Variable  ${UTF_RESULT}  ${UTF_RESULT}
-  Check Rspamc  ${UTF_RESULT}  USER_IN_BLACKLIST (
-
-WLBL To Blacklist
-  Should Contain  ${UTF_RESULT.stdout}  USER_IN_BLACKLIST_TO
-
-WLBL To Whitelist Miss
-  Should Not Contain  ${UTF_RESULT.stdout}  USER_IN_WHITELIST_TO
-
-WLBL From Whitelist Miss
-  Should Not Contain  ${UTF_RESULT.stdout}  USER_IN_WHITELIST (
+WLBL BLACKLIST
+  Scan File  ${TESTDIR}/messages/utf.eml
+  Expect Symbol  USER_IN_BLACKLIST
+  Expect Symbol  USER_IN_BLACKLIST_TO
+  Do Not Expect Symbol  USER_IN_WHITELIST_TO
+  Do Not Expect Symbol  USER_IN_WHITELIST
 
 *** Keywords ***
 SpamAssassin Setup

--- a/test/functional/cases/140_proxy.robot
+++ b/test/functional/cases/140_proxy.robot
@@ -11,11 +11,10 @@ ${MESSAGE}      ${TESTDIR}/messages/spam_message.eml
 ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
-Rspamc Client
-  ${result} =  Run Rspamc  -h  ${LOCAL_ADDR}:${PORT_PROXY}  -p  ${MESSAGE}
-  Run Keyword If  ${result.rc} != 0  Log  ${result.stderr}
-  Should Contain  ${result.stdout}  SIMPLE_TEST
-  Should Be Equal As Integers  ${result.rc}  0
+HTTP PROTOCOL
+  Set Test Variable  ${PORT_NORMAL}  ${PORT_PROXY}
+  Scan File  ${MESSAGE}
+  Expect Symbol  SIMPLE_TEST
 
 SPAMC
   ${result} =  Spamc  ${LOCAL_ADDR}  ${PORT_PROXY}  ${MESSAGE}

--- a/test/functional/cases/160_antivirus.robot
+++ b/test/functional/cases/160_antivirus.robot
@@ -17,81 +17,81 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 *** Test Cases ***
 CLAMAV MISS
   Run Dummy Clam  ${PORT_CLAM}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  CLAM_VIRUS  inverse=1
+  Scan File  ${MESSAGE}
+  Do Not Expect Symbol  CLAM_VIRUS
   Shutdown clamav
 
 CLAMAV HIT
   Run Dummy Clam  ${PORT_CLAM}  1
-  ${result} =  Scan Message With Rspamc  ${MESSAGE2}
-  Check Rspamc  ${result}  CLAM_VIRUS
-  Should Not Contain  ${result.stdout}  CLAMAV_VIRUS_FAIL
+  Scan File  ${MESSAGE2}
+  Expect Symbol  CLAM_VIRUS
+  Do Not Expect Symbol  CLAMAV_VIRUS_FAIL
   Shutdown clamav
 
 CLAMAV CACHE HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE2}
-  Check Rspamc  ${result}  CLAM_VIRUS
-  Should Not Contain  ${result.stdout}  CLAMAV_VIRUS_FAIL
+  Scan File  ${MESSAGE2}
+  Expect Symbol  CLAM_VIRUS
+  Do Not Expect Symbol  CLAMAV_VIRUS_FAIL
 
 CLAMAV CACHE MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  CLAM_VIRUS  inverse=1
-  Should Not Contain  ${result.stdout}  CLAMAV_VIRUS_FAIL
+  Scan File  ${MESSAGE}
+  Do Not Expect Symbol  CLAM_VIRUS
+  Do Not Expect Symbol  CLAMAV_VIRUS_FAIL
 
 FPROT MISS
   Run Dummy Fprot  ${PORT_FPROT}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE2}
-  Check Rspamc  ${result}  FPROT_VIRUS  inverse=1
-  Should Not Contain  ${result.stdout}  FPROT_EICAR
+  Scan File  ${MESSAGE2}
+  Do Not Expect Symbol  FPROT_VIRUS
+  Do Not Expect Symbol  FPROT_EICAR
   Shutdown fport
 
 FPROT HIT - PATTERN
   Run Dummy Fprot  ${PORT_FPROT}  1
   Run Dummy Fprot  ${PORT_FPROT2_DUPLICATE}  1  /tmp/dummy_fprot_dupe.pid
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  FPROT_EICAR
-  Should Not Contain  ${result.stdout}  CLAMAV_VIRUS
+  Scan File  ${MESSAGE}
+  Expect Symbol  FPROT_EICAR
+  Do Not Expect Symbol  CLAMAV_VIRUS
   # Also check ordered pattern match
-  Should Contain  ${result.stdout}  FPROT2_VIRUS_DUPLICATE_PATTERN
-  Should Not Contain  ${result.stdout}  FPROT2_VIRUS_DUPLICATE_DEFAULT
-  Should Not Contain  ${result.stdout}  FPROT2_VIRUS_DUPLICATE_NOPE
+  Expect Symbol  FPROT2_VIRUS_DUPLICATE_PATTERN
+  Do Not Expect Symbol  FPROT2_VIRUS_DUPLICATE_DEFAULT
+  Do Not Expect Symbol  FPROT2_VIRUS_DUPLICATE_NOPE
   Shutdown fport
   Shutdown fport duplicate
 
 FPROT CACHE HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  FPROT_EICAR
-  Should Not Contain  ${result.stdout}  CLAMAV_VIRUS
+  Scan File  ${MESSAGE}
+  Expect Symbol  FPROT_EICAR
+  Do Not Expect Symbol  CLAMAV_VIRUS
   # Also check ordered pattern match
-  Should Contain  ${result.stdout}  FPROT2_VIRUS_DUPLICATE_PATTERN
-  Should Not Contain  ${result.stdout}  FPROT2_VIRUS_DUPLICATE_DEFAULT
+  Expect Symbol  FPROT2_VIRUS_DUPLICATE_PATTERN
+  Do Not Expect Symbol  FPROT2_VIRUS_DUPLICATE_DEFAULT
 
 FPROT CACHE MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE2}
-  Check Rspamc  ${result}  FPROT_VIRUS  inverse=1
+  Scan File  ${MESSAGE2}
+  Do Not Expect Symbol  FPROT_VIRUS
 
 AVAST MISS
   Run Dummy Avast  ${PORT_AVAST}
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  AVAST_VIRUS  inverse=1
+  Scan File  ${MESSAGE}
+  Do Not Expect Symbol  AVAST_VIRUS
   Shutdown avast
 
 AVAST HIT
   Run Dummy Avast  ${PORT_AVAST}  1
-  ${result} =  Scan Message With Rspamc  ${MESSAGE2}
-  Check Rspamc  ${result}  AVAST_VIRUS
-  Should Not Contain  ${result.stdout}  AVAST_VIRUS_FAIL
+  Scan File  ${MESSAGE2}
+  Expect Symbol  AVAST_VIRUS
+  Do Not Expect Symbol  AVAST_VIRUS_FAIL
   Shutdown avast
 
 AVAST CACHE HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE2}
-  Check Rspamc  ${result}  AVAST_VIRUS
-  Should Not Contain  ${result.stdout}  AVAST_VIRUS_FAIL
+  Scan File  ${MESSAGE2}
+  Expect Symbol  AVAST_VIRUS
+  Do Not Expect Symbol  AVAST_VIRUS_FAIL
 
 AVAST CACHE MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  AVAST_VIRUS  inverse=1
-  Should Not Contain  ${result.stdout}  AVAST_VIRUS_FAIL
+  Scan File  ${MESSAGE}
+  Do Not Expect Symbol  AVAST_VIRUS
+  Do Not Expect Symbol  AVAST_VIRUS_FAIL
 
 *** Keywords ***
 Antivirus Setup

--- a/test/functional/cases/161_p0f.robot
+++ b/test/functional/cases/161_p0f.robot
@@ -17,74 +17,65 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 *** Test Cases ***
 p0f MISS
   Run Dummy p0f
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.1
-  Check Rspamc  ${result}  P0F
-  Check Rspamc  ${result}  Linux 3.11 and newer
-  Check Rspamc  ${result}  Ethernet or modem
-  Check Rspamc  ${result}  WINDOWS  inverse=1
-  Check Rspamc  ${result}  P0F_FAIL  inverse=1
+  Scan File  ${MESSAGE}  IP=1.1.1.1
+  Do Not Expect Symbol  P0F_FAIL
+  Do Not Expect Symbol  WINDOWS
+  Expect Symbol With Exact Options  P0F  Linux 3.11 and newer  link=Ethernet or modem  distance=10
   Shutdown p0f
 
 p0f HIT
   Run Dummy p0f  ${P0F_SOCKET}  windows
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.2
-  Check Rspamc  ${result}  P0F
-  Check Rspamc  ${result}  P0F_FAIL  inverse=1
-  Check Rspamc  ${result}  Ethernet or modem
-  Check Rspamc  ${result}  WINDOWS
-  Check Rspamc  ${result}  Linux 3.11 and newer  inverse=1
+  Scan File  ${MESSAGE}  IP=1.1.1.2
+  Do Not Expect Symbol  P0F_FAIL
+  Expect Symbol With Exact Options  P0F  link=Ethernet or modem  distance=10
+  Expect Symbol  WINDOWS
   Shutdown p0f
 
 p0f MISS CACHE
   Run Dummy p0f
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.3
-  Check Rspamc  ${result}  WINDOWS  inverse=1
+  Scan File  ${MESSAGE}  IP=1.1.1.3
+  Do Not Expect Symbol  WINDOWS
   Shutdown p0f
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.3
-  Check Rspamc  ${result}  WINDOWS  inverse=1
-  Check Rspamc  ${result}  P0F_FAIL  inverse=1
+  Scan File  ${MESSAGE}  IP=1.1.1.3
+  Do Not Expect Symbol  WINDOWS
+  Do Not Expect Symbol  P0F_FAIL
 
 p0f HIT CACHE
   Run Dummy p0f  ${P0F_SOCKET}  windows
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.4
-  Check Rspamc  ${result}  WINDOWS
+  Scan File  ${MESSAGE}  IP=1.1.1.4
+  Expect Symbol  WINDOWS
   Shutdown p0f
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.4
-  Check Rspamc  ${result}  WINDOWS
-  Check Rspamc  ${result}  P0F_FAIL  inverse=1
+  Scan File  ${MESSAGE}  IP=1.1.1.4
+  Expect Symbol  WINDOWS
+  Do Not Expect Symbol  P0F_FAIL
 
 p0f NO REDIS
   Shutdown Process With Children  ${REDIS_PID}
   Run Dummy p0f
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.5
-  Check Rspamc  ${result}  P0F
-  Check Rspamc  ${result}  Linux 3.11 and newer
-  Check Rspamc  ${result}  Ethernet or modem
-  Check Rspamc  ${result}  P0F_FAIL  inverse=1
-  Should Contain  ${result.stdout}  distance=10
+  Scan File  ${MESSAGE}  IP=1.1.1.5
+  Expect Symbol With Exact Options  P0F  Linux 3.11 and newer  link=Ethernet or modem  distance=10
+  Do Not Expect Symbol  P0F_FAIL
   Shutdown p0f
 
 p0f NO MATCH
   Run Dummy p0f  ${P0F_SOCKET}  windows  no_match
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.6
-  Check Rspamc  ${result}  P0F  inverse=1
-  Check Rspamc  ${result}  WINDOWS  inverse=1
+  Scan File  ${MESSAGE}  IP=1.1.1.6
+  Do Not Expect Symbol  P0F
+  Do Not Expect Symbol  WINDOWS
   Shutdown p0f
 
 p0f BAD QUERY
   Run Dummy p0f  ${P0F_SOCKET}  windows  bad_query
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.7
-  Check Rspamc  ${result}  P0F_FAIL
-  Check Rspamc  ${result}  Malformed Query
-  Check Rspamc  ${result}  WINDOWS  inverse=1
+  Scan File  ${MESSAGE}  IP=1.1.1.7
+  Expect Symbol With Exact Options  P0F_FAIL  Malformed Query: /tmp/p0f.sock
+  Do Not Expect Symbol  WINDOWS
   Shutdown p0f
 
 p0f BAD RESPONSE
   Run Dummy p0f  ${P0F_SOCKET}  windows  bad_response
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --ip  1.1.1.8
-  Check Rspamc  ${result}  P0F_FAIL
-  Check Rspamc  ${result}  Error getting result: IO read error: connection terminated
-  Check Rspamc  ${result}  WINDOWS  inverse=1
+  Scan File  ${MESSAGE}  IP=1.1.1.8
+  Expect Symbol With Exact Options  P0F_FAIL  Error getting result: IO read error: connection terminated
+  Do Not Expect Symbol  WINDOWS
   Shutdown p0f
 
 *** Keywords ***

--- a/test/functional/cases/220_http.robot
+++ b/test/functional/cases/220_http.robot
@@ -36,8 +36,8 @@ HTTP empty response
   Check url  /empty  post  HTTP_DNS_ERROR  HTTP_ERROR  HTTP_CORO_DNS_ERROR  HTTP_CORO_ERROR  method_post  IO read error: unexpected EOF
 
 SSL Large HTTP request
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  HTTP_SSL_LARGE
+  Scan File  ${MESSAGE}
+  Expect Symbol  HTTP_SSL_LARGE
 
 *** Keywords ***
 Lua Setup

--- a/test/functional/cases/230_tcp.robot
+++ b/test/functional/cases/230_tcp.robot
@@ -15,34 +15,33 @@ ${RSPAMD_SCOPE}  Suite
 
 *** Test Cases ***
 Simple TCP request
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  HTTP_ASYNC_RESPONSE
-  Check Rspamc  ${result}  HTTP_ASYNC_RESPONSE_2
+  Scan File  ${MESSAGE}
+  Expect Symbol  HTTP_ASYNC_RESPONSE
+  Expect Symbol  HTTP_ASYNC_RESPONSE_2
 
 SSL TCP request
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  TCP_SSL_RESPONSE (0.00)[hello]
-  Check Rspamc  ${result}  TCP_SSL_RESPONSE_2 (0.00)[hello]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  TCP_SSL_RESPONSE  hello
+  Expect Symbol With Exact Options  TCP_SSL_RESPONSE_2  hello
 
 SSL Large TCP request
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  TCP_SSL_LARGE (0.00)
-  Check Rspamc  ${result}  TCP_SSL_LARGE_2 (0.00)
+  Scan File  ${MESSAGE}
+  Expect Symbol  TCP_SSL_LARGE
+  Expect Symbol  TCP_SSL_LARGE_2
 
 Sync API TCP request
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  HTTP_SYNC_RESPONSE
-  Check Rspamc  ${result}  HTTP_SYNC_RESPONSE_2
-  Check Rspamc  ${result}  hello world
-  Check Rspamc  ${result}  hello post
+  Scan File  ${MESSAGE}
+  Expect Symbol  HTTP_SYNC_RESPONSE
+  Should Contain  ${SCAN_RESULT}[symbols][HTTP_SYNC_RESPONSE][options][0]  hello world
+  Should Contain  ${SCAN_RESULT}[symbols][HTTP_SYNC_RESPONSE_2][options][0]  hello post
 
 Sync API TCP get request
-  Check url  /request  get  HTTP_SYNC_EOF_get (0.00)[hello world]
-  Check url  /content-length  get  HTTP_SYNC_CONTENT_get (0.00)[hello world]
+  Check url  /request  get  HTTP_SYNC_EOF_get  hello world
+  Check url  /content-length  get  HTTP_SYNC_CONTENT_get  hello world
 
 Sync API TCP post request
-  Check url  /request  post  HTTP_SYNC_EOF_post (0.00)[hello post]
-  Check url  /content-length  post  HTTP_SYNC_CONTENT_post (0.00)[hello post]
+  Check url  /request  post  HTTP_SYNC_EOF_post  hello post
+  Check url  /content-length  post  HTTP_SYNC_CONTENT_post  hello post
 
 *** Keywords ***
 Lua Setup
@@ -73,8 +72,6 @@ Run Dummy Ssl
   Wait Until Created  /tmp/dummy_ssl.pid  timeout=2 second
 
 Check url
-  [Arguments]  ${url}  ${method}  @{expect_results}
-  ${result} =  Scan Message With Rspamc  --header=url:${url}  --header=method:${method}  ${MESSAGE}
-  FOR  ${expect}  IN  @{expect_results}
-    Check Rspamc  ${result}  ${expect}
-  END
+  [Arguments]  ${url}  ${method}  ${expect_symbol}  @{expect_options}
+  Scan File  ${MESSAGE}  URL=${url}  Method=${method}
+  Expect Symbol With Exact Options  ${expect_symbol}  @{expect_options}

--- a/test/functional/cases/240_redis.robot
+++ b/test/functional/cases/240_redis.robot
@@ -19,10 +19,10 @@ ${MESSAGE}      ${TESTDIR}/messages/spam_message.eml
 *** Test Cases ***
 Redis client
   Redis SET  test_key  test value
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  REDIS (0.00)[hello from lua on redis]
-  Check Rspamc  ${result}  REDIS_ASYNC (0.00)[test value]
-  Check Rspamc  ${result}  REDIS_ASYNC201809 (0.00)[test value]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  REDIS  hello from lua on redis
+  Expect Symbol With Exact Options  REDIS_ASYNC  test value
+  Expect Symbol With Exact Options  REDIS_ASYNC201809  test value
 
 *** Keywords ***
 Lua Setup

--- a/test/functional/cases/241_redis_is_dead.robot
+++ b/test/functional/cases/241_redis_is_dead.robot
@@ -20,10 +20,10 @@ ${MESSAGE}      ${TESTDIR}/messages/spam_message.eml
 
 *** Test Cases ***
 Dead Redis client
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  REDIS_ERROR_3 (0.00)[Connection refused]
-  Check Rspamc  ${result}  REDIS_ASYNC201809_ERROR (0.00)[Connection refused]
-  Check Rspamc  ${result}  REDIS_ASYNC_ERROR (0.00)[Connection refused]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  REDIS_ERROR_3  Connection refused
+  Expect Symbol With Exact Options  REDIS_ASYNC201809_ERROR  Connection refused
+  Expect Symbol With Exact Options  REDIS_ASYNC_ERROR  Connection refused
 
 *** Keywords ***
 Lua Setup

--- a/test/functional/cases/250_dns.robot
+++ b/test/functional/cases/250_dns.robot
@@ -14,14 +14,14 @@ ${RSPAMD_SCOPE}  Test
 
 *** Test Cases ***
 Simple DNS request
-  ${result} =  Scan Message With Rspamc  --header=to-resolve:example.com  ${MESSAGE}
-  Check Rspamc  ${result}  DNS_SYNC (0.00)[93.184.216.34]
-  Check Rspamc  ${result}  DNS (0.00)[93.184.216.34]
+  Scan File  ${MESSAGE}  To-Resolve=example.com
+  Expect Symbol With Exact Options  DNS_SYNC  93.184.216.34
+  Expect Symbol With Exact Options  DNS  93.184.216.34
 
 Faulty DNS request
-  ${result} =  Scan Message With Rspamc  --header=to-resolve:not-resolvable.com  ${MESSAGE}
-  Check Rspamc  ${result}  DNS_SYNC_ERROR (0.00)[requested record is not found]
-  Check Rspamc  ${result}  DNS_ERROR (0.00)[requested record is not found]
+  Scan File  ${MESSAGE}  To-Resolve=not-resolvable.com
+  Expect Symbol With Exact Options  DNS_SYNC_ERROR  requested record is not found
+  Expect Symbol With Exact Options  DNS_ERROR  requested record is not found
 
 *** Keywords ***
 Lua Setup

--- a/test/functional/cases/260_regex.robot
+++ b/test/functional/cases/260_regex.robot
@@ -15,17 +15,17 @@ ${RSPAMD_SCOPE}  Test
 
 *** Test Cases ***
 Newlines 
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  SA_BODY_WORD
-  Check Rspamc  ${result}  SA_BODY_WORD_WITH_SPACE
-  Check Rspamc  ${result}  SA_BODY_WORD_WITH_NEWLINE  inverse=true
-  Check Rspamc  ${result}  SA_BODY_WORD_WITH_SPACE_BOUNDARIES
-  Check Rspamc  ${result}  SA_BODY_WORD_WITH_SPACE_BOUNDARIES_2
-  Check Rspamc  ${result}  SA_BODY_WORD_WITH_SPACE_BOUNDARIES_3
-  Check Rspamc  ${result}  SA_BODY_WORD_WITH_SPACE_AND_DOT
-  Check Rspamc  ${result}  https://google.com/maps/
-  Check Rspamc  ${result}  https://www.google.com/search?q\=hello world&oq\=hello world&aqs\=chrome..69i57j0l5.3045j0j7&sourceid\=chrome&ie\=UTF-8
-  Check Rspamc  ${result}  https://github.com/google/sanitizers/wiki/AddressSanitizer
+  Scan File  ${MESSAGE}
+  Expect Symbol  SA_BODY_WORD
+  Expect Symbol  SA_BODY_WORD_WITH_SPACE
+  Do Not Expect Symbol  SA_BODY_WORD_WITH_NEWLINE
+  Expect Symbol  SA_BODY_WORD_WITH_SPACE_BOUNDARIES
+  Expect Symbol  SA_BODY_WORD_WITH_SPACE_BOUNDARIES_2
+  Expect Symbol  SA_BODY_WORD_WITH_SPACE_BOUNDARIES_3
+  Expect Symbol  SA_BODY_WORD_WITH_SPACE_AND_DOT
+  Expect Symbol With Option  FOUND_URL  https://google.com/maps/
+  Expect Symbol With Option  FOUND_URL  https://www.google.com/search?q\=hello world&oq\=hello world&aqs\=chrome..69i57j0l5.3045j0j7&sourceid\=chrome&ie\=UTF-8
+  Expect Symbol With Option  FOUND_URL  https://github.com/google/sanitizers/wiki/AddressSanitizer
 
 
 *** Keywords ***

--- a/test/functional/cases/270_selector.robot
+++ b/test/functional/cases/270_selector.robot
@@ -15,9 +15,9 @@ ${RSPAMD_SCOPE}  Test
 
 *** Test Cases ***
 Newlines 
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --user  test@user.com
-  Check Rspamc  ${result}  CONFIG_SELECTOR_RE_RCPT_SUBJECT
-  Check Rspamc  ${result}  LUA_SELECTOR_RE
+  Scan File  ${MESSAGE}  User=test@user.com  Pass=all
+  Expect Symbol  CONFIG_SELECTOR_RE_RCPT_SUBJECT
+  Expect Symbol  LUA_SELECTOR_RE
 
 
 *** Keywords ***

--- a/test/functional/cases/280_rules.robot
+++ b/test/functional/cases/280_rules.robot
@@ -22,93 +22,93 @@ ${RSPAMD_SCOPE}  Suite
 
 *** Test Cases ***
 Broken MIME
-  ${result} =  Scan Message With Rspamc  ${MESSAGE3}
-  Check Rspamc  ${result}  MISSING_SUBJECT
+  Scan File  ${MESSAGE3}
+  Expect Symbol  MISSING_SUBJECT
 
 Issue 2584
-  ${result} =  Scan Message With Rspamc  ${MESSAGE1}
-  Check Rspamc  ${result}  BROKEN_CONTENT_TYPE  inverse=1
-  Should Not Contain  ${result.stdout}  MISSING_SUBJECT
-  Should Not Contain  ${result.stdout}  R_MISSING_CHARSET
+  Scan File  ${MESSAGE1}
+  Do Not Expect Symbol  BROKEN_CONTENT_TYPE
+  Do Not Expect Symbol  MISSING_SUBJECT
+  Do Not Expect Symbol  R_MISSING_CHARSET
 
 Issue 2349
-  ${result} =  Scan Message With Rspamc  ${MESSAGE2}
-  Check Rspamc  ${result}  MULTIPLE_UNIQUE_HEADERS  inverse=1
+  Scan File  ${MESSAGE2}
+  Do Not Expect Symbol  MULTIPLE_UNIQUE_HEADERS
 
 Broken Rich Text
-  ${result} =  Scan Message With Rspamc  ${MESSAGE4}
-  Check Rspamc  ${result}  BROKEN_CONTENT_TYPE
+  Scan File  ${MESSAGE4}
+  Expect Symbol  BROKEN_CONTENT_TYPE
 
 Dynamic Config
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  SA_BODY_WORD (10
-  Check Rspamc  ${result}  \/ 20
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  SA_BODY_WORD  10
+  Expect Required Score  20
 
 Broken boundary
-  ${result} =  Scan Message With Rspamc  ${MESSAGE4}
-  Check Rspamc  ${result}  BROKEN_CONTENT_TYPE
+  Scan File  ${MESSAGE4}
+  Expect Symbol  BROKEN_CONTENT_TYPE
 
 PDF encrypted
-  ${result} =  Scan Message With Rspamc  ${MESSAGE6}
-  Check Rspamc  ${result}  PDF_ENCRYPTED
+  Scan File  ${MESSAGE6}
+  Expect Symbol  PDF_ENCRYPTED
 
 PDF javascript
-  ${result} =  Scan Message With Rspamc  ${MESSAGE7}
-  Check Rspamc  ${result}  PDF_JAVASCRIPT
+  Scan File  ${MESSAGE7}
+  Expect Symbol  PDF_JAVASCRIPT
 
 BITCOIN ADDR
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/btc.eml
-  Should Contain  ${result.stdout}  BITCOIN_ADDR
+  Scan File  ${TESTDIR}/messages/btc.eml
+  Expect Symbol  BITCOIN_ADDR
 
 BITCOIN ADDR 2
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/btc2.eml
-  Should Contain  ${result.stdout}  BITCOIN_ADDR
+  Scan File  ${TESTDIR}/messages/btc2.eml
+  Expect Symbol  BITCOIN_ADDR
 
 BITCOIN ADDR 3
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/btc3.eml
-  Should Contain  ${result.stdout}  BITCOIN_ADDR
+  Scan File  ${TESTDIR}/messages/btc3.eml
+  Expect Symbol  BITCOIN_ADDR
 
 RCVD_COUNT_ONE
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/btc.eml
-  Should Contain  ${result.stdout}  RCVD_COUNT_ONE
+  Scan File  ${TESTDIR}/messages/btc.eml
+  Expect Symbol  RCVD_COUNT_ONE
 
 RCVD_COUNT_FIVE
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/yand_forward.eml
-  Should Contain  ${result.stdout}  RCVD_COUNT_FIVE
+  Scan File  ${TESTDIR}/messages/yand_forward.eml
+  Expect Symbol  RCVD_COUNT_FIVE
 
 RCVD_COUNT_SEVEN
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/rcvd7.eml
-  Should Contain  ${result.stdout}  RCVD_COUNT_SEVEN
+  Scan File  ${TESTDIR}/messages/rcvd7.eml
+  Expect Symbol  RCVD_COUNT_SEVEN
 
 FROM_NEQ_ENVFROM
-  ${result} =  Scan Message With Rspamc  ${MESSAGE8}  --from  test@test.net
-  Check Rspamc  ${result}  FROM_NEQ_ENVFROM
+  Scan File  ${MESSAGE8}  From=test@test.net
+  Expect Symbol  FROM_NEQ_ENVFROM
 
 PHISH_SENDER_A
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/phish_sender.eml
-  Should Contain  ${result.stdout}  MULTIPLE_FROM (9.00)[any@attack.com,admin@legitimate.com]
-  Should Contain  ${result.stdout}  MULTIPLE_UNIQUE_HEADERS (7.00)[From]
+  Scan File  ${TESTDIR}/messages/phish_sender.eml
+  Expect Symbol With Score And Exact Options  MULTIPLE_FROM  9.0  any@attack.com,admin@legitimate.com
+  Expect Symbol With Score And Exact Options  MULTIPLE_UNIQUE_HEADERS  7.0  From
 
 PHISH_SENDER_B
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/phish_sender2.eml
-  Should Contain  ${result.stdout}  BROKEN_HEADERS
+  Scan File  ${TESTDIR}/messages/phish_sender2.eml
+  Expect Symbol  BROKEN_HEADERS
 
 PHISH_SENDER_C
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/phish_sender3.eml
-  Should Contain  ${result.stdout}  BROKEN_HEADERS
+  Scan File  ${TESTDIR}/messages/phish_sender3.eml
+  Expect Symbol  BROKEN_HEADERS
 
 PHISH_SENDER_D
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/phish_sender4.eml
-  Should Contain  ${result.stdout}  BROKEN_HEADERS
+  Scan File  ${TESTDIR}/messages/phish_sender4.eml
+  Expect Symbol  BROKEN_HEADERS
 
 PHISH_SENDER_E
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/phish_sender5.eml
-  Should Contain  ${result.stdout}  MULTIPLE_FROM
-  Should Contain  ${result.stdout}  DMARC_NA (0.00)[Duplicate From header]
+  Scan File  ${TESTDIR}/messages/phish_sender5.eml
+  Expect Symbol  MULTIPLE_FROM
+  Expect Symbol With Exact Options  DMARC_NA  Duplicate From header
 
 PHISH_SENDER_ROUTING_PART
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/phish_sender6.eml
-  Should Contain  ${result.stdout}  FROM_INVALID
+  Scan File  ${TESTDIR}/messages/phish_sender6.eml
+  Expect Symbol  FROM_INVALID
 
 
 *** Keywords ***

--- a/test/functional/cases/281_fnames.robot
+++ b/test/functional/cases/281_fnames.robot
@@ -14,9 +14,9 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 FILE NAMES
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/fname.eml
-  Should Contain  ${result.stdout}  TEST_FNAME
-  Should Contain  ${result.stdout}  [삼성생명]2020.08.14 데일리 경제뉴스.pdf, 01029_402110_10620_RGT06902_PRT180ML_20200803_101820.pdf
+  Scan File  ${TESTDIR}/messages/fname.eml
+  Expect Symbol With Option  TEST_FNAME  [삼성생명]2020.08.14 데일리 경제뉴스.pdf
+  Expect Symbol With Option  TEST_FNAME  01029_402110_10620_RGT06902_PRT180ML_20200803_101820.pdf
 
 
 *** Keywords ***

--- a/test/functional/cases/290_greylist.robot
+++ b/test/functional/cases/290_greylist.robot
@@ -14,17 +14,17 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 GREYLIST NEW
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  GREYLIST (0.00)[greylisted
+  Scan File  ${MESSAGE}
+  Expect Symbol With Option  GREYLIST  greylisted
 
 GREYLIST EARLY
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  GREYLIST (0.00)[greylisted
+  Scan File  ${MESSAGE}
+  Expect Symbol With Option  GREYLIST  greylisted
 
 GREYLIST PASS
   Sleep  4s  Wait greylisting timeout
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  GREYLIST (0.00)[pass
+  Scan File  ${MESSAGE}
+  Expect Symbol With Option  GREYLIST  pass
 
 *** Keywords ***
 Greylist Setup

--- a/test/functional/cases/300_rbl.robot
+++ b/test/functional/cases/300_rbl.robot
@@ -13,41 +13,42 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 RBL FROM MISS
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  1.2.3.4
-  Check Rspamc  ${result}  FAKE_RBL_CODE_2  inverse=True
+  Scan File  ${MESSAGE}  IP=1.2.3.4
+  Do Not Expect Symbol  FAKE_RBL_CODE_2
 
 RBL FROM HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  4.3.2.1
-  Check Rspamc  ${result}  FAKE_RBL_CODE_2
+  Scan File  ${MESSAGE}  IP=4.3.2.1
+  Expect Symbol  FAKE_RBL_CODE_2
 
 RBL FROM MULTIPLE HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  4.3.2.3
-  Check Rspamc  ${result}  FAKE_RBL_CODE_2  FAKE_RBL_CODE_3
+  Scan File  ${MESSAGE}  IP=4.3.2.3
+  Expect Symbol  FAKE_RBL_CODE_2
+  Expect Symbol  FAKE_RBL_CODE_3
 
 RBL FROM UNKNOWN HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  4.3.2.2
-  Check Rspamc  ${result}  FAKE_RBL_UNKNOWN
+  Scan File  ${MESSAGE}  IP=4.3.2.2
+  Expect Symbol  FAKE_RBL_FAKE_RBL_UNKNOWN
 
 RBL RECEIVED HIT
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  8.8.8.8
-  Check Rspamc  ${result}  FAKE_RECEIVED_RBL_CODE_3
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Expect Symbol  FAKE_RECEIVED_RBL_CODE_3
 
 RBL FROM HIT WL
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  -i  4.3.2.4
-  Check Rspamc  ${result}  FAKE_RBL_CODE_2  inverse=True
-  Should Contain  ${result.stdout}  FAKE_WL_RBL_CODE_2 (0.00)[4.3.2.4:from]
+  Scan File  ${MESSAGE}  IP=4.3.2.4
+  Do Not Expect Symbol  FAKE_RBL_CODE_2
+  Expect Symbol With Exact Options  FAKE_WL_RBL_CODE_2  4.3.2.4:from
 
 EMAILBL Compose Map 1
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url14.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL (0.00)[dirty.sanchez.com:email]
+  Scan File  ${TESTDIR}/messages/url14.eml
+  Expect Symbol With Exact Options  RSPAMD_EMAILBL  dirty.sanchez.com:email
 
 EMAILBL Compose Map 2
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url15.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL (0.00)[very.dirty.sanchez.com:email]
+  Scan File  ${TESTDIR}/messages/url15.eml
+  Expect Symbol With Exact Options  RSPAMD_EMAILBL  very.dirty.sanchez.com:email
 
 EMAILBL Compose Map 3
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url16.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL (0.00)[41.black.sanchez.com:email]
+  Scan File  ${TESTDIR}/messages/url16.eml
+  Expect Symbol With Exact Options  RSPAMD_EMAILBL  41.black.sanchez.com:email
 
 
 *** Keywords ***

--- a/test/functional/cases/310_udp.robot
+++ b/test/functional/cases/310_udp.robot
@@ -14,16 +14,16 @@ ${RSPAMD_SCOPE}  Test
 
 *** Test Cases ***
 Simple UDP request
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  UDP_SUCCESS (0.00)[helloworld]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  UDP_SUCCESS  helloworld
 
 Sendonly UDP request
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  UDP_SENDTO
+  Scan File  ${MESSAGE}
+  Expect Symbol  UDP_SENDTO
 
 Errored UDP request
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}
-  Check Rspamc  ${result}  UDP_FAIL (0.00)[read timeout]
+  Scan File  ${MESSAGE}
+  Expect Symbol With Exact Options  UDP_FAIL  read timeout
 
 *** Keywords ***
 Lua Setup

--- a/test/functional/cases/330_neural.robot
+++ b/test/functional/cases/330_neural.robot
@@ -17,50 +17,50 @@ ${RSPAMD_SCOPE}  Suite
 Train
   Sleep  2s  Wait for redis mess
   FOR    ${INDEX}    IN RANGE    0    10
-    ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_enabled = ["SPAM_SYMBOL"]}
-    Check Rspamc  ${result}  SPAM_SYMBOL
-    ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_enabled = ["HAM_SYMBOL"]}
-    Check Rspamc  ${result}  HAM_SYMBOL
+    Scan File  ${MESSAGE}  Settings={symbols_enabled = ["SPAM_SYMBOL"]}
+    Expect Symbol  SPAM_SYMBOL
+    Scan File  ${MESSAGE}  Settings={symbols_enabled = ["HAM_SYMBOL"]}
+    Expect Symbol  HAM_SYMBOL
   END
 
 Check Neural HAM
   Sleep  2s  Wait for neural to be loaded
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_enabled = ["HAM_SYMBOL"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
-  Check Rspamc  ${result}  NEURAL_HAM_SHORT (
-  Check Rspamc  ${result}  NEURAL_SPAM_SHORT (  inverse=1
-  Check Rspamc  ${result}  NEURAL_HAM_SHORT_PCA (
-  Check Rspamc  ${result}  NEURAL_SPAM_SHORT_PCA (  inverse=1
+  Scan File  ${MESSAGE}  Settings={symbols_enabled = ["HAM_SYMBOL"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_HAM_SHORT
+  Do Not Expect Symbol  NEURAL_SPAM_SHORT
+  Expect Symbol  NEURAL_HAM_SHORT_PCA
+  Do Not Expect Symbol  NEURAL_SPAM_SHORT_PCA
 
 Check Neural SPAM
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_enabled = ["SPAM_SYMBOL"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
-  Check Rspamc  ${result}  NEURAL_SPAM_SHORT (
-  Check Rspamc  ${result}  NEURAL_HAM_SHORT (  inverse=1
-  Check Rspamc  ${result}  NEURAL_SPAM_SHORT_PCA (
-  Check Rspamc  ${result}  NEURAL_HAM_SHORT_PCA (  inverse=1
+  Scan File  ${MESSAGE}  Settings={symbols_enabled = ["SPAM_SYMBOL"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_SPAM_SHORT
+  Do Not Expect Symbol  NEURAL_HAM_SHORT
+  Expect Symbol  NEURAL_SPAM_SHORT_PCA
+  Do Not Expect Symbol  NEURAL_HAM_SHORT_PCA
 
 
 Train INVERSE
   FOR    ${INDEX}    IN RANGE    0    10
-    ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_enabled = ["SPAM_SYMBOL"]; SPAM_SYMBOL = -5;}
-    Check Rspamc  ${result}  SPAM_SYMBOL
-    ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_enabled = ["HAM_SYMBOL"]; HAM_SYMBOL = 5;}
-    Check Rspamc  ${result}  HAM_SYMBOL
+    Scan File  ${MESSAGE}  Settings={symbols_enabled = ["SPAM_SYMBOL"]; SPAM_SYMBOL = -5;}
+    Expect Symbol  SPAM_SYMBOL
+    Scan File  ${MESSAGE}  Settings={symbols_enabled = ["HAM_SYMBOL"]; HAM_SYMBOL = 5;}
+    Expect Symbol  HAM_SYMBOL
   END
 
 Check Neural HAM INVERSE
   Sleep  2s  Wait for neural to be loaded
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_enabled = ["HAM_SYMBOL"];groups_enabled=["neural"]}
-  Check Rspamc  ${result}  NEURAL_SPAM_SHORT (
-  Check Rspamc  ${result}  NEURAL_SPAM_SHORT_PCA (
-  Check Rspamc  ${result}  NEURAL_HAM_SHORT (  inverse=1
-  Check Rspamc  ${result}  NEURAL_HAM_SHORT_PCA (  inverse=1
+  Scan File  ${MESSAGE}  Settings={symbols_enabled = ["HAM_SYMBOL"];groups_enabled=["neural"]}
+  Expect Symbol  NEURAL_SPAM_SHORT
+  Expect Symbol  NEURAL_SPAM_SHORT_PCA
+  Do Not Expect Symbol  NEURAL_HAM_SHORT
+  Do Not Expect Symbol  NEURAL_HAM_SHORT_PCA
 
 Check Neural SPAM INVERSE
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings={symbols_enabled = ["SPAM_SYMBOL"];groups_enabled=["neural"]}
-  Check Rspamc  ${result}  NEURAL_HAM_SHORT (
-  Check Rspamc  ${result}  NEURAL_HAM_SHORT_PCA (
-  Check Rspamc  ${result}  NEURAL_SPAM_SHORT (  inverse=1
-  Check Rspamc  ${result}  NEURAL_SPAM_SHORT_PCA (  inverse=1
+  Scan File  ${MESSAGE}  Settings={symbols_enabled = ["SPAM_SYMBOL"];groups_enabled=["neural"]}
+  Expect Symbol  NEURAL_HAM_SHORT
+  Expect Symbol  NEURAL_HAM_SHORT_PCA
+  Do Not Expect Symbol  NEURAL_SPAM_SHORT
+  Do Not Expect Symbol  NEURAL_SPAM_SHORT_PCA
 
 *** Keywords ***
 Neural Setup

--- a/test/functional/cases/340_surbl.robot
+++ b/test/functional/cases/340_surbl.robot
@@ -12,156 +12,154 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 SURBL resolve ip
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url7.eml
-  Should Contain  ${result.stdout}  URIBL_SBL_CSS (0.00)[8.8.8.9:example.ru
-  Should Contain  ${result.stdout}  URIBL_XBL (0.00)[8.8.8.8:example.ru
-  Should Contain  ${result.stdout}  URIBL_PBL (0.00)[8.8.8.8:example.ru
+  Scan File  ${TESTDIR}/messages/url7.eml
+  Expect Symbol With Exact Options  URIBL_SBL_CSS  8.8.8.9:example.ru:url
+  Expect Symbol With Exact Options  URIBL_XBL  8.8.8.8:example.ru:url
+  Expect Symbol With Exact Options  URIBL_PBL  8.8.8.8:example.ru:url
 
 SURBL Example.com domain
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url4.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL
-  Should Contain  ${result.stdout}  DBL_SPAM
-  Should Not Contain  ${result.stdout}  DBL_PHISH
-  Should Not Contain  ${result.stdout}  URIBL_BLACK
+  Scan File  ${TESTDIR}/messages/url4.eml
+  Expect Symbol  RSPAMD_URIBL
+  Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL Example.net domain
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url5.eml
-  Should Contain  ${result.stdout}  DBL_PHISH
-  Should Not Contain  ${result.stdout}  DBL_SPAM
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL
-  Should Not Contain  ${result.stdout}  URIBL_BLACK
+  Scan File  ${TESTDIR}/messages/url5.eml
+  Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  RSPAMD_URIBL
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL Example.org domain
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url6.eml
-  Should Contain  ${result.stdout}  URIBL_BLACK
-  Should Not Contain  ${result.stdout}  DBL_SPAM
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL
-  Should Not Contain  ${result.stdout}  DBL_PHISH
+  Scan File  ${TESTDIR}/messages/url6.eml
+  Expect Symbol  URIBL_BLACK
+  Do Not Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  RSPAMD_URIBL
+  Do Not Expect Symbol  DBL_PHISH
 
 SURBL Example.ru domain
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url7.eml
-  Should Contain  ${result.stdout}  URIBL_GREY
-  Should Contain  ${result.stdout}  URIBL_RED
-  Should Not Contain  ${result.stdout}  DBL_SPAM
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL
-  Should Not Contain  ${result.stdout}  DBL_PHISH
-  Should Not Contain  ${result.stdout}  URIBL_BLACK
+  Scan File  ${TESTDIR}/messages/url7.eml
+  Expect Symbol  URIBL_GREY
+  Expect Symbol  URIBL_RED
+  Do Not Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  RSPAMD_URIBL
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL Example.ru ZEN domain
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url7.eml
-  Should Contain  ${result.stdout}  URIBL_SBL_CSS (
-  Should Contain  ${result.stdout}  URIBL_XBL (
-  Should Contain  ${result.stdout}  URIBL_PBL (
-  Should Not Contain  ${result.stdout}  URIBL_SBL (
-  Should Not Contain  ${result.stdout}  DBL_SPAM (
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL (
-  Should Not Contain  ${result.stdout}  DBL_PHISH (
-  Should Not Contain  ${result.stdout}  URIBL_BLACK (
+  Scan File  ${TESTDIR}/messages/url7.eml
+  Expect Symbol  URIBL_SBL_CSS
+  Expect Symbol  URIBL_XBL
+  Expect Symbol  URIBL_PBL
+  Do Not Expect Symbol  URIBL_SBL
+  Do Not Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  RSPAMD_URIBL
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL Example.com domain image false
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/urlimage.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL_IMAGES
-  Should Not Contain  ${result.stdout}  DBL_SPAM (
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL (
-  Should Not Contain  ${result.stdout}  DBL_PHISH (
-  Should Not Contain  ${result.stdout}  URIBL_BLACK (
+  Scan File  ${TESTDIR}/messages/urlimage.eml
+  Expect Symbol  RSPAMD_URIBL_IMAGES
+  Do Not Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  RSPAMD_URIBL
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL @example.com mail html
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/mailadr.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL (
-  Should Contain  ${result.stdout}  DBL_SPAM (
-  Should Contain  ${result.stdout}  example.com:email
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL_IMAGES (
-  Should Not Contain  ${result.stdout}  DBL_PHISH (
-  Should Not Contain  ${result.stdout}  URIBL_BLACK (
+  Scan File  ${TESTDIR}/messages/mailadr.eml
+  Expect Symbol  RSPAMD_URIBL
+  Expect Symbol With Exact Options  DBL_SPAM  example.com:email
+  Do Not Expect Symbol  RSPAMD_URIBL_IMAGES
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL @example.com mail text
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/mailadr2.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL (
-  Should Contain  ${result.stdout}  DBL_SPAM (
-  Should Contain  ${result.stdout}  example.com:email
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL_IMAGES (
-  Should Not Contain  ${result.stdout}  DBL_PHISH (
-  Should Not Contain  ${result.stdout}  URIBL_BLACK (
+  Scan File  ${TESTDIR}/messages/mailadr2.eml
+  Expect Symbol  RSPAMD_URIBL
+  Expect Symbol With Exact Options  DBL_SPAM  example.com:email
+  Do Not Expect Symbol  RSPAMD_URIBL_IMAGES
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL example.com not encoded url in subject
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/urlinsubject.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL (
-  Should Contain  ${result.stdout}  DBL_SPAM (
-  Should Not Contain  ${result.stdout}  DBL_PHISH (
-  Should Not Contain  ${result.stdout}  URIBL_BLACK (
+  Scan File  ${TESTDIR}/messages/urlinsubject.eml
+  Expect Symbol  RSPAMD_URIBL
+  Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL example.com encoded url in subject
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/urlinsubjectencoded.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL (
-  Should Contain  ${result.stdout}  DBL_SPAM (
-  Should Not Contain  ${result.stdout}  DBL_PHISH (
-  Should Not Contain  ${result.stdout}  URIBL_BLACK (
+  Scan File  ${TESTDIR}/messages/urlinsubjectencoded.eml
+  Expect Symbol  RSPAMD_URIBL
+  Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 WHITELIST
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/whitelist.eml
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL (
-  Should Not Contain  ${result.stdout}  DBL_SPAM (
-  Should Not Contain  ${result.stdout}  RSPAMD_URIBL_IMAGES (
+  Scan File  ${TESTDIR}/messages/whitelist.eml
+  Do Not Expect Symbol  RSPAMD_URIBL
+  Do Not Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  RSPAMD_URIBL_IMAGES
 
 EMAILBL full address & domain only
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/emailbltext.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL_FULL (
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL_DOMAINONLY (
+  Scan File  ${TESTDIR}/messages/emailbltext.eml
+  Expect Symbol  RSPAMD_EMAILBL_FULL
+  Expect Symbol  RSPAMD_EMAILBL_DOMAINONLY
 
 EMAILBL full subdomain address
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/emailbltext2.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL_FULL (
+  Scan File  ${TESTDIR}/messages/emailbltext2.eml
+  Expect Symbol  RSPAMD_EMAILBL_FULL
 
 EMAILBL full subdomain address & domain only
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/emailbltext3.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL_DOMAINONLY (0.00)[baddomain.com:email]
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL_FULL (0.00)[user.subdomain.baddomain.com:email]
+  Scan File  ${TESTDIR}/messages/emailbltext3.eml
+  Expect Symbol With Exact Options  RSPAMD_EMAILBL_DOMAINONLY  baddomain.com:email
+  Expect Symbol With Exact Options  RSPAMD_EMAILBL_FULL  user.subdomain.baddomain.com:email
 
 EMAILBL REPLY TO full address
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/replyto.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL_FULL (
-  Should Not Contain  ${result.stdout}  RSPAMD_EMAILBL_DOMAINONLY (
+  Scan File  ${TESTDIR}/messages/replyto.eml
+  Expect Symbol  RSPAMD_EMAILBL_FULL
+  Do Not Expect Symbol  RSPAMD_EMAILBL_DOMAINONLY
 
 EMAILBL REPLY TO domain only
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/replyto2.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL_DOMAINONLY (
-  Should Not Contain  ${result.stdout}  RSPAMD_EMAILBL_FULL (
+  Scan File  ${TESTDIR}/messages/replyto2.eml
+  Expect Symbol  RSPAMD_EMAILBL_DOMAINONLY
+  Do Not Expect Symbol  RSPAMD_EMAILBL_FULL
 
 EMAILBL REPLY TO full subdomain address
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/replytosubdomain.eml
-  Should Contain  ${result.stdout}  RSPAMD_EMAILBL_FULL (
-  Should Not Contain  ${result.stdout}  RSPAMD_EMAILBL_DOMAINONLY (
+  Scan File  ${TESTDIR}/messages/replytosubdomain.eml
+  Expect Symbol  RSPAMD_EMAILBL_FULL
+  Do Not Expect Symbol  RSPAMD_EMAILBL_DOMAINONLY
 
 SURBL IDN domain
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url8.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL
-  Should Contain  ${result.stdout}  DBL_SPAM
-  Should Not Contain  ${result.stdout}  DBL_PHISH
-  Should Not Contain  ${result.stdout}  URIBL_BLACK
+  Scan File  ${TESTDIR}/messages/url8.eml
+  Expect Symbol  RSPAMD_URIBL
+  Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL IDN Punycode domain
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url9.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL
-  Should Contain  ${result.stdout}  DBL_SPAM
-  Should Not Contain  ${result.stdout}  DBL_PHISH
-  Should Not Contain  ${result.stdout}  URIBL_BLACK
+  Scan File  ${TESTDIR}/messages/url9.eml
+  Expect Symbol  RSPAMD_URIBL
+  Expect Symbol  DBL_SPAM
+  Do Not Expect Symbol  DBL_PHISH
+  Do Not Expect Symbol  URIBL_BLACK
 
 SURBL html entity&shy
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url10.eml
-  Should Contain  ${result.stdout}  RSPAMD_URIBL
+  Scan File  ${TESTDIR}/messages/url10.eml
+  Expect Symbol  RSPAMD_URIBL
 
 SURBL url compose map 1
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url11.eml
-  Should Contain  ${result.stdout}  BAD_SUBDOMAIN (0.00)[clean.dirty.sanchez.com:url]
+  Scan File  ${TESTDIR}/messages/url11.eml
+  Expect Symbol With Exact Options  BAD_SUBDOMAIN  clean.dirty.sanchez.com:url
 
 SURBL url compose map 2
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url12.eml
-  Should Contain  ${result.stdout}  BAD_SUBDOMAIN (0.00)[4.very.dirty.sanchez.com:url]
+  Scan File  ${TESTDIR}/messages/url12.eml
+  Expect Symbol With Exact Options  BAD_SUBDOMAIN  4.very.dirty.sanchez.com:url
 
 SURBL url compose map 3
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/url13.eml
-  Should Contain  ${result.stdout}  BAD_SUBDOMAIN (0.00)[41.black.sanchez.com:url]
+  Scan File  ${TESTDIR}/messages/url13.eml
+  Expect Symbol With Exact Options  BAD_SUBDOMAIN  41.black.sanchez.com:url
 
 *** Keywords ***
 Surbl Setup

--- a/test/functional/cases/350_magic.robot
+++ b/test/functional/cases/350_magic.robot
@@ -13,60 +13,60 @@ ${URL_TLD}      ${TESTDIR}/../lua/unit/test_tld.dat
 
 *** Test Cases ***
 Magic detections bundle 1
-  ${result} =  Scan Message With Rspamc  ${TESTDIR}/messages/gargantua.eml
-  Should Contain  ${result.stdout}  MAGIC_SYM_ZIP_2
-  Should Contain  ${result.stdout}  MAGIC_SYM_RAR_3
-  Should Contain  ${result.stdout}  MAGIC_SYM_EXE_4
-  Should Contain  ${result.stdout}  MAGIC_SYM_ELF_5
-  Should Contain  ${result.stdout}  MAGIC_SYM_LNK_6
-  Should Contain  ${result.stdout}  MAGIC_SYM_CLASS_7
-  Should Contain  ${result.stdout}  MAGIC_SYM_RTF_8
-  Should Contain  ${result.stdout}  MAGIC_SYM_PDF_9
-  Should Contain  ${result.stdout}  MAGIC_SYM_PS_10
-  Should Contain  ${result.stdout}  MAGIC_SYM_CHM_11
-  Should Contain  ${result.stdout}  MAGIC_SYM_DJVU_12
-  Should Contain  ${result.stdout}  MAGIC_SYM_ARJ_13
-  Should Contain  ${result.stdout}  MAGIC_SYM_CAB_14
-  Should Contain  ${result.stdout}  MAGIC_SYM_ACE_15
-  Should Contain  ${result.stdout}  MAGIC_SYM_TAR_16
-  Should Contain  ${result.stdout}  MAGIC_SYM_BZ2_17
-  Should Contain  ${result.stdout}  MAGIC_SYM_XZ_18
-  Should Contain  ${result.stdout}  MAGIC_SYM_LZ4_19
-  Should Contain  ${result.stdout}  MAGIC_SYM_ZST_20
-  Should Contain  ${result.stdout}  MAGIC_SYM_DMG_21
-  Should Contain  ${result.stdout}  MAGIC_SYM_ISO_22
-  Should Contain  ${result.stdout}  MAGIC_SYM_ZOO_23
-  Should Contain  ${result.stdout}  MAGIC_SYM_EPUB_24
-  Should Contain  ${result.stdout}  MAGIC_SYM_XAR_25
-  Should Contain  ${result.stdout}  MAGIC_SYM_PSD_26
-  Should Contain  ${result.stdout}  MAGIC_SYM_PCX_27
-  Should Contain  ${result.stdout}  MAGIC_SYM_TIFF_28
-  Should Contain  ${result.stdout}  MAGIC_SYM_ICO_29
-  Should Contain  ${result.stdout}  MAGIC_SYM_SWF_30
-  Should Contain  ${result.stdout}  MAGIC_SYM_DOC_31
-  Should Contain  ${result.stdout}  MAGIC_SYM_XLS_32
-  Should Contain  ${result.stdout}  MAGIC_SYM_PPT_33
-  Should Contain  ${result.stdout}  MAGIC_SYM_MSI_34
-  Should Contain  ${result.stdout}  MAGIC_SYM_MSG_35
-  Should Contain  ${result.stdout}  MAGIC_SYM_DOCX_36
-  Should Contain  ${result.stdout}  MAGIC_SYM_XLSX_37
-  Should Contain  ${result.stdout}  MAGIC_SYM_PPTX_38
-  Should Contain  ${result.stdout}  MAGIC_SYM_ODT_39
-  Should Contain  ${result.stdout}  MAGIC_SYM_ODS_40
-  Should Contain  ${result.stdout}  MAGIC_SYM_ODP_41
-  Should Contain  ${result.stdout}  MAGIC_SYM_7Z_42
-  Should Contain  ${result.stdout}  MAGIC_SYM_VSD_43
-  Should Contain  ${result.stdout}  MAGIC_SYM_PNG_44
-  Should Contain  ${result.stdout}  MAGIC_SYM_JPG_45
-  Should Contain  ${result.stdout}  MAGIC_SYM_GIF_46
-  Should Contain  ${result.stdout}  MAGIC_SYM_BMP_47
-  Should Contain  ${result.stdout}  MAGIC_SYM_TXT_48
-  Should Contain  ${result.stdout}  MAGIC_SYM_HTML_49
-  Should Contain  ${result.stdout}  MAGIC_SYM_CSV_50
-  Should Contain  ${result.stdout}  MAGIC_SYM_DWG_51
-  Should Contain  ${result.stdout}  MAGIC_SYM_JAR_52
-  Should Contain  ${result.stdout}  MAGIC_SYM_APK_53
-  Should Contain  ${result.stdout}  MAGIC_SYM_BAT_54
-  Should Contain  ${result.stdout}  MAGIC_SYM_ICS_55
-  Should Contain  ${result.stdout}  MAGIC_SYM_VCF_56
+  Scan File  ${TESTDIR}/messages/gargantua.eml
+  Expect Symbol  MAGIC_SYM_ZIP_2
+  Expect Symbol  MAGIC_SYM_RAR_3
+  Expect Symbol  MAGIC_SYM_EXE_4
+  Expect Symbol  MAGIC_SYM_ELF_5
+  Expect Symbol  MAGIC_SYM_LNK_6
+  Expect Symbol  MAGIC_SYM_CLASS_7
+  Expect Symbol  MAGIC_SYM_RTF_8
+  Expect Symbol  MAGIC_SYM_PDF_9
+  Expect Symbol  MAGIC_SYM_PS_10
+  Expect Symbol  MAGIC_SYM_CHM_11
+  Expect Symbol  MAGIC_SYM_DJVU_12
+  Expect Symbol  MAGIC_SYM_ARJ_13
+  Expect Symbol  MAGIC_SYM_CAB_14
+  Expect Symbol  MAGIC_SYM_ACE_15
+  Expect Symbol  MAGIC_SYM_TAR_16
+  Expect Symbol  MAGIC_SYM_BZ2_17
+  Expect Symbol  MAGIC_SYM_XZ_18
+  Expect Symbol  MAGIC_SYM_LZ4_19
+  Expect Symbol  MAGIC_SYM_ZST_20
+  Expect Symbol  MAGIC_SYM_DMG_21
+  Expect Symbol  MAGIC_SYM_ISO_22
+  Expect Symbol  MAGIC_SYM_ZOO_23
+  Expect Symbol  MAGIC_SYM_EPUB_24
+  Expect Symbol  MAGIC_SYM_XAR_25
+  Expect Symbol  MAGIC_SYM_PSD_26
+  Expect Symbol  MAGIC_SYM_PCX_27
+  Expect Symbol  MAGIC_SYM_TIFF_28
+  Expect Symbol  MAGIC_SYM_ICO_29
+  Expect Symbol  MAGIC_SYM_SWF_30
+  Expect Symbol  MAGIC_SYM_DOC_31
+  Expect Symbol  MAGIC_SYM_XLS_32
+  Expect Symbol  MAGIC_SYM_PPT_33
+  Expect Symbol  MAGIC_SYM_MSI_34
+  Expect Symbol  MAGIC_SYM_MSG_35
+  Expect Symbol  MAGIC_SYM_DOCX_36
+  Expect Symbol  MAGIC_SYM_XLSX_37
+  Expect Symbol  MAGIC_SYM_PPTX_38
+  Expect Symbol  MAGIC_SYM_ODT_39
+  Expect Symbol  MAGIC_SYM_ODS_40
+  Expect Symbol  MAGIC_SYM_ODP_41
+  Expect Symbol  MAGIC_SYM_7Z_42
+  Expect Symbol  MAGIC_SYM_VSD_43
+  Expect Symbol  MAGIC_SYM_PNG_44
+  Expect Symbol  MAGIC_SYM_JPG_45
+  Expect Symbol  MAGIC_SYM_GIF_46
+  Expect Symbol  MAGIC_SYM_BMP_47
+  Expect Symbol  MAGIC_SYM_TXT_48
+  Expect Symbol  MAGIC_SYM_HTML_49
+  Expect Symbol  MAGIC_SYM_CSV_50
+  Expect Symbol  MAGIC_SYM_DWG_51
+  Expect Symbol  MAGIC_SYM_JAR_52
+  Expect Symbol  MAGIC_SYM_APK_53
+  Expect Symbol  MAGIC_SYM_BAT_54
+  Expect Symbol  MAGIC_SYM_ICS_55
+  Expect Symbol  MAGIC_SYM_VCF_56
 

--- a/test/functional/cases/360_force_actions.robot
+++ b/test/functional/cases/360_force_actions.robot
@@ -13,34 +13,34 @@ ${RSPAMD_SCOPE}  Suite
 
 *** Test Cases ***
 FORCE ACTIONS from reject to add header
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_reject
-  Check Rspamc  ${result}  Action: add header
-  Should Contain  ${result.stdout}  FORCE_ACTION_FORCE_REJECT_TO_ADD_HEADER
+  Scan File  ${MESSAGE}  Settings-Id=id_reject
+  Expect Action  add header
+  Expect Symbol  FORCE_ACTION_FORCE_REJECT_TO_ADD_HEADER
 
 FORCE ACTIONS from reject to no action
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_reject_no_action
-  Check Rspamc  ${result}  Action: no action
-  Should Contain  ${result.stdout}  FORCE_ACTION_FORCE_REJECT_TO_NO_ACTION
+  Scan File  ${MESSAGE}  Settings-Id=id_reject_no_action
+  Expect Action  no action
+  Expect Symbol  FORCE_ACTION_FORCE_REJECT_TO_NO_ACTION
 
 FORCE ACTIONS from no action to reject
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_no_action
-  Check Rspamc  ${result}  Action: reject
-  Should Contain  ${result.stdout}  FORCE_ACTION_FORCE_NO_ACTION_TO_REJECT
+  Scan File  ${MESSAGE}  Settings-Id=id_no_action
+  Expect Action  reject
+  Expect Symbol  FORCE_ACTION_FORCE_NO_ACTION_TO_REJECT
 
 FORCE ACTIONS from no action to add header
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_no_action_to_add_header
-  Check Rspamc  ${result}  Action: add header
-  Should Contain  ${result.stdout}  FORCE_ACTION_FORCE_NO_ACTION_TO_ADD_HEADER
+  Scan File  ${MESSAGE}  Settings-Id=id_no_action_to_add_header
+  Expect Action  add header
+  Expect Symbol  FORCE_ACTION_FORCE_NO_ACTION_TO_ADD_HEADER
 
 FORCE ACTIONS from add header to no action
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_add_header
-  Check Rspamc  ${result}  Action: no action
-  Should Contain  ${result.stdout}  FORCE_ACTION_FORCE_ADD_HEADER_TO_NO_ACTION
+  Scan File  ${MESSAGE}  Settings-Id=id_add_header
+  Expect Action  no action
+  Expect Symbol  FORCE_ACTION_FORCE_ADD_HEADER_TO_NO_ACTION
 
 FORCE ACTIONS from add header to reject
-  ${result} =  Scan Message With Rspamc  ${MESSAGE}  --header  Settings-Id=id_add_header_to_reject
-  Check Rspamc  ${result}  Action: reject
-  Should Contain  ${result.stdout}  FORCE_ACTION_FORCE_ADD_HEADER_TO_REJECT
+  Scan File  ${MESSAGE}  Settings-Id=id_add_header_to_reject
+  Expect Action  reject
+  Expect Symbol  FORCE_ACTION_FORCE_ADD_HEADER_TO_REJECT
 
 
 *** Keywords ***

--- a/test/functional/lib/rspamd.py
+++ b/test/functional/lib/rspamd.py
@@ -139,8 +139,18 @@ def rspamc(addr, port, filename):
     r = s.recv(2048)
     return r.decode('utf-8')
 
-def scan_file(addr, port, filename):
-    return str(urlopen("http://%s:%s/symbols?file=%s" % (addr, port, filename)).read())
+def Scan_File(filename, **headers):
+    addr = BuiltIn().get_variable_value("${LOCAL_ADDR}")
+    port = BuiltIn().get_variable_value("${PORT_NORMAL}")
+    headers["Queue-Id"] = BuiltIn().get_variable_value("${TEST_NAME}")
+    c = http.client.HTTPConnection("%s:%s" % (addr, port))
+    c.request("POST", "/checkv2", open(filename, "rb"), headers)
+    r = c.getresponse()
+    assert r.status == 200
+    d = demjson.decode(r.read())
+    c.close()
+    BuiltIn().set_test_variable("${SCAN_RESULT}", d)
+    return
 
 def Send_SIGUSR1(pid):
     pid = int(pid)

--- a/test/functional/lib/rspamd.robot
+++ b/test/functional/lib/rspamd.robot
@@ -44,6 +44,10 @@ Check Rspamc Match String
   Run Keyword If  ${inverse} == False  Should Contain  ${subject}  ${str}
   ...  ELSE  Should Not Contain  ${subject}  ${str}
 
+Do Not Expect Symbol
+  [Arguments]  ${symbol}
+  Run Keyword And Expect Error  *  Expect Symbol  ${symbol}
+
 Generic Setup
   [Arguments]  @{vargs}  &{kwargs}
   &{d} =  Run Rspamd  @{vargs}  &{kwargs}
@@ -53,6 +57,59 @@ Generic Setup
     ...  ELSE IF  '${RSPAMD_SCOPE}' == 'Test'  Set Test Variable  ${${i}}  ${d}[${i}]
     ...  ELSE  Fail  'RSPAMD_SCOPE must be Test or Suite'
   END
+
+Expect Action
+  [Arguments]  ${action}
+  Should Be Equal  ${SCAN_RESULT}[action]  ${action}
+
+Expect Email
+  [Arguments]  ${email}
+  List Should Contain Value  ${SCAN_RESULT}[emails]  ${email}
+
+Expect Required Score
+  [Arguments]  ${required_score}
+  Should Be Equal As Numbers  ${SCAN_RESULT}[required_score]  ${required_score}
+
+Expect Required Score To Be Null
+  Should Be Equal  ${SCAN_RESULT}[required_score]  ${NONE}
+
+Expect Score
+  [Arguments]  ${score}
+  Should Be Equal As Numbers  ${SCAN_RESULT}[score]  ${score}
+
+Expect Symbol
+  [Arguments]  ${symbol}
+  Dictionary Should Contain Key  ${SCAN_RESULT}[symbols]  ${symbol}
+  ...  msg=Symbol ${symbol} wasn't found in result
+
+Expect URL
+  [Arguments]  ${url}
+  List Should Contain Value  ${SCAN_RESULT}[urls]  ${url}
+
+Expect Symbol With Exact Options
+  [Arguments]  ${symbol}  @{options}
+  Expect Symbol  ${symbol}
+  ${have_options} =  Convert To List  ${SCAN_RESULT}[symbols][${symbol}][options]
+  Lists Should Be Equal  ${have_options}  ${options}
+  ...  msg="Symbol ${symbol} has options ${SCAN_RESULT}[symbols][${symbol}][options] but expected ${options}"
+
+Expect Symbol With Option
+  [Arguments]  ${symbol}  ${option}
+  Expect Symbol  ${symbol}
+  ${have_options} =  Convert To List  ${SCAN_RESULT}[symbols][${symbol}][options]
+  Should Contain  ${have_options}  ${option}
+  ...  msg="Options for symbol ${symbol} ${SCAN_RESULT}[symbols][${symbol}][options] doesn't contain ${option}"
+
+Expect Symbol With Score
+  [Arguments]  ${symbol}  ${score}
+  Expect Symbol  ${symbol}
+  Should Be Equal As Numbers  ${SCAN_RESULT}[symbols][${symbol}][score]  ${score}
+  ...  msg="Symbol ${symbol} has score of ${SCAN_RESULT}[symbols][${symbol}][score] but expected ${score}"
+
+Expect Symbol With Score And Exact Options
+  [Arguments]  ${symbol}  ${score}  @{options}
+  Expect Symbol With Exact Options  ${symbol}  @{options}
+  Expect Symbol With Score  ${symbol}  ${score}
 
 Generic Teardown
   Run Keyword If  '${CONTROLLER_ERRORS}' == 'True'  Check Controller Errors
@@ -154,6 +211,12 @@ Run Rspamd
 
 Simple Teardown
   Generic Teardown
+
+Scan File By Reference
+  [Arguments]  ${filename}  &{headers}
+  Set To Dictionary  ${headers}  File=${filename}
+  ${result} =  Scan File  /dev/null  &{headers}
+  [Return]  ${result}
 
 Scan Message With Rspamc
   [Arguments]  ${msg_file}  @{vargs}


### PR DESCRIPTION
Ideas are to:
* get rid of dumb string matching
* try use a single instance of rspamd for whatever tests we could & [settings](https://rspamd.com/doc/configuration/settings.html) to test what we need
* try parallelise most scans with a [pre-run modifier](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#pre-run-modifier) or some other way.