### PR TITLE
Fix metadata_exporter with many recipients

### DIFF
--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -191,7 +191,7 @@ local formatters = {
     else
       for _, e in ipairs(mail_rcpt) do
         table.insert(display_emails, string.format('<%s>', e))
-        table.insert(mail_targets, mail_rcpt)
+        table.insert(mail_targets, e)
       end
     end
     if rule.email_alert_sender then


### PR DESCRIPTION
Hello and many thanks for this great software :)

This commit fix sending mail alert with backend "send_mail" and many recipients.
Config I use :
```
rules {
SEND_ALERT_ON_SPAM {
  selector = "is_spam";  
  backend = "send_mail";  
  smtp = "smtp.example.org";  
  smtp_port = 25;  
  helo = "localhost.example.intra";  
  mail_to = ["recipent1@example.org","recipient2@example.org"];  
  mail_from = "rspamd@example.org";  
  formatter = "email_alert";  
}  
```


Without this fix, mail is never sent, sendmail_cb is never called.