### PR TITLE
Regexp: Extend UNITEDINTERNET_SPAM upstream spam filter regexp

### DIFF
--- a/rules/regexp/upstream_spam_filters.lua
+++ b/rules/regexp/upstream_spam_filters.lua
@@ -51,7 +51,9 @@ reconf['SPAM_FLAG'] = {
 }
 
 reconf['UNITEDINTERNET_SPAM'] = {
-  re = 'X-UI-Out-Filterresults=/^junk:/H',
+  re = string.format('%s || %s',
+       'X-UI-Filterresults=/^junk:/H',
+       'X-UI-Out-Filterresults=/^junk:/H'),
   score = 5.0,
   description = "United Internet says this message is spam",
   group = 'upstream_spam_filters'


### PR DESCRIPTION
In addition to `X-UI-Out-Filterresults` the header `X-UI-Filterresults` is also in use.