### PR TITLE
[Minor] Init pyzor

### DIFF
--- a/lualib/lua_scanners/init.lua
+++ b/lualib/lua_scanners/init.lua
@@ -48,6 +48,7 @@ require_scanner('vadesecure')
 require_scanner('spamassassin')
 require_scanner('p0f')
 require_scanner('razor')
+require_scanner('pyzor')
 
 exports.add_scanner = function(name, t, conf_func, check_func)
   assert(type(conf_func) == 'function' and type(check_func) == 'function',


### PR DESCRIPTION
Just upgraded to **rspamd-2.8-53.gitd04d85307** and noticed that pyzor was no longer loading:

```
2021-08-10 11:34:40 #3667(main) <t595kk>; lua; external_services.lua:124: unknown external scanner type: pyzor
2021-08-10 11:34:40 #3667(main) <t595kk>; lua; external_services.lua:212: cannot add rule: "pyzor"
```

Suppose i forgot a file in #3816, my bad...