### PR TITLE
[Minor] Fix compiler warnings in src/libutil/util.c

### DIFF
--- a/src/libutil/util.c
+++ b/src/libutil/util.c
@@ -1359,9 +1359,6 @@ gint
 rspamd_read_passphrase (gchar *buf, gint size, gint rwflag, gpointer key)
 {
 #ifdef HAVE_READPASSPHRASE_H
-	gint len = 0;
-	gchar pass[BUFSIZ];
-
 	if (readpassphrase ("Enter passphrase: ", buf, size, RPP_ECHO_OFF |
 		RPP_REQUIRE_TTY) == NULL) {
 		return 0;


### PR DESCRIPTION
```
src/libutil/util.c:1362:7: warning: unused variable 'len' [-Wunused-variable]
        gint len = 0;
             ^
src/libutil/util.c:1363:8: warning: unused variable 'pass' [-Wunused-variable]
        gchar pass[BUFSIZ];
              ^
2 warnings generated.
```