### PR TITLE
[Minor] forged_recipients: fix for uppercase RFC5321.MailFrom domain

### DIFF
--- a/src/plugins/lua/forged_recipients.lua
+++ b/src/plugins/lua/forged_recipients.lua
@@ -126,7 +126,7 @@ local function check_forged_headers(task)
   end
   for _,smtp_rcpt in ipairs(smtp_rcpts) do
     if not smtp_rcpt.matched then
-      if not smtp_rcpt_domain_map[smtp_rcpt.domain]._seen_mime_domain then
+      if not smtp_rcpt_domain_map[smtp_rcpt.domain:lower()]._seen_mime_domain then
         seen_smtp_unmatched = true
         table.insert(opts, 's:' .. smtp_rcpt.addr)
       end


### PR DESCRIPTION
If RFC5321.MailFrom has an address with uppercase domain following error
happens:
/usr/share/rspamd/plugins/forged_recipients.lua:129: attempt to index a nil value; trace: [1]:{/usr/share/rspamd/plugins/forged_recipients.lua:129 - <unknown> [Lua]};

Lowercase a domain.