### PR TITLE
Set required_score = reject score and minor change to the report

### DIFF
--- a/src/client/rspamc.cxx
+++ b/src/client/rspamc.cxx
@@ -971,14 +971,19 @@ rspamc_metric_output(FILE *out, const ucl_object_t *obj)
 	const auto *thresholds_obj = ucl_object_lookup(obj, "thresholds");
 
 	if (thresholds_obj && ucl_object_type(thresholds_obj) == UCL_OBJECT) {
-		const auto *greylist_obj = ucl_object_lookup(thresholds_obj, "greylist");
-		if (greylist_obj) {
-			greylist_score = ucl_object_todouble(greylist_obj);
+		const auto *action_obj = ucl_object_lookup(thresholds_obj, "greylist");
+		if (action_obj) {
+			greylist_score = ucl_object_todouble(action_obj);
 		}
 
-		const auto *add_header_obj = ucl_object_lookup(thresholds_obj, "add header");
-		if (add_header_obj) {
-			addheader_score = ucl_object_todouble(add_header_obj);
+		action_obj = ucl_object_lookup(thresholds_obj, "add header");
+		if (action_obj) {
+			addheader_score = ucl_object_todouble(action_obj);
+		}
+
+		action_obj = ucl_object_lookup(thresholds_obj, "reject");
+		if (action_obj) {
+			required_score = ucl_object_todouble(action_obj);
 		}
 	}
 
@@ -1075,7 +1080,7 @@ rspamc_metric_output(FILE *out, const ucl_object_t *obj)
 	if (humanreport) {
 		fmt::print(out, "Content analysis details:   ({} points, {} required)\n\n",
 			emphasis_argument(score, 2),
-			emphasis_argument(required_score, 2));
+			emphasis_argument(addheader_score, 2));
 		fmt::print(out, " pts rule name              description\n");
 		fmt::print(out, "---- ---------------------- --------------------------------------------------\n");
 	}


### PR DESCRIPTION
In human report (rspamc -R option) when message is detected as SPAM, it means that message score is greater than or equal to the **add header** threshold but it may not  be greater than or equal to **reject score**.

For example we get output like this in human report:
Content analysis details:   (6.62 points, 15.00 required)

This creates a confusion that message score was low (6.62 is less than 15) and yet it was detected as SPAM. But actually message was detected as SPAM because its score was more than 6 (the add header score).

So this PR fixes this in human report. i.e. it prints add header score as required score instead of reject score as required score.

New output will be like this:
Content analysis details:   (6.62 points, 6.00 required)

Additionally, after a new "thresholds" object was introduced recently in JSON output. If thresholds -> reject score is available then this PR (re-) sets "required_score" to "reject score". Because that seems more appropriate.