### PR TITLE
[Minor] Dockerfile: Set signing-key

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN	set -x \
 	&& rm -rf "$GNUPGHOME" \
 	&& apt-key list > /dev/null
 
-RUN	echo "deb https://rspamd.com/apt-stable/ buster main" > /etc/apt/sources.list.d/rspamd.list
+RUN	echo "deb [signed-by=/etc/apt/trusted.gpg.d/rspamd.gpg] https://rspamd.com/apt-stable/ buster main" > /etc/apt/sources.list.d/rspamd.list
 
 RUN	apt-get update \
 	&& apt-get install -y rspamd \


### PR DESCRIPTION
Small change to ensure that the signing key is used for the fetching the debian package.