### PR TITLE
fix: redis schema parsing

### DIFF
--- a/lualib/lua_util.lua
+++ b/lualib/lua_util.lua
@@ -619,6 +619,19 @@ end
 exports.table_cmp = table_cmp
 
 --[[[
+-- @function lua_util.table_merge(t1, t2)
+-- Merge two tables
+--]]
+local function table_merge(t1, t2)
+  for k, v in pairs(t2) do
+    t1[k] = v
+  end
+  return t1
+end
+
+exports.table_merge = table_merge
+
+--[[[
 -- @function lua_util.table_cmp(task, name, value, stop_chars)
 -- Performs header folding
 --]]

--- a/src/plugins/lua/bimi.lua
+++ b/src/plugins/lua/bimi.lua
@@ -34,7 +34,7 @@ local settings = {
 }
 local redis_params
 
-local settings_schema = ts.shape({
+local settings_schema = lua_redis.generate_schema({
   helper_url = ts.string,
   helper_timeout = ts.number + ts.string / lua_util.parse_time_interval,
   helper_sync = ts.boolean,
@@ -42,7 +42,7 @@ local settings_schema = ts.shape({
   redis_min_expiry = ts.number + ts.string / lua_util.parse_time_interval,
   redis_prefix = ts.string,
   enabled = ts.boolean:is_optional(),
-}, {extra_fields = lua_redis.config_schema})
+})
 
 local function check_dmarc_policy(task)
   local dmarc_sym = task:get_symbol('DMARC_POLICY_ALLOW')

--- a/src/plugins/lua/history_redis.lua
+++ b/src/plugins/lua/history_redis.lua
@@ -65,7 +65,7 @@ local settings = {
   subject_privacy_length = 16, -- cut the length of the hash
 }
 
-local settings_schema = ts.shape({
+local settings_schema = lua_redis.generate_schema({
   key_prefix = ts.string,
   expire = (ts.number + ts.string / lua_util.parse_time_interval):is_optional(),
   nrows = ts.number,
@@ -74,7 +74,7 @@ local settings_schema = ts.shape({
   subject_privacy_alg = ts.string:is_optional(),
   subject_privacy_prefix = ts.string:is_optional(),
   subject_privacy_length = ts.number:is_optional(),
-}, {extra_fields = lua_redis.config_schema})
+})
 
 local function process_addr(addr)
   if addr then

--- a/src/plugins/lua/reputation.lua
+++ b/src/plugins/lua/reputation.lua
@@ -1064,7 +1064,7 @@ end
 --]]
 local backends = {
   redis = {
-    schema = ts.shape({
+    schema = lua_redis.generate_schema({
       prefix = ts.string,
       expiry = ts.number + ts.string / lua_util.parse_time_interval,
       buckets = ts.array_of(ts.shape{
@@ -1072,7 +1072,7 @@ local backends = {
         name = ts.string,
         mult = ts.number + ts.string / tonumber
       }),
-    }, {extra_fields = lua_redis.config_schema}),
+    }),
     config = {
       expiry = default_expiry,
       prefix = default_prefix,


### PR DESCRIPTION
Attempt to fix https://github.com/rspamd/rspamd/issues/4318

This issue is still not fixed, at least for us (@ajs124 and me) so he asked me if i could look into it.
I think the problem is a misuse of the tableshape library, also see https://github.com/leafo/tableshape/issues/17

The rewritten code now merges tables rather than using on `extra_fileds` because looking at this source code all remaining keys, which includes `read_server`, `write_server` and `password` e.g. need to have the correct type specified in `extra_fields`, also see https://github.com/leafo/tableshape/blob/master/tableshape/init.lua#L1509-L1515
`password` being a string will then result in what ajs124 saw here: https://github.com/rspamd/rspamd/issues/4318#issuecomment-1453502529

There are two possible options on solving this issue, either we extend tableshape to support this use case of we update the usage here. I decided to do the last one because it seemed simpler.

Its a rather simple solution and i'd like to write some test but struggled to get the lua testing runtime to work. So if you have some pointers on how to get that running, i'd love to add a couple of tests

I validated it with the minimal reproduce

```lua
package.path = package.path .. ";./?.lua;"
local ts = require("contrib.lua-tableshape.tableshape").types

local function table_merge(t1, t2)
  for k, v in pairs(t2) do
    t1[k] = v
  end
  return t1
end

local common = { key_prefix = ts.string, nrows = ts.number, compress = ts.boolean }

local settings_schema = ts.one_of {
  ts.shape(common),
  ts.shape(table_merge({
    read_servers = ts.string + ts.array_of(ts.string),
    password = ts.string:is_optional(),
  }, common)),
  ts.shape(table_merge({
    write_servers = ts.string + ts.array_of(ts.string),
    password = ts.string:is_optional(),
  }, common)),
  ts.shape(table_merge({
    write_servers = ts.string + ts.array_of(ts.string),
    read_servers = ts.string + ts.array_of(ts.string),
    password = ts.string:is_optional(),
  }, common)),
}

local obj1 = {
  key_prefix = "rs_history",
  nrows = 1000,
  compress = true,

  -- read_servers = "127.0.0.1:6381",
  write_servers = "127.0.0.1:6381",
  password = "<password hidden>",
}

local res, err = settings_schema:transform(obj1)
print(res, err)
``` 