### PR TITLE
Reflect recent doctest version bump in dependency info table

### DIFF
--- a/contrib/DEPENDENCY_INFO.md
+++ b/contrib/DEPENDENCY_INFO.md
@@ -34,5 +34,5 @@
 | robin-hood    | 3.9.1   | MIT                 | NO      |                    |
 | frozen        | 1.0.1   | Apache 2            | NO      |                    |
 | fmt           | 7.1.3   | MIT                 | NO      |                    |
-| doctest       | 2.4.5   | MIT                 | NO      |                    |
+| doctest       | 2.4.6   | MIT                 | NO      |                    |
 | function2     | 4.1.0   | Boost               | NO      |                    |


### PR DESCRIPTION
This just bumps the version number of currently bundled doctest library in dependency info table.