### PR TITLE
Enable PCRE2 by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ OPTION(INSTALL_WEBUI       "Install web interface [default: ON]"                
 OPTION(WANT_SYSTEMD_UNITS  "Install systemd unit files on Linux [default: OFF]" OFF)
 OPTION(ENABLE_SNOWBALL     "Enable snowball stemmer [default: ON]"              ON)
 OPTION(ENABLE_CLANG_PLUGIN "Enable clang static analysing plugin [default: OFF]" OFF)
-OPTION(ENABLE_PCRE2        "Enable pcre2 instead of pcre  [default: OFF]"         OFF)
+OPTION(ENABLE_PCRE2        "Enable pcre2 instead of pcre  [default: ON]"         ON)
 OPTION(ENABLE_JEMALLOC     "Build rspamd with jemalloc allocator  [default: OFF]" OFF)
 OPTION(ENABLE_UTILS        "Build rspamd internal utils [default: OFF]" OFF)
 OPTION(ENABLE_LIBUNWIND    "Use libunwind to print crash traces [default: OFF]" OFF)


### PR DESCRIPTION
There are 2 major versions of the PCRE library, PCRE and PCRE2. Rspamd supports both and current default is the former. But according to the web page of PCRE library it has reached its end of life. So change the default to the latter.