### PR TITLE
[Enhancement] Adjust scores of Spamhaus SBL hits

### DIFF
--- a/conf/scores.d/rbl_group.conf
+++ b/conf/scores.d/rbl_group.conf
@@ -87,7 +87,7 @@ symbols = {
         groups = ["spamhaus"];
     }
     "RBL_SPAMHAUS_SBL" {
-        weight = 2.0;
+        weight = 4.0;
         description = "From address is listed in ZEN SBL";
         groups = ["spamhaus"];
     }
@@ -127,7 +127,7 @@ symbols = {
         groups = ["spamhaus"];
     }
     "RECEIVED_SPAMHAUS_SBL" {
-        weight = 1.0;
+        weight = 3.0;
         description = "Received address is listed in ZEN SBL";
         groups = ["spamhaus"];
         one_shot = true;


### PR DESCRIPTION
While I assume most `rspamd` users will take advantage of [force actions](https://rspamd.com/doc/modules/force_actions.html) for symbols like this to make the rejection behaviour of their infrastructure deterministic and enforce their AUPs, I found the score of 2.0 points to be too low in environments not using force actions.

Besides, according to its [homepage](https://www.spamhaus.org/sbl/), the SBL is described as "a database of IP addresses from which Spamhaus does not recommend the acceptance of electronic mail". `rspamd` already features the XBL with 4.0 points (3.0 for deep header parsing), so I guess there is no sense in scoring the SBL lower than the XBL.