### PR TITLE
Penalize bounce spam

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -53,7 +53,17 @@ composites {
     expression = "R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA";
     score = 1.0;
     policy = "remove_weight";
-    description = "Authenticating message via SPF/DKIM/DMARC/ARC not possible";
+    description = "Authenticating message via SPF/DKIM/DMARC/ARC not available";
+  }
+  AUTH_NA_OR_FAIL {
+    expression = "!AUTH_NA & (R_DKIM_NA | R_DKIM_TEMPFAIL | R_DKIM_PERMFAIL) & (R_SPF_NA | R_SPF_DNSFAIL) & DMARC_NA & (ARC_NA | ARC_DNSFAIL)";
+    score = 1.0;
+    policy = "remove_weight";
+    description = "Authenticating message via SPF/DKIM/DMARC/ARC not available or failed";
+  }
+  BOUNCE_NO_AUTH {
+    expression = "(AUTH_NA | AUTH_NA_OR_FAIL) & (BOUNCE | SUBJ_BOUNCE_WORDS)";
+    score = 1.0;
   }
   DKIM_MIXED {
     expression = "-R_DKIM_ALLOW & (R_DKIM_TEMPFAIL | R_DKIM_PERMFAIL | R_DKIM_REJECT)"

--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -59,7 +59,7 @@ composites {
     expression = "!(R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA) & (R_DKIM_NA | R_DKIM_TEMPFAIL | R_DKIM_PERMFAIL) & (R_SPF_NA | R_SPF_DNSFAIL) & DMARC_NA & (ARC_NA | ARC_DNSFAIL)";
     score = 1.0;
     policy = "remove_weight";
-    description = "Authenticating message via SPF/DKIM/DMARC/ARC not available or failed";
+    description = "No authenticating method SPF/DKIM/DMARC/ARC was successful";
   }
   BOUNCE_NO_AUTH {
     expression = "(AUTH_NA | AUTH_NA_OR_FAIL) & (BOUNCE | SUBJ_BOUNCE_WORDS)";

--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -56,7 +56,7 @@ composites {
     description = "Authenticating message via SPF/DKIM/DMARC/ARC not available";
   }
   AUTH_NA_OR_FAIL {
-    expression = "!AUTH_NA & (R_DKIM_NA | R_DKIM_TEMPFAIL | R_DKIM_PERMFAIL) & (R_SPF_NA | R_SPF_DNSFAIL) & DMARC_NA & (ARC_NA | ARC_DNSFAIL)";
+    expression = "!(R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA) & (R_DKIM_NA | R_DKIM_TEMPFAIL | R_DKIM_PERMFAIL) & (R_SPF_NA | R_SPF_DNSFAIL) & DMARC_NA & (ARC_NA | ARC_DNSFAIL)";
     score = 1.0;
     policy = "remove_weight";
     description = "Authenticating message via SPF/DKIM/DMARC/ARC not available or failed";


### PR DESCRIPTION
This PR includes two changes.

1. It suggests a default rule to include a penalty for bounce messages with AUTH_NA to protect against fake bounce messages (bounce spam).
2. It adds AUTH_NA_OR_FAIL, because when e.g. R_DKIM_PERMFAIL is included R_DKIM_NA does apply anymore and AUTH_NA is not added. This creates an opportunity to willingly create a R_DKIM_PERMFAIL by a spammer.