### PR TITLE
[Feature] Add junk_threshold for autolearn

### DIFF
--- a/conf/statistic.conf
+++ b/conf/statistic.conf
@@ -44,8 +44,9 @@ classifier "bayes" {
 
   # Autolearn sample
   # autolearn {
-  #  spam_threshold = 6.0; # When to learn spam (score >= threshold)
-  #  ham_threshold = -0.5; # When to learn ham (score <= threshold)
+  #  spam_threshold = 6.0; # When to learn spam (score >= threshold and action is reject)
+  #  junk_threshold = 4.0; # When to learn spam (score >= threshold and action is rewrite subject or add header, and has two or more positive results)
+  #  ham_threshold = -0.5; # When to learn ham (score <= threshold and action is no action, and score is negative or has three or more negative results)
   #  check_balance = true; # Check spam and ham balance
   #  min_balance = 0.9; # Keep diff for spam/ham learns for at least this value
   #}

--- a/lualib/lua_bayes_learn.lua
+++ b/lualib/lua_bayes_learn.lua
@@ -92,6 +92,11 @@ exports.autolearn = function(task, conf)
         log_can_autolearn(verdict, score, conf.spam_threshold)
         learn_spam = true
       end
+    elseif verdict == 'junk' then
+      if conf.junk_threshold and score >= conf.junk_threshold then
+        log_can_autolearn(verdict, score, conf.junk_threshold)
+        learn_spam = true
+      end
     elseif verdict == 'ham' then
       if conf.ham_threshold and score <= conf.ham_threshold then
         log_can_autolearn(verdict, score, conf.ham_threshold)


### PR DESCRIPTION
Right now autolearning can learn spam only if the lua verdict is `spam`, which means it must have an action set to reject, see [the code]( https://github.com/rspamd/rspamd/blob/57bf1e47ddbda63545fdf33a312062d7f41c812e/lualib/lua_verdict.lua#L42-L56). That prevents autolearning from non-rejected mails that still have high scores. This situation occurs in particular when you have conservatively high reject score thresholds, or simply never reject out of policy.

The commit adds `junk_threshold` which acts as a minimum threshold for autolearning to occur, when the lua verdict is `junk`, allowing for more autolearning spam opportunities.