### PR TITLE
[Test] Remove test case with non-deterministic result

### DIFF
--- a/test/lua/unit/lua_util.extract_specific_urls.lua
+++ b/test/lua/unit/lua_util.extract_specific_urls.lua
@@ -108,7 +108,6 @@ context("Lua util - extract_specific_urls plain", function()
   local cases = {
     {expect = url_list, filter = nil, limit = 9999, need_emails = true, prefix = 'p'},
     {expect = {}, filter = (function() return false end), limit = 9999, need_emails = true, prefix = 'p'},
-    {expect = {"domain4.co.net", "test.com"}, filter = nil, limit = 2, need_emails = true, prefix = 'p'},
     {expect = {"domain4.co.net", "test.com", "domain3.org"}, filter = nil, limit = 3, need_emails = true, prefix = 'p'},
     {
       expect = {"gov.co.net", "tesco.co.net", "domain1.co.net", "domain2.co.net", "domain3.co.net", "domain4.co.net"},


### PR DESCRIPTION
Removed test case does not work with luajit-2.1 anymore as it depends on internal behavior of lujait-2.0.

The order of URL list returned by `extract_specific_urls` function from `lualib/lua_util` depends on order of keys in table of TLDs.  The test case incorrectly expects "net" and "com" being in front of the table, however, "org" can appear there as well.

---

I have found this issue when I was trying rspamd `3.4`, however, it affects older versions as well. The error output looks like this:

```
------------------------------------------------------------------------
Lua util - extract_specific_urls plain:                              
extract_specific_urls, backward compatibility case #1                [F]
extract_specific_urls 1                                              [F]
------------------------------------------------------------------------
656 tests 650 passed 810480 assertions 2 failed 0 errors 4 unassertive 0 pending

extract_specific_urls, backward compatibility case #3:
Failed asserting that 
  (actual)   : {[1] = test.com, [2] = domain3.org} 
 equals to
  (expected) : {[1] = domain4.co.net, [2] = test.com}
===== diff (-expect, +actual) ======
-[1] = string: domain4.co.net
+[1] = string: test.com
-[2] = string: test.com
+[2] = string: domain3.org
stack traceback:
	.../rspamd-3.4/work/rspamd-3.4_build/test/lua/telescope.lua:199: in function 'assert_rspamd_table_eq_sorted'
	...4_build/test/lua/unit/lua_util.extract_specific_urls.lua:164: in function <...4_build/test/lua/unit/lua_util.extract_specific_urls.lua:150>
	[C]: in function 'xpcall'
	.../rspamd-3.4/work/rspamd-3.4_build/test/lua/telescope.lua:441: in function 'invoke_test'
	.../rspamd-3.4/work/rspamd-3.4_build/test/lua/telescope.lua:481: in function 'run'
	...lter/rspamd-3.4/work/rspamd-3.4_build/test/lua/tests.lua:28: in main chunk
extract_specific_urls 3:
Failed asserting that 
  (actual)   : {[1] = test.com, [2] = domain3.org} 
 equals to
  (expected) : {[1] = domain4.co.net, [2] = test.com}
===== diff (-expect, +actual) ======
-[1] = string: domain4.co.net
+[1] = string: test.com
-[2] = string: test.com
+[2] = string: domain3.org
stack traceback:
	.../rspamd-3.4/work/rspamd-3.4_build/test/lua/telescope.lua:199: in function 'assert_rspamd_table_eq_sorted'
	...4_build/test/lua/unit/lua_util.extract_specific_urls.lua:185: in function <...4_build/test/lua/unit/lua_util.extract_specific_urls.lua:167>
	[C]: in function 'xpcall'
	.../rspamd-3.4/work/rspamd-3.4_build/test/lua/telescope.lua:441: in function 'invoke_test'
	.../rspamd-3.4/work/rspamd-3.4_build/test/lua/telescope.lua:481: in function 'run'
	...lter/rspamd-3.4/work/rspamd-3.4_build/test/lua/tests.lua:28: in main chunk
ninja: build stopped: subcommand failed.
```

It took me some time to realize that it is related to new `luajit-2.1`, but then it was easy to git bisect commit changing the behavior. It is this one https://github.com/LuaJIT/LuaJIT/commit/ff34b48ddd6f2b3bdd26d6088662a214ba6b0288 - `Redesign and harden string interning.`.