### PR TITLE
[Enhancement] Make Google URL redirection rules productive

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -908,16 +908,16 @@ reconf['HAS_LIST_UNSUB'] = {
 
 reconf['HAS_GUC_PROXY_URI'] = {
   re = '/\\.googleusercontent\\.com\\/proxy/{url}i',
-  description = 'Has googleusercontent.com proxy URI',
-  score = 0.01,
-  group = 'experimental'
+  description = 'Has googleusercontent.com proxy URL',
+  score = 1.0,
+  group = 'url'
 }
 
 reconf['HAS_GOOGLE_REDIR'] = {
   re = '/\\.google\\.com\\/url\\?/{url}i',
   description = 'Has google.com/url redirection',
-  score = 0.01,
-  group = 'experimental'
+  score = 1.0,
+  group = 'url'
 }
 
 reconf['XM_UA_NO_VERSION'] = {


### PR DESCRIPTION
Both rules frequently trigger in spam messages, and seem to do their job quite well, without causing any harm to legitimate mails. Therefore, this patch suggests to raise their score to 1.0 each, and retag them to the `url` group rather than `experimental`.

While the `googleusercontent.com` rule is complete, the `HAS_GOOGLE_REDIR` one could be bypassed by using a different Google domain, e.g. google.at - is there an easy way to write a rule triggering on any `google.[TLD]` FQDN? If so, that might be a potential enhancement as well.