### PR TITLE
[Fix] Clickhouse: escape carriage return

### DIFF
--- a/lualib/lua_clickhouse.lua
+++ b/lualib/lua_clickhouse.lua
@@ -45,11 +45,12 @@ end
 
 local function clickhouse_quote(str)
   if str then
-    return str:gsub('[\'\\\n\t]', {
+    return str:gsub('[\'\\\n\t\r]', {
       ['\''] = [[\']],
       ['\\'] = [[\\]],
       ['\n'] = [[\n]],
       ['\t'] = [[\t]],
+      ['\r'] = [[\r]],
     })
   end
 


### PR DESCRIPTION
If the last column in the table is a string and the last character of that string is the carriage return then the write will fail without escaping.