### PR TITLE
dkim: Enforce a space character after comma in the recipient list

### DIFF
--- a/src/libutil/util.c
+++ b/src/libutil/util.c
@@ -2460,3 +2460,19 @@ rspamd_ptr_array_shuffle (GPtrArray *ar)
 		g_ptr_array_index (ar, i) = t;
 	}
 }
+
+guint rspamd_count_comma(const gchar *str)
+{
+       const gchar *p = str;
+       guint cnt = 0;
+
+       do {
+               p = strchr(p, ',');
+               if (p) {
+                       cnt++;
+                       p++;
+               }
+       } while (p);
+
+       return cnt;
+}

--- a/src/libutil/util.h
+++ b/src/libutil/util.h
@@ -518,6 +518,8 @@ struct rspamd_controller_pbkdf {
 
 extern const struct rspamd_controller_pbkdf pbkdf_list[];
 
+guint rspamd_count_comma(const gchar *str);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/src/plugins/dkim_check.c
+++ b/src/plugins/dkim_check.c
@@ -1591,6 +1591,7 @@ lua_dkim_canonicalize_handler (lua_State *L)
 
 	if (hname && hvalue && nlen > 0) {
 		inlen = nlen + vlen + sizeof (":" CRLF);
+		inlen += rspamd_count_comma(hvalue);
 
 		if (inlen > sizeof (st_buf)) {
 			buf = g_malloc (inlen);


### PR DESCRIPTION
A Cc list like:

  cc:Person A <a@example.org>,Person B <b@example.org>

will be signed as such. The problem is that there should be a white space
after the comma. If the line gets (later) reformed such as

  Cc: Person A <a@example.org>,
  \TABPerson B <b@example.org>

then line is interpreted as
  cc: Person A <a@example.org>, Person B <b@example.org>

which is different and the verification will failed.

In RFC 6376 section 3.4.2. (The "relaxed" Header Canonicalization
Algorithm) it is described how to unfold/replace white space
characters. It refers to RFC 5322 to how unfold continuation lines. I've
been looking for official behaviour but couldn't find. The space after
the comma is what I observed the missing space being the exception.

Enforce a space after a comma. Ignore this if the comma is found within
a quote block ( started by ' or ") or if the comma is escaped (by \).

Issue: #3842

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>