### PR TITLE
Rdns tcp rework

### DIFF
--- a/contrib/librdns/compression.c
+++ b/contrib/librdns/compression.c
@@ -66,7 +66,7 @@ rdns_add_compressed (const char *pos, const char *end,
 }
 
 void
-rnds_compression_free (struct rdns_compression_entry *comp)
+rdns_compression_free (struct rdns_compression_entry *comp)
 {
 	struct rdns_compression_entry *cur, *tmp;
 

--- a/contrib/librdns/compression.h
+++ b/contrib/librdns/compression.h
@@ -40,6 +40,6 @@ bool rdns_write_name_compressed (struct rdns_request *req,
 		const char *name, unsigned int namelen,
 		struct rdns_compression_entry **comp);
 
-void rnds_compression_free (struct rdns_compression_entry *comp);
+void rdns_compression_free (struct rdns_compression_entry *comp);
 
 #endif /* COMPRESSION_H_ */

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "uthash.h"
 #include "utlist.h"
+#include "khash.h"
 #include "rdns.h"
 #include "upstream.h"
 #include "ref.h"
@@ -107,7 +108,7 @@ enum rdns_io_channel_flags {
 #define IS_CHANNEL_CONNECTED(ioc) (((ioc)->flags & RDNS_CHANNEL_CONNECTED) != 0)
 #define IS_CHANNEL_ACTIVE(ioc) (((ioc)->flags & RDNS_CHANNEL_ACTIVE) != 0)
 
-
+KHASH_DECLARE(rdns_requests_hash, int, struct rdns_request *);
 /**
  * IO channel for a specific DNS server
  */
@@ -119,7 +120,7 @@ struct rdns_io_channel {
 	int sock; /**< persistent socket                                          */
 	int flags; /**< see enum rdns_io_channel_flags */
 	void *async_io; /** async opaque ptr */
-	struct rdns_request *requests; /**< requests in flight                                         */
+	khash_t(rdns_requests_hash) *requests;
 	uint64_t uses;
 	ref_entry_t ref;
 };

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -102,6 +102,8 @@ enum rdns_request_state {
 	RDNS_REQUEST_WAIT_REPLY,
 	RDNS_REQUEST_REPLIED,
 	RDNS_REQUEST_FAKE,
+	RDNS_REQUEST_ERROR,
+	RDNS_REQUEST_TCP,
 };
 
 struct rdns_request {
@@ -151,8 +153,8 @@ enum rdns_io_channel_flags {
  * Used to chain output DNS requests for a TCP connection
  */
 struct rdns_tcp_output_chain {
-	uint16_t next_write_size;
-	uint16_t cur_write;
+	uint16_t next_write_size; /* Network byte order! */
+	uint16_t cur_write; /* Cur bytes written including `next_write_size` */
 	struct rdns_request *req;
 	struct rdns_tcp_output_chain *prev, *next;
 };
@@ -161,9 +163,10 @@ struct rdns_tcp_output_chain {
  * Specific stuff for a TCP IO chain
  */
 struct rdns_tcp_channel {
-	uint16_t next_read_size;
-	uint16_t cur_read;
+	uint16_t next_read_size; /* Network byte order on read, then host byte order */
+	uint16_t cur_read; /* Cur bytes read including `next_read_size` */
 	unsigned char *cur_read_buf;
+	unsigned read_buf_allocated;
 
 	/* Chained set of the planned writes */
 	struct rdns_tcp_output_chain *output_chain;

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -98,6 +98,16 @@ struct rdns_request {
 };
 
 
+enum rdns_io_channel_flags {
+	RDNS_CHANNEL_CONNECTED = 1u << 0u,
+	RDNS_CHANNEL_ACTIVE = 1u << 1u,
+	RDNS_CHANNEL_TCP = 1u << 2u,
+};
+
+#define IS_CHANNEL_CONNECTED(ioc) (((ioc)->flags & RDNS_CHANNEL_CONNECTED) != 0)
+#define IS_CHANNEL_ACTIVE(ioc) (((ioc)->flags & RDNS_CHANNEL_ACTIVE) != 0)
+
+
 /**
  * IO channel for a specific DNS server
  */
@@ -107,8 +117,7 @@ struct rdns_io_channel {
 	struct sockaddr *saddr;
 	socklen_t slen;
 	int sock; /**< persistent socket                                          */
-	bool active;
-	bool connected;
+	int flags; /**< see enum rdns_io_channel_flags */
 	void *async_io; /** async opaque ptr */
 	struct rdns_request *requests; /**< requests in flight                                         */
 	uint64_t uses;
@@ -131,7 +140,6 @@ struct rdns_fake_reply {
 
 struct rdns_resolver {
 	struct rdns_server *servers;
-	struct rdns_io_channel *io_channels; /**< hash of io chains indexed by socket        */
 	struct rdns_async_context *async; /** async callbacks */
 	void *periodic; /** periodic event for resolver */
 	struct rdns_upstream_context *ups;

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -36,7 +36,7 @@ static const int dns_port = 53;
 static const int default_io_cnt = 8;
 static const int default_tcp_io_cnt = 1;
 
-#define UDP_PACKET_SIZE (4096 * 2)
+#define UDP_PACKET_SIZE (512)
 
 #define DNS_COMPRESSION_BITS 0xC0
 

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -36,7 +36,7 @@ static const int dns_port = 53;
 static const int default_io_cnt = 8;
 static const int default_tcp_io_cnt = 1;
 
-#define UDP_PACKET_SIZE (512)
+#define UDP_PACKET_SIZE (4096)
 
 #define DNS_COMPRESSION_BITS 0xC0
 

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -152,8 +152,8 @@ enum rdns_io_channel_flags {
  */
 struct rdns_tcp_output_chain {
 	uint16_t next_write_size;
-	struct rdns_request *req;
 	uint16_t cur_write;
+	struct rdns_request *req;
 	struct rdns_tcp_output_chain *prev, *next;
 };
 
@@ -162,8 +162,8 @@ struct rdns_tcp_output_chain {
  */
 struct rdns_tcp_channel {
 	uint16_t next_read_size;
-	unsigned char *cur_read_buf;
 	uint16_t cur_read;
+	unsigned char *cur_read_buf;
 
 	/* Chained set of the planned writes */
 	struct rdns_tcp_output_chain *output_chain;

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -154,7 +154,7 @@ enum rdns_io_channel_flags {
 struct rdns_tcp_output_chain {
 	uint16_t next_write_size; /* Network byte order! */
 	uint16_t cur_write; /* Cur bytes written including `next_write_size` */
-	struct rdns_request *req;
+	unsigned char *write_buf;
 	struct rdns_tcp_output_chain *prev, *next;
 };
 

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -34,7 +34,7 @@
 
 static const int dns_port = 53;
 static const int default_io_cnt = 8;
-static const int default_tcp_io_cnt = 2;
+static const int default_tcp_io_cnt = 1;
 
 #define UDP_PACKET_SIZE (4096 * 2)
 
@@ -174,10 +174,12 @@ struct rdns_tcp_channel {
 };
 
 KHASH_DECLARE(rdns_requests_hash, int, struct rdns_request *);
+#define RDNS_IO_CHANNEL_TAG UINT64_C(0xe190a5ba12f094c8)
 /**
  * IO channel for a specific DNS server
  */
 struct rdns_io_channel {
+	uint64_t struct_magic; /**< tag for this structure */
 	struct rdns_server *srv;
 	struct rdns_resolver *resolver;
 	struct sockaddr *saddr;

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -34,6 +34,7 @@
 
 static const int dns_port = 53;
 static const int default_io_cnt = 8;
+static const int default_tcp_io_cnt = 2;
 
 #define UDP_PACKET_SIZE (4096 * 2)
 
@@ -51,8 +52,10 @@ struct rdns_server {
 	char *name;
 	unsigned int port;
 	unsigned int io_cnt;
+	unsigned int tcp_io_cnt;
 
 	struct rdns_io_channel **io_channels;
+	struct rdns_io_channel **tcp_io_channels;
 	void *ups_elt;
 	upstream_entry_t up;
 };

--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -134,7 +134,6 @@ struct rdns_request {
 	void *curve_plugin_data;
 #endif
 
-	UT_hash_handle hh;
 	ref_entry_t ref;
 };
 

--- a/contrib/librdns/rdns.h
+++ b/contrib/librdns/rdns.h
@@ -480,7 +480,7 @@ bool rdns_format_dns_name (struct rdns_resolver *resolver,
 
 void rdns_process_read (int fd, void *arg);
 void rdns_process_timer (void *arg);
-void rdns_process_retransmit (int fd, void *arg);
+void rdns_process_write (int fd, void *arg);
 
 #ifdef  __cplusplus
 }

--- a/contrib/librdns/rdns_ev.h
+++ b/contrib/librdns/rdns_ev.h
@@ -88,7 +88,7 @@ rdns_libev_read_event (struct ev_loop *loop, ev_io *ev, int revents)
 static void
 rdns_libev_write_event (struct ev_loop *loop, ev_io *ev, int revents)
 {
-	rdns_process_retransmit (ev->fd, ev->data);
+	rdns_process_write(ev->fd, ev->data);
 }
 
 static void

--- a/contrib/librdns/rdns_event.h
+++ b/contrib/librdns/rdns_event.h
@@ -85,7 +85,7 @@ rdns_libevent_read_event (int fd, short what, void *ud)
 static void
 rdns_libevent_write_event (int fd, short what, void *ud)
 {
-	rdns_process_retransmit (fd, ud);
+	rdns_process_write (fd, ud);
 }
 
 static void

--- a/contrib/librdns/resolver.c
+++ b/contrib/librdns/resolver.c
@@ -817,6 +817,7 @@ rdns_process_tcp_write (int fd, struct rdns_io_channel *ioc)
 			/* Packet has been fully written, remove it */
 			DL_DELETE(ioc->tcp->output_chain, oc);
 			/* Data in output buffer belongs to request */
+			REF_RELEASE(oc->req);
 			free (oc);
 			ioc->tcp->cur_output_chains --;
 		}

--- a/contrib/librdns/resolver.c
+++ b/contrib/librdns/resolver.c
@@ -507,7 +507,7 @@ rdns_process_timer (void *arg)
 			req->async->del_timer (req->async->data,
 					req->async_event);
 			req->async_event = NULL;
-			kh_del(rdns_requests_hash, req->io->requests, req->id);
+			rdns_request_remove_from_hash(req);
 		}
 
 		/* We have not scheduled timeout actually due to send error */

--- a/contrib/librdns/util.c
+++ b/contrib/librdns/util.c
@@ -548,6 +548,9 @@ rdns_ioc_new (struct rdns_server *serv,
 	}
 
 	nioc->struct_magic = RDNS_IO_CHANNEL_TAG;
+	nioc->srv = serv;
+	nioc->resolver = resolver;
+
 	nioc->sock = rdns_make_client_socket (serv->name, serv->port,
 			is_tcp ? SOCK_STREAM : SOCK_DGRAM, &nioc->saddr, &nioc->slen);
 	if (nioc->sock == -1) {
@@ -570,12 +573,7 @@ rdns_ioc_new (struct rdns_server *serv,
 
 		nioc->flags |= RDNS_CHANNEL_TCP;
 	}
-
-	nioc->srv = serv;
-	nioc->resolver = resolver;
-
-	/* If it is not NULL then we are in a delayed connection state */
-	if (!is_tcp) {
+	else {
 		nioc->flags |= RDNS_CHANNEL_ACTIVE;
 		nioc->async_io = resolver->async->add_read(resolver->async->data,
 				nioc->sock, nioc);

--- a/contrib/librdns/util.c
+++ b/contrib/librdns/util.c
@@ -540,6 +540,7 @@ rdns_ioc_new (struct rdns_server *serv,
 		return NULL;
 	}
 
+	nioc->struct_magic = RDNS_IO_CHANNEL_TAG;
 	nioc->sock = rdns_make_client_socket (serv->name, serv->port,
 			is_tcp ? SOCK_STREAM : SOCK_DGRAM, &nioc->saddr, &nioc->slen);
 	if (nioc->sock == -1) {

--- a/contrib/librdns/util.c
+++ b/contrib/librdns/util.c
@@ -665,6 +665,21 @@ rdns_ioc_tcp_reset (struct rdns_io_channel *ioc)
 		}
 
 		/* Clean all buffers and temporaries */
+		if (ioc->tcp->cur_read_buf) {
+			free (ioc->tcp->cur_read_buf);
+			ioc->tcp->read_buf_allocated = 0;
+			ioc->tcp->next_read_size = 0;
+			ioc->tcp->cur_read = 0;
+		}
+
+		struct rdns_tcp_output_chain *oc, *tmp;
+		DL_FOREACH_SAFE(ioc->tcp->output_chain, oc, tmp) {
+			REF_RELEASE(oc->req);
+			DL_DELETE (ioc->tcp->output_chain, oc);
+			free (oc);
+		}
+
+		ioc->tcp->cur_output_chains = 0;
 
 		ioc->flags &= ~RDNS_CHANNEL_CONNECTED;
 	}

--- a/contrib/librdns/util.c
+++ b/contrib/librdns/util.c
@@ -643,6 +643,12 @@ rdns_request_unschedule (struct rdns_request *req)
 			req->async_event = NULL;
 		}
 	}
+	else if (req->state == RDNS_REQUEST_TCP) {
+		req->async->del_timer(req->async->data,
+				req->async_event);
+
+		req->async_event = NULL;
+	}
 }
 
 void

--- a/contrib/librdns/util.c
+++ b/contrib/librdns/util.c
@@ -506,6 +506,9 @@ rdns_request_free (struct rdns_request *req)
 				req->async_event = NULL;
 			}
 		}
+		if (req->state == RDNS_REQUEST_TCP) {
+			rdns_request_remove_from_hash(req);
+		}
 #ifdef TWEETNACL
 		if (req->curve_plugin_data != NULL) {
 			req->resolver->curve_plugin->cb.curve_plugin.finish_cb (

--- a/contrib/librdns/util.h
+++ b/contrib/librdns/util.h
@@ -51,11 +51,23 @@ uint16_t rdns_permutor_generate_id (void);
 void rdns_ioc_free (struct rdns_io_channel *ioc);
 
 /**
- * C
+ * Creates a new IO channel
  */
 struct rdns_io_channel * rdns_ioc_new (struct rdns_server *srv,
 									   struct rdns_resolver *resolver,
 									   bool is_tcp);
+
+/**
+ * Resets inactive/errored TCP chain as recommended by RFC
+ * @param ioc
+ */
+void rdns_ioc_tcp_reset (struct rdns_io_channel *ioc);
+
+/**
+ * Connect TCP IO channel to a server
+ * @param ioc
+ */
+bool rdns_ioc_tcp_connect (struct rdns_io_channel *ioc);
 
 /**
  * Free request

--- a/contrib/librdns/util.h
+++ b/contrib/librdns/util.h
@@ -64,6 +64,12 @@ struct rdns_io_channel * rdns_ioc_new (struct rdns_server *srv,
 void rdns_request_free (struct rdns_request *req);
 
 /**
+ * Removes request from a channel's hash (e.g. if needed to migrate to another channel)
+ * @param req
+ */
+void rdns_request_remove_from_hash (struct rdns_request *req);
+
+/**
  * Free reply
  * @param rep
  */

--- a/contrib/librdns/util.h
+++ b/contrib/librdns/util.h
@@ -51,6 +51,13 @@ uint16_t rdns_permutor_generate_id (void);
 void rdns_ioc_free (struct rdns_io_channel *ioc);
 
 /**
+ * C
+ */
+struct rdns_io_channel * rdns_ioc_new (struct rdns_server *srv,
+									   struct rdns_resolver *resolver,
+									   bool is_tcp);
+
+/**
  * Free request
  * @param req
  */

--- a/contrib/librdns/util.h
+++ b/contrib/librdns/util.h
@@ -82,6 +82,13 @@ void rdns_request_free (struct rdns_request *req);
 void rdns_request_remove_from_hash (struct rdns_request *req);
 
 /**
+ * Creates a new reply
+ * @param req
+ * @param rcode
+ * @return
+ */
+struct rdns_reply * rdns_make_reply (struct rdns_request *req, enum dns_rcode rcode);
+/**
  * Free reply
  * @param rep
  */


### PR DESCRIPTION
This is a rework of RDNS library that allows to re-send truncated UDP requests over TCP channels. TCP channels are maintained in a way described in [RFC7766](https://datatracker.ietf.org/doc/html/rfc7766), meaning that RDNS will re-use TCP connections for as many requests as it can but it will reap idle connections out. Rspamd will also create a single TCP connection to a DNS server per process. This change allows to parse very large replies from brain-damaged domain owners, see #4012 for more details.