### PR TITLE
[Enhancement] Query HELOs, PTRs, and Reply-To's against SURBL and URIBL as well

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -192,7 +192,7 @@ rbl {
     "SURBL_MULTI" {
       ignore_defaults = true;
       rbl = "multi.surbl.org";
-      checks = ['emails', 'dkim', 'urls'];
+      checks = ['emails', 'dkim', 'helo', 'rdns', 'replyto', 'urls'];
       emails_domainonly = true;
 
       returnbits = {
@@ -207,7 +207,7 @@ rbl {
     "URIBL_MULTI" {
       ignore_defaults = true;
       rbl = "multi.uribl.com";
-      checks = ['emails', 'dkim', 'urls'];
+      checks = ['emails', 'dkim', 'helo', 'rdns', 'replyto', 'urls'];
       emails_domainonly = true;
 
       returnbits {


### PR DESCRIPTION
In several environments, querying HELOs, PTRs, and Reply-To's against SURBL and URIBL as well was found to increase the spam detection rates notably, particularly if spam or phishing messages were directly sent from compromised webservers (SURBL seems to have a good coverage of these). No false positives were detected related to this over the period of several weeks.

Also, this will increase the number of DNS queries made per message by 6 at the most (contrary to checks like URL and DKIM, which might pile up to tenths of lookups), so I guess it is not an inappropriate suggestion for `rspamd`s default configuration.

(See also: https://github.com/rspamd/rspamd/pull/4052)