### PR TITLE
Allow fuzzy worker to listen on AF_UNIX sockets successfully

### DIFF
--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -363,6 +363,9 @@ rspamd_fuzzy_check_write (struct fuzzy_session *session)
 	}
 
 	if (session->ctx->update_ips != NULL && session->addr) {
+		if (rspamd_inet_address_get_af (session->addr) == AF_UNIX) {
+			return TRUE;
+		}
 		if (rspamd_match_radix_map_addr (session->ctx->update_ips,
 				session->addr) == NULL) {
 			return FALSE;

--- a/src/libutil/addr.c
+++ b/src/libutil/addr.c
@@ -1060,6 +1060,19 @@ rspamd_inet_address_connect (const rspamd_inet_addr_t *addr, gint type,
 
 	if (addr->af == AF_UNIX) {
 		sa = (const struct sockaddr *)&addr->u.un->addr;
+
+		if (type == (int)SOCK_DGRAM) {
+			struct sockaddr ca;
+
+			memset (&ca, 0, sizeof(ca));
+			ca.sa_family = AF_UNIX;
+
+			r = bind (fd, &ca, sizeof (sa_family_t));
+			if (r == -1) {
+				msg_info ("unix socket client autobind failed: %s, '%s'",
+						addr->u.un->addr.sun_path, strerror (errno));
+			}
+		}
 	}
 	else {
 		sa = &addr->u.in.addr.sa;

--- a/src/libutil/addr.c
+++ b/src/libutil/addr.c
@@ -1680,7 +1680,8 @@ rspamd_inet_address_from_sa (const struct sockaddr *sa, socklen_t slen)
 	rspamd_inet_addr_t *addr;
 
 	g_assert (sa != NULL);
-	g_assert (slen >= sizeof (struct sockaddr));
+	/* Address of an AF_UNIX socket can be tiny */
+	g_assert (slen >= sizeof (sa_family_t) + 1);
 
 	addr = rspamd_inet_addr_create (sa->sa_family, NULL);
 
@@ -1689,12 +1690,13 @@ rspamd_inet_address_from_sa (const struct sockaddr *sa, socklen_t slen)
 		const struct sockaddr_un *un = (const struct sockaddr_un *)sa;
 
 		g_assert (slen >= SUN_LEN (un));
+		g_assert (slen <= sizeof (addr->u.un->addr));
 
-		rspamd_strlcpy (addr->u.un->addr.sun_path, un->sun_path,
-				sizeof (addr->u.un->addr.sun_path));
-#if defined(FREEBSD) || defined(__APPLE__)
-		addr->u.un->addr.sun_len = un->sun_len;
-#endif
+		/* sun_path can legally contain intermittent NULL bytes */
+		memcpy (&addr->u.un->addr, un, slen);
+
+		/* length of AF_UNIX addresses is variable */
+		addr->slen = slen;
 	}
 	else if (sa->sa_family == AF_INET) {
 		g_assert (slen >= sizeof (struct sockaddr_in));


### PR DESCRIPTION
This aims to fix https://github.com/rspamd/rspamd/issues/4278

The first action is to bind a DGRAM unix client-socket to an anonymous abstract socket.
This is a special case, as documented on man 7 unix: If the address length is sizeof(sa_family_t), it will automatically assign an abstract free for use address for the socket.
Thus, the server has some address to reply to.

This uncovered a few further issues:
rspamd_inet_address_from_sa was not prepared for such addresses.
For one, they can be very short, so the default length check failed.
Then they do contain a null byte in the string, so any strlen/cpy functions will fail. Instead just memcpy the whole struct with the given slen.

Additionally, the allow_update check in the fuzzy worker makes no sense for unix sockets, since there isn't really any IPs to check, so the check always fails, preventing any kind of write-access.
It was thus extended to always succeed the address check on an AF_UNIX socket, no matter what the configured address is. This matches how a lot of other places seem to treat unix sockets.


I have deployed this set to my rspamd instance, backported on top of 3.2, and it seems to work fine so far.


The main issue I see with this is that the autobind behavior seems to be entirely Linux-Specific.
An idea to deal with this would be to just drop the "return -1" from that bind, so it just prints an informational message on other systems, but otherwise continues on as it would right now, at least not making the situation worse.

The entire block could also be put into a preprocessor-check for Linux, which throws an error on other OS to indicate that the given configuration does not work.