### PR TITLE
[Enhancement] Query HELOs, PTRs, and Reply-To's against Spamhaus DBL as well

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -238,7 +238,7 @@ rbl {
       ignore_defaults = true;
       rbl = "dbl.spamhaus.org";
       no_ip = true;
-      checks = ['emails', 'dkim', 'urls'];
+      checks = ['emails', 'dkim', 'helo', 'rdns', 'replyto', 'urls'];
       emails_domainonly = true;
 
       returncodes = {


### PR DESCRIPTION
On https://www.spamhaus.org/dbl/, Spamhaus explicitly recommends doing so:

> It is effective for filtering email during the SMTP session for all header domain checks - rDNS, HELO, MAIL FROM, From, Reply-To, and Message-ID domains - as well as URLs in messages.

In several productive environments, this was found to pose a small, but noticeable improvement to spam detection rates. Therefore, it makes sense to bring this change upstream IMHO.