### PR TITLE
Add basic auth to metadata_exporter http pusher

### DIFF
--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -323,6 +323,8 @@ local pushers = {
     rspamd_http.request({
       task=task,
       url=rule.url,
+      user=rule.user,
+      password=rule.password,
       body=formatted,
       callback=http_callback,
       mime_type=rule.mime_type or settings.mime_type,


### PR DESCRIPTION
Hello,

I found that specifying credentials in "url" key in metadata_exporter rule definition seems not supported :
```
url = http://upload:upload123@server.example.intra:8080/upload;
```
Although this method is working well in http map declarations.

So this commit add basic authentication, with new "user" and "password" keys in rule definition :
```
  LOG_SPAM_TO_HTTP {
    backend = "http";
    selector = "is_spam";
    url = http://server.example.intra:8080/upload;
    user = "upload";
    password = "upload123";
    meta_headers = true;
  }
```
