### PR TITLE
Check gsize against G_MAXSIZE not ULLONG_MAX

### DIFF
--- a/src/libserver/http/http_message.c
+++ b/src/libserver/http/http_message.c
@@ -198,7 +198,7 @@ rspamd_http_message_set_body (struct rspamd_http_message *msg,
 			return FALSE;
 		}
 
-		if (len != 0 && len != ULLONG_MAX) {
+		if (len != 0 && len != G_MAXSIZE) {
 			if (ftruncate (storage->shared.shm_fd, len) == -1) {
 				return FALSE;
 			}
@@ -227,7 +227,7 @@ rspamd_http_message_set_body (struct rspamd_http_message *msg,
 		}
 	}
 	else {
-		if (len != 0 && len != ULLONG_MAX) {
+		if (len != 0 && len != G_MAXSIZE) {
 			if (data == NULL) {
 				storage->normal = rspamd_fstring_sized_new (len);
 				msg->body_buf.len = 0;


### PR DESCRIPTION
```
/builds/cgzones/rspamd/debian/output/source_dir/src/libserver/http/http_message.c: In function 'rspamd_http_message_set_body':
/builds/cgzones/rspamd/debian/output/source_dir/src/libserver/http/http_message.c:201:23: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  201 |   if (len != 0 && len != ULLONG_MAX) {
      |                       ^~
/builds/cgzones/rspamd/debian/output/source_dir/src/libserver/http/http_message.c:230:23: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  230 |   if (len != 0 && len != ULLONG_MAX) {
      |                       ^~
```

There is another interesting warning:
```
/builds/cgzones/rspamd/debian/output/source_dir/src/plugins/fuzzy_check.c: In function 'fuzzy_lua_gen_hashes_handler':
/builds/cgzones/rspamd/debian/output/source_dir/src/plugins/fuzzy_check.c:3878:7: warning: variable 'cmd' set but not used [-Wunused-but-set-variable]
 3878 |  gint cmd = FUZZY_WRITE;
      |       ^~~
```
This variable is indeed only initialized at https://github.com/rspamd/rspamd/blob/8d7a7668dd68f12a3d9232ee5323805107b70cbb/src/plugins/fuzzy_check.c#L3878 and assigned at https://github.com/rspamd/rspamd/blob/8d7a7668dd68f12a3d9232ee5323805107b70cbb/src/plugins/fuzzy_check.c#L3946 and https://github.com/rspamd/rspamd/blob/8d7a7668dd68f12a3d9232ee5323805107b70cbb/src/plugins/fuzzy_check.c#L3949, but never used or read from.

Can this variable get removed or should the value be actually checked somewhere?