### PR TITLE
[Feature] Allow hyperscan for ppc64, as vectorscan now suports it.

### DIFF
--- a/src/hs_helper.c
+++ b/src/hs_helper.c
@@ -303,7 +303,7 @@ static gboolean
 rspamd_rs_compile (struct hs_helper_ctx *ctx, struct rspamd_worker *worker,
 		gboolean forced)
 {
-#ifndef __aarch64__
+#if !defined(__aarch64__) && !defined(__powerpc64__)
 	if (!(ctx->cfg->libs_ctx->crypto_ctx->cpu_config & CPUID_SSSE3)) {
 		msg_warn ("CPU doesn't have SSSE3 instructions set "
 				"required for hyperscan, disable hyperscan compilation");

--- a/src/libserver/cfg_utils.c
+++ b/src/libserver/cfg_utils.c
@@ -817,7 +817,7 @@ rspamd_config_post_load (struct rspamd_config *cfg,
 	rspamd_regexp_library_init (cfg);
 	rspamd_multipattern_library_init (cfg->hs_cache_dir);
 
-#if defined(WITH_HYPERSCAN) && !defined(__aarch64__)
+#if defined(WITH_HYPERSCAN) && !defined(__aarch64__) && !defined(__powerpc64__)
 	if (!cfg->disable_hyperscan) {
 		if (!(cfg->libs_ctx->crypto_ctx->cpu_config & CPUID_SSSE3)) {
 			msg_warn_config ("CPU doesn't have SSSE3 instructions set "

--- a/src/libserver/maps/map_helpers.c
+++ b/src/libserver/maps/map_helpers.c
@@ -1306,7 +1306,7 @@ rspamd_re_map_finalize (struct rspamd_regexp_map_helper *re_map)
 
 	map = re_map->map;
 
-#ifndef __aarch64__
+#if !defined(__aarch64__) && !defined(__powerpc64__)
 	if (!(map->cfg->libs_ctx->crypto_ctx->cpu_config & CPUID_SSSE3)) {
 		msg_info_map ("disable hyperscan for map %s, ssse3 instructons are not supported by CPU",
 				map->name);


### PR DESCRIPTION
Tested in alpine ci: https://gitlab.alpinelinux.org/a16bitsysop/aports/-/jobs/605308

With tests passing.