### PR TITLE
Uncomment but disable SpamHaus URIBL

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -269,18 +269,19 @@ rbl {
     }
 
     # Not enabled by default due to privacy concerns! (see also groups.d/surbl_group.conf)
-    #"SPAMHAUS_ZEN_URIBL" {
-    #  suffix = "zen.spamhaus.org";
-    #  resolve_ip = true;
-    #  check_emails = true;
-    #  ips {
-    #    URIBL_SBL = "127.0.0.2";
-    #    URIBL_SBL_CSS = "127.0.0.3";
-    #    URIBL_XBL = ["127.0.0.4", "127.0.0.5", "127.0.0.6", "127.0.0.7"];
-    #    URIBL_PBL = ["127.0.0.10", "127.0.0.11"];
-    #    URIBL_DROP = "127.0.0.9";
-    #  }
-    #}
+    "SPAMHAUS_ZEN_URIBL" {
+      enabled = false;
+      rbl = "zen.spamhaus.org";
+      checks = ['emails'];
+      resolve_ip = true;
+      returncodes = {
+        URIBL_SBL = "127.0.0.2";
+        URIBL_SBL_CSS = "127.0.0.3";
+        URIBL_XBL = ["127.0.0.4", "127.0.0.5", "127.0.0.6", "127.0.0.7"];
+        URIBL_PBL = ["127.0.0.10", "127.0.0.11"];
+        URIBL_DROP = "127.0.0.9";
+      }
+    }
 
     "SEM_URIBL_UNKNOWN" {
       ignore_defaults = true;

--- a/conf/scores.d/surbl_group.conf
+++ b/conf/scores.d/surbl_group.conf
@@ -212,42 +212,48 @@ symbols = {
         one_shot = true;
         groups = ["uribl"];
     }
-    #"SPAMHAUS_ZEN_URIBL" {
-    #    weight = 0.0;
-    #    description = "Spamhaus ZEN URIBL: Filtered result";
-    #    one_shot = true;
-    #    groups = ["spamhaus"];
-    #}
-    #"URIBL_SBL" {
-    #    weight = 6.5;
-    #    description = "A domain in the message body resolves to an IP listed in Spamhaus SBL";
-    #    one_shot = true;
-    #    groups = ["v"];
-    #}
-    #"URIBL_SBL_CSS" {
-    #   weight = 6.5;
-    #    description = "A domain in the message body resolves to an IP listed in Spamhaus SBL CSS";
-    #    one_shot = true;
-    #    groups = ["spamhaus"];
-    #}
-    #"URIBL_XBL" {
-    #    weight = 1.5;
-    #    description = "A domain in the message body resolves to an IP listed in Spamhaus XBL";
-    #    one_shot = true;
-    #    groups = ["spamhaus"];
-    #}
-    #"URIBL_PBL" {
-    #    weight = 0.01;
-    #    description = "A domain in the message body resolves to an IP listed in Spamhaus PBL";
-    #    one_shot = true;
-    #    groups = ["spamhaus"];
-    #}
-    #"URIBL_DROP" {
-    #    weight = 5.0;
-    #    description = "A domain in the message body resolves to an IP listed in Spamhaus DROP";
-    #    one_shot = true;
-    #    groups = ["spamhaus"];
-    #}
+    "SPAMHAUS_ZEN_URIBL" {
+        ignore = true;
+        weight = 0.0;
+        description = "Spamhaus ZEN URIBL: Filtered result";
+        one_shot = true;
+        groups = ["spamhaus"];
+    }
+    "URIBL_SBL" {
+        ignore = true;
+        weight = 6.5;
+        description = "A domain in the message body resolves to an IP listed in Spamhaus SBL";
+        one_shot = true;
+        groups = ["spamhaus"];
+    }
+    "URIBL_SBL_CSS" {
+        ignore = true;
+        weight = 6.5;
+        description = "A domain in the message body resolves to an IP listed in Spamhaus SBL CSS";
+        one_shot = true;
+        groups = ["spamhaus"];
+    }
+    "URIBL_XBL" {
+        ignore = true;
+        weight = 1.5;
+        description = "A domain in the message body resolves to an IP listed in Spamhaus XBL";
+        one_shot = true;
+        groups = ["spamhaus"];
+    }
+    "URIBL_PBL" {
+        ignore = true;
+        weight = 0.01;
+        description = "A domain in the message body resolves to an IP listed in Spamhaus PBL";
+        one_shot = true;
+        groups = ["spamhaus"];
+    }
+    "URIBL_DROP" {
+        ignore = true;
+        weight = 5.0;
+        description = "A domain in the message body resolves to an IP listed in Spamhaus DROP";
+        one_shot = true;
+        groups = ["spamhaus"];
+    }
     #"RBL_SARBL_BAD" {
     #    weight = 2.5;
     #    description = "A domain in the message body is blacklisted in SARBL";


### PR DESCRIPTION
Fix the Spamhaus URIBL and uncomment but disable it.
This way it can be easily enabled in local.d without the need to copy
the whole block.
Symbols are also ignored as this will generate a warning otherwise.