### PR TITLE
[Feature] Enable Mime part filters on antivirus module

### DIFF
--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -148,7 +148,7 @@ local function add_antivirus_rule(sym, opts)
   rule.mime_parts_filter_regex = common.create_regex_table(opts.mime_parts_filter_regex or {})
 
   rule.mime_parts_filter_ext = common.create_regex_table(opts.mime_parts_filter_ext or {})
-  
+ 
   if opts.whitelist then
     rule.whitelist = rspamd_config:add_hash_map(opts.whitelist)
   end

--- a/src/plugins/lua/antivirus.lua
+++ b/src/plugins/lua/antivirus.lua
@@ -134,6 +134,21 @@ local function add_antivirus_rule(sym, opts)
         type = 'string',
       })
 
+  -- if any mime_part filter defined, do not scan all attachments
+  if opts.mime_parts_filter_regex ~= nil
+      or opts.mime_parts_filter_ext ~= nil then
+    rule.scan_all_mime_parts = false
+  else
+    rule.scan_all_mime_parts = true
+  end
+
+  rule.patterns = common.create_regex_table(opts.patterns or {})
+  rule.patterns_fail = common.create_regex_table(opts.patterns_fail or {})
+
+  rule.mime_parts_filter_regex = common.create_regex_table(opts.mime_parts_filter_regex or {})
+
+  rule.mime_parts_filter_ext = common.create_regex_table(opts.mime_parts_filter_ext or {})
+  
   if opts.whitelist then
     rule.whitelist = rspamd_config:add_hash_map(opts.whitelist)
   end


### PR DESCRIPTION
Hi, I hope it could be useful to have mime_parts_filter_regex mime_parts_filter_ext filters as in the _External services_ module.