### PR TITLE
add greylist_score and addheader_score to scan result

### DIFF
--- a/src/client/rspamc.cxx
+++ b/src/client/rspamc.cxx
@@ -969,13 +969,11 @@ rspamc_metric_output(FILE *out, const ucl_object_t *obj)
 		got_scores++;
 	}
 
-	/* XXX: greylist_score is not yet in checkv2 */
 	elt = ucl_object_lookup(obj, "greylist_score");
 	if (elt) {
 		greylist_score = ucl_object_todouble(elt);
 	}
 
-	/* XXX: addheader_score is not yet in checkv2 */
 	elt = ucl_object_lookup(obj, "addheader_score");
 	if (elt) {
 		addheader_score = ucl_object_todouble(elt);
@@ -1054,12 +1052,6 @@ rspamc_metric_output(FILE *out, const ucl_object_t *obj)
 	}
 
 	if (humanreport) {
-		/* XXX: why checkv2 does not provide "is_spam"? */
-		elt = ucl_object_lookup(obj, "is_spam");
-		if (elt) {
-			is_spam = ucl_object_toboolean(elt);
-		}
-
 		elt = ucl_object_lookup(obj, "is_skipped");
 		if (elt) {
 			is_skipped = ucl_object_toboolean(elt);

--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -1239,6 +1239,16 @@ rspamd_scan_result_ucl (struct rspamd_task *task,
 			ucl_object_fromdouble (0.0), "score", 0, false);
 	}
 
+	struct rspamd_action *taction = rspamd_config_get_action_by_type (task->cfg, METRIC_ACTION_GREYLIST);
+	ucl_object_insert_key (obj,
+			ucl_object_fromdouble ((!taction || isnan(taction->threshold)) ? 0.0 : taction->threshold),
+			"greylist_score", 0, false);
+
+	taction = rspamd_config_get_action_by_type (task->cfg, METRIC_ACTION_ADD_HEADER);
+	ucl_object_insert_key (obj,
+			ucl_object_fromdouble ((!taction || isnan(taction->threshold)) ? 0.0 : taction->threshold),
+			"addheader_score", 0, false);
+
 	ucl_object_insert_key (obj,
 			ucl_object_fromdouble (rspamd_task_get_required_score (task, mres)),
 			"required_score", 0, false);


### PR DESCRIPTION
"rspamc" (human report option) needs greylist and add header thresholds.

This helps a calling program (program that calls rspamc) to decide "own" custom actions OR create on custom report.

This PR adds greylist_score and addheader_score to scan result.