### PR TITLE
[Feature] Support feed exclusions in phishing module

### DIFF
--- a/conf/modules.d/phishing.conf
+++ b/conf/modules.d/phishing.conf
@@ -21,6 +21,12 @@ phishing {
   # Phishtank is disabled by default in the module, so let's enable it here explicitly
   phishtank_enabled = true;
 
+  # List of excluded hosts from checks over openphish, phishtank and generic_service
+  phishing_feed_exclusion_symbol = "PHISHED_EXCLUDED";
+  # Disabled by default
+  phishing_feed_exclusion_enabled = false;
+  phishing_feed_exclusion_map = "$LOCAL_CONFDIR/local.d/maps.d/phishing_feed_exclusion.inc";
+
   # Make exclusions for known redirectors and domains
   exceptions = {
     REDIRECTOR_FALSE = [

--- a/conf/scores.d/phishing_group.conf
+++ b/conf/scores.d/phishing_group.conf
@@ -25,6 +25,10 @@ symbols = {
         description = "Phished URL";
         one_shot = true;
     }
+    "PHISHED_EXCLUDED" {
+        weight = 0.0;
+        description = "Phished URL found in exclusions list";
+    }
     "PHISHED_OPENPHISH" {
         weight = 7.0;
         description = "Phished URL found in openphish.com";


### PR DESCRIPTION
Currently, if you use `openfish`, `phishtank` or `generic_service` lists for checking URLs existing `exceptions` or `phishing_exceptions` not applied for them. This lists cover only logic for checking if URL just looks as phishing, but not excluding them from datafeed checks in mentioned services. This PR created a separate exclusion list for this case.

To economy compute units (and DNS requests in case of  `phishtank`) hosts from the exclusion list will be not checked, excluded symbol will be added even it not appear in  `openfish`, `phishtank` or `generic_service`.