### PR TITLE
[Fix] Skip sending dmarc reports in no-opt mode

### DIFF
--- a/lualib/rspamadm/dmarc_report.lua
+++ b/lualib/rspamadm/dmarc_report.lua
@@ -725,7 +725,11 @@ local function handler(args)
 
     pool:destroy()
   end
-  send_reports_by_smtp(opts, all_reports, finish_cb)
+  if not opts.no_opt then
+    send_reports_by_smtp(opts, all_reports, finish_cb)
+  else
+    logger.messagex('Skip sending mails due to -n / --no-opt option')
+  end
 end
 
 return {


### PR DESCRIPTION
Skip sending DMARC reports if the `-n` / `--no-opt` option is set

fixes https://github.com/rspamd/rspamd/issues/4241