### PR TITLE
Use the correct mime format for 7z

### DIFF
--- a/lualib/lua_magic/types.lua
+++ b/lualib/lua_magic/types.lua
@@ -251,7 +251,7 @@ local types = {
     type = 'archive',
   },
   ['7z'] = {
-    ct = 'x-7z-compressed',
+    ct = 'application/x-7z-compressed',
     type = 'archive',
   },
   gz = {


### PR DESCRIPTION
Before this change:
```
jst@localhost:~/source/repos/rspamd-mta-src$ sudo docker exec -it 9a /bin/sh
/etc/rspamd # rspamadm mime dump --json /eml/4Qf5RZ5LF5z2DJl-wr967dushxqxsexgn4ksu85zyd.eml | grep x-7z-compressed
            "detected_type": "x-7z-compressed/",
/etc/rspamd # 
```

After the change:
```
jst@localhost:~/source/repos/rspamd-mta-src$ sudo docker exec -it d4 /bin/sh
/etc/rspamd # rspamadm mime dump --json /eml/4Qf5RZ5LF5z2DJl-wr967dushxqxsexgn4ksu85zyd.eml | grep x-7z-compressed
            "detected_type": "application/x-7z-compressed",
/etc/rspamd # 
```

As per https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types I believe the previous behavior was wrong.