### PR TITLE
Escape redis+selector

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -1099,14 +1099,14 @@ local function add_multimap_rule(key, newrule)
       ret = true
     end
   elseif type(newrule['map']) == 'string' and
-      string.find(newrule['map'], '^redis+selector://.*$') then
+      string.find(newrule['map'], '^redis%+selector://.*$') then
     if not redis_params then
       rspamd_logger.infox(rspamd_config, 'no redis servers are specified, ' ..
           'cannot add redis map %s: %s', newrule['symbol'], newrule['map'])
       return nil
     end
 
-    local selector_str = string.match(newrule['map'], '^redis+selector://(.*)$')
+    local selector_str = string.match(newrule['map'], '^redis%+selector://(.*)$')
     local selector = lua_selectors.create_selector_closure(
         rspamd_config, selector_str, newrule['delimiter'] or "")
 


### PR DESCRIPTION
**Describe the bug**

redis+selector maps are not recognized as valid map types.

**Steps to Reproduce**
```

cat /etc/rspamd/local.d/multimap.conf

test_map {
        type = "from"
        filter = "email"
        map = "redis+selector://id('blacklist:');rcpts:addr.take_n(5).lower";
        description = "Test map";
        symbol = "TEST_MAP"
        score = 5.0;
}
```

**Expected behavior**

The map should be read at startup. Redis keys should be processed accordingly.

**Versions**

Both 2.7 and master

**Additional Information**

I believe multimap.lua should have the "redis+selector" pattern escaped as "redis%+selector". This would make it easier for string.find to match the documented map string.
