### PR TITLE
[Fix] - Fix URL extraction method that ignores spaces

### DIFF
--- a/src/libserver/html/html_url.cxx
+++ b/src/libserver/html/html_url.cxx
@@ -380,10 +380,7 @@ html_process_url(rspamd_mempool_t *pool, std::string_view &input)
 	 * including essential ones
 	 */
 	for (auto i = 0; i < sz; i++) {
-		if (G_UNLIKELY (g_ascii_isspace(s[i]))) {
-			continue;
-		}
-		else if (G_UNLIKELY (((guint) s[i]) < 0x80 && !g_ascii_isgraph(s[i]))) {
+		if (G_UNLIKELY (((guint) s[i]) < 0x80 && !g_ascii_isgraph(s[i]))) {
 			/* URL encode */
 			*d++ = '%';
 			*d++ = hexdigests[(s[i] >> 4) & 0xf];


### PR DESCRIPTION
Rspamd ignores spaces in URL while extracting them -- Consider this example:

`<img src="https://rcbcbankard.com/img_email/social icons.png" width="180" usemap="#Map">`

Get extracted as:

 ```   
{
        "url": "https://rcbcbankard.com/img_email/socialicons.png",
        "tld": "rcbcbankard.com",
        "host": "rcbcbankard.com",
        "flags": [
            "image"
        ]
    }
```
(the difference is that Rspamd ignore the space in `social icons.png`)

Although space is disallowed in URL, Apple mail and web browsers correctly substitute them with `%20` and this causes problems.

I realized by looking at code comments that there are complexities involved with spaces in URL and this bug might introduce regressions in other cases, I have tested this change with multiple scenarios and it seems to work fine with this change. Please let me know if there are cases that I might have missed or if this design was intended :)