### PR TITLE
[Fix] RBL: collapse chained selectors into single label

### DIFF
--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -601,10 +601,8 @@ local function gen_rbl_callback(rule)
       local res = selector(task)
 
       if res then
-        for _,r in ipairs(res) do
-          add_dns_request(task, r, false, false, requests_table,
-              selector_label, whitelist)
-        end
+        add_dns_request(task, table.concat(res, ''), false, false,
+	    requests_table, selector_label, whitelist)
       end
     end
 


### PR DESCRIPTION
This changes behaviour in a backward-incompatible way but it matches my expectation of how it should have worked and possibly the general expectation.

If old behaviour is really desired, one can unchain one's selectors & use table format of `selector` option.