### PR TITLE
[Minor] Move HAS_ONION_URI from "experimental" to "url" group

### DIFF
--- a/rules/regexp/misc.lua
+++ b/rules/regexp/misc.lua
@@ -58,7 +58,7 @@ reconf['HAS_ONION_URI'] = {
     re = string.format('(%s | %s)', onion_uri_v2, onion_uri_v3),
     description = 'Contains .onion hidden service URI',
     score = 0.0,
-    group = 'experimental'
+    group = 'url'
 }
 
 local my_victim = [[/(?:victim|prey)/{words}]]


### PR DESCRIPTION
Having not seen this rule causing any false-positives during a long time, I think it is time to move it to the regular "url" group.