### PR TITLE
make gcc 8.5 happy

### DIFF
--- a/src/libutil/cxx/local_shared_ptr.hxx
+++ b/src/libutil/cxx/local_shared_ptr.hxx
@@ -128,7 +128,7 @@ public:
 	// custom deleter
 	template<class Y, class D, typename std::enable_if<
 			std::is_convertible<Y*, element_type*>::value, bool>::type = true>
-	explicit local_shared_ptr(Y* p, D &&d) : px(p), cnt(new detail::ptr_and_refcnt(p, std::forward<D>(d)))
+	explicit local_shared_ptr(Y* p, D &&d) : px(p), cnt(new detail::ptr_and_refcnt<Y, D>(p, std::forward<D>(d)))
 	{
 	}
 


### PR DESCRIPTION
gcc 8.5 doesn't compile this file without template parameters for ptr_and_refcnt constructor.