### PR TITLE
lua_scanners/icap

### DIFF
--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -556,10 +556,11 @@ local function icap_check(task, content, digest, rule, maybe_part)
 
           if icap_headers.icap and string.find(icap_headers.icap, 'ICAP%/1%.. 2%d%d') then
             if icap_headers['Methods'] and string.find(icap_headers['Methods'], 'RESPMOD') then
-              --Preview is currently ununsed
-              --if icap_headers['Allow'] and string.find(icap_headers['Allow'], '204') then
-              -- add_respond_header('Allow', '204')
-              --end
+              -- Allow "204 No Content" responses 
+              -- https://datatracker.ietf.org/doc/html/rfc3507#section-4.6
+              if icap_headers['Allow'] and string.find(icap_headers['Allow'], '204') then
+                add_respond_header('Allow', '204')
+              end
 
               if rule.x_client_header then
                 local client = task:get_from_ip()

--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -272,7 +272,7 @@ local function icap_check(task, content, digest, rule, maybe_part)
         local resp_http_headers
 
         -- Append all extra headers
-        if rule.user_agent ~= "none" then 
+        if rule.user_agent ~= "none" then
           table.insert(respond_headers, string.format("User-Agent: %s\r\n", rule.user_agent))
         end
 
@@ -472,7 +472,6 @@ local function icap_check(task, content, digest, rule, maybe_part)
           icap_requery(err_m, "icap_r_respond_http_cb")
         else
           local result = tostring(data)
-          connection:close()
 
           local icap_http_headers = result_header_table(result) or {}
           -- Find HTTP/[12].x [234]xx response
@@ -550,16 +549,16 @@ local function icap_check(task, content, digest, rule, maybe_part)
         end
       end
 
-      local function icap_w_respond_cb(err_m, conn)
-        if err_m or conn == nil then
+      local function icap_w_respond_cb(err_m, connection)
+        if err_m or connection == nil then
           icap_requery(err_m, "icap_w_respond_cb")
         else
-          conn:add_read(icap_r_respond_cb, '\r\n\r\n')
+          connection:add_read(icap_r_respond_cb, '\r\n\r\n')
         end
       end
 
-      local function icap_r_options_cb(err_m, data, conn)
-        if err_m or conn == nil then
+      local function icap_r_options_cb(err_m, data, connection)
+        if err_m or connection == nil then
           icap_requery(err_m, "icap_r_options_cb")
         else
           local icap_headers = result_header_table(tostring(data))
@@ -592,7 +591,7 @@ local function icap_check(task, content, digest, rule, maybe_part)
 
               end
 
-              conn:add_write(icap_w_respond_cb, get_respond_query())
+              connection:add_write(icap_w_respond_cb, get_respond_query())
 
             else
               rspamd_logger.errx(task, '%s: RESPMOD method not advertised: Methods: %s',

--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -223,6 +223,8 @@ local function icap_check(task, content, digest, rule, maybe_part)
 
           tcp_options.host = addr:to_string()
           tcp_options.port = addr:get_port()
+          tcp_options.callback = icap_callback
+          tcp_options.data = options_request
 
           tcp.request(tcp_options)
 
@@ -408,6 +410,7 @@ local function icap_check(task, content, digest, rule, maybe_part)
                 '%s: icap error X-Infection-Found: %s', rule.log_prefix, icap_threat)
             common.yield_result(task, rule, icap_threat, 0,
                 'fail', maybe_part)
+            return true
           else
             lua_util.debugm(rule.name, task,
                 '%s: icap X-Infection-Found: %s', rule.log_prefix, icap_threat)


### PR DESCRIPTION
More complete ICAP implementation:

- Support REQ and HTTP encapsulated headers
- Support TLS
- Follow Connection header directives
- Analyse HTTP Return Headers (if no ICAP header was found)

Add Support for:
- McAfee Web Gateway 11
- Kaspersky Scan Engine 2.0 (you really should use http mode)
- Trend Micro Web Gateway