### PR TITLE
[Minor] Tweak HAS_GOOGLE_REDIR to detect Google AMP URLs as well

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -912,7 +912,7 @@ reconf['HAS_GUC_PROXY_URI'] = {
 }
 
 reconf['HAS_GOOGLE_REDIR'] = {
-  re = '/\\.google\\.([a-z]{2,3}(|\\.[a-z]{2,3})|info|jobs)\\/url\\?/{url}i',
+  re = '/\\.google\\.([a-z]{2,3}(|\\.[a-z]{2,3})|info|jobs)\\/(amp\\/s\\/|url\\?)/{url}i',
   description = 'Has google.com/url or alike Google redirection URL',
   score = 1.0,
   group = 'url'


### PR DESCRIPTION
Rationale: https://cofense.com/blog/google-amp-the-newest-of-evasive-phishing-tactic/