### PR TITLE
rspamc: add -R option for human readable report

### DIFF
--- a/doc/rspamc.1
+++ b/doc/rspamc.1
@@ -149,6 +149,11 @@ Bind to specified ip address
 .RS
 .RE
 .TP
+.B \-R, \-\-human
+Output human readable report
+.RS
+.RE
+.TP
 .B \-j, \-\-json
 Output formatted JSON
 .RS

--- a/doc/rspamc.1.md
+++ b/doc/rspamc.1.md
@@ -86,6 +86,9 @@ requires input.
 -b *host:port*, \--bind=*host:port*
 :	Bind to specified ip address
 
+-R, \--human
+:	Output human readable report
+
 -j, \--json
 :	Output formatted JSON
 


### PR DESCRIPTION
Spamassassin has a nice feature of printing human readable report. (see spamc -R option)

I had created a feature request for the same which describes the requirement in detail. The feature request can be read here #4373 

This pull request (PR) tries to emulate "spamc -R" option of spamassassin.

First line will print score/threshold,Action=action,Spam=bool and then followed by human readable report.

Sample report is as follows:

```
10.80/15.00,Action=add header,Spam=true
Content analysis details:   (10.80 points, 15.00 required)

 pts rule name              description
---- ---------------------- --------------------------------------------------
 0.0 ARC_NA                 ARC signature absent
 0.0 ASN                    [asn:34245, ipnet:212.17.32.0/19, country:IE]
 0.1 DMARC_POLICY_SOFTFAIL  DMARC failed [buap.mx : No valid SPF, No valid DKI
                            M,none]
 0.0 FROM_NEQ_ENVFROM       From address is different to the envelope [xl6Ety0
                            0V@fismat1.fcfm.buap.mx,dev_null_sample_spam@examp
                            le.com]
 0.0 FROM_NO_DN             From header does not have a display name
 1.5 INVALID_DATE           Malformed date header
 1.7 INVALID_MSGID          Message id is incorrect
-0.1 MIME_GOOD              Known content-type [text/plain]
 0.0 MIME_TRACE             [0:+]
 0.0 RCPT_COUNT_ONE         One recipient [1]
 0.0 RCVD_COUNT_FIVE        Message has 5-7 Received headers [6]
 0.1 RCVD_NO_TLS_LAST       Last hop did not use encrypted transports
 0.0 R_DKIM_NA              Missing DKIM signature
 1.0 R_SPF_FAIL             SPF verification failed [-all:c]
 3.0 R_UNDISC_RCPT          Recipients are absent or undisclosed
 0.0 TO_DN_ALL              All the recipients have display names
 3.5 VIOLATED_DIRECT_SPF    Has no Received (or no trusted received relays) an
                            d SPF policy fails or soft fails

Emails: ["maillistdrop@post.com"]

```

This is more or less same output that spamc of spamassassin gives with its -R option.

I have done some more additions to it, like printing of URLS and Emails (if available) at the end. Which can act as a preview for links embedded in the email.

I have tried to do minimal changes to the existing "rspamc_symbols output()" function. Such that it does not change the original flow of the code.

Please review the PR.

Thank you