### PR TITLE
rspamadm configdump: parsing fixes and output enhancements

### DIFF
--- a/src/libserver/cfg_utils.c
+++ b/src/libserver/cfg_utils.c
@@ -1630,8 +1630,9 @@ rspamd_config_add_symbol (struct rspamd_config *cfg,
 					sym_group = rspamd_config_new_group (cfg, group);
 				}
 
-				if (!sym_def->gr) {
+				if ((!sym_def->gr) || (sym_def->flags & RSPAMD_SYMBOL_FLAG_UNGROUPPED)) {
 					sym_def->gr = sym_group;
+					sym_def->flags &= ~RSPAMD_SYMBOL_FLAG_UNGROUPPED;
 				}
 
 				g_hash_table_insert (sym_group->symbols, sym_def->name, sym_def);

--- a/src/libserver/rspamd_symcache.c
+++ b/src/libserver/rspamd_symcache.c
@@ -3384,6 +3384,27 @@ rspamd_symcache_set_symbol_flags (struct rspamd_symcache *cache,
 	return FALSE;
 }
 
+void
+rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
+										   const gchar *symbol,
+										   const ucl_object_t *this_sym_ucl)
+{
+	struct rspamd_symcache_item *item;
+
+	g_assert (cache != NULL);
+	g_assert (symbol != NULL);
+
+	item = rspamd_symcache_find_filter (cache, symbol, false);
+
+	if (item) {
+		ucl_object_insert_key (this_sym_ucl,
+			ucl_object_fromstring(item->type_descr),
+			"type", strlen("type"), false);
+
+		// any other data?
+	}
+}
+
 guint
 rspamd_symcache_get_symbol_flags (struct rspamd_symcache *cache,
 										const gchar *symbol)

--- a/src/libserver/rspamd_symcache.c
+++ b/src/libserver/rspamd_symcache.c
@@ -3387,7 +3387,7 @@ rspamd_symcache_set_symbol_flags (struct rspamd_symcache *cache,
 void
 rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
 										   const gchar *symbol,
-										   const ucl_object_t *this_sym_ucl)
+										   ucl_object_t *this_sym_ucl)
 {
 	struct rspamd_symcache_item *item;
 

--- a/src/libserver/rspamd_symcache.h
+++ b/src/libserver/rspamd_symcache.h
@@ -301,6 +301,11 @@ gboolean rspamd_symcache_set_symbol_flags (struct rspamd_symcache *cache,
 guint rspamd_symcache_get_symbol_flags (struct rspamd_symcache *cache,
 										const gchar *symbol);
 
+void rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
+								 const gchar *symbol,
+								 const ucl_object_t *this_sym_ucl);
+
+
 /**
  * Process settings for task
  * @param task

--- a/src/libserver/rspamd_symcache.h
+++ b/src/libserver/rspamd_symcache.h
@@ -303,7 +303,7 @@ guint rspamd_symcache_get_symbol_flags (struct rspamd_symcache *cache,
 
 void rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
 								 const gchar *symbol,
-								 const ucl_object_t *this_sym_ucl);
+								 ucl_object_t *this_sym_ucl);
 
 
 /**

--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -2899,12 +2899,12 @@ lua_config_newindex (lua_State *L)
 				}
 				lua_pop (L, 1);
 				if (group) {
-					if (sym->flags & RSPAMD_SYMBOL_FLAG_UNGROUPPED)
-					{
+					if (sym->flags & RSPAMD_SYMBOL_FLAG_UNGROUPPED) {
 						/* Unset the "ungrouped" group */
 						sym->gr = NULL;
 					}
-					/* Add the group */
+					/* Add the group. If the symbol was ungrouped, this will
+					* clear RSPAMD_SYMBOL_FLAG_UNGROUPPED from the flags. */
 					rspamd_config_add_symbol_group (cfg, name, group);
 				}
 			}

--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -2873,6 +2873,41 @@ lua_config_newindex (lua_State *L)
 					lua_pop (L, 1);
 				}
 			}
+			else
+			{
+				/* Fill in missing fields from lua defintion if they are not set */
+				if (sym->description == NULL) {
+					lua_pushstring (L, "description");
+					lua_gettable (L, -2);
+
+					if (lua_type (L, -1) == LUA_TSTRING) {
+						description = lua_tostring (L, -1);
+					}
+					lua_pop (L, 1);
+
+					if (description) {
+						sym->description = rspamd_mempool_strdup (cfg->cfg_pool, description);
+					}
+				}
+
+				/* If ungrouped and there is a group defined in lua, change the primary group
+				 * Otherwise, add to the list of groups for this symbol. */
+				lua_pushstring (L, "group");
+				lua_gettable (L, -2);
+				if (lua_type (L, -1) == LUA_TSTRING) {
+					group = lua_tostring (L, -1);
+				}
+				lua_pop (L, 1);
+				if (group) {
+					if (sym->flags & RSPAMD_SYMBOL_FLAG_UNGROUPPED)
+					{
+						/* Unset the "ungrouped" group */
+						sym->gr = NULL;
+					}
+					/* Add the group */
+					rspamd_config_add_symbol_group (cfg, name, group);
+				}
+			}
 
 			/* Remove table from stack */
 			lua_pop (L, 1);

--- a/src/rspamadm/configdump.c
+++ b/src/rspamadm/configdump.c
@@ -330,6 +330,7 @@ rspamadm_configdump (gint argc, gchar **argv, const struct rspamadm_command *cmd
 						ucl_object_fromdouble (s->score),
 						"score", strlen ("score"),
 						false);
+
 				ucl_object_insert_key (this_sym_ucl,
 						ucl_object_fromstring (s->description),
 						"description", strlen ("description"), false);
@@ -368,17 +369,17 @@ rspamadm_configdump (gint argc, gchar **argv, const struct rspamadm_command *cmd
 						ucl_object_t *add_groups = ucl_object_typed_new (UCL_ARRAY);
 						guint j;
 						struct rspamd_symbols_group *add_gr;
-						bool one_extra = false;
+						bool has_extra_groups = false;
 
 						PTR_ARRAY_FOREACH (s->groups, j, add_gr) {
 							if (add_gr->name && strcmp (add_gr->name, gr_name) != 0) {
 								ucl_array_append (add_groups,
 									ucl_object_fromstring (add_gr->name));
-								one_extra = true;
+								has_extra_groups = true;
 							}
 						}
 
-						if (one_extra == true) {
+						if (has_extra_groups == true) {
 							ucl_object_insert_key (this_sym_ucl,
 								add_groups,
 								"groups", strlen ("groups"),

--- a/src/rspamadm/configdump.c
+++ b/src/rspamadm/configdump.c
@@ -28,6 +28,7 @@ static gboolean show_help = FALSE;
 static gboolean show_comments = FALSE;
 static gboolean modules_state = FALSE;
 static gboolean symbol_groups_only = FALSE;
+static gboolean symbol_full_details = FALSE;
 static gboolean skip_template = FALSE;
 static gchar *config = NULL;
 extern struct rspamd_main *rspamd_main;
@@ -52,7 +53,7 @@ static GOptionEntry entries[] = {
 		{"compact", 'C', 0, G_OPTION_ARG_NONE, &compact,
 				"Compacted json output", NULL},
 		{"config", 'c', 0, G_OPTION_ARG_STRING, &config,
-				"Config file to test",     NULL},
+				"Config file to test", NULL},
 		{"show-help", 'h', 0, G_OPTION_ARG_NONE, &show_help,
 				"Show help as comments for each option", NULL },
 		{"show-comments", 's', 0, G_OPTION_ARG_NONE, &show_comments,
@@ -61,6 +62,8 @@ static GOptionEntry entries[] = {
 				"Show modules state only", NULL},
 		{"groups", 'g', 0, G_OPTION_ARG_NONE, &symbol_groups_only,
 				"Show symbols groups only", NULL},
+		{"symbol-details", 'd', 0, G_OPTION_ARG_NONE, &symbol_full_details,
+				"Show full symbol details only", NULL},
 		{"skip-template", 'T', 0, G_OPTION_ARG_NONE, &skip_template,
 				"Do not apply Jinja templates", NULL},
 		{NULL,  0,   0, G_OPTION_ARG_NONE, NULL, NULL, NULL}
@@ -237,7 +240,7 @@ rspamadm_configdump (gint argc, gchar **argv, const struct rspamadm_command *cmd
 	GOptionContext *context;
 	GError *error = NULL;
 	const gchar *confdir;
-	const ucl_object_t *obj, *cur, *doc_obj;
+	const ucl_object_t *obj = NULL, *cur, *doc_obj;
 	struct rspamd_config *cfg = rspamd_main->cfg;
 	gboolean ret = TRUE;
 	worker_t **pworker;
@@ -302,6 +305,119 @@ rspamadm_configdump (gint argc, gchar **argv, const struct rspamadm_command *cmd
 					"plugins_stats",
 					FALSE);
 
+			exit (EXIT_SUCCESS);
+		}
+
+		if (symbol_full_details) {
+			/*
+			 * Create object from symbols groups and output it using the
+			 * specified format
+			 */
+			ucl_object_t *out = ucl_object_typed_new (UCL_OBJECT);
+			GHashTableIter it;
+			gpointer sk, sv;
+
+			g_hash_table_iter_init (&it, cfg->symbols);
+			ucl_object_t *sym_ucl = ucl_object_typed_new (UCL_OBJECT);
+			const ucl_object_t *all_symbols_ucl = ucl_object_lookup(cfg->rcl_obj, "symbols");
+
+			while (g_hash_table_iter_next (&it, &sk, &sv)) {
+				const gchar *sym_name = (const gchar *)sk;
+				struct rspamd_symbol *s = (struct rspamd_symbol *)sv;
+				ucl_object_t *this_sym_ucl = ucl_object_typed_new (UCL_OBJECT);
+
+				ucl_object_insert_key (this_sym_ucl,
+						ucl_object_fromdouble (s->score),
+						"score", strlen ("score"),
+						false);
+				ucl_object_insert_key (this_sym_ucl,
+						ucl_object_fromstring (s->description),
+						"description", strlen ("description"), false);
+
+				rspamd_symcache_get_symbol_details(cfg->cache, sym_name, this_sym_ucl);
+
+				ucl_object_insert_key (this_sym_ucl,
+						ucl_object_frombool (!!(s->flags & RSPAMD_SYMBOL_FLAG_DISABLED)),
+						"disabled", strlen ("disabled"),
+						false);
+
+				if (s->nshots == 1) {
+					ucl_object_insert_key (this_sym_ucl,
+							ucl_object_frombool (true),
+							"one_shot", strlen ("one_shot"),
+							false);
+				}
+				else {
+					ucl_object_insert_key (this_sym_ucl,
+							ucl_object_frombool (false),
+							"one_shot", strlen ("one_shot"),
+							false);
+				}
+
+				if (s->gr != NULL) {
+					struct rspamd_symbols_group *gr = s->gr;
+					const char *gr_name = gr->name;
+					if (strcmp(gr_name, "ungrouped") != 0) {
+						ucl_object_insert_key (this_sym_ucl,
+							ucl_object_fromstring (gr_name),
+							"group", strlen("group"),
+							false);
+					}
+
+					if (s->groups) {
+						ucl_object_t *add_groups = ucl_object_typed_new (UCL_ARRAY);
+						guint j;
+						struct rspamd_symbols_group *add_gr;
+						bool one_extra = false;
+
+						PTR_ARRAY_FOREACH (s->groups, j, add_gr) {
+							if (add_gr->name && strcmp (add_gr->name, gr_name) != 0) {
+								ucl_array_append (add_groups,
+									ucl_object_fromstring (add_gr->name));
+								one_extra = true;
+							}
+						}
+
+						if (one_extra == true) {
+							ucl_object_insert_key (this_sym_ucl,
+								add_groups,
+								"groups", strlen ("groups"),
+								false);
+						}
+					}
+				}
+
+				const ucl_object_t *loaded_symbol_ucl = ucl_object_lookup(all_symbols_ucl, sym_name);
+				if (loaded_symbol_ucl) {
+					ucl_object_iter_t it = NULL;
+					while ((cur = ucl_iterate_object (loaded_symbol_ucl, &it, true)) != NULL)
+					{
+						const char *key = ucl_object_key(cur);
+						/* If this key isn't something we have direct in the symbol item, grab the key/value */
+						if ((strcmp(key, "score") != 0 ) &&
+							(strcmp(key, "description") != 0) &&
+							(strcmp(key, "disabled") != 0) &&
+							(strcmp(key, "condition") != 0) &&
+							(strcmp(key, "score") != 0) &&
+							(strcmp(key, "one_shot") != 0) &&
+							(strcmp(key, "any_shot") != 0) &&
+							(strcmp(key, "nshots") != 0) &&
+							(strcmp(key, "one_param") != 0) &&
+							(strcmp(key, "priority") != 0))
+						{
+							ucl_object_insert_key(this_sym_ucl, (ucl_object_t *)cur, key, strlen(key), false);
+						}
+					}
+				}
+
+				ucl_object_insert_key (sym_ucl, this_sym_ucl, sym_name,
+								strlen (sym_name), true);
+
+			}
+			ucl_object_insert_key (out, sym_ucl, "symbols",
+					strlen ("symbols"), true);
+
+			rspamadm_dump_section_obj (cfg, out, NULL);
 			exit (EXIT_SUCCESS);
 		}
 


### PR DESCRIPTION
Details of changes included in this pull request:

- symbol score defined in a conf file, but no description provided in the conf file (as is done in `scores.d/headers_group.conf`)

For example, symbols where scores are defined or one_shot is changed in `local.d/headers_groups.conf,` and no description is provided, use the description from lua. If the description is provided in both, the one from the config file is used.  This eliminates the need to replicate a description between config file and lua.

See changes in `src/lua/lua_config.c`

* Properly group symbols that start out “ungrouped” when another group is later defined.

If a symbol is scored separately in a conf file and that conf file does not include a group definition, the symbol starts out ungrouped.  When the regex config, for example, is read where the symbol is fully defined, the group was not getting set because the symbol was initially ungrouped. This allows the definition to put the symbol in the proper group as defined in the regex config.

See changes in `src/libserver/cfg_utils.c`, `src/lua/lua_config.c`

* Enhancement support for `rspamadm configdump --symbol-detail` (or `-d`)

This option dumps the details for all symbols in a single table (versus the different groups and symbol tables when no options are specified). It will also include output for any custom metadata that is defined in a config file that are not rspamd specific keywords.

The output format helps save having to look in different places when looking at all of the different options/settings for symbols that are defined across multiple config files and lua.

Using this option, here is the example output for the `DKIM_CHECK` symbol with this option with 2 example custom fields as specified in my local config.

```
    DKIM_CHECK {
        score = 0.0;
        description = "DKIM check callback";
        type = "normal";
        disabled = false;
        one_shot = true;
        group = "policies";
        groups [
            "dkim",
        ]
        custom_field_1 = true;
        some_other_custom_field = false;
    }
```

Relevant help from `rspamadm configdump --help`:

```
Usage:
  rspamadm [OPTION…] configdump - dumps Rspamd configuration

...
Application Options:
  -d, --symbol-details     Show full symbol details only
...
```

See changes to `src/libserver/rspamd_symcache.h`, `src/libserver/rspamd_symcache.c` and `src/rspamadm/configdump.c`.