### PR TITLE
[Minor] lua_maps - maybe fix using multiple maps in multimap

### DIFF
--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -236,10 +236,18 @@ local function rspamd_map_add_from_ucl(opt, mtype, description)
                   local key = table.remove(pieces, 1)
                   data[key] = table.concat(pieces, ' ')
                 else
-                  data[elt] = true
+                  data[elt] = rspamd_config:add_map{
+                    type = mtype,
+                    description = description,
+                    url = elt,
+                  }
                 end
               else
-                data[elt] = true
+                data[elt] = rspamd_config:add_map{
+                  type = mtype,
+                  description = description,
+                  url = elt,
+                }
               end
 
               nelts = nelts + 1
@@ -256,7 +264,7 @@ local function rspamd_map_add_from_ucl(opt, mtype, description)
 
               return nil
             end
-
+            --setmetatable(ret, ret_mt)
             maps_cache[cache_key] = ret
             return ret
           else


### PR DESCRIPTION
When using more than one hash map the multimap plugin is not loading the map files:

  map = [
        "file:///etc/rspamd/maps.d/whitelist_email.txt",
        "file:///etc/rspamd/maps.d/whitelist_email2.txt"
  ];
