### PR TITLE
Fix regression in invokation of rspamd-test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,7 +779,7 @@ IF (NOT DEBIAN_BUILD)
     ADD_CUSTOM_TARGET(check DEPENDS rspamd-test-cxx rspamd-test)
     ADD_CUSTOM_TARGET(run-test DEPENDS check
             COMMAND test/rspamd-test-cxx
-            COMMAND sh -c 'LUA_PATH= "${CMAKE_SOURCE_DIR}/lualib/?.lua\;${CMAKE_SOURCE_DIR}/lualib/?/?.lua\;${CMAKE_SOURCE_DIR}/lualib/?/init.lua\;${CMAKE_SOURCE_DIR}/contrib/lua-?/?.lua"
+            COMMAND sh -c 'LUA_PATH="${CMAKE_SOURCE_DIR}/lualib/?.lua\;${CMAKE_SOURCE_DIR}/lualib/?/?.lua\;${CMAKE_SOURCE_DIR}/lualib/?/init.lua\;${CMAKE_SOURCE_DIR}/contrib/lua-?/?.lua"
             test/rspamd-test -p /rspamd/lua')
 ENDIF (NOT DEBIAN_BUILD)
 


### PR DESCRIPTION
A space seems to have sneaked into the setting of LUA_PATH environment.