### PR TITLE
add a symbol to differentiate fail and clamav sig limits exceeded

### DIFF
--- a/lualib/lua_scanners/clamav.lua
+++ b/lualib/lua_scanners/clamav.lua
@@ -145,7 +145,7 @@ local function clamav_check(task, content, digest, rule)
             common.yield_result(task, rule, vname, 0.0, 'macro')
           elseif string.find(vname, '^Heuristics%.Limits%.Exceeded') then
             rspamd_logger.errx(task, '%s: ClamAV Limits Exceeded', rule.log_prefix)
-            common.yield_result(task, rule, 'Limits Exceeded: '.. vname, 0.0, 'fail')
+            common.yield_result(task, rule, 'Limits Exceeded: '.. vname, 0.0, 'limits_exceeded')
           elseif vname then
             common.yield_result(task, rule, vname)
             cached = vname

--- a/lualib/lua_scanners/common.lua
+++ b/lualib/lua_scanners/common.lua
@@ -91,6 +91,11 @@ local function yield_result(task, rule, vname, dyn_weight, is_fail)
     symbol = rule.symbol_macro
     threat_info = "Scan has returned that input contains macros"
     dyn_weight = 1.0
+  elseif is_fail == 'limits_exceeded' then
+    patterns = rule.patterns
+    symbol = rule.symbol_exceed
+    threat_info = "Scan has returned signature limits exceeded - bypass risk"
+    dyn_weight = 1.0
   end
 
   if type(vname) == 'string' then

--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -94,6 +94,9 @@ local function add_antivirus_rule(sym, opts)
   if not opts.symbol_macro then
     opts.symbol_macro = opts.symbol .. '_MACRO'
   end
+  if not opts.symbol_exceed then
+    opts.symbol_exceed = opts.symbol .. '_LIMITS_EXCEEDED'
+  end
 
   -- WORKAROUND for deprecated attachments_only
   if opts.attachments_only ~= nil then
@@ -194,6 +197,13 @@ if opts and type(opts) == 'table' then
         rspamd_config:register_symbol({
           type = 'virtual',
           name = m['symbol_macro'],
+          parent = id,
+          score = 0.0,
+          group = N
+        })
+        rspamd_config:register_symbol({
+          type = 'virtual',
+          name = m['symbol_exceed'],
           parent = id,
           score = 0.0,
           group = N


### PR DESCRIPTION
To facilitate the difference in action between:
 - clamav returns a fail type error because it is down (action = soft rebut / greylist)
and 
 - a signature return exceeded because the analyzed file exceeds the thresholds (action = rejection or increase in score)

I added in your code the symbol "CLAM_VIRUS_LIMITS_EXCEEDED", what makes it possible to do this (for example):
---------force_actions.conf--------
  CLAM_FAIL {
     expression = "CLAM_VIRUS_FAIL";
     action = "greylist";
  }
  CLAM_EXCEED {
     expression = "CLAM_VIRUS_LIMITS_EXCEEDED";
     action = "reject";
  }
---------
Thank you for your very powerful tools!