### PR TITLE
[Fix]: Lua ASN - CB func should also return in case of an error

### DIFF
--- a/src/plugins/lua/asn.lua
+++ b/src/plugins/lua/asn.lua
@@ -74,7 +74,7 @@ local function asn_check(task)
         task:insert_result(options['symbol'] .. '_FAIL', 1, string.format('%s:%s', req_name, dns_err))
         return
       end
-      if not (results and results[1]) then
+      if not (results or results[1]) then
         rspamd_logger.infox(task, 'cannot query ip %s on %s: no results',
             req_name, serv)
         return
@@ -147,6 +147,13 @@ if configure_asn_module() then
       flags = 'empty',
       score = 0,
     })
+    rspamd_config:register_symbol{
+      name = options['symbol'] .. '_FAIL',
+      parent = id,
+      type = 'virtual',
+      flags = 'nostat',
+      score = 0,
+    }
   end
 else
   lua_util.disable_module(N, 'config')

--- a/src/plugins/lua/asn.lua
+++ b/src/plugins/lua/asn.lua
@@ -71,6 +71,8 @@ local function asn_check(task)
       if dns_err and (dns_err ~= 'requested record is not found' and dns_err ~= 'no records with this name') then
         rspamd_logger.errx(task, 'error querying dns "%s" on %s: %s',
             req_name, serv, dns_err)
+        task:insert_result(options['symbol'] .. '_FAIL', 1, string.format('%s:%s', req_name, dns_err))
+        return
       end
       if not (results and results[1]) then
         rspamd_logger.infox(task, 'cannot query ip %s on %s: no results',


### PR DESCRIPTION
In case of an dns timeout or error in common, the DNS callback function does not return. 
It then still tries to process the results. This interrupts the further processing of the mail.

Example: 
<img width="1419" alt="CleanShot 2021-07-11 at 20 35 34@2x" src="https://user-images.githubusercontent.com/3989428/125206435-913ba680-e287-11eb-90a5-e4d0134ca039.png">
<img width="1356" alt="CleanShot 2021-07-11 at 20 35 49@2x" src="https://user-images.githubusercontent.com/3989428/125206441-9862b480-e287-11eb-87b7-1c4933e2e5b3.png">

