### PR TITLE
[Fix] Disable IPv6 lookups for Blocklist.de RBL

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -136,7 +136,6 @@ rbl {
       }
       symbol = "BLOCKLISTDE";
       rbl = "bl.blocklist.de";
-      ipv6 = true;
       checks = ['from', 'received'];
     }
 


### PR DESCRIPTION
While `blocklist.de`'s web site shows hits for IPv6 addresses, their RBL server network does not seem to serve IPv6 queries. To avoid unnecessary DNS lookups, IPv6 can be disabled for `blocklist.de` for now without losing any information.