### PR TITLE
[WebUI] Use /auth to get data missing in /stat

### DIFF
--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -254,7 +254,7 @@ define(["jquery", "d3pie"],
                         for (var e in neighbours_status) {
                             if (neighbours_status[e].status === true) {
                                 // Remove alert status
-                                localStorage.removeItem(e + "_alerted");
+                                sessionStorage.removeItem("alerted_stats_" + neighbours_status[e].name);
 
                                 var data = neighbours_status[e].data;
                                 for (var action in neighbours_sum.actions) {

--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -29,6 +29,7 @@ define(["jquery", "d3pie"],
         "use strict";
         // @ ms to date
         function msToTime(seconds) {
+            if (!Number.isFinite(seconds)) return "???";
             /* eslint-disable no-bitwise */
             var years = seconds / 31536000 >> 0; // 3600*24*365
             var months = seconds % 31536000 / 2628000 >> 0; // 3600*24*365/12


### PR DESCRIPTION
response on legacy servers.

Namely "config_id", "version" and "uptime".