### PR TITLE
[Minor] Improve lua_magic HTML content type check

### DIFF
--- a/lualib/lua_magic/heuristics.lua
+++ b/lualib/lua_magic/heuristics.lua
@@ -434,7 +434,7 @@ exports.text_part_heuristic = function(part, log_obj, _)
         end
       end
 
-      if mtype == 'text' and (msubtype == 'html' or msubtype == 'htm') then
+      if (mtype == 'text' or mtype == 'application') and (msubtype == 'html' or msubtype == 'xhtml+xml') then
         return 'html',21
       end
 


### PR DESCRIPTION
Types which are used for html (xhtml) attachments:
text/html
application/html
application/xhtml+xml

Type which cannot be found in the wild: application/htm