### PR TITLE
[Rules] Fix symbol for DKIM temporary failure

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -56,7 +56,7 @@ composites {
     description = "Authenticating message via SPF/DKIM/DMARC/ARC not possible";
   }
   DKIM_MIXED {
-    expression = "-R_DKIM_ALLOW & (R_DKIM_DNSFAIL | R_DKIM_PERMFAIL | R_DKIM_REJECT)"
+    expression = "-R_DKIM_ALLOW & (R_DKIM_TEMPFAIL | R_DKIM_PERMFAIL | R_DKIM_REJECT)"
     policy = "remove_weight";
   }
   MAIL_RU_MAILER_BASE64 {


### PR DESCRIPTION
There is no R_DKIM_DNSFAIL symbol (in default config), but there is R_DKIM_TEMPFAIL.