### PR TITLE
[Fix] src/lua/lua_mimepart.c: fix null dereference

### DIFF
--- a/src/lua/lua_mimepart.c
+++ b/src/lua/lua_mimepart.c
@@ -1240,7 +1240,16 @@ lua_textpart_get_fuzzy_hashes (lua_State * L)
 	rspamd_stat_token_t *word;
 	struct lua_shingle_filter_cbdata cbd;
 
-	if (part && pool) {
+
+	if (part == NULL || pool == NULL) {
+		return luaL_error (L, "invalid arguments");
+	}
+
+	if (IS_TEXT_PART_EMPTY (part) || part->utf_words == NULL) {
+		lua_pushnil (L);
+		lua_pushnil (L);
+	}
+	else {
 		/* TODO: add keys and algorithms support */
 		rspamd_cryptobox_hash (key, "rspamd", strlen ("rspamd"), NULL, 0);
 
@@ -1293,9 +1302,6 @@ lua_textpart_get_fuzzy_hashes (lua_State * L)
 				lua_rawseti (L, -2, i + 1); /* Store table */
 			}
 		}
-	}
-	else {
-		return luaL_error (L, "invalid arguments");
 	}
 
 	return 2;


### PR DESCRIPTION
The fix can be tested e.g. on the sample _test/functional/messages/dmarc/good_dkim_spam.eml_
Before the fix:

> Results for file: test/functional/messages/dmarc/good_dkim_rspamd.eml (0.959 seconds)
> IO read error: unexpected EOF

After the fix:

> Results for file: test/functional/messages/dmarc/good_dkim_rspamd.eml (1.100 seconds)
> [Metric: default]
> Action: no action
> Spam: false
> Score: 0.80 / 10.00
> Symbol: ASN (0.00)[asn:24940, ipnet:88.99.0.0/16, country:DE]
> Symbol: BL_VFRBL_HWL (-1.00)[88.99.142.95:from]
> Symbol: DATE_IN_PAST (1.00)[25560]
> Symbol: DKIM_TRACE (0.00)[rspamd.com:+]
> Symbol: DMARC_NA (0.00)[rspamd.com]
> Symbol: FREEMAIL_ENVRCPT (0.00)[gmail.com]
> Symbol: FREEMAIL_TO (0.00)[gmail.com]
> Symbol: FROM_EQ_ENVFROM (0.00)
> Symbol: FROM_HAS_DN (0.00)
> Symbol: MID_RHS_MATCH_FROM (0.00)
> Symbol: MIME_GOOD (0.00)[text/plain]
> Symbol: MIME_TRACE (0.00)[0:+]
> Symbol: PREVIOUSLY_DELIVERED (0.00)[vstakhov@gmail.com]
> Symbol: RCPT_COUNT_ONE (0.00)[1]
> Symbol: RCVD_COUNT_ONE (0.00)[1]
> Symbol: RCVD_TLS_ALL (0.00)
> Symbol: RECEIVED_TRUSTED (0.00)
> Symbol: R_DKIM_ALLOW (-0.20)[rspamd.com:s=dkim]
> Symbol: R_SPF_FAIL (1.00)[-all]
> Symbol: TO_DN_NONE (0.00)
> Message-ID: 6f4415bf-ff61-f0f5-b60c-ba71a56b9e48@rspamd.com
