### PR TITLE
Fix DMARC reporting to subdomains

### DIFF
--- a/lualib/rspamadm/dmarc_report.lua
+++ b/lualib/rspamadm/dmarc_report.lua
@@ -345,7 +345,7 @@ end
 local function validate_reporting_domain(reporting_domain)
   -- Now check the domain policy
   -- DMARC domain is a esld for the reporting domain
-  local dmarc_domain = rspamd_util.get_tld(reporting_domain)
+  local dmarc_domain = reporting_domain
   local is_ok, results = rspamd_dns.request({
     config = rspamd_config,
     session = rspamadm_session,

--- a/src/plugins/lua/dmarc.lua
+++ b/src/plugins/lua/dmarc.lua
@@ -309,7 +309,7 @@ local function dmarc_validate_policy(task, policy, hdrfromdom, dmarc_esld)
 
     -- Dmarc domain key must include dmarc domain, rua and period
     local dmarc_domain_key = table.concat(
-        {settings.reporting.redis_keys.report_prefix, dmarc_esld, policy.rua, period},
+        {settings.reporting.redis_keys.report_prefix, policy.domain, policy.rua, period},
         settings.reporting.redis_keys.join_char)
     local report_data = dmarc_common.dmarc_report(task, settings, {
         spf_ok = spf_ok and 'pass' or 'fail',


### PR DESCRIPTION
[Fix] DMARC reports for subdomains (of Organizational Domain) with their own DMARC policy.
Reports were wrongly addressed to rua address(es) taken from Organizational Domain policy, not to rua from subdomain policy.