### PR TITLE
Map application/x-pdf to pdf

### DIFF
--- a/conf/modules.d/mime_types.conf
+++ b/conf/modules.d/mime_types.conf
@@ -30,7 +30,8 @@ mime_types {
     ];
     pdf = [
       "application/octet-stream",
-      "application/pdf"
+      "application/pdf",
+      "application/x-pdf"
     ];
   }
 


### PR DESCRIPTION
Some mails were marked as
MIME_BAD_ATTACHMENT (4) [pdf:application/x-pdf]

application/x-pdf might be obsolete but still used.