### PR TITLE
Assign weights to Mailspike Whitelists

### DIFF
--- a/conf/scores.d/rbl_group.conf
+++ b/conf/scores.d/rbl_group.conf
@@ -117,14 +117,14 @@ symbols = {
         groups = ["spamhaus"];
     }
     "RBL_SPAMHAUS_BLOCKED_OPENRESOLVER" {
-      weight = 0.0;
-      description = "You are querying Spamhaus from an open resolver, please see https://www.spamhaus.org/returnc/pub/";
-      groups = ["spamhaus"];
+        weight = 0.0;
+        description = "You are querying Spamhaus from an open resolver, please see https://www.spamhaus.org/returnc/pub/";
+        groups = ["spamhaus"];
     }
     "RBL_SPAMHAUS_BLOCKED" {
-      weight = 0.0;
-      description = "You are exceeding the query limit, please see https://www.spamhaus.org/returnc/vol/";
-      groups = ["spamhaus"];
+        weight = 0.0;
+        description = "You are exceeding the query limit, please see https://www.spamhaus.org/returnc/vol/";
+        groups = ["spamhaus"];
     }
     "RECEIVED_SPAMHAUS_SBL" {
         weight = 1.0;
@@ -157,14 +157,14 @@ symbols = {
         one_shot = true;
     }
     "RECEIVED_SPAMHAUS_BLOCKED_OPENRESOLVER" {
-      weight = 0.0;
-      description = "You are querying Spamhaus from an open resolver, please see https://www.spamhaus.org/returnc/pub/";
-      groups = ["spamhaus"];
+        weight = 0.0;
+        description = "You are querying Spamhaus from an open resolver, please see https://www.spamhaus.org/returnc/pub/";
+        groups = ["spamhaus"];
     }
     "RECEIVED_SPAMHAUS_BLOCKED" {
-      weight = 0.0;
-      description = "You are exceeding the query limit, please see https://www.spamhaus.org/returnc/vol/";
-      groups = ["spamhaus"];
+        weight = 0.0;
+        description = "You are exceeding the query limit, please see https://www.spamhaus.org/returnc/vol/";
+        groups = ["spamhaus"];
     }
 
     "RBL_SENDERSCORE" {
@@ -202,17 +202,17 @@ symbols = {
         groups = ["mailspike"];
     }
     "RWL_MAILSPIKE_GOOD" {
-        weight = 0.0;
+        weight = -0.1;
         description = "From address is listed in RWL - good reputation";
         groups = ["mailspike"];
     }
     "RWL_MAILSPIKE_VERYGOOD" {
-        weight = 0.0;
+        weight = -0.2;
         description = "From address is listed in RWL - very good reputation";
         groups = ["mailspike"];
     }
     "RWL_MAILSPIKE_EXCELLENT" {
-        weight = 0.0;
+        weight = -0.4;
         description = "From address is listed in RWL - excellent reputation";
         groups = ["mailspike"];
     }


### PR DESCRIPTION
Assign a weight to the MAILSPIKE whitelist RBL symbols.
Use the same but negative weight as its blacklist counterparts.

Also fix some indents in the file