### PR TITLE
[FIX] Clickhouse Migrations SQL Syntax Error

### DIFF
--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -210,7 +210,7 @@ local migrations = {
   [4] = {
     [[ALTER TABLE rspamd
       MODIFY COLUMN Action Enum8('reject' = 0, 'rewrite subject' = 1, 'add header' = 2, 'greylist' = 3, 'no action' = 4, 'soft reject' = 5, 'custom' = 6) DEFAULT 'no action',
-      ADD IF NOT EXISTS COLUMN CustomAction String AFTER Action
+      ADD COLUMN IF NOT EXISTS CustomAction String AFTER Action
     ]],
     -- New version
     [[INSERT INTO rspamd_version (Version) Values (5)]],


### PR DESCRIPTION
While performing the Clickhouse SQL migrations this error line occurs: 

`2020-09-29 14:54:45 #72388(controller) <6oiiuq>; lua; clickhouse.lua:1109: cannot apply migration 4: 'ALTER TABLE rspamd\0a      MODIFY COLUMN Action Enum8('reject' = 0, 'rewrite subject' = 1, 'add header' = 2, 'greylist' = 3, 'no action' = 4, 'soft reject' = 5, 'custom' = 6) DEFAULT 'no action',\0a      ADD IF NOT EXISTS COLUMN CustomAction String AFTER Action\0a    ' on clickhouse server [***]:8123: Code: 62, e.displayText() = DB::Exception: Syntax error: failed at position 205 ('IF') (line 3, col 11): IF NOT EXISTS COLUMN CustomAction String AFTER Action\0a    . Expected one of: INDEX, CONSTRAINT, COLUMN (version 20.8.3.18 (official build))\0a`

This is caused by a [Clickhouse SQL Syntax Error](https://clickhouse.tech/docs/en/sql-reference/statements/alter/column/) which is to be fixed by this commit.
 