### PR TITLE
Update rspamd.spec to fix Fedora 36 build

### DIFF
--- a/centos/rspamd.spec
+++ b/centos/rspamd.spec
@@ -54,6 +54,9 @@ lua.
         -DCMAKE_BUILD_TYPE="Release" \
         -DCMAKE_C_FLAGS_RELEASE="%{optflags}" \
         -DCMAKE_CXX_FLAGS_RELEASE="%{optflags}" \
+%if 0%{?fedora} >= 36
+        -DLINKER_NAME=/usr/bin/ld.bfd \
+%endif
         -DCMAKE_INSTALL_PREFIX=%{_prefix} \
         -DCONFDIR=%{_sysconfdir}/rspamd \
         -DMANDIR=%{_mandir} \


### PR DESCRIPTION
The build on Fedora 36 is failing due to [a bug in ld.gold](https://bugzilla.redhat.com/show_bug.cgi?id=2043178) that prevents successful linking.
The recommended work around is to use ld.bfd instead.

I've also tried [ld.mold](https://github.com/rui314/mold) which works as well, but I was unsure of the stance on adding another build time dependency.

With this I was able to build and run test rspamd on el7, el8, el9 as well as Fedora 34, 35 and 36.