### PR TITLE
Remove dangling comment

### DIFF
--- a/test/rspamd_test_suite.c
+++ b/test/rspamd_test_suite.c
@@ -54,8 +54,6 @@ main (int argc, char **argv)
 	}
 
 	/* Setup logger */
-
-	/* Setup logger */
 	if (verbose || g_test_verbose ()) {
 		rspamd_main->logger = rspamd_log_open_emergency (rspamd_main->server_pool,
 				RSPAMD_LOG_FLAG_USEC|RSPAMD_LOG_FLAG_ENFORCED|RSPAMD_LOG_FLAG_RSPAMADM);


### PR DESCRIPTION
The dangling comment is result of commit bfe48b659baf - `[Fix] Fix logging for rspamadm`, where the same comment was removed from `rspamadm` but this one stayed. It should be removed as well.