### PR TITLE
[Minor] fix lower transformation for utf symbols

### DIFF
--- a/lualib/lua_selectors/transforms.lua
+++ b/lualib/lua_selectors/transforms.lua
@@ -40,6 +40,17 @@ local transform_function = {
     end,
     ['description'] = 'Returns the lowercased string',
   },
+  -- Returns the lowercased utf8 string
+  ['lower_utf8'] = {
+    ['types'] = {
+      ['string'] = true,
+    },
+    ['map_type'] = 'string',
+    ['process'] = function(inp, t)
+      return rspamd_util.lower_utf8(inp), t
+    end,
+    ['description'] = 'Returns the lowercased utf8 string',
+  },
   -- Returns the first element
   ['first'] = {
     ['types'] = {

--- a/lualib/lua_selectors/transforms.lua
+++ b/lualib/lua_selectors/transforms.lua
@@ -17,6 +17,7 @@ limitations under the License.
 local fun = require 'fun'
 local lua_util = require "lua_util"
 local rspamd_util = require "rspamd_util"
+local rspamd_text = require "rspamd_text"
 local ts = require("tableshape").types
 local logger = require 'rspamd_logger'
 local common = require "lua_selectors/common"
@@ -36,7 +37,7 @@ local transform_function = {
     },
     ['map_type'] = 'string',
     ['process'] = function(inp, _)
-      return inp:lower(),'string'
+      return rspamd_text.fromstring(inp):lower(true),'string'
     end,
     ['description'] = 'Returns the lowercased string',
   },

--- a/lualib/lua_selectors/transforms.lua
+++ b/lualib/lua_selectors/transforms.lua
@@ -17,7 +17,6 @@ limitations under the License.
 local fun = require 'fun'
 local lua_util = require "lua_util"
 local rspamd_util = require "rspamd_util"
-local rspamd_text = require "rspamd_text"
 local ts = require("tableshape").types
 local logger = require 'rspamd_logger'
 local common = require "lua_selectors/common"
@@ -37,7 +36,7 @@ local transform_function = {
     },
     ['map_type'] = 'string',
     ['process'] = function(inp, _)
-      return rspamd_text.fromstring(inp):lower(true),'string'
+      return inp:lower(),'string'
     end,
     ['description'] = 'Returns the lowercased string',
   },

--- a/test/lua/unit/selectors.lua
+++ b/test/lua/unit/selectors.lua
@@ -53,7 +53,13 @@ context("Selectors test", function()
 
     ["header Subject lower"] = {
                 selector = "header(Subject).lower",
-                expect = {"second, lower-cased header subject"}},
+                expect = {"second, lower-cased header subject"}
+    },
+
+    ["header Subject lower_utf8"] = {
+                selector = "header(Subject).lower_utf8",
+                expect = {"second, lower-cased header subject"}
+    },
 
     ["header full Subject lower"] = {
                 selector = "header(Subject, 'full').lower",


### PR DESCRIPTION
Now, lower transformation uses default lower function and doesn't work with utf symbols as expected. Test case:

multimap.conf:

```
bl_test_subj {
    map = "${CONFDIR}/maps/bl-test.map";
    type = "selector";
    selector = "header('Subject').lower";
    score = 0.0;
    symbol = "BL_TEST";
}
```

/etc/rspamd/maps/bl-test.map

```
тест
```

```bash
$ echo test | mail -s "Тест" XXX@XXX:
multimap.lua:437: check value Тест for multimap BL_TEST
multimap.lua:476: found return "false" for multimap BL_TEST

$ echo test | mail -s "тест" XXX@XXX:
multimap.lua:437: check value тест for multimap BL_TEST
multimap.lua:476: found return "" for multimap BL_TEST
```

But there is rspamd_text:lower method that works with utf symbols. With this patch, it works as expected:

```bash
$ echo test | mail -s "Тест" XXX@XXX:
multimap.lua:437: check value тест for multimap BL_TEST
multimap.lua:476: found return "" for multimap BL_TEST

$ echo test | mail -s "тест" XXX@XXX:
multimap.lua:437: check value тест for multimap BL_TEST
multimap.lua:476: found return "" for multimap BL_TEST
```