### PR TITLE
Fix for x-rspamd-action in Milter headers module

### DIFF
--- a/src/plugins/lua/milter_headers.lua
+++ b/src/plugins/lua/milter_headers.lua
@@ -360,7 +360,7 @@ local function milter_headers(task)
     local local_mod = settings.routines['x-rspamd-action']
     if skip_wanted('x-rspamd-action') then return end
     if not common['metric_action'] then
-      common['metric_action'] = task:get_metric_score()
+      common['metric_action'] = task:get_metric_action()
     end
     local action = common['metric_action']
     if local_mod.remove then


### PR DESCRIPTION
When metric action is not defined, it reads a score causing a type error where the value should be a string and the actual action.

As a side note, the documentation for this module seems fairly out of date.