### PR TITLE
[Minor] Increase score for BAD_REP_POLICIES

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -125,7 +125,7 @@ composites {
   BAD_REP_POLICIES {
     description = "Contains valid policies but are also marked by fuzzy/bayes/surbl/rbl";
     expression = "(~g-:policies) & (-g+:fuzzy | -g+:statistics | -g+:surbl | -g+:rbl)";
-    score = 0.1;
+    score = 0.5;
   }
 
   VIOLATED_DIRECT_SPF {


### PR DESCRIPTION
From my experience with various rspamd setups, the current score of `BAD_REP_POLICIES` seems to be too low, as it does not fully counterbalance the positive scores of a message having valid SPF/DKIM/DMARC policies. [Some projects](https://github.com/mailcow/mailcow-dockerized/blob/master/data/conf/rspamd/local.d/groups.conf#L9-L11) even go for a higher score, however, increasing the rules' score from 0.1 to 0.5 seems like a sensible conservative approach to me for the time being.