### PR TITLE
[Test] Use TMPDIR if available

### DIFF
--- a/test/lua/unit/sqlite3.lua
+++ b/test/lua/unit/sqlite3.lua
@@ -1,18 +1,19 @@
 context("Sqlite3 API", function()
   local sqlite3 = require "rspamd_sqlite3"
+  local tmpdir = os.getenv("TMPDIR") or "/tmp"
   
   test("Sqlite3 open", function()
-    os.remove('/tmp/rspamd_unit_test_sqlite3.sqlite')
-    local db = sqlite3.open('/tmp/rspamd_unit_test_sqlite3.sqlite')
+    os.remove(tmpdir .. '/rspamd_unit_test_sqlite3.sqlite')
+    local db = sqlite3.open(tmpdir .. '/rspamd_unit_test_sqlite3.sqlite')
     assert_not_nil(db, "should be able to create sqlite3 db")
     db = sqlite3.open('/non/existent/path/rspamd_unit_test_sqlite3.sqlite')
     assert_nil(db, "should not be able to create sqlite3 db")
-    os.remove('/tmp/rspamd_unit_test_sqlite3.sqlite')
+    os.remove(tmpdir .. '/rspamd_unit_test_sqlite3.sqlite')
   end)
 
   test("Sqlite3 query", function()
-    os.remove('/tmp/rspamd_unit_test_sqlite3-1.sqlite')
-    local db = sqlite3.open('/tmp/rspamd_unit_test_sqlite3-1.sqlite')
+    os.remove(tmpdir .. '/rspamd_unit_test_sqlite3-1.sqlite')
+    local db = sqlite3.open(tmpdir .. '/rspamd_unit_test_sqlite3-1.sqlite')
     assert_not_nil(db, "should be able to create sqlite3 db")
     
     local ret = db:sql([[
@@ -23,12 +24,12 @@ context("Sqlite3 API", function()
       INSERT INTO x VALUES (?1, ?2);
     ]], 1, 'test')
     assert_true(ret, "should be able to insert row")
-    os.remove('/tmp/rspamd_unit_test_sqlite3-1.sqlite')
+    os.remove(tmpdir .. '/rspamd_unit_test_sqlite3-1.sqlite')
   end)
 
   test("Sqlite3 rows", function()
-    os.remove('/tmp/rspamd_unit_test_sqlite3-2.sqlite')
-    local db = sqlite3.open('/tmp/rspamd_unit_test_sqlite3-2.sqlite')
+    os.remove(tmpdir .. '/rspamd_unit_test_sqlite3-2.sqlite')
+    local db = sqlite3.open(tmpdir .. '/rspamd_unit_test_sqlite3-2.sqlite')
     assert_not_nil(db, "should be able to create sqlite3 db")
     
     local ret = db:sql([[
@@ -44,6 +45,6 @@ context("Sqlite3 API", function()
       assert_equal(row.id, '1')
       assert_equal(row.value, 'test')
     end
-    os.remove('/tmp/rspamd_unit_test_sqlite3-2.sqlite')
+    os.remove(tmpdir .. '/rspamd_unit_test_sqlite3-2.sqlite')
   end)
 end)


### PR DESCRIPTION
Couple of tests were designed to use hardcoded `/tmp` directory, which could be problematic in some cases. For example, in case of sqlite3 related tests, multiple users cannot run it in parallel. Additionally some leftovers remain in `/tmp` directory after this test, `*.sqlite-shm` and `*.sqlite-wal` files, which was actually main motivation for me to create this PR.

From perspective of Gentoo packager `$TMPDIR` is set for the package to a safe place controlled by a package manager, which is automatically cleaned when something remains there. Moreover, I can run tests for multiple versions in parallel without risk of file collision.