### PR TITLE
Implement an endpoint for OpenMetrics / Prometheus

### DIFF
--- a/src/libserver/worker_util.c
+++ b/src/libserver/worker_util.c
@@ -600,6 +600,32 @@ rspamd_controller_send_error (struct rspamd_http_connection_entry *entry,
 }
 
 void
+rspamd_controller_send_openmetrics (struct rspamd_http_connection_entry *entry,
+	const gchar *str)
+{
+	struct rspamd_http_message *msg;
+	rspamd_fstring_t *reply;
+
+	msg = rspamd_http_new_message (HTTP_RESPONSE);
+	msg->date = time (NULL);
+	msg->code = 200;
+	msg->status = rspamd_fstring_new_init ("OK", 2);
+	reply = rspamd_fstring_new_init (str, strlen (str));
+
+	rspamd_http_message_set_body_from_fstring_steal (msg,
+			rspamd_controller_maybe_compress (entry, reply, msg));
+	rspamd_http_connection_reset (entry->conn);
+	rspamd_http_router_insert_headers (entry->rt, msg);
+	rspamd_http_connection_write_message (entry->conn,
+		msg,
+		NULL,
+		"application/openmetrics-text; version=1.0.0; charset=utf-8",
+		entry,
+		entry->rt->timeout);
+	entry->is_reply = TRUE;
+}
+
+void
 rspamd_controller_send_string (struct rspamd_http_connection_entry *entry,
 	const gchar *str)
 {

--- a/src/libserver/worker_util.h
+++ b/src/libserver/worker_util.h
@@ -119,6 +119,15 @@ void rspamd_controller_send_error (struct rspamd_http_connection_entry *entry,
 								   gint code, const gchar *error_msg, ...);
 
 /**
+ * Send openmetrics-formatted strings using HTTP
+ * @param entry router entry
+ * @param str string to send
+ */
+void
+rspamd_controller_send_openmetrics (struct rspamd_http_connection_entry *entry,
+	const gchar *str);
+
+/**
  * Send a custom string using HTTP
  * @param entry router entry
  * @param str string to send


### PR DESCRIPTION
This is a first attempt to have OpenMetrics / Prometheus formatted metrics natively included in rspamd.

If the /stat endpoint is requested with a parameter format=openmetrics,
it will respond in OpenMetrics format instead of JSON.

Currently this is a WIP to get early feedback on the approach, as I'm using horrible string concatenation to get a formatted output.

Linking discussion: https://github.com/rspamd/rspamd/discussions/3484
