### PR TITLE
[Fix] lua_cfg_transform - actions without score (discard)

### DIFF
--- a/lualib/lua_cfg_transform.lua
+++ b/lualib/lua_cfg_transform.lua
@@ -374,7 +374,9 @@ return function(cfg)
             not cfg.actions['accept'] then
       for _,d in ipairs(actions_defs) do
         if cfg.actions[d] then
-          if type(cfg.actions[d]) ~= 'number' then
+          if type(cfg.actions[d]) ~= 'table' then
+            break
+          elseif type(cfg.actions[d]) ~= 'number' then
             cfg.actions[d] = nil
           elseif cfg.actions[d] < 0 then
             cfg.actions['no_action'] = cfg.actions[d] - 0.001


### PR DESCRIPTION
Defined actions without score are deactivated in sanity check (#3693)