### PR TITLE
[Fix] buffer overflow in rspamc counters

### DIFF
--- a/src/client/rspamc.c
+++ b/src/client/rspamc.c
@@ -1035,7 +1035,8 @@ rspamc_counters_output (FILE *out, ucl_object_t *obj)
 	const ucl_object_t *cur, *sym, *weight, *freq, *freq_dev, *nhits;
 	ucl_object_iter_t iter = NULL;
 	gchar fmt_buf[64], dash_buf[82], sym_buf[82];
-	gint l, max_len = INT_MIN, i;
+	gint l, i;
+	gint max_len = sizeof("Symbol") - 1;
 	static const gint dashes = 44;
 
 	if (obj->type != UCL_ARRAY) {
@@ -1054,11 +1055,12 @@ rspamc_counters_output (FILE *out, ucl_object_t *obj)
 		if (sym != NULL) {
 			l = sym->len;
 			if (l > max_len) {
-				max_len = MIN (sizeof (dash_buf) - dashes - 1, l);
+				max_len = l;
 			}
 		}
 	}
 
+	max_len = MIN (sizeof (dash_buf) - dashes - 1, max_len);
 	rspamd_snprintf (fmt_buf, sizeof (fmt_buf),
 		"| %%3s | %%%ds | %%7s | %%13s | %%7s |\n", max_len);
 	memset (dash_buf, '-', dashes + max_len);

--- a/src/client/rspamc.c
+++ b/src/client/rspamc.c
@@ -1035,8 +1035,6 @@ rspamc_counters_output (FILE *out, ucl_object_t *obj)
 	const ucl_object_t *cur, *sym, *weight, *freq, *freq_dev, *nhits;
 	ucl_object_iter_t iter = NULL;
 	gchar fmt_buf[64], dash_buf[82], sym_buf[82];
-	gint l, i;
-	gint max_len = sizeof("Symbol") - 1;
 	static const gint dashes = 44;
 
 	if (obj->type != UCL_ARRAY) {
@@ -1050,12 +1048,12 @@ rspamc_counters_output (FILE *out, ucl_object_t *obj)
 	}
 
 	/* Find maximum width of symbol's name */
+	gint max_len = sizeof("Symbol") - 1;
 	while ((cur = ucl_object_iterate (obj, &iter, true)) != NULL) {
 		sym = ucl_object_lookup (cur, "symbol");
 		if (sym != NULL) {
-			l = sym->len;
-			if (l > max_len) {
-				max_len = l;
+			if (sym->len > max_len) {
+				max_len = sym->len;
 			}
 		}
 	}
@@ -1081,7 +1079,7 @@ rspamc_counters_output (FILE *out, ucl_object_t *obj)
 		"| %%3d | %%%ds | %%7.1f | %%6.3f(%%5.3f) | %%7ju |\n", max_len);
 
 	iter = NULL;
-	i = 0;
+	gint i = 0;
 	while ((cur = ucl_object_iterate (obj, &iter, true)) != NULL) {
 		printf (" %s \n", dash_buf);
 		sym = ucl_object_lookup (cur, "symbol");


### PR DESCRIPTION
If request to `/counters` returns no symbols then `max_len` would have
a negative value which would cause a buffer overflow in `memset`:
```
Results for command: counters (0.003 seconds)
=================================================================
==22096==ERROR: AddressSanitizer: negative-size-param: (size=-2147483604)
    #0 0x33ff13 in __asan_memset (/usr/bin/rspamc+0x33ff13)
    #1 0x383432 in rspamc_counters_output /usr/src/debug/rspamd/src/client/rspamc.c:1064:2
    #2 0x388c49 in rspamc_client_cb /usr/src/debug/rspamd/src/client/rspamc.c:1600:6
    ...
```