### PR TITLE
Switch PGP keyserver to hkps://keys.openpgp.org

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,11 +6,42 @@ RUN	apt-get update && apt-get install -y --no-install-recommends \
 		gnupg \
 	&& rm -rf /var/lib/apt/lists/*
 
+SHELL ["/bin/bash", "-c"]
 RUN	set -x \
 # gpg: key FFA232EDBF21E25E: public key "Rspamd Nightly Builds (Rspamd Nightly Builds) <vsevolod@highsecure.ru>" imported
 	&& key='3FA347D5E599BE4595CA2576FFA232EDBF21E25E' \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+	&& gpg --import <<<$'\
+-----BEGIN PGP PUBLIC KEY BLOCK-----                                    \n\
+                                                                        \n\
+mQINBFW3VB8BEADAV1lBy8DPcSEBSLYVKgwsBx/dRmgenKeliMpiZyNYJJmF6tSV        \n\
+s3v5DtDIUESgI2mBKNeptdneri3CDJScI/LgPLKqemrLBkAMfe+f57JgppY5ti4H        \n\
+xo+VZdbF9bhCAwYwJnqnyuLjYSUu6nCuW4uPDoqBHXynwsIWr1O3fREpY+vgIgaT        \n\
+Oqm3ncssqxSicymd6k0yuo55xuUvrc4Yu4IEnhFVRU53e0E3zmHg/7ONI99YtBan        \n\
+7G/w2IfA1bfRDYZ2Avau+JqGcEl8vy+eLmYayKirdsMPN8Tx6RFOstDf1CnjW/bj        \n\
+IX7SDOklIGJjJwcWW/iY+1P9SfNNqSDgXavJj2wmLMlUhgjyJFTXfdDRjmN0PFxo        \n\
+f6OQu5xok1WHfKFJL+hLGknjHdXLmGd5MSuFlutdVHJQrieknjBea9xCiEsrfe8V        \n\
+zyNqGhzgIYjOi/bO7jGpY/WiFHvM9XtBVp862tqM1S1WbAWW5u+es6NK4q9Cv0DR        \n\
+tIalss+5gFhdsIFGFYQWfY7CrjOIC+C0+c5IGaBkHte35hCCvDpOO909xxVqUZYe        \n\
+9Pl8zYgPDe1H4arMO+p6rSvVntvIWOqLqkuWYSiOY4TGADJTkeZRbopZhvqs/9mc        \n\
+847fVMbOwKfkbeuGiHhUK0QFewXSu+cXJyGtyu3RgokBWr2yyzJFXIvJbQARAQAB        \n\
+tEZSc3BhbWQgTmlnaHRseSBCdWlsZHMgKFJzcGFtZCBOaWdodGx5IEJ1aWxkcykg        \n\
+PHZzZXZvbG9kQGhpZ2hzZWN1cmUucnU+iQI4BBMBAgAiBQJVt1QfAhsDBgsJCAcD        \n\
+AgYVCAIJCgsEFgIDAQIeAQIXgAAKCRD/ojLtvyHiXucND/4ja0t+4RMiD0c0z3xD        \n\
+Vp0Ysq7kZvzlteUrw98f1BMYbmSTJ+43JVZV67GJ8fV2d9/atIlyLce8Gn9hYmF7        \n\
+C5nPpCCOlNejkwkc9MhZgoM0z7sTNZwKLZ4fSnxHD10Z923G+IRQYeXswM7hE/T5        \n\
+8NgANOWBFs9BxIEIT6IfRNHF23SCmCeNFNmUen6uXLznjRzYbMmwP7u2BopfJcpN        \n\
+ajnm66IypQDsUqVwBRnm9o9GAWUPbp4ahhf1vYu04T1vD7n4qhrLdhHmEJpukEhD        \n\
+q613Wl/k0g0O8SahfSAaM1x5zLOJ0sMacyxCktQKXypAhkhhJc4J1KLbnNUsxZdk        \n\
+Gn4wLZuhfIuzh2KfKBdwoL3zRq7kjgumJo7AQhEIIDGKutl6sZnbRHjBr4qBb1NJ        \n\
+/7GC7UiZhIesdO6HdqrriNF0l8dRVIaHXGKF0PQWWG+J+147oQM+SJmm4W4oONSx        \n\
+YCjyTllxwh/54fhu81jhSyBgbKAmV1gYLIPvAUgPkguAb5JWcvZOeXytHWZYLK9T        \n\
+8rW5R0bviiouHHRyQYu0AX+wiSyAfoVnTVyad6xTWUT3aQ8jeL0I3uy323Mrq56U        \n\
+7Yo0NFwKPF9z5kbuQje3daudQQymkhOfNcQm3dOaaWKGp5KPRi3OtKYMu+5Aphor        \n\
+lwJWDec6PUe835YwqrARXtPaNA==                                            \n\
+=4Cm3                                                                   \n\
+-----END PGP PUBLIC KEY BLOCK-----' \
+	&& gpg --keyserver hkps://keys.openpgp.org --recv-keys "$key" \
 	&& gpg --export "$key" > /etc/apt/trusted.gpg.d/rspamd.gpg \
 	&& rm -rf "$GNUPGHOME" \
 	&& apt-key list > /dev/null


### PR DESCRIPTION
The SKS keyserver infrastructure has been under attack for some time, and at the moment is unreachable.  The keys.openpgp.org keyserver has the rspamd key, and is resistant to the sort of attack that is hurting the SKS keyservers.  This change switches to that keyserver.

gpg won't load new keys from keys.openpgp.org unless the owner consented to publish the uids (see https://keys.openpgp.org/about/faq#older-gnupg).  This means you need the key imported first with the uid attached.  Here, we include the essential part of the key (the master key, uid, and its self-signature) in the Dockerfile.  We still poll keys.openpgp.org for updates, such as expiration extensions and revocations.

See https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f for background.