### PR TITLE
[Fix] Avoid overriding IP with Sender IP

### DIFF
--- a/contrib/elastic/rspamd_template.json
+++ b/contrib/elastic/rspamd_template.json
@@ -1,7 +1,7 @@
 {
   "mappings": {
     "_meta": {
-      "version": "5.5.2"
+      "version": "5.5.3"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/contrib/elastic/rspamd_template.json
+++ b/contrib/elastic/rspamd_template.json
@@ -90,6 +90,10 @@
           "webmail": {
             "type": "boolean"
           },
+          "sender_ip": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "geoip": {
             "properties": {
               "city_name": {

--- a/src/plugins/lua/elastic.lua
+++ b/src/plugins/lua/elastic.lua
@@ -121,27 +121,24 @@ local function get_general_metadata(task)
   local r = {}
   local ip_addr = task:get_ip()
 
-  r.webmail = false
-
   if ip_addr  and ip_addr:is_valid() then
     r.is_local = ip_addr:is_local()
-    local origin = task:get_header('X-Originating-IP')
-    if origin then
-      origin = string.sub(origin, 2, -2)
-      local rspamd_ip = require "rspamd_ip"
-      local test = rspamd_ip.from_string(origin)
-
-      if test and test:is_valid() then
-        r.webmail = true
-        r.ip = origin
-      else
-        r.ip = tostring(ip_addr)
-      end
-    else
-      r.ip = tostring(ip_addr)
-    end
+    r.ip = tostring(ip_addr)
   else
     r.ip = '127.0.0.1'
+  end
+
+  r.webmail = false
+  r.sender_ip = 'unknown'
+  local origin = task:get_header('X-Originating-IP')
+  if origin then
+    origin = origin:gsub('%[', ''):gsub('%]', '')
+    local rspamd_ip = require "rspamd_ip"
+    local origin_ip = rspamd_ip.from_string(origin)
+    if origin_ip and origin_ip:is_valid() then
+      r.webmail = true
+      r.sender_ip = origin -- use string here
+    end
   end
 
   r.direction = "Inbound"


### PR DESCRIPTION
This PR provides a fix for:
1. Not override IP with a user-supplied header
2. DoS in writing logs to Elastic which external sender can exploit. IP validation in Elastic is stricter than in Rspamd, so the user can supply data that looks for Rspamd as valid IP, f.e.: `.23.24.1`, but fail to pass validation on Elastic side. Now basic string is used which should not result in such errors