### PR TITLE
[Minor] milter_headers: new option skip_all

### DIFF
--- a/src/plugins/lua/milter_headers.lua
+++ b/src/plugins/lua/milter_headers.lua
@@ -35,6 +35,7 @@ local settings = {
   remove_upstream_spam_flag = true;
   skip_local = true,
   skip_authenticated = true,
+  skip_all = false,
   local_headers = {},
   authenticated_headers = {},
   routines = {
@@ -157,6 +158,9 @@ local function milter_headers(task)
       return found
     end
 
+    if settings.extended_headers_rcpt and match_extended_headers_rcpt() then
+      return false
+    end
 
     if settings.skip_local and not settings.local_headers[hdr] then
       local ip = task:get_ip()
@@ -167,7 +171,7 @@ local function milter_headers(task)
       if task:get_user() ~= nil then return true end
     end
 
-    if settings.extended_headers_rcpt and not match_extended_headers_rcpt() then
+    if settings.skip_all then
       return true
     end
 
@@ -635,6 +639,10 @@ end
 
 if type(opts['skip_authenticated']) == 'boolean' then
   settings.skip_authenticated = opts['skip_authenticated']
+end
+
+if type(opts['skip_all']) == 'boolean' then
+  settings.skip_all = opts['skip_all']
 end
 
 for _, s in ipairs(opts['use']) do


### PR DESCRIPTION
This PR introduces the new configuration option "skip_all" for milter_headers.
This config option will skip the addition of extended spam headers for every mail, except those with recipients listed in the extended_headers_rcpt map.

Documentation is updated in https://github.com/rspamd/rspamd.com/pull/487

This solution was proposed by @moisseev in https://github.com/rspamd/rspamd/pull/3607#issuecomment-762319736. 
It works well, is backward-compatible with previous configurations and enables the new usage of only adding extended headers to a specific list of recipients. 