### PR TITLE
addition: add Betterbird to `user_agent_thunderbird`

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -439,7 +439,7 @@ reconf['FORGED_MUA_OPERA_MSGID'] = {
 -- Detect forged Mozilla Mail/Thunderbird/Seamonkey/Postbox headers
 -- Mozilla based X-Mailer
 local user_agent_mozilla5	= 'User-Agent=/^\\s*Mozilla\\/5\\.0/H'
-local user_agent_thunderbird	= 'User-Agent=/^\\s*(Thunderbird|Mozilla Thunderbird|Mozilla\\/.*Gecko\\/.*(Thunderbird|Icedove)\\/)/H'
+local user_agent_thunderbird	= 'User-Agent=/^\\s*(Thunderbird|Mozilla Thunderbird|Mozilla\\/.*Gecko\\/.*(Thunderbird|Betterbird|Icedove)\\/)/H'
 local user_agent_seamonkey	= 'User-Agent=/^\\s*Mozilla\\/5\\.0\\s.+\\sSeaMonkey\\/\\d+\\.\\d+/H'
 local user_agent_postbox	= [[User-Agent=/^\s*Mozilla\/5\.0\s\([^)]+\)\sGecko\/\d+\sPostboxApp\/\d+(?:\.\d+){2,3}$/H]]
 local user_agent_mozilla	= string.format('(%s) & !(%s) & !(%s) & !(%s)', user_agent_mozilla5, user_agent_thunderbird, user_agent_seamonkey, user_agent_postbox)


### PR DESCRIPTION
See <https://github.com/Betterbird/thunderbird-patches/issues/125> for reference.

This way, Rspamd will not add `FORGED_MUA_MOZILLA_MAIL_MSGID_UNKNOWN` to mails sent perfectly fine with Betterbird.

_Betterbird_ (<https://www.betterbird.eu/>) is an adjusted version of Thunderbird, fixing many bugs and adding long-wanted features. It is a common and well-known alternative to Thunderbird, so I think the addition is justified.