### PR TITLE
[Fix] Avoid overwriting whitelisted_signers_map

### DIFF
--- a/lualib/lua_dkim_tools.lua
+++ b/lualib/lua_dkim_tools.lua
@@ -705,6 +705,8 @@ exports.process_signing_settings = function(N, settings, opts)
       else
         logger.errx(rspamd_config, 'cannot load sign condition %s: %s', v, f)
       end
+    elseif k == 'whitelisted_signers_map' then
+      settings[k] = lua_maps.map_add(N, k, 'set', 'ARC trusted signers domains')
     else
       settings[k] = v
     end

--- a/src/plugins/lua/arc.lua
+++ b/src/plugins/lua/arc.lua
@@ -413,24 +413,6 @@ rspamd_config:register_symbol({
   groups = {'arc'},
 })
 
-if settings.whitelisted_signers_map then
-  local lua_maps = require "lua_maps"
-  settings.whitelisted_signers_map = lua_maps.map_add_from_ucl(settings.whitelisted_signers_map,
-      'set',
-      'ARC trusted signers domains')
-  if settings.whitelisted_signers_map then
-    arc_symbols.trusted_allow = arc_symbols.trusted_allow or 'ARC_ALLOW_TRUSTED'
-    rspamd_config:register_symbol({
-      name = arc_symbols.trusted_allow,
-      parent = id,
-      type = 'virtual',
-      score = -2.0,
-      group = 'policies',
-      groups = {'arc'},
-    })
-  end
-end
-
 rspamd_config:register_dependency('ARC_CALLBACK', 'SPF_CHECK')
 rspamd_config:register_dependency('ARC_CALLBACK', 'DKIM_CHECK')
 
@@ -739,6 +721,18 @@ if type(settings.allowed_ids) == 'table' then
 end
 if type(settings.forbidden_ids) == 'table' then
   sym_reg_tbl.forbidden_ids = settings.forbidden_ids
+end
+
+if settings.whitelisted_signers_map then
+  arc_symbols.trusted_allow = arc_symbols.trusted_allow or 'ARC_ALLOW_TRUSTED'
+  rspamd_config:register_symbol({
+    name = arc_symbols.trusted_allow,
+    parent = id,
+    type = 'virtual',
+    score = -2.0,
+    group = 'policies',
+    groups = {'arc'},
+  })
 end
 
 rspamd_config:register_symbol(sym_reg_tbl)


### PR DESCRIPTION
The whitelisted_signers_map defined [here](https://github.com/rspamd/rspamd/blob/master/src/plugins/lua/arc.lua#L418) is getting overwritten by [`dkim_sign_tools.process_signing_settings(N, settings, opts)`](https://github.com/rspamd/rspamd/blob/master/src/plugins/lua/arc.lua#L418). As a result the `trusted_allow` symbol is never inserted. Rspamd logs the following error:

```
2021-12-23 21:49:17 #16197(normal) <c9818c>; task; dkim_module_lua_push_verify_result: call to verify callback failed: /usr/share/rspamd/plugins/arc.lua:236: attempt to index field 'whitelisted_signers_map' (a nil value)
```

I suggest that we move the `map_add` to the [`process_signing_settings` function in lua_dkim_tools.lua](https://github.com/rspamd/rspamd/blob/e2c9ea10a36bd2f48d4570123062d8af6dffc513/lualib/lua_dkim_tools.lua#L686) and move [the `register_symbol` block ](https://github.com/rspamd/rspamd/blob/master/src/plugins/lua/arc.lua#L416-L432) further down (after [line 701](https://github.com/rspamd/rspamd/blob/master/src/plugins/lua/arc.lua#L701) where `process_signing_settings` is called).