### PR TITLE
msgpack 'content' field is written as binary always

### DIFF
--- a/lualib/lua_mime.lua
+++ b/lualib/lua_mime.lua
@@ -615,7 +615,7 @@ exports.message_to_ucl = function(task, stringify_content)
         type = string.format('%s/%s', part:get_type()),
         detected_type = string.format('%s/%s', part:get_detected_type()),
         filename = part:get_filename(),
-        content = maybe_stringify_f(part:get_content()),
+        content = part:get_content(),
         headers =  part:get_headers(true) or E,
         boundary = part:get_enclosing_boundary(),
       }

--- a/lualib/lua_mime.lua
+++ b/lualib/lua_mime.lua
@@ -579,8 +579,6 @@ end
 exports.message_to_ucl = function(task, stringify_content)
   local E = {}
 
-  local maybe_stringify_f = stringify_content and
-    tostring or function(t) return t  end
   local result = {
     size = task:get_size(),
     digest = task:get_digest(),


### PR DESCRIPTION
When writing out msgpack file, the content field is better written consistently as binary for consistent handling at decode time