### PR TITLE
[Minor] Fix typo in lua_fuzzy options

### DIFF
--- a/lualib/lua_fuzzy.lua
+++ b/lualib/lua_fuzzy.lua
@@ -58,7 +58,7 @@ local policy_schema = ts.shape{
   scan_archives = ts.boolean,
   short_text_direct_hash = ts.boolean,
   text_shingles = ts.boolean,
-  skip_imagess = ts.boolean,
+  skip_images = ts.boolean,
 }
 
 


### PR DESCRIPTION
Fix typo: `skip_imagess` -> `skip_images`