### PR TITLE
force_actions - maybe disable current action bypass

### DIFF
--- a/src/plugins/lua/force_actions.lua
+++ b/src/plugins/lua/force_actions.lua
@@ -91,9 +91,7 @@ local function gen_cb(params)
     end
 
     local cact = task:get_metric_action('default')
-    if params.act and cact == params.act then
-      return false
-    end
+
     if params.honor and params.honor[cact] then
       return false
     elseif params.raction and not params.raction[cact] then

--- a/src/plugins/lua/force_actions.lua
+++ b/src/plugins/lua/force_actions.lua
@@ -91,7 +91,9 @@ local function gen_cb(params)
     end
 
     local cact = task:get_metric_action('default')
-
+    if not params.message and not params.subject and params.act and cact == params.act then
+      return false
+    end
     if params.honor and params.honor[cact] then
       return false
     elseif params.raction and not params.raction[cact] then


### PR DESCRIPTION
When the current action is the same as the configured action processing of the force_action rule ist bypassed.
But subject or message should be set as configured.