### PR TITLE
[Enhancement] Add composite rule for messages only containing a redirector URL

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -154,6 +154,12 @@ composites {
     policy = "leave";
     description = "Message exhibits strong characteristics of advance fee fraud (AFF a/k/a '419' spam) involving freemail addresses";
   }
+  REDIRECTOR_URL_ONLY {
+    expression = "HFILTER_URL_ONLY & REDIRECTOR_URL";
+    score = 1.0;
+    policy = "leave";
+    description = "Message only contains a redirector URL";
+  }
 
   .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/composites.conf"
   .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/composites.conf"


### PR DESCRIPTION
This composite rule is an attempt to improve detection rates on some recently observed spearphishing e-mails, which only contained a redirector URL, presumably to thwart Bayes and Fuzzy checks.