### PR TITLE
[Minor] Query EBLs for authenticated users as well

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -159,6 +159,7 @@ rbl {
     RSPAMD_EMAILBL {
       ignore_whitelist = true;
       ignore_defaults = true;
+      exclude_users = false;
       emails_delimiter = ".";
       hash_format = "base32";
       hash_len = 32;
@@ -172,6 +173,7 @@ rbl {
     MSBL_EBL {
       ignore_whitelist = true;
       ignore_defaults = true;
+      exclude_users = false;
       rbl = "ebl.msbl.org";
       checks = ['emails', 'replyto'];
       emails_domainonly = false;


### PR DESCRIPTION
Giving these a closer look, I think it makes sense to conduct EBL queries for mails submitted by authenticated users as well:
- Might catch some BEC, e. g. if a user fell for a previously accepted phish mail, and is now replying to the phisher
- Might catch spam/phishing from a compromised account, where the `Reply-To` address is already known to be bad