### PR TITLE
Check url

### DIFF
--- a/conf/modules.d/url_redirector.conf
+++ b/conf/modules.d/url_redirector.conf
@@ -14,13 +14,17 @@
 
 url_redirector {
   expire = 1d; # 1 day by default
-  timeout = 10; # 10 seconds by default
+  timeout = 4; # 4 seconds by default - because task.timeout is 8
   nested_limit = 1; # How many redirects to follow
   #proxy = "http://example.com:3128"; # Send request through proxy
   key_prefix = "rdr:"; # default hash name
   check_ssl = false; # check ssl certificates
   max_size = 10k; # maximum body to process
-
+  max_urls = 10; #max url to check
+  internal_url = false; #check internal URL
+  mx_check = false; #check if record mx exist on domain
+  a_check = false; #check if A record host is equal to A record domain
+  all_urls = false; #check all url in message
   .include(try=true,priority=5) "${DBDIR}/dynamic/url_redirector.conf"
   .include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/url_redirector.conf"
   .include(try=true,priority=10) "$LOCAL_CONFDIR/override.d/url_redirector.conf"

--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ]]--
+
+-- !!WARNING!!: 
+-- - This task needs a long time to finish, it is therefore important to adapt the global option "task_timeout"
+-- - Redis save more informations in memory, especially if you use check all_urls
+
+-- CHANGE LISTE (extended features of this plugin -- @lprat)
+-- - Add: you can check all site or just redirect site map list (if all_url == true)
+-- - Change: use synchrone request
+-- - Add: Check if internal site or ip before request 'HEAD'
+-- - Remove: 'top_urls' because dont understand usage
+-- - Add: symbol if url is direct ip (ex: http://X.X.X.X) but diffference with symbol 'HTTP_TO_IP' is not internal IP
+-- - Add: extract information mimetype, filename, expire date (if redirectors_only == false)
+-- - Add: "suspect_mimetype_in_url_map" for create symbol if content-type is present in map
+-- - Add: "suspect_filename_in_url" for create symbol if filename is present in map
+-- - Add: symbol if max deep in url redirect is execeeded
+-- - Add: symbol if port no standard
+-- - Add: symbol if path is suspect in map suspect_path_in_url_map (regexp)
+-- - Add: symbol suspect Host (sub host with many .. => paypal.com.realdom.xx)
+
+-- TODO: dig +nocmd +noall +answer +ttlunits A host == time to cache in redis?
 
 if confighelp then
   return
@@ -22,20 +42,28 @@ local rspamd_logger = require "rspamd_logger"
 local rspamd_http = require "rspamd_http"
 local hash = require "rspamd_cryptobox_hash"
 local rspamd_url = require "rspamd_url"
+local rspamd_dns = require "rspamd_dns"
+local rspamd_ip = require 'rspamd_ip'
+local rspamd_redis = require 'rspamd_redis'
 local lua_util = require "lua_util"
 local lua_redis = require "lua_redis"
+local ucl = require "ucl"
 local N = "url_redirector"
 
 -- Some popular UA
 local default_ua = {
-  'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)',
-  'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
-  'Wget/1.9.1',
-  'Mozilla/5.0 (Android; Linux armv7l; rv:9.0) Gecko/20111216 Firefox/9.0 Fennec/9.0',
-  'Mozilla/5.0 (Windows NT 5.2; RW; rv:7.0a1) Gecko/20091211 SeaMonkey/9.23a1pre',
-  'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko',
-  'W3C-checklink/4.5 [4.160] libwww-perl/5.823',
-  'Lynx/2.8.8dev.3 libwww-FM/2.14 SSL-MM/1.4.1',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36)',
+  'Mozilla/5.0 (Windows NT 5.1; rv:36.0) Gecko/20100101 Firefox/36.0',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36',
+  'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
+  'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 Firefox/52.0',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:67.0) Gecko/20100101 Firefox/67.0',
+  'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362',
 }
 
 local redis_params
@@ -45,287 +73,448 @@ local settings = {
   timeout = 10, -- 10 seconds by default
   nested_limit = 5, -- How many redirects to follow
   --proxy = "http://example.com:3128", -- Send request through proxy
-  key_prefix = 'rdr:', -- default hash name
+  key_prefix= 'rdr:', -- default hash name
   check_ssl = false, -- check ssl certificates
   max_urls = 5, -- how many urls to check
   max_size = 10 * 1024, -- maximum body to process
+  mx_check = false, -- check mx on domaine url
+  a_check = false, -- check if resolv A host is same than A domain
   user_agent = default_ua,
+  mimetype_url_only_allow = true, -- check suspect_mimetype_in_url_map in mode only allowed
+  internal_url = false, -- no check url/ip internal
   redirector_symbol = nil, -- insert symbol if redirected url has been found
+  download_symbol = nil, -- insert symbol if download file has been found
+  mimetype_symbol = nil, -- insert symbol if suspect mimetype (in or not in map suspect_mimetype_in_url_map)
+  filename_symbol = nil, -- insert symbol if suspect filename (in map suspect_filename_in_url_map)
+  path_symbol = nil, -- insert symbol if suspect url path(in map suspect_path_in_url_map)
+  subhost_suspect_symbol = nil, -- suspect subhost
+  free_download_symbol = nil, --  download on free site like: google, drive live.com or pastbin/raw
+  freehost_symbol = nil, -- insert symbol if suspect use freehost (in map free_hosted_dom_map)
+  too_much_redir_symbol = nil, -- to much redirect, cannot be followed
+  subhost_max_part_symbol = nil, -- if sub host has lot of part (ex: sub0.sub1.sub2.dom.com) -> sub_host_number_part_max
+  port_symbol = nil, -- insert symbol if port url is not standard has been found
+  ip_symbol = nil, -- insert symbol if ip direct in url has been found
+  mx_symbol = nil, -- insert symbol if domain url have no mx record
+  a_symbol = nil, -- insert symbol if domain resolv A is same than host domain A
   redirectors_only = true, -- follow merely redirectors
-  top_urls_key = 'rdr:top_urls', -- key for top urls
-  top_urls_count = 200, -- how many top urls to save
-  redirector_hosts_map = nil -- check only those redirectors
+  all_urls = false, -- check all url, not just redirector_hosts_map
+  top_urls_key = 'rdr:top_urls', -- key for top urls -> i don't understand usage of this
+  top_urls_count = 200, -- how many top urls to save -> i don't understand usage of this
+  redirector_hosts_map = nil, -- check only those redirectors
+  suspect_mimetype_in_url_map = nil, -- check mimetype url suspected by user
+  mimetype_map_regexp = false, -- if map type regexp: suspect_mimetype_in_url_map 
+  suspect_path_in_url_map = nil, -- check mimetype url suspected by user
+  suspect_filename_in_url_map = nil, -- check mimetype url suspected by user
+  sub_host_number_part_max = 2, -- if sub host has more than 2 part (sub1.sub2.dom.com)
+  free_hosted_dom_map = nil, -- map free hosted (tld & host)
+  sub_host_suspect_map = nil, -- map subhost suspect regexp (ex: paypal, facebook, bank, ...)
+  host_use_get_map = nil -- map host to use get method (ex: onedrive.live.com)
 }
 
-local function adjust_url(task, orig_url, redir_url)
-  if type(redir_url) == 'string' then
-    redir_url = rspamd_url.create(task:get_mempool(), redir_url)
-  end
-
-  if redir_url then
-    orig_url:set_redirected(redir_url)
-    task:inject_url(redir_url)
-    if settings.redirector_symbol then
-      task:insert_result(settings.redirector_symbol, 1.0,
-          string.format('%s->%s', orig_url:get_host(), redir_url:get_host()))
+local function add_dyn_info_url(task, url, value)
+  rspamd_logger.debugm(N, task, 'Enter: add_dyn_info_url -> URL [%s] value: %s ', url, value)
+  -- add info symbol
+  -- table = {redir=URL, mimetype=MT, expire=EXP, filename=FN, }
+  local redir_url = nil
+  if value then
+    if value['nomx'] ~= nil then
+      task:insert_result(settings.mx_symbol, 1.0, tostring(url:get_tld()))
     end
-  else
-    rspamd_logger.infox(task, 'bad url %s as redirection for %s', redir_url, orig_url)
-  end
-end
-
-local function cache_url(task, orig_url, url, key, param)
-  -- String representation
-  local str_orig_url = tostring(orig_url)
-  local str_url = tostring(url)
-
-  if str_url ~= str_orig_url then
-    -- Set redirected url
-    adjust_url(task, orig_url, url)
-  end
-
-  local function redis_trim_cb(err, _)
-    if err then
-      rspamd_logger.errx(task, 'got error while getting top urls count: %s', err)
-    else
-      rspamd_logger.infox(task, 'trimmed url set to %s elements',
-        settings.top_urls_count)
+    if value['samea'] ~= nil then
+      task:insert_result(settings.a_symbol, 1.0, tostring(url:get_host()))
     end
-  end
-
-  -- Cleanup logic
-  local function redis_card_cb(err, data)
-    if err then
-      rspamd_logger.errx(task, 'got error while getting top urls count: %s', err)
-    else
-      if data then
-        if tonumber(data) > settings.top_urls_count * 2 then
-          local ret = lua_redis.redis_make_request(task,
-            redis_params, -- connect params
-            key, -- hash key
-            true, -- is write
-            redis_trim_cb, --callback
-            'ZREMRANGEBYRANK', -- command
-            {settings.top_urls_key, '0',
-              tostring(settings.top_urls_count + 1)} -- arguments
-          )
-          if not ret then
-            rspamd_logger.errx(task, 'cannot trim top urls set')
-          else
-            rspamd_logger.infox(task, 'need to trim urls set from %s to %s elements',
-              data,
-              settings.top_urls_count)
-            return
-          end
-        end
+    if value['redir'] ~= nil then
+      -- add information
+      redir_url = rspamd_url.create(task:get_mempool(), value['redir'])
+      url:set_redirected(redir_url)
+      task:inject_url(redir_url)
+      if settings.redirector_symbol then
+        task:insert_result(settings.redirector_symbol, 1.0,
+          string.format('%s->%s', url:get_host(), redir_url:get_host()))
       end
-    end
-  end
-
-  local function redis_set_cb(err, _)
-    if err then
-      rspamd_logger.errx(task, 'got error while setting redirect keys: %s', err)
     else
-      local ret = lua_redis.redis_make_request(task,
-        redis_params, -- connect params
-        key, -- hash key
-        false, -- is write
-        redis_card_cb, --callback
-        'ZCARD', -- command
-        {settings.top_urls_key} -- arguments
-      )
-      if not ret then
-        rspamd_logger.errx(task, 'cannot make redis request to cache results')
-      end
-    end
-  end
-
-  local ret,conn,_ = lua_redis.redis_make_request(task,
-    redis_params, -- connect params
-    key, -- hash key
-    true, -- is write
-    redis_set_cb, --callback
-    'SETEX', -- command
-    {key, tostring(settings.expire), str_url} -- arguments
-  )
-
-  if not ret then
-    rspamd_logger.errx(task, 'cannot make redis request to cache results')
-  else
-    conn:add_cmd('ZINCRBY', {settings.top_urls_key, '1', str_url})
-  end
-end
-
--- Resolve maybe cached url
--- Orig url is the original url object
--- url should be a new url object...
-local function resolve_cached(task, orig_url, url, key, ntries)
-  local function resolve_url()
-    if ntries > settings.nested_limit then
-      -- We cannot resolve more, stop
-      rspamd_logger.debugm(N, task, 'cannot get more requests to resolve %s, stop on %s after %s attempts',
-        orig_url, url, ntries)
-      cache_url(task, orig_url, url, key)
-
-      return
-    end
-
-    local function http_callback(err, code, _, headers)
-      if err then
-        rspamd_logger.infox(task, 'found redirect error from %s to %s, err message: %s',
-          orig_url, url, err)
-        cache_url(task, orig_url, url, key)
-      else
-        if code == 200 then
-          if orig_url == url then
-            rspamd_logger.infox(task, 'direct url %s, err code 200',
-              url)
-          else
-            rspamd_logger.infox(task, 'found redirect from %s to %s, err code 200',
-              orig_url, url)
-          end
-
-          cache_url(task, orig_url, url, key)
-
-        elseif code == 301 or code == 302 then
-          local loc = headers['location']
-          local redir_url
-          if loc then
-            redir_url = rspamd_url.create(task:get_mempool(), loc)
-          end
-          rspamd_logger.debugm(N, task, 'found redirect from %s to %s, err code %s',
-            orig_url, loc, code)
-
-          if redir_url then
-            if settings.redirectors_only then
-              if settings.redirector_hosts_map:get_key(redir_url:get_host()) then
-                resolve_cached(task, orig_url, redir_url, key, ntries + 1)
-              else
-                lua_util.debugm(N, task,
-                  "stop resolving redirects as %s is not a redirector", loc)
-                cache_url(task, orig_url, redir_url, key)
-              end
-            else
-              resolve_cached(task, orig_url, redir_url, key, ntries + 1)
-            end
-          else
-            rspamd_logger.debugm(N, task, "no location, headers: %s", headers)
-            cache_url(task, orig_url, url, key)
+      local host = url:get_host()
+      -- check mimetype
+      if value['mimetype'] ~= nil then
+        -- check if suspect mimetype
+        if settings.mimetype_url_only_allow then
+          if settings.suspect_mimetype_in_url_map and not settings.suspect_mimetype_in_url_map:get_key(value['mimetype']) then
+            -- mode not in whitelist
+            task:insert_result(settings.mimetype_symbol, 1.0,
+              string.format('%s->%s', host, value['mimetype'] ))
           end
         else
-          rspamd_logger.debugm(N, task, 'found redirect error from %s to %s, err code: %s',
-            orig_url, url, code)
-          cache_url(task, orig_url, url, key)
-        end
-      end
-    end
-
-    local ua
-    if type(settings.user_agent) == 'string' then
-      ua = settings.user_agent
-    else
-      ua = settings.user_agent[math.random(#settings.user_agent)]
-    end
-
-    lua_util.debugm(N, task, 'select user agent %s', ua)
-
-    rspamd_http.request{
-      headers = {
-        ['User-Agent'] = ua,
-      },
-      url = tostring(url),
-      task = task,
-      method = 'head',
-      max_size = settings.max_size,
-      timeout = settings.timeout,
-      opaque_body = true,
-      no_ssl_verify = not settings.check_ssl,
-      callback = http_callback
-    }
-  end
-  local function redis_get_cb(err, data)
-    if not err then
-      if type(data) == 'string' then
-        if data ~= 'processing' then
-          -- Got cached result
-          rspamd_logger.debugm(N, task, 'found cached redirect from %s to %s',
-            url, data)
-          if data ~= tostring(orig_url) then
-            adjust_url(task, orig_url, data)
+          if settings.suspect_mimetype_in_url_map and settings.suspect_mimetype_in_url_map:get_key(value['mimetype']) then
+            -- mode blacklist
+            task:insert_result(settings.mimetype_symbol, 1.0,
+              string.format('%s->%s', host, value['mimetype'] ))
           end
-          return
+        end
+      end
+      -- check filename
+      if value['filename'] ~= nil then
+        -- check if suspect filename extension or name
+        task:insert_result(settings.download_symbol, 1.0,
+              string.format('%s->%s', host, value['filename'] ))
+        if settings.suspect_filename_in_url_map and settings.suspect_filename_in_url_map:get_key(value['filename']) then
+          -- regexp check
+          task:insert_result(settings.filename_symbol, 1.0,
+            string.format('%s->%s', host, value['filename'] ))
+        end
+      elseif value['code'] ~= nil and value['code'] == 200 then
+        -- check if filename is in URL
+        local path = url:get_path()
+        local filename = nil
+        for i in string.gmatch(path, "[^%/]+") do
+          filename = i
+        end
+        if filename ~= nil and settings.suspect_filename_in_url_map and settings.suspect_filename_in_url_map:get_key(filename) then
+          task:insert_result(settings.filename_symbol, 1.0,
+            string.format('%s->%s', host, value['filename'] ))
         end
       end
     end
-    local function redis_reserve_cb(nerr, ndata)
-      if nerr then
-        rspamd_logger.errx(task, 'got error while setting redirect keys: %s', nerr)
-      elseif ndata == 'OK' then
-        resolve_url()
-      end
-    end
-
-    if ntries == 1 then
-      -- Reserve key in Redis that we are processing this redirection
-      local ret = lua_redis.redis_make_request(task,
-        redis_params, -- connect params
-        key, -- hash key
-        true, -- is write
-        redis_reserve_cb, --callback
-        'SET', -- command
-        {key, 'processing', 'EX', tostring(settings.timeout * 2), 'NX'} -- arguments
-      )
-      if not ret then
-        rspamd_logger.errx(task, 'Couldn\'t schedule SET')
-      end
-    else
-      -- Just continue resolving
-      resolve_url()
-    end
-
   end
-  local ret = lua_redis.redis_make_request(task,
-    redis_params, -- connect params
-    key, -- hash key
-    false, -- is write
-    redis_get_cb, --callback
-    'GET', -- command
-    {key} -- arguments
-  )
-  if not ret then
-    rspamd_logger.errx(task, 'cannot make redis request to check results')
-  end
+  return redir_url
 end
 
-local function url_redirector_process_url(task, url)
-  local url_str = url:get_raw()
+local function redis_read(task, key, command, args)
+  local addr = redis_params['read_servers']:get_upstream_by_hash(key)
+  if redis_params['expand_keys'] then
+    local m = get_key_expansion_metadata(task)
+    local indexes = get_key_indexes(command, args)
+    for _, i in ipairs(indexes) do
+      args[i] = lutil.template(args[i], m)
+    end
+  end
+  local ip_addr = addr:get_addr()
+  local options = {
+    task = task,
+    host = ip_addr,
+    timeout = redis_params['timeout'],
+    cmd = command,
+    args = args
+  }
+  if redis_params['password'] then
+    options['password'] = redis_params['password']
+  end
+  if redis_params['db'] then
+    options['dbname'] = redis_params['db']
+  end
+  local is_ok, results = rspamd_redis.make_request_sync(options)
+  return is_ok, results
+end
+
+local function redis_write(task, key, command, args)
+  local addr = redis_params['write_servers']:get_upstream_by_hash(key)
+  if redis_params['expand_keys'] then
+    local m = get_key_expansion_metadata(task)
+    local indexes = get_key_indexes(command, args)
+    for _, i in ipairs(indexes) do
+      args[i] = lutil.template(args[i], m)
+    end
+  end
+  local ip_addr = addr:get_addr()
+  local options = {
+    task = task,
+    host = ip_addr,
+    timeout = redis_params['timeout'],
+    cmd = command,
+    args = args
+  }
+  if redis_params['password'] then
+    options['password'] = redis_params['password']
+  end
+  if redis_params['db'] then
+    options['dbname'] = redis_params['db']
+  end
+  local is_ok, results = rspamd_redis.make_request_sync(options)
+  return is_ok, results
+end
+
+local function url_redirector_process_url(task, urlx, ntries)
+  local url_str = urlx:get_raw()
   -- 32 base32 characters are roughly 20 bytes of data or 160 bits
   local key = settings.key_prefix .. hash.create(url_str):base32():sub(1, 32)
-  resolve_cached(task, url, url, key, 1)
+  rspamd_logger.debugm(N, task, 'Enter: url_redirector_process_url -> URL [%s] count: %s -- key: %s', urlx, ntries, key)
+  -- resolve_cached(task, url, url, key, 1) -- old
+  -- extract host and port and path ...
+  local port = urlx:get_port()
+  local host = urlx:get_host()
+  local tld = urlx:get_tld()
+  local path = '/' .. urlx:get_path()
+  local subhost = host:sub(1,-string.len(tld)-1)
+  -- check port no standard
+  if port and not (port == 0) and not ((string.find(string.lower(url_str), 'https://') and port == 443) or (string.find(string.lower(url_str), 'http://') and port == 80) or (string.find(string.lower(url_str), 'ftp://') and port == 21)) then
+    task:insert_result(settings.port_symbol, 1.0,string.format('%s->%s', tostring(host), tostring(port)))
+  end
+  -- check Path suspect
+  if  settings.suspect_path_in_url_map and settings.suspect_path_in_url_map:get_key(tostring(path)) then
+    task:insert_result(settings.path_symbol, 1.0,string.format('%s->%s', tostring(host), tostring(path)))
+  end
+  -- check if free site download
+  -- TODO: find idea for use user config
+  if (string.find(string.lower(url_str), 'drive.google.com/uc') and string.find(string.lower(url_str), 'export=download')) 
+                or string.find(string.lower(url_str), 'onedrive.live.com/download')
+                or (string.find(string.lower(url_str), 'googleusercontent.com') and string.find(string.lower(url_str), 'e=download')) 
+                or string.find(string.lower(url_str), 'pastebin.com/raw/')
+  then
+    task:insert_result(settings.free_download_symbol, 1.0, tostring(host))
+  end
+  -- check sub hosting
+  local count = 0
+  for nouse in string.gmatch(subhost, "[^%.]+")  do
+    count = count + 1
+  end
+  if count > settings.sub_host_number_part_max then
+     task:insert_result(settings.subhost_max_part_symbol, 1.0,tostring(host))
+  end
+  if  settings.sub_host_suspect_map and settings.sub_host_suspect_map:get_key(subhost) then
+    task:insert_result(settings.subhost_suspect_symbol, 1.0,tostring(host))
+  end
+  -- check free hosting
+  if  settings.free_hosted_dom_map and (settings.free_hosted_dom_map:get_key(host) or settings.free_hosted_dom_map:get_key(tld)) then
+    task:insert_result(settings.freehost_symbol, 1.0, tostring(host))
+  end
+  -- check if ip local
+  local host = urlx:get_host()
+  local chunks = {host:match("(%d+)%.(%d+)%.(%d+)%.(%d+)")}
+  local host_is_ip = true
+  local try_connect = true
+  local ip_host = nil
+  if (#chunks == 4) then
+    for _,v in pairs(chunks) do
+      if (tonumber(v) < 0 or tonumber(v) > 255) then
+        host_is_ip = false
+      end
+    end
+  else
+    host_is_ip = false
+  end
+  local ip4 = nil
+  if host_is_ip then ip4 = rspamd_ip.from_string(host) end
+  if host_is_ip and ip4:is_valid() then
+    if ip4:is_local() then
+      try_connect = false
+    else
+      if settings.redirector_symbol then
+        task:insert_result(settings.ip_symbol, 1.0,tostring(host))
+      end
+    end
+  end
+  -- check url in cache
+  if try_connect then
+    -- check in redis cache url
+    local is_ok, results = redis_read(task, key, 'GET', {key})
+    rspamd_logger.debugm(N, task, 'Redis return %s -> %s', is_ok, results)
+    if is_ok and results ~= nil and type(results) == 'string' and results ~= "" then
+      try_connect = false
+      -- add info
+      -- extract information format ucl
+      local parser = ucl.parser()
+      local resp,err = parser:parse_string(results)
+      if err then
+        rspamd_logger.errx(task, 'URL [%s] error [%s] to parse ucl string format: %s ', urlx, err, results)
+      else
+        local value = parser:get_object()
+        rspamd_logger.debugm(N, task, 'URL [%s] cache: %s ', urlx, value)
+        rurl=add_dyn_info_url(task, urlx, value)
+        if rurl ~= nil then
+          if not (ntries > settings.nested_limit) then
+            if settings.all_urls or not settings.redirectors_only or (settings.redirector_hosts_map and settings.redirector_hosts_map:get_key(rurl:get_host())) then
+              -- url redir to check
+              rspamd_logger.debugm(N, task, 'Follow Redir URL (from cache): %s', rurl)
+              url_redirector_process_url(task, rurl, ntries+1)
+            end
+          else
+            -- too much redirect for url, cannot be fully followed
+            task:insert_result(settings.too_much_redir_symbol, 1.0,
+                string.format('%s', rurl:get_host()))
+          end
+        end
+      end
+    elseif not host_is_ip then
+      -- no cache - verify resolv and not internal
+      local is_ok, results = rspamd_dns.request({
+                task = task,
+                type = 'a',
+                name = tostring(host)
+      })
+      if is_ok then
+        rspamd_logger.debugm(N, task, 'Resolved return %s', results)
+        for _,r in ipairs(results) do
+          local ip4 = rspamd_ip.from_string(tostring(r))
+          if ip4:is_valid() then
+            if ip4:is_local() then
+              try_connect = false
+              -- add in cache
+              local cache = {}
+              local str_table = ucl.to_format(cache, 'ucl')
+              local is_ok, results = redis_write(task, key, 'SETEX',  {key, tostring(settings.expire), str_table})
+            else
+              ip_host = tostring(ip4)
+            end
+          end
+        end
+      else
+        -- error resolve
+        rspamd_logger.errx(task, 'Error to Resolved %s', host)
+        try_connect = false
+        -- cache info
+        -- Would it be interesting to keep the information from the error? but it will take up unnecessary space
+        local cache = {}
+        local str_table = ucl.to_format(cache, 'ucl')
+        local is_ok, results = redis_write(task, key, 'SETEX',  {key, tostring(settings.expire), str_table})
+      end
+    end
+  end
+  -- connect to url if not local and not in cache
+  if try_connect then
+    rspamd_logger.debugm(N, task, 'Create HEAD request to %s', urlx)
+    -- special host change methode to get
+    local meth = 'head'
+    -- check free hosting
+    if  settings.host_use_get_map and settings.host_use_get_map:get_key(host) then
+      meth = 'get'
+    end
+    local err, response = rspamd_http.request({
+                  url =  url_str ,
+                  task = task,
+                  max_size = settings.max_size,
+                  timeout = settings.timeout,
+                  method = meth,
+                  opaque_body = true,
+                  no_ssl_verify = not settings.check_ssl
+    })
+    -- ret http
+    rspamd_logger.debugm(N, task,  'Return request to %s ou %s : %s - %s', url_str, err, response)
+    if err then
+      rspamd_logger.errx(task, 'Error request on %s because error request: %s', host, err)
+      -- Would it be interesting to keep the information from the error? but it will take up unnecessary space
+      local cache = {}
+      local str_table = ucl.to_format(cache, 'ucl')
+      local is_ok, results = redis_write(task, key, 'SETEX',  {key, tostring(settings.expire), str_table})
+    else
+      -- parse info
+      local cache = {}
+      local redir_url = nil
+      local code = response['code']
+      local headers = response['headers']
+      if code == 200 then
+        -- code 200 - extract mime & filename if existe
+        cache['code'] = 200        
+        local head_ct = headers['content-type']
+        local head_cd = headers['content-disposition']
+        -- local head_lm = headers['last-modified']
+        -- local head_date = headers['date']
+        if head_ct then
+          -- TODO: fix "content-type: text/html; charset=UTF-8" to extract just ct
+          cache['mimetype'] = head_ct
+        end
+        if head_cd then
+          local attrs = {}
+          string.gsub(head_cd, ';%s*([^%s=]+)="(.-)"', function(attr, val)
+	        attrs[attr] = val 
+	      end)
+	      if attrs.filename then
+            cache['filename'] = attrs.filename 
+          end
+        end
+      elseif code == 301 or code == 302 then
+        -- code 30X - extract redirect location
+        local loc = headers['location']
+        if loc then
+          if not (string.find(string.lower(loc), 'http://') or string.find(string.lower(loc), 'https://')  or string.find(string.lower(loc), 'ftp://')) then
+            -- loc local
+            if port and not (port == 0) then
+              loc = urlx:get_protocol() .. '://'.. urlx:get_host() .. ':' ..  port .. loc
+            else
+              loc = urlx:get_protocol() .. '://' .. urlx:get_host() .. loc
+            end
+          end
+          cache['redir']=loc
+          redir_url = rspamd_url.create(task:get_mempool(), loc)
+        end
+      end
+      -- check MX domain
+      if settings.mx_check then
+        local is_ok_mx, results_mx = rspamd_dns.request({
+                  task = task,
+                  type = 'mx',
+                  name = tostring(tld)
+        })
+        if is_ok_mx then
+          -- TODO len()
+          local count = true
+          for _,r in ipairs(results_mx) do
+            count = false
+          end
+          if count then
+             cache['nomx']=true
+          end
+        else
+          cache['nomx']=true
+        end
+      end
+      -- Check A host == A domain
+      if settings.a_check and tostring(tld) ~= tostring(host) then
+        local is_ok_a, results_a = rspamd_dns.request({
+                  task = task,
+                  type = 'a',
+                  name = tostring(tld)
+        })
+        if is_ok_a then
+          for _,r in ipairs(results_a) do
+            if tostring(r) == ip_host then
+              cache['samea'] = true
+            end
+          end
+        end
+      end
+      -- add symboles
+      add_dyn_info_url(task, urlx, cache)
+      -- cache parsing
+      rspamd_logger.debugm(N, task, 'Cache information request for %s -> %s', urlx, cache)
+      local str_table = ucl.to_format(cache, 'ucl')
+      local is_ok, results = redis_write(task, key, 'SETEX',  {key, tostring(settings.expire), str_table})
+      if redir_url ~= nil then 
+        if not (ntries > settings.nested_limit) then
+          if settings.all_urls or not settings.redirectors_only or (settings.redirector_hosts_map and settings.redirector_hosts_map:get_key(rurl:get_host())) then
+            -- url redir to check
+            rspamd_logger.debugm(N, task, 'Follow Redir URL: %s', redir_url)
+            url_redirector_process_url(task, redir_url, ntries+1)
+          end
+        else
+          task:insert_result(settings.too_much_redir_symbol, 1.0,
+            string.format('%s', redir_url:get_host()))
+        end
+      end
+    end
+  end
 end
 
 local function url_redirector_handler(task)
   local sp_urls = lua_util.extract_specific_urls({
-    task = task,
-    limit = settings.max_urls,
-    filter = function(url)
-      local host = url:get_host()
-      if settings.redirector_hosts_map:get_key(host) then
-        lua_util.debugm(N, task, 'check url %s', tostring(url))
-        return true
-      end
-    end,
-    no_cache = true,
-  })
+      task = task,
+      limit = settings.max_urls,
+      filter = function(url)
+        local host = url:get_host()
+        if settings.all_urls or (settings.redirector_hosts_map and settings.redirector_hosts_map:get_key(host)) then
+          lua_util.debugm(N, task, 'check url %s', tostring(url))
+          return true
+        end
+      end,
+      no_cache = true,
+    })
 
   if sp_urls then
     for _,u in ipairs(sp_urls) do
-      url_redirector_process_url(task, u)
+      url_redirector_process_url(task, u, 1)
     end
   end
 end
 
-local opts =  rspamd_config:get_all_opt('url_redirector')
+local opts = rspamd_config:get_all_opt('url_redirector')
 if opts then
   settings = lua_util.override_defaults(settings, opts)
   redis_params = lua_redis.parse_redis_server('url_redirector', settings)
@@ -334,34 +523,162 @@ if opts then
     rspamd_logger.infox(rspamd_config, 'no servers are specified, disabling module')
     lua_util.disable_module(N, "redis")
   else
-
-    if not settings.redirector_hosts_map then
+    if not settings.all_urls and not settings.redirector_hosts_map then
       rspamd_logger.infox(rspamd_config, 'no redirector_hosts_map option is specified, disabling module')
       lua_util.disable_module(N, "config")
     else
       local lua_maps = require "lua_maps"
-      settings.redirector_hosts_map = lua_maps.map_add_from_ucl(settings.redirector_hosts_map,
+      if settings.redirector_hosts_map then
+        settings.redirector_hosts_map = lua_maps.map_add_from_ucl(settings.redirector_hosts_map,
           'set', 'Redirectors definitions')
+      end
+      if settings.suspect_mimetype_in_url_map then
+        local maptype = 'set'
+        if settings.mimetype_map_regexp then
+          maptype = 'regexp'
+        end
+        settings.suspect_mimetype_in_url_map = lua_maps.map_add_from_ucl(settings.suspect_mimetype_in_url_map,
+          maptype, 'Mimetype Suspect definitions')
+      end
+      if settings.suspect_filename_in_url_map then
+        settings.suspect_filename_in_url_map = lua_maps.map_add_from_ucl(settings.suspect_filename_in_url_map,
+          'regexp', 'Filename regexp Suspect definitions')
+      end
+      if settings.suspect_path_in_url_map then
+        settings.suspect_path_in_url_map = lua_maps.map_add_from_ucl(settings.suspect_path_in_url_map,
+          'regexp', 'Path regexp Suspect definitions')
+      end
+      if settings.free_hosted_dom_map then
+        settings.free_hosted_dom_map = lua_maps.map_add_from_ucl(settings.free_hosted_dom_map,
+          'set', 'Freehosting host or tld definitions')
+      end
+      if settings.sub_host_suspect_map then
+        settings.sub_host_suspect_map = lua_maps.map_add_from_ucl(settings.sub_host_suspect_map,
+          'regexp', 'Subhost regexp Suspect definitions')
+      end
+      if settings.host_use_get_map then
+        settings.host_use_get_map = lua_maps.map_add_from_ucl(settings.host_use_get_map,
+          'set', 'Subhost regexp Suspect definitions')
+      end
 
       lua_redis.register_prefix(settings.key_prefix .. '[a-z0-9]{32}', N,
-          'URL redirector hashes', {
-            type = 'string',
-          })
-      if settings.top_urls_key then
-        lua_redis.register_prefix(settings.top_urls_key, N,
-            'URL redirector top urls', {
-              type = 'zlist',
-            })
-      end
+        'URL informations hashes', {
+          type = 'string',
+        })
       local id = rspamd_config:register_symbol{
         name = 'URL_REDIRECTOR_CHECK',
         type = 'callback,prefilter',
+        flags = 'coro', 
         callback = url_redirector_handler,
       }
 
       if settings.redirector_symbol then
         rspamd_config:register_symbol{
           name = settings.redirector_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.download_symbol then
+        rspamd_config:register_symbol{
+          name = settings.download_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.mx_symbol then
+        rspamd_config:register_symbol{
+          name = settings.mx_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.ip_symbol then
+        rspamd_config:register_symbol{
+          name = settings.ip_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.port_symbol then
+        rspamd_config:register_symbol{
+          name = settings.port_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.mimetype_symbol then
+        rspamd_config:register_symbol{
+          name = settings.mimetype_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.freehost_symbol then
+        rspamd_config:register_symbol{
+          name = settings.freehost_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.free_download_symbol then
+        rspamd_config:register_symbol{
+          name = settings.free_download_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.subhost_suspect_symbol then
+        rspamd_config:register_symbol{
+          name = settings.subhost_suspect_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.path_symbol then
+        rspamd_config:register_symbol{
+          name = settings.path_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.filename_symbol then
+        rspamd_config:register_symbol{
+          name = settings.filename_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.too_much_redir_symbol then
+        rspamd_config:register_symbol{
+          name = settings.too_much_redir_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.subhost_max_part_symbol then
+        rspamd_config:register_symbol{
+          name = settings.subhost_max_part_symbol,
+          type = 'virtual',
+          parent = id,
+          score = 0,
+        }
+      end
+      if settings.a_symbol then
+        rspamd_config:register_symbol{
+          name = settings.a_symbol,
           type = 'virtual',
           parent = id,
           score = 0,


### PR DESCRIPTION
Hi,
I added feature to check URL in message.
  - Add: you can check all site or just redirect site map list (if all_url == true)
  - Change: use synchrone request
  - Stock response HEAD on REDIS in UCL format 
  - Add: Check if internal site 
  - Add check resolv before test request HEAD
  - Remove: 'top_urls' because I dont understand usage
  - Add: symbol if url is direct ip (ex: http://X.X.X.X) but diffference with symbol 'HTTP_TO_IP' is not internal IP
  - Add: extract information mimetype, filename (if redirectors_only == false)
  - Add: "suspect_mimetype_in_url_map" for create symbol if content-type is present in map
  - Add: "suspect_filename_in_url" for create symbol if filename is present in map
  - Add: symbol if max deep in url redirect is execeeded
  - Add: symbol if port no standard
  - Add: symbol if path is suspect in map suspect_path_in_url_map (regexp)
  - Add: symbol suspect Sub Host (sub host with many .. => paypal.com.realdom.xx)
  - Add: symbol for free hosting

This is just a suggestion, I hope that some checks will seem interesting to you.
I think modifying url_redirector wasn't the best idea, as it's more of a global url checks (not just redirect).

Another problem is that you have to adapt the value of "task_timeout" ... Unfortunately I did not find how to adapt it just for this plugin without affecting the whole.
Thanks.

Config exemple :
 - local.d/url_redirector.conf
```
# How long to cache dereferenced links in Redis (default 1 day)
expire = 1d;
# Timeout for HTTP requests (10 seconds by default)
timeout = 4; # 10 seconds by default
# How many nested redirects to follow (default 1)
nested_limit = 2;
# Prefix for keys in redis (default "rdr:")
key_prefix = "urld:";
# Check SSL certificates (default false)
check_ssl = false;
# How many urls to check
max_urls = 10;
# Maximum body to process
max_size = 8;
# no check internal url/ip
internal_url = false;
# check mx for domain
mx_check = true;
# check if resolv A host is same than A domain
a_check = true;
# Insert symbol if redirected url has been found
redirector_symbol = "URL_REDIRECTED";
download_symbol = "URL_DOWNLOAD";
mimetype_symbol = "URL_SUSPECT_MIMETYPE";
filename_symbol = "URL_SUSPECT_FILENAME";
path_symbol = "URL_SUSPECT_PATH";
port_symbol = "URL_WITH_NO_STANDARD_PORT";
ip_symbol = "URL_WITH_IP";
subhost_suspect_symbol = "URL_WITH_SUSPECT_SUBHOST";
freehost_symbol = "URL_USE_FREEHOST";
mx_symbol = "URL_WITH_DOMAIN_NO_MX";
a_symbol = "URL_WITH_HOST_RESOLV_DOMAIN";
# adjust with "sub_host_number_part_max"
subhost_max_part_symbol = "SUBHOST_HAS_LOTOF_PART"
free_download_symbol = "URL_DOWNLOAD_ON_FREESITE";
# too much redirect for url, cannot be fully followed 
too_much_redir_symbol = "URL_TOO_MUCH_REDIRECT";
# Follow merely redirectors
redirectors_only = false;
# check all url, not just redirector_hosts_map
all_urls = true;
# Check only those redirectors
#redirector_hosts_map = "${LOCAL_CONFDIR}/local.d/maps.d/redirectors.map";
# check mimetype in url header
suspect_mimetype_in_url_map = "${LOCAL_CONFDIR}/local.d/maps.d/suspect_mimetype_url.map";
# check mimetype map only allowed -- if false then map is checked in mode blacklist
mimetype_url_only_allow = true;
# if suspect_mimetype_in_url_map is map type regexp
mimetype_map_regexp = true;
# check filename (content-disposition) in url -- regexp map
suspect_filename_in_url_map = "${LOCAL_CONFDIR}/local.d/maps.d/suspect_filname_url.map";
# Check suspect path
suspect_path_in_url_map = "${LOCAL_CONFDIR}/local.d/maps.d/suspect_path_url.map";
#free hosted domain
free_hosted_dom_map = "${LOCAL_CONFDIR}/local.d/maps.d/freehosting.map";
#sub host max part for no suspect
sub_host_number_part_max = 2;
#subhost name suspect: paypal, bank, facebook...
sub_host_suspect_map = "${LOCAL_CONFDIR}/local.d/maps.d/subhost.map";
#host to use get method
host_use_get_map = "${LOCAL_CONFDIR}/local.d/maps.d/host_use_get.map";
```
  -local.d/maps.d/freehosting.map
```
storage.googleapis.com
atwebpages.com
getenjoyment.net
medianewsonline.com
myartsonline.com
mygamesonline.org
mypressonline.com
mywebcommunity.org
onlinewebshop.net
scienceontheweb.net
sportsontheweb.net
eu5.net
wixsite.com
000webhostapp.com
000webhost.com
weebly.com
10001mb.com
22web.org
2kool4u.net
66ghz.com
a0001.net
fast-page.org
html-5.me
humorme.info
iblogger.org
is-best.net
is-great.net
is-great.org
joomla-host.org
likesyou.org
loveslife.biz
my-board.org
my-style.in
mydiscussion.net
nichesite.org
social-networking.me
synergize.co
talk4fun.net
totalh.net
web1337.net
```
  -local.d/maps.d/suspect_path_url.map
```
/\/cgi\-bin\//i
/\/wp\-include\//i
/\/wp\-includes\//i
/\/wp\-admin\//i
/\/wp\-content\//i
/\/css\//i
/\/js\//i
/\/static\//i
/\/swift\//i
/\/img\//i
/\/image\//i
/\/imgs\//i
/\/images\//i
/\/temp\//i
/\/temps\//i
/\/sql\//i
/\/plugins\//i
/\/[A-Za-z0-9_\-]{1,20}\.[A-Za-z0-9_\-]{1,20}(\.[A-Za-z0-9_\-]{1,20})?\//i
```
  -local.d/maps.d/suspect_mimetype_url.map
```
/text\/html/i
```
  -local.d/maps.d/suspect_filname_url.map
```
/\.exe$/i
/\.bin$/i
/\.dll$/i
/\.com$/i
/\.pif$/i
/\.cpl$/i
/\.ocx$/i
/\.sys$/i
/\.scr$/i
/\.cpl$/i
/\.efi$/i
/\.drv$/i
/\.ps[a-z0-9]?$/i
/\.doc[a-z]?$/i
/\.xls[a-z]?$/i
/\.pdf$/i
/\.zip$/i
/\.rar$/i
/\.ace$/i
/\.7z$/i
/\.swf$/i
/\.jar$/i
/\.hta$/i
/\.vb[a-z]?$/i
/\.js[a-z]?$/i
```
  -local.d/maps.d/suspect_mimetype_url.map
```
/text\/html/i
```
  -local.d/maps.d/subhost.map
```
/paypal/i
/gmail/i
/facebook/i
/netflix/i
/bank/i
/banque/i
/linkedin/i
/alibaba/i
/yahoo/i
/amazon/i
/wetransfer/i
/microsoft/i
/apple/i
/google/i
```
  -local.d/maps.d/host_use_get.map
```
onedrive.live.com
```

