### PR TITLE
[Minor] cfg_transform - fix actions sanity check

### DIFF
--- a/lualib/lua_cfg_transform.lua
+++ b/lualib/lua_cfg_transform.lua
@@ -367,7 +367,8 @@ return function(cfg)
     -- Perform sanity check for actions
     local actions_defs = {'no action', 'no_action', -- In case if that's added
                           'greylist', 'add header', 'add_header',
-                          'rewrite subject', 'rewrite_subject', 'reject'}
+                          'rewrite subject', 'rewrite_subject', 'quarantine',
+                          'reject', 'discard'}
 
     if not cfg.actions['no action'] and not cfg.actions['no_action'] and
             not cfg.actions['accept'] then


### PR DESCRIPTION
Fix "unknown element in actions section: discard" message for quarantine and discard actions.

This warning would be also present for other custom actions.