### PR TITLE
[Rules] Add thread hijacking composite rule

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -160,6 +160,13 @@ composites {
     policy = "leave";
     description = "Message only contains a redirector URL";
   }
+  THREAD_HIJACKING_FROM_INJECTOR {
+    expression = "FAKE_REPLY & RCVD_VIA_SMTP_AUTH & (!RECEIVED_SPAMHAUS_PBL | RECEIVED_SPAMHAUS_XBL | RECEIVED_SPAMHAUS_SBL)";
+    score = 2.0;
+    policy = "leave";
+    description = "Fake reply exhibiting characteristics of being injected into a compromised mail server, possibly e-mail thread hijacking";
+    group = "compromised_hosts";
+  }
 
   .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/composites.conf"
   .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/composites.conf"

--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -83,8 +83,8 @@ composites {
     policy = "leave";
   }
   RCVD_UNAUTH_PBL {
-    expression = "RECEIVED_PBL & !RCVD_VIA_SMTP_AUTH";
-    description = "Relayed through Spamhaus PBL IP without sufficient authentication (possible indicating an open relay)";
+    expression = "RECEIVED_SPAMHAUS_PBL & !RCVD_VIA_SMTP_AUTH";
+    description = "Relayed through Spamhaus PBL IP without sufficient authentication (possibly indicating an open relay)";
     score = 2.0;
     policy = "leave";
   }


### PR DESCRIPTION
This merge request introduces a new composite rule for catching malspam disseminated by Qakbot, SquirrelWaffle and alike threat actors. Recent campaigns often involved compromised account at legitimate mailservers, through which e-mails were sent to potential victims, quoting previous conversation to improve credibility.

Such fake replies, in combination with an authenticated SMTP hand-off, and an IP address in the `Received` headers that is either not a dial-up one (i.e. no PBL listing, as the injector systems are predominantly located in datacenters), or already known for being compromised (XBL listing) or having an otherwise ill reputation (SBL listing), are now additionally scored by `THREAD_HIJACKING_FROM_INJECTOR`.

In addition, `RCVD_UNAUTH_PBL` was dependent on a symbol no longer in use, and has been fixed to be operational again.