### PR TITLE
[Minor] Remove unused variables

### DIFF
--- a/src/libutil/mem_pool.c
+++ b/src/libutil/mem_pool.c
@@ -284,8 +284,6 @@ rspamd_mempool_new_(gsize size, const gchar *tag, gint flags, const gchar *loc)
 {
 	rspamd_mempool_t *new_pool;
 	gpointer map;
-	const gchar hexdigits[] = "0123456789abcdef";
-	unsigned i;
 
 	/* Allocate statistic structure if it is not allocated before */
 	if (mem_pool_stat == NULL) {

--- a/src/rspamadm/pw.c
+++ b/src/rspamadm/pw.c
@@ -187,7 +187,7 @@ rspamadm_pw_check(void)
 	guchar *salt_decoded, *key_decoded, *local_key;
 	gsize salt_len, key_len, size;
 	gchar test_password[8192], encrypted_password[8192];
-	gsize plen, term = 0, i;
+	gsize plen, i;
 	gint id;
 	gboolean ret = FALSE;
 

--- a/test/rspamd_mem_pool_test.c
+++ b/test/rspamd_mem_pool_test.c
@@ -16,8 +16,6 @@ void rspamd_mem_pool_test_func(void)
 	rspamd_mempool_t *pool;
 	rspamd_mempool_stat_t st;
 	char *tmp, *tmp2, *tmp3;
-	pid_t pid;
-	int ret;
 
 	pool = rspamd_mempool_new(sizeof(TEST_BUF), NULL, 0);
 	tmp = rspamd_mempool_alloc(pool, sizeof(TEST_BUF));

--- a/test/rspamd_radix_test.c
+++ b/test/rspamd_radix_test.c
@@ -206,7 +206,6 @@ void rspamd_radix_test_func(void)
 {
 	struct btrie *btrie;
 	rspamd_mempool_t *pool;
-	radix_compressed_t *comp_tree = radix_create_compressed(NULL);
 	struct {
 		guint32 addr;
 		guint32 mask;


### PR DESCRIPTION
Reported by clang `-Wunused-variable`, ignoring contrib/*.