### PR TITLE
Fixes to support global lua maps in user settings

### DIFF
--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -510,21 +510,18 @@ local function rspamd_maybe_check_map(key, what)
   end
   if type(rspamd_maps) == "table" then
     local mn
-    if starts(what, "map:") then
-      mn = string.sub(what, 4)
-    elseif starts(what, "map://") then
-      mn = string.sub(what, 6)
+    if starts(key, "map:") then
+      mn = string.sub(key, 5)
+    elseif starts(key, "map://") then
+      mn = string.sub(key, 7)
     end
 
     if mn and rspamd_maps[mn] then
-      return rspamd_maps[mn]:get_key(key)
-    else
-      return what:lower() == key
+      return rspamd_maps[mn]:get_key(what)
     end
-  else
-    return what:lower() == key
   end
 
+  return what:lower() == key
 end
 
 exports.rspamd_maybe_check_map = rspamd_maybe_check_map

--- a/rules/rspamd.lua
+++ b/rules/rspamd.lua
@@ -57,7 +57,7 @@ local rmaps =  rspamd_config:get_all_opt("lua_maps")
 if rmaps and type(rmaps) == 'table' then
   local rspamd_logger = require "rspamd_logger"
   for k,v in pairs(rmaps) do
-    local status,map_or_err = pcall(rspamd_config:add_map(v))
+    local status,map_or_err = pcall(function () return rspamd_config:add_map(v) end)
 
     if not status then
       rspamd_logger.errx(rspamd_config, "cannot add map %s: %s", k, map_or_err)

--- a/src/plugins/lua/settings.lua
+++ b/src/plugins/lua/settings.lua
@@ -255,10 +255,10 @@ local function check_ip_setting(expected, ip)
   else
     if expected[2] ~= 0 then
       local nip = ip:apply_mask(expected[2])
-      if nip and nip:to_string() == expected[1]:to_string() then
+      if nip and nip:to_string() == expected[1] then
         return true
       end
-    elseif ip:to_string() == expected[1]:to_string() then
+    elseif ip:to_string() == expected[1] then
       return true
     end
   end
@@ -478,18 +478,18 @@ local function process_ip_condition(ip)
       local res = rspamd_ip.from_string(ip)
 
       if res:is_valid() then
-        out[1] = res
+        out[1] = res:to_string()
         out[2] = 0
       else
         -- It can still be a map
-        out[1] = res
+        out[1] = ip
       end
     else
       local res = rspamd_ip.from_string(string.sub(ip, 1, slash - 1))
       local mask = tonumber(string.sub(ip, slash + 1))
 
       if res:is_valid() then
-        out[1] = res
+        out[1] = res:to_string()
         out[2] = mask
       else
         rspamd_logger.errx(rspamd_config, "bad IP address: " .. ip)


### PR DESCRIPTION
The support for the global maps in user settings is currently broken.

With the proposed patches the following sample configuration now works perfectly:
```
# in rspamd.conf.local:
lua_maps {
        trusted_networks {
            type = "radix";
            url = "/path/to/trusted_networks"
        }
}
```

```
# in local.d/settings.conf
already_processed {
    id = "skip_checks";
    ip = "map:trusted_networks";
    #header = {
    #   "X-Processed" = "1";
    #}
    want_spam = yes;
}
```

See also [#1802](https://github.com/rspamd/rspamd/issues/1802).
