### PR TITLE
[Minor] Add Rspamd version to ICAP User Agent

### DIFF
--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -32,6 +32,7 @@ local tcp = require "rspamd_tcp"
 local upstream_list = require "rspamd_upstream_list"
 local rspamd_logger = require "rspamd_logger"
 local common = require "lua_scanners/common"
+local rspamd_version = rspamd_version
 
 local N = 'icap'
 
@@ -105,7 +106,7 @@ local function icap_check(task, content, digest, rule)
     local options_request = {
       string.format("OPTIONS icap://%s:%s/%s ICAP/1.0\r\n", addr:to_string(), addr:get_port(), rule.scheme),
       string.format('Host: %s\r\n', addr:to_string()),
-      "User-Agent: Rspamd\r\n",
+      string.format("User-Agent: Rspamd/%s-%s\r\n", rspamd_version('main'), rspamd_version('id')),
       "Encapsulated: null-body=0\r\n\r\n",
     }
     local size = string.format("%x", tonumber(#content))

--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -88,10 +88,6 @@ local function icap_config(opts)
     icap_conf.servers,
     icap_conf.default_port)
 
-  if icap_conf.user_agent == "extended" then
-    icap_conf.user_agent = string.format("Rspamd/%s-%s (%s)", rspamd_version('main'), rspamd_version('id'), rspamd_util.get_hostname())
-  end
-
   if icap_conf.upstreams then
     lua_util.add_debug_alias('external_services', icap_conf.name)
     return icap_conf
@@ -108,6 +104,11 @@ local function icap_check(task, content, digest, rule)
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local respond_headers = {}
+
+    -- Build extended User Agent
+    if rule.user_agent == "extended" then
+      rule.user_agent = string.format("Rspamd/%s-%s (%s/%s)", rspamd_version('main'), rspamd_version('id'), rspamd_util.get_hostname(), string.sub(task:get_uid(), 1,6))
+    end
 
     -- Build the icap queries
     local options_request = {


### PR DESCRIPTION
The ICAP User Agent is more useful when it is providing version information. 

Furthermore this will accidentially resolve issue #3495. 