### PR TITLE
[Fix] ClickHouse cleanup of old partitions

### DIFF
--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -988,16 +988,16 @@ local function get_last_removal_ago()
     f:close()
   end
 
+  if last_ts == nil or (last_ts + settings.retention.period) <= current_ts then
+    return write_ts_to_file() and 0
+  end
+
   if last_ts > current_ts then
     -- Clock skew detected, overwrite last_ts with current_ts and wait for the next
     -- retention period
     rspamd_logger.errx(rspamd_config, 'Last collection time is in future: %s; overwrite it with %s in %s',
         last_ts, current_ts, ts_file)
     return write_ts_to_file() and -1
-  end
-
-  if last_ts == nil or (last_ts + settings.retention.period) <= current_ts then
-    return write_ts_to_file() and 0
   end
 
   return (last_ts + settings.retention.period) - current_ts


### PR DESCRIPTION
If `/var/lib/rspamd/clickhouse_retention_run` file is missing or has no
number cleanup was not performed because of a following Lua error:
```
lua_periodic_callback_error: call to periodic script (registered at clickhouse.lua:1531) failed: /usr/share/rspamd/plugins/clickhouse.lua:991: attempt to compare number with nil; trace: [1]:{/usr/share/rspamd/plugins/clickhouse.lua:1069 - <unknown> [Lua]};
```