### PR TITLE
[Minor] Microoptimize lua_util.str_endswith

### DIFF
--- a/lualib/lua_util.lua
+++ b/lualib/lua_util.lua
@@ -113,7 +113,7 @@ end
 -- @return {boolean} true if text ends with the specified suffix, false otherwise
 --]]
 exports.str_endswith = function(s, suffix)
-  return s:sub(-suffix:len()) == suffix
+  return s:find(suffix, -suffix:len(), true) ~= nil
 end
 
 --[[[

--- a/test/lua/unit/lua_util.misc.lua
+++ b/test/lua/unit/lua_util.misc.lua
@@ -28,3 +28,34 @@ context("Lua util - callback_from_string", function()
     end)
   end
 end)
+
+context("Lua util - str_endswith", function()
+  local ending = {
+    {'a', 'a'},
+    {'ab', 'b'},
+    {'ab', 'ab'},
+    {'abc', 'bc'},
+    {'any', ''},
+  }
+  local not_ending = {
+    {'a', 'b'},
+    {'', 'a'},
+    {'ab', 'a'},
+    {'ab', 'ba'},
+    {'ab', 'lab'},
+    {'abc', 'ab'},
+    {'abcd', 'bc'},
+    {'a', 'A'},
+    {'aB', 'b'},
+  }
+  for _, c in ipairs(ending) do
+    test(string.format('True case: str_endswith("%s", "%s")', c[1], c[2]), function()
+      assert_true(util.str_endswith(c[1], c[2]))
+    end)
+  end
+  for _, c in ipairs(not_ending) do
+    test(string.format('False case: str_endswith("%s", "%s")', c[1], c[2]), function()
+      assert_false(util.str_endswith(c[1], c[2]))
+    end)
+  end
+end)


### PR DESCRIPTION
Use find to check string suffix instead of sub (which involves string
interning of a returned string).  Benchmarks with LuaJIT 2.1.0 shows
that an option with find is significantly faster.

While here added a unit test for this function.

Was tested using LuaJIT 2.1.0-beta3 and a following code snippet:
```
local util = require 'rspamd_util'
local lua_util = require 'lua_util'
local suffix = 'beef'
local c = 0
for i=1, 1e8 do
        local str = util.random_hex(16)
        if lua_util.str_endswith_sub(str, suffix) then
                c = c + 1
        end
end
```
Results (CPU time for the code above):
```
x sub
+ find
+------------------------------------------------------------------------------+
|         +                                                         x     xx   |
|+   + +  +++++ +                                                  xx     xxx x|
|    |____A___|                                                      |___AM__| |
+------------------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10         39.01        40.704       40.1035       39.9244    0.58433214
+  10        28.838        31.165       30.2955       30.2193    0.69805254
Difference at 95.0% confidence
        -9.7051 +/- 0.604826
        -24.3087% +/- 1.3752%
        (Student's t, pooled s = 0.643709)
```