### PR TITLE
[Fix] Remove aarch64 GC64 workaround

### DIFF
--- a/contrib/lua-lpeg/lptree.c
+++ b/contrib/lua-lpeg/lptree.c
@@ -1149,11 +1149,7 @@ static size_t initposition (lua_State *L, size_t len) {
 ** Main match function
 */
 static int lp_match (lua_State *L) {
-#ifdef LPEG_LUD_WORKAROUND
-  Capture *capture = lpeg_allocate_mem_low(sizeof(Capture) * INITCAPSIZE);
-#else
   Capture capture[INITCAPSIZE];
-#endif
   const char *r;
   size_t l;
   const char *s;
@@ -1167,9 +1163,6 @@ static int lp_match (lua_State *L) {
   else if (lua_type (L, SUBJIDX) == LUA_TUSERDATA) {
   	struct rspamd_lua_text *t = lua_check_text (L, SUBJIDX);
   	if (!t) {
-#ifdef LPEG_LUD_WORKAROUND
-		lpeg_free_mem_low (capture);
-#endif
 		return luaL_error (L, "invalid argument (not a text)");
   	}
   	s = t->start;
@@ -1177,16 +1170,10 @@ static int lp_match (lua_State *L) {
 
   	if (s == NULL) {
 		lua_pushnil(L);
-#ifdef LPEG_LUD_WORKAROUND
-		lpeg_free_mem_low (capture);
-#endif
 		return 1;
   	}
   }
   else {
-#ifdef LPEG_LUD_WORKAROUND
-  	lpeg_free_mem_low (capture);
-#endif
   	return luaL_error (L, "invalid argument: %s",
   			lua_typename (L, lua_type (L, SUBJIDX)));
   }
@@ -1198,15 +1185,9 @@ static int lp_match (lua_State *L) {
   r = match(L, s, s + i, s + l, code, capture, ptop);
   if (r == NULL) {
     lua_pushnil(L);
-#ifdef LPEG_LUD_WORKAROUND
-    lpeg_free_mem_low (capture);
-#endif
     return 1;
   }
   rs = getcaptures(L, s, r, ptop);
-#ifdef LPEG_LUD_WORKAROUND
-  lpeg_free_mem_low (capture);
-#endif
   return rs;
 }
 

--- a/contrib/lua-lpeg/lptypes.h
+++ b/contrib/lua-lpeg/lptypes.h
@@ -9,15 +9,12 @@
 #define lptypes_h
 
 
-#include "config.h"
-
 #if !defined(LPEG_DEBUG) && !defined(NDEBUG)
 #define NDEBUG
 #endif
 
 #include <assert.h>
 #include <limits.h>
-#include <stdint.h>
 
 #include "lua.h"
 
@@ -152,13 +149,6 @@ typedef struct Charset {
 
 #define testchar(st,c)	(((int)(st)[((c) >> 3)] & (1 << ((c) & 7))))
 
-/* Special workaround for luajit lightuserdata limitations with GC64 */
-#if defined(WITH_LUAJIT) && INTPTR_MAX == INT64_MAX && \
-	!(defined(_X86_) || defined(__x86_64__) || defined(__i386__) || defined(__powerpc__))
-# define LPEG_LUD_WORKAROUND 1
-void * lpeg_allocate_mem_low(size_t sz);
-void lpeg_free_mem_low(void *p);
-#endif
 
 #endif
 


### PR DESCRIPTION
Removes the 64bit LUD workaround since 64bit LUD natively supported in LuaJIT for a while. This fixes the issues described in #3563, please see this issue for details.