### PR TITLE
Fix: BAD_REP_POLICIES does not trigger for Bayes

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -124,7 +124,7 @@ composites {
   }
   BAD_REP_POLICIES {
     description = "Contains valid policies but are also marked by fuzzy/bayes/surbl/rbl";
-    expression = "(~g-:policies) & (-g+:fuzzy | -g+:bayes | -g+:surbl | -g+:rbl)";
+    expression = "(~g-:policies) & (-g+:fuzzy | -g+:statistics | -g+:surbl | -g+:rbl)";
     score = 0.1;
   }
 


### PR DESCRIPTION
When a message is classified as spam by the bayes classifier, the ```BAD_REP_POLICIES``` symbol does not trigger, even though it says in its description that it should. This is because the expression for the symbol contains a reference to a non-existing group "bayes", while the actual group is called "statistics". Proposing a change to fix this.