### PR TITLE
Fix disabling symbols

### DIFF
--- a/src/libserver/cfg_rcl.c
+++ b/src/libserver/cfg_rcl.c
@@ -539,7 +539,7 @@ rspamd_rcl_symbol_handler (rspamd_mempool_t *pool, const ucl_object_t *obj,
 			return FALSE;
 		}
 
-		if (ucl_object_toboolean (elt)) {
+		if (!ucl_object_toboolean (elt)) {
 			flags |= RSPAMD_SYMBOL_FLAG_DISABLED;
 		}
 	}


### PR DESCRIPTION
If enabled = false, then we should set RSPAMD_SYMBOL_FLAG_DISABLED.
Now setting enabled = true sets RSPAMD_SYMBOL_FLAG_DISABLED. Which is
incorrect.