### PR TITLE
Minor updates to X-Mailer regexps

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -983,14 +983,21 @@ local bad_x_mailers = {
   -- Mozilla Thunderbird 1.0.2 (Windows/20050317)
   -- Thunderbird 2.0.0.23 (X11/20090812)
   [[(?:Mozilla )?Thunderbird \d]],
-  -- Was used by Yahoo Groups in 2000s
+  -- Was used by Yahoo Groups in 2000s, no one expected to use this in 2020s
   [[eGroups Message Poster]],
+  -- Regexp for genuene iOS X-Mailer is below, anything which doesn't match it,
+  -- but starts with 'iPhone Mail' or 'iPad Mail' is likely fake
+  [[i(?:Phone|Pad) Mail]],
 }
+-- Apple iPhone/iPad Mail X-Mailer contains iOS build number, e. g. 9B206, 16H5, 18G5023c
+-- https://en.wikipedia.org/wiki/IOS_version_history
+local apple_ios_x_mailer = [[i(?:Phone|Pad) Mail \((?:1[AC]|[34][AB]|5[ABCFGH]|7[A-E]|8[ABCEFGHJKL]|9[AB]|\d{2}[A-Z])\d+[a-z]?\)]]
 
 reconf['FORGED_X_MAILER'] = {
   description = 'Forged X-Mailer header',
-  re = string.format('X-Mailer=/^(?:%s)/{header}', table.concat(bad_x_mailers, '|')),
-  score = 4.0,
+  re = string.format('X-Mailer=/^(?:%s)/{header} && !X-Mailer=/^%s/{header}',
+    table.concat(bad_x_mailers, '|'), apple_ios_x_mailer),
+  score = 4.5,
   group = 'headers',
 }
 

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -962,9 +962,10 @@ local old_x_mailers = {
   [[Microsoft Outlook IMO, Build 9\.0\.]],
   -- Outlook 2002 (Office XP)
   [[Microsoft Outlook, Build 10\.]],
-  -- Some old Apple iOS version are used on old devices, so instead of matching
-  -- all old versions, match only versions seen in spam
-  [[i(Phone|Pad) Mail \((?:12[A-Z]|13E)]],
+  -- Some old Apple iOS versions are used on old devices, match only very old
+  -- versions (iOS 4.3.5 buid 8L1 was supported until 2013) and less old
+  -- versions frequently seen in spam
+  [[i(Phone|Pad) Mail \((?:[1-8][A-L]|12H|13E)]],
 }
 
 reconf['OLD_X_MAILER'] = {


### PR DESCRIPTION
Add more regexps to `FORGED_X_MAILER` and `OLD_X_MAILER`.  While here increase score for `FORGED_X_MAILER` a bit.