### PR TITLE
[Minor] Add no soft reject selector for metadata exporter

### DIFF
--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -245,6 +245,10 @@ local selectors = {
     local action = task:get_metric_action('default')
     return (action == 'reject')
   end,
+  is_not_soft_reject = function(task)
+    local action = task:get_metric_action('default')
+    return (action ~= 'soft reject')
+  end,
 }
 
 local function maybe_defer(task, rule)


### PR DESCRIPTION
I think its quite common to not export soft rejects via the metadata
exporter. Because when its not spam, the sender will most likely try to
redeliver it again anyway.