### PR TITLE
[Minor] rspamc: fix crash on non-string element in `messages`

### DIFF
--- a/src/client/rspamc.cxx
+++ b/src/client/rspamc.cxx
@@ -1030,8 +1030,16 @@ rspamc_symbols_output(FILE *out, ucl_object_t *obj)
 		const ucl_object_t *cmesg;
 
 		while ((cmesg = ucl_object_iterate (elt, &mit, true)) != nullptr) {
-			fmt::print(out, "Message - {}: {}\n",
-					ucl_object_key(cmesg), ucl_object_tostring(cmesg));
+			if (ucl_object_type(cmesg) == UCL_STRING) {
+				fmt::print(out, "Message - {}: {}\n",
+						ucl_object_key(cmesg), ucl_object_tostring(cmesg));
+			} else {
+				unsigned char *rendered_message;
+				rendered_message = ucl_object_emit(cmesg, UCL_EMIT_JSON_COMPACT);
+				fmt::print(out, "Message - {}: {:.60}\n",
+						ucl_object_key(cmesg), rendered_message);
+				free(rendered_message);
+			}
 		}
 	}
 


### PR DESCRIPTION
Lists and dictionaries can be added to the protocol response inside `messages`, e.g.

```
          task:append_message({foo = 'bar'}, 'yolo')
          task:append_message({'bar','foo'}, 'swag')
```

Currently this is causing a crash in `rspamc`.

```
(gdb) p ucl_object_tostring(cmesg)
$3 = 0x0
```

This doesn't look quite as I might have imagined it but it's better than crashing:
```
Message - yolo: object
Message - swag: array
```