### PR TITLE
[Fix] ezmlm mailing list software triggering MULTIPLE_UNIQUE_HEADERS by duplicate "Reply-To" header

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -45,6 +45,12 @@ composites {
   FORGED_MUA_MAILLIST {
     expression = "g:mua & -MAILLIST";
   }
+  MULTIPLE_UNIQUE_HEADERS_MAILLIST {
+    expression = "MULTIPLE_UNIQUE_HEADERS & -MAILLIST";
+    description = "Mailing list software adds duplicate Reply-To header";
+    score = 0.0;
+    policy = "remove_weight";
+  }
   RBL_SPAMHAUS_XBL_ANY {
     expression = "RBL_SPAMHAUS_XBL & RECEIVED_SPAMHAUS_XBL";
     description = "From and Received address are listed in Spamhaus XBL";

--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -49,7 +49,6 @@ composites {
     expression = "MULTIPLE_UNIQUE_HEADERS & -MAILLIST";
     description = "Mailing list software adds duplicate Reply-To header";
     score = 0.0;
-    policy = "remove_weight";
   }
   RBL_SPAMHAUS_XBL_ANY {
     expression = "RBL_SPAMHAUS_XBL & RECEIVED_SPAMHAUS_XBL";


### PR DESCRIPTION
This fixes #3821