### PR TITLE
[Fix] Empty envelopes should not be emitted as arrays, drop from schema instead

### DIFF
--- a/lualib/lua_mime.lua
+++ b/lualib/lua_mime.lua
@@ -607,7 +607,7 @@ exports.message_to_ucl = function(task, stringify_content)
     from_ip = maybe_stringify_ip(task:get_from_ip()),
   }
   if not next(result.envelope) then
-    result.envelope = nil
+    result.envelope = ucl.null
   end
 
   local parts = task:get_parts() or E

--- a/lualib/lua_mime.lua
+++ b/lualib/lua_mime.lua
@@ -21,6 +21,7 @@ limitations under the License.
 
 local rspamd_util = require "rspamd_util"
 local rspamd_text = require "rspamd_text"
+local ucl = require "ucl"
 
 local exports = {}
 

--- a/lualib/lua_mime.lua
+++ b/lualib/lua_mime.lua
@@ -596,7 +596,8 @@ exports.message_to_ucl = function(task, stringify_content)
 
     return nil
   end
-  -- Envelope (smtp) information form email
+
+  -- Envelope (smtp) information from email (nil if empty)
   result.envelope = {
     from_smtp = (task:get_from('smtp') or E)[1],
     recipients_smtp = task:get_recipients('smtp'),
@@ -605,6 +606,9 @@ exports.message_to_ucl = function(task, stringify_content)
     client_ip = maybe_stringify_ip(task:get_client_ip()),
     from_ip = maybe_stringify_ip(task:get_from_ip()),
   }
+  if not next(result.envelope) then
+    result.envelope = nil
+  end
 
   local parts = task:get_parts() or E
   result.parts = {}


### PR DESCRIPTION
Populated envelopes are objects, but empty envelopes are arrays. This greatly complicates decoding in strictly typed languages as we are no longer able to map onto a typed schema. Examples below are in json, but this also affects messagepack.

### Empty envelope before change
```
{
    "parts": [
        {
            "content": "Very simple, ok, lovely\r\n",
            "size": 25,
            "type": "text/plain",
            "detected_type": "text/plain",
            "headers": []
        }
    ],
    "newlines": "crlf",
    "digest": "18e1406d9bb715b849d8339718d6475f",
    "envelope": [],
```
### Empty envelope after change    
```
{
    "parts": [
        {
            "content": "Very simple, ok, lovely\r\n",
            "size": 25,
            "type": "text/plain",
            "detected_type": "text/plain",
            "headers": []
        }
    ],
    "newlines": "crlf",
    "digest": "18e1406d9bb715b849d8339718d6475f",
    ...
```
### Populated envelope (unchanged)
```
{
"newlines": "crlf",
    "digest": "b0cf8c13097e67c53a7c7bf1e4e5f720",
    "envelope": {
        "from_smtp": {
            "addr": "testin@gmail.com",
            "raw": "<testin@gmail.com>",
            "flags": {
                "braced": true,
                "valid": true
            },
            "user": "testin",
            "name": "",
            "domain": "gmail.com"
        }
    },
    ...
```

NOTE: In an ideal world json `null` and msgpack `0xc0` would be emitted instead of the envelope being ommited from the schema. I thought about trying to make this change but was unsure whether it would be possible to determine between "I want to emit an empty array" and "I want to emit a nil/null value" in the lua.