### PR TITLE
conf/modules.d/arc.conf: fix parameter name

### DIFF
--- a/conf/modules.d/arc.conf
+++ b/conf/modules.d/arc.conf
@@ -44,7 +44,7 @@ arc {
   # If false, messages from local networks are not selected for signing
   sign_local = false;
   # Symbol to add when message is signed
-  symbol_sign = "ARC_SIGNED";
+  sign_symbol = "ARC_SIGNED";
   # Whether to fallback to global config
   try_fallback = true;
   # Domain to use for ARC signing: can be "header", "envelope" or "recipient"


### PR DESCRIPTION
rename symbol_sign -> sign_symbol