### PR TITLE
Add new exporter to push JSON to a raw TCP socket

### DIFF
--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -357,10 +357,10 @@ local pushers = {
       timeout = rule.timeout or settings.timeout,
     }, formatted, sendmail_cb)
   end,
-  json_raw = function(task, formatted, rule)
-    local function json_raw_callback(err, code)
+  json_raw_tcp = function(task, formatted, rule)
+    local function json_raw_tcp_callback(err, code)
       if err then
-        rspamd_logger.errx(task, 'got error %s in json_raw callback', err)
+        rspamd_logger.errx(task, 'got error %s in json_raw_tcp callback', err)
         return maybe_defer(task, rule)
       end
       return true
@@ -370,7 +370,7 @@ local pushers = {
       host=rule.host,
       port=rule.port,
       data=formatted,
-      callback=json_raw_callback,
+      callback=json_raw_tcp_callback,
       read=false,
     })
   end,
@@ -552,18 +552,18 @@ if type(settings.rules) ~= 'table' then
       settings.rules[r.backend:upper()] = r
     end
   end
-  if settings.pusher_enabled.json_raw then
+  if settings.pusher_enabled.json_raw_tcp then
     if not (settings.host and settings.port) then
       rspamd_logger.errx(rspamd_config, 'No host and/or port is specified')
-      settings.pusher_enabled.json_raw = nil
+      settings.pusher_enabled.json_raw_tcp = nil
     else
       local r = {}
-      r.backend = 'json_raw'
+      r.backend = 'json_raw_tcp'
       r.host = settings.host
       r.port = settings.port
       r.defer = settings.defer
-      r.selector = settings.pusher_select.json_raw
-      r.formatter = settings.pusher_format.json_raw
+      r.selector = settings.pusher_select.json_raw_tcp
+      r.formatter = settings.pusher_format.json_raw_tcp
       settings.rules[r.backend:upper()] = r
     end
   end
@@ -590,7 +590,7 @@ local backend_required_elements = {
   redis_pubsub = {
     'channel',
   },
-  json_raw = {
+  json_raw_tcp = {
     'host',
     'port',
   },

--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -26,6 +26,7 @@ local lua_util = require "lua_util"
 local rspamd_http = require "rspamd_http"
 local rspamd_util = require "rspamd_util"
 local rspamd_logger = require "rspamd_logger"
+local rspamd_tcp = require "rspamd_tcp"
 local ucl = require "ucl"
 local E = {}
 local N = 'metadata_exporter'
@@ -356,6 +357,23 @@ local pushers = {
       timeout = rule.timeout or settings.timeout,
     }, formatted, sendmail_cb)
   end,
+  json_raw = function(task, formatted, rule)
+    local function json_raw_callback(err, code)
+      if err then
+        rspamd_logger.errx(task, 'got error %s in json_raw callback', err)
+        return maybe_defer(task, rule)
+      end
+      return true
+    end
+    rspamd_tcp.request({
+      task=task,
+      host=rule.host,
+      port=rule.port,
+      data=formatted,
+      callback=json_raw_callback,
+      read=false,
+    })
+  end,
 }
 
 local opts = rspamd_config:get_all_opt(N)
@@ -534,6 +552,21 @@ if type(settings.rules) ~= 'table' then
       settings.rules[r.backend:upper()] = r
     end
   end
+  if settings.pusher_enabled.json_raw then
+    if not (settings.host and settings.port) then
+      rspamd_logger.errx(rspamd_config, 'No host and/or port is specified')
+      settings.pusher_enabled.json_raw = nil
+    else
+      local r = {}
+      r.backend = 'json_raw'
+      r.host = settings.host
+      r.port = settings.port
+      r.defer = settings.defer
+      r.selector = settings.pusher_select.json_raw
+      r.formatter = settings.pusher_format.json_raw
+      settings.rules[r.backend:upper()] = r
+    end
+  end
   if not next(settings.pusher_enabled) then
     rspamd_logger.errx(rspamd_config, 'No push backend enabled')
     return
@@ -556,6 +589,10 @@ local backend_required_elements = {
   },
   redis_pubsub = {
     'channel',
+  },
+  json_raw = {
+    'host',
+    'port',
   },
 }
 local check_element = {


### PR DESCRIPTION
This is for example useful with Graylog.

Although Graylog has various HTTP inputs, they are for GELF and others, which would need additional formatters on the `rspamd` side.

Using the raw input results in IO timeouts from the `rspamd` side, because Graylog's raw input doesn't "speak" HTTP.

This resolves the issue.  Combined with an appropriate Graylog pipeline to split into fields, this works well.

Example Graylog pipeline:

```
rule "JSON to fields"
when
  starts_with(to_string($message.message), "{") && ends_with(to_string($message.message), "}")
then
  let json = parse_json(to_string($message.message));
  let map = to_map(json);
  set_fields(map, "rspamd_");
  set_field("rspamd_score", to_double(map.score));
end
```
