### PR TITLE
fix incorrect asn references in bimi.conf

### DIFF
--- a/conf/modules.d/bimi.conf
+++ b/conf/modules.d/bimi.conf
@@ -1,16 +1,17 @@
 # Please don't modify this file as your changes might be overwritten with
 # the next update.
 #
-# You can modify 'local.d/asn.conf' to add and merge
+# You can modify 'local.d/bimi.conf' to add and merge
 # parameters defined inside this section
 #
-# You can modify 'override.d/asn.conf' to strictly override all
+# You can modify 'override.d/bimi.conf' to strictly override all
 # parameters defined inside this section
 #
 # See https://rspamd.com/doc/faq.html#what-are-the-locald-and-overrided-directories
 # for details
 #
-# Module documentation can be found at  https://rspamd.com/doc/modules/asn.html
+# Currently there is no documentation for this module. When it is written it will 
+# be available at https://rspamd.com/doc/modules/bimi.html
 
 bimi {
   # Required attributes


### PR DESCRIPTION
Looks like bimi.conf was copied from asn.conf. This fixes those references.