### PR TITLE
[Feature] Detect Apple Mail and remove scores for their known common behavior

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -65,6 +65,14 @@ composites {
     expression = "-R_DKIM_ALLOW & (R_DKIM_TEMPFAIL | R_DKIM_PERMFAIL | R_DKIM_REJECT)"
     policy = "remove_weight";
   }
+  APPLE_MAILER_COMMON {
+    description = "Message was sent by 'Apple Mail' and has common symbols in place";
+    expression = "APPLE_MAILER & MV_CASE";
+  }
+  APPLE_IOS_MAILER_COMMON {
+    description = "Message was sent by 'Apple iOS Mail' and has common symbols in place";
+    expression = "APPLE_IOS_MAILER & (MV_CASE | MIME_MA_MISSING_TEXT)";
+  }
   HACKED_WP_PHISHING {
     expression = "(HAS_X_POS | HAS_PHPMAILER_SIG) & HAS_WP_URI & (PHISHING | CRACKED_SURBL | PH_SURBL_MULTI | DBL_PHISH | DBL_ABUSE_PHISH | URIBL_BLACK | PHISHED_OPENPHISH | PHISHED_PHISHTANK)";
     description = "Phish message sent by hacked Wordpress instance";

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -975,7 +975,7 @@ reconf['APPLE_MAILER'] = {
 -- Detect Apple iPhone/iPad Mail
 -- Apple iPhone/iPad Mail X-Mailer contains iOS build number, e. g. 9B206, 16H5, 18G5023c
 -- https://en.wikipedia.org/wiki/IOS_version_history
-local apple_ios_x_mailer = [[i(?:Phone|Pad) Mail \((?:1[AC]|[34][AB]|5[ABCFGH]|7[A-E]|8[ABCEFGHJKL]|9[AB]|\d{2}[A-Z])\d+[a-z]?\)]]
+local apple_ios_x_mailer = [[i(?:Phone|Pad) Mail \(\d{1,2}[A-Z]\d{1,4}[a-z]?\)]]
 reconf['APPLE_IOS_MAILER'] = {
   description = 'Sent with Apple iPhone/iPad Mail',
   re = string.format('X-Mailer=/^%s/{header}', apple_ios_x_mailer),

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -963,6 +963,26 @@ reconf['OLD_X_MAILER'] = {
   group = 'headers',
 }
 
+-- Detect Apple Mail
+local apple_x_mailer = [[Apple Mail \(((Version )?[1-9]\.[0-9]*|[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*)\)]]
+reconf['APPLE_MAILER'] = {
+  description = 'Sent with Apple Mail',
+  re = string.format('X-Mailer=/^%s/{header}', apple_x_mailer),
+  score = 0.0,
+  group = 'headers',
+}
+
+-- Detect Apple iPhone/iPad Mail
+-- Apple iPhone/iPad Mail X-Mailer contains iOS build number, e. g. 9B206, 16H5, 18G5023c
+-- https://en.wikipedia.org/wiki/IOS_version_history
+local apple_ios_x_mailer = [[i(?:Phone|Pad) Mail \((?:1[AC]|[34][AB]|5[ABCFGH]|7[A-E]|8[ABCEFGHJKL]|9[AB]|\d{2}[A-Z])\d+[a-z]?\)]]
+reconf['APPLE_IOS_MAILER'] = {
+  description = 'Sent with Apple iPhone/iPad Mail',
+  re = string.format('X-Mailer=/^%s/{header}', apple_ios_x_mailer),
+  score = 0.0,
+  group = 'headers',
+}
+
 -- X-Mailer header values which should not occur (in the modern mail) at all
 local bad_x_mailers = {
   -- header name repeated in the header value
@@ -978,9 +998,6 @@ local bad_x_mailers = {
   -- but starts with 'iPhone Mail' or 'iPad Mail' is likely fake
   [[i(?:Phone|Pad) Mail]],
 }
--- Apple iPhone/iPad Mail X-Mailer contains iOS build number, e. g. 9B206, 16H5, 18G5023c
--- https://en.wikipedia.org/wiki/IOS_version_history
-local apple_ios_x_mailer = [[i(?:Phone|Pad) Mail \((?:1[AC]|[34][AB]|5[ABCFGH]|7[A-E]|8[ABCEFGHJKL]|9[AB]|\d{2}[A-Z])\d+[a-z]?\)]]
 
 reconf['FORGED_X_MAILER'] = {
   description = 'Forged X-Mailer header',


### PR DESCRIPTION
Both Apple Mail and Apple iOS Mail always use `Mime-Version` instead of `MIME-Version` leading to `MV_CASE`, so it need to be excluded for them. Specifically Apple iOS Mail not add `plain-text` version of email leading to `MIME_MA_MISSING_TEXT` which need to be excluded as well. 

Note about `plain-text`: it will be added by Apple iOS Mail __only__ on replies, in the case when the email to which the reply is made has `plain-text` part. As such behavior can't be captured, we just can drop  `MIME_MA_MISSING_TEXT` generally for Apple iOS Mail