### PR TITLE
Add application/pgp-keys to known mime types

### DIFF
--- a/conf/maps.d/mime_types.inc
+++ b/conf/maps.d/mime_types.inc
@@ -199,6 +199,7 @@ application/p2p-overlay+xml 0
 application/patch-ops-error+xml 0
 application/pdf 0
 application/pgp-encrypted 0
+application/pgp-keys 0
 application/pgp-signature 0
 application/pidf+xml 0
 application/pidf-diff+xml 0


### PR DESCRIPTION
When I send PGP-signed mails with Roundcube and attach my PGP key the mail gets -0,1 spam points from rspamd because it is an unknown MIME type. 

I hope I found the code correctly so that the MIME type is known then. If not, I am happy if someone could correct my pr.

![image](https://user-images.githubusercontent.com/4103693/143462642-39a275e0-ce4d-4af9-ac3d-7440c7048f08.png)
