### PR TITLE
[Minor] Mimedump improvements

### DIFF
--- a/lualib/rspamadm/mime.lua
+++ b/lualib/rspamadm/mime.lua
@@ -919,7 +919,6 @@ local function write_dump_content(dump_content, fname, extension, outdir)
   else
       io.write(dump_content)
   end
-luacheck
   return wrote_filepath
 end
 

--- a/lualib/rspamadm/mime.lua
+++ b/lualib/rspamadm/mime.lua
@@ -949,14 +949,12 @@ local function get_dump_content(task, opts, fname)
     local extension = output_fmt(opts)
     return ucl.to_format(ucl_object, extension), extension
   end
-  
   local content = task:get_content()
   if type(content) == "string" then
     return content, "mime"
   else
     return tostring(content), "mime"
   end
-  
 end
 
 local function dump_handler(opts)

--- a/lualib/rspamadm/mime.lua
+++ b/lualib/rspamadm/mime.lua
@@ -890,7 +890,7 @@ end
   -- ../home/very_simple.eml
 --All the above end up as very_simple
 local function filename_only(filepath)
-  filename = filepath:match(".*%/([^%.]+)")
+  local filename = filepath:match(".*%/([^%.]+)")
   if not filename then
     filename = filepath:match("([^%.]+)")
   end
@@ -899,8 +899,7 @@ end
 
 --Write the dump content to file or standard out
 local function write_dump_content(dump_content, fname, extension, outdir)
-  
-  wrote_filepath = nil
+  local wrote_filepath = nil
   if outdir then
     if outdir:sub(-1) ~= "/" then
       outdir = outdir .. "/"
@@ -920,7 +919,7 @@ local function write_dump_content(dump_content, fname, extension, outdir)
   else
       io.write(dump_content)
   end
-
+luacheck
   return wrote_filepath
 end
 
@@ -928,8 +927,7 @@ end
 local function get_dump_content(task, opts, fname)
   if opts.ucl or opts.json or opts.messagepack then
     local ucl_object = lua_mime.message_to_ucl(task)
-    
-    --Split out the content field into separate raws and update the ucl
+    -- Split out the content field into separate raws and update the ucl
     if opts.split then
       for i, part in ipairs(ucl_object.parts) do
         if part.content then
@@ -955,7 +953,6 @@ local function dump_handler(opts)
 
   for _,fname in ipairs(opts.file) do
     local task = load_task(opts, fname)
-    
     local data, extension = get_dump_content(task, opts, fname)
     write_dump_content(data, fname, extension, opts.outdir)
 

--- a/lualib/rspamadm/mime.lua
+++ b/lualib/rspamadm/mime.lua
@@ -915,7 +915,6 @@ local function write_dump_content(dump_content, fname, extension, outdir)
     if rspamd_util.file_exists(outpath) then
       os.remove(outpath)
     end
-    
     if dump_content:save_in_file(outpath) then
       wrote_filepath = outpath
       io.write(wrote_filepath.."\n")


### PR DESCRIPTION
## Summary
Add the ability to write to a specified directory instead of stdout
Add the ability to split contents out into files, when output directory is specified (-o) and formatting is performed (--json/--messagepack etc)

This is a rework of https://github.com/rspamd/rspamd/pull/4203

### [Existing] Single file, no formatting, to stdout
```
rspamadm mime dump ./samples/very_simple.eml
```

### [Existing] Multiple files, no formatting, to stdout
```
rspamadm mime dump ./samples/very_simple.eml ./samples/Zipfile_test.eml
```

### [Existing] Multiple files, formatted, to stdout
```
rspamadm mime dump --json ./samples/very_simple.eml ./samples/Zipfile_test.eml
rspamadm mime dump --messagepack ./samples/very_simple.eml ./samples/Zipfile_test.eml
```

### [New] Multiple files, formatted, to output directory (filenames written to stdout instead)
```
rspamadm mime dump -o /tmp --json ./samples/very_simple.eml ./samples/Zipfile_test.eml
rspamadm mime dump -o /tmp/ --messagepack ./samples/very_simple.eml ./samples/Zipfile_test.eml
```

### [New] Multiple files, formatted, to output directory, content split (filenames written to stdout instead)
```
rspamadm mime dump -o /tmp --json --split ./samples/very_simple.eml ./samples/Zipfile_test.eml
rspamadm mime dump -o /tmp --messagepack --split ./samples/very_simple.eml ./samples/Zipfile_test.eml
```

## Example --split usage
```
> rspamadm mime dump -o /tmp --json --split ./samples/Zipfile_test.eml
got empty text part
/tmp/Zipfile_test-part3.raw
/tmp/Zipfile_test-part4.raw
/tmp/Zipfile_test-part5.raw
/tmp/Zipfile_test.json

> cat /tmp/Zipfile_test.json
{
    "size": 927862,
    "digest": "0c0853fbae3edeccf358d29d1529b90e",
    "parts": [
        {
            "multipart_boundary": "_004_VI1P194MB0495A8C9FFAD6200D0582E4FDAA49VI1P194MB0495EURP_",
            "size": 0,
            "type": "multipart/mixed",
            "headers": []
        },
        {
            "size": 0,
            "multipart_boundary": "_000_VI1P194MB0495A8C9FFAD6200D0582E4FDAA49VI1P194MB0495EURP_",
            "type": "multipart/alternative",
            "boundary": "_004_VI1P194MB0495A8C9FFAD6200D0582E4FDAA49VI1P194MB0495EURP_",
            "headers": [
                ...
            ]
        },
        {
            "content": null,
            "size": 4,
            "boundary": "_000_VI1P194MB0495A8C9FFAD6200D0582E4FDAA49VI1P194MB0495EURP_",
            "type": "text/plain",
            "content_path": "/tmp/Zipfile_test-part3.raw",
            "detected_type": "text/plain",
            "headers": [
                ...
            ]
        },
        {
            "content": null,
            "size": 2,
            "boundary": "_000_VI1P194MB0495A8C9FFAD6200D0582E4FDAA49VI1P194MB0495EURP_",
            "type": "text/html",
            "content_path": "/tmp/Zipfile_test-part4.raw",
            "detected_type": "text/html",
            "headers": [
                ...
            ]
        },
        {
            "content": null,
            "size": 676901,
            "boundary": "_004_VI1P194MB0495A8C9FFAD6200D0582E4FDAA49VI1P194MB0495EURP_",
            "type": "application/zip",
            "content_path": "/tmp/Zipfile_test-part5.raw",
            "detected_type": "application/zip",
            "filename": "Embedded_plain.zip",
            "headers": [
                ...
            ]
        }
        ...
        
> ls -ltr /tmp | grep Zip
-rw-rw-r--. 1 jst  jst   10534 Jul 22 10:50 Zipfile_test.json
-rw-rw-r--. 1 jst  jst       4 Jul 22 10:50 Zipfile_test-part3.raw
-rw-rw-r--. 1 jst  jst       2 Jul 22 10:50 Zipfile_test-part4.raw
-rw-rw-r--. 1 jst  jst  676901 Jul 22 10:50 Zipfile_test-part5.raw
```