### PR TITLE
[Enhancement] Add composite rule against AFF involving freemailers

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -154,6 +154,13 @@ composites {
     score = 7.0;
     group = "scams";
   }
+  
+  FREEMAIL_AFF {
+	  expression = "(FREEMAIL_FROM | FREEMAIL_ENVFROM | FREEMAIL_REPLYTO) & R_UNDISC_RCPT & (INTRODUCTION | FROM_NAME_HAS_TITLE | FREEMAIL_REPLYTO_NEQ_FROM_DOM)";
+	  score = 4.0;
+	  policy = "leave";
+	  description = "Message exhibits strong characteristics of advance fee fraud (AFF a/k/a '419' spam) involving freemail addresses";
+  }
 
   .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/composites.conf"
   .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/composites.conf"


### PR DESCRIPTION
This composite rule has been in use for quite a while in various rspamd setups. Since messages originating from freemail providers tend to have more signs of positive reputation, thanks to IP-/DKIM-/FQDN-reputation tracking, I found the existing symbols, such as `R_UNDISC_RCPT` insufficient to push advance free fraud (AFF) messages "over the edge".

Therefore, this composite rule puts additional weight on messages exhibiting strong AFF patterns, and involve freemail addresses, such as the plethora of such mails emitted by GMail, in the hope to gain better catch rates on these.