### PR TITLE
[Fix] Correct format string for unw_word_t

### DIFF
--- a/src/libserver/worker_util.c
+++ b/src/libserver/worker_util.c
@@ -1643,7 +1643,7 @@ rspamd_print_crash(ucontext_t *uap)
 					level, (unsigned long)ip, name, (unsigned long)off);
 		}
 		else {
-			msg_err("%d: %ul: <unknown>", level, ip);
+			msg_err("%d: %0x%xl: <unknown>", level, (unsigned long)ip);
 		}
 
 		level++;

--- a/src/libserver/worker_util.c
+++ b/src/libserver/worker_util.c
@@ -1639,11 +1639,11 @@ rspamd_print_crash(ucontext_t *uap)
 		ret = unw_get_proc_name(&cursor, name, sizeof(name), &off);
 
 		if (ret == 0) {
-			msg_err("%d: %p: %s()+0x%xl",
+			msg_err("%d: %ul: %s()+0x%xl",
 					level, ip, name, (uintptr_t) off);
 		}
 		else {
-			msg_err("%d: %p: <unknown>", level, ip);
+			msg_err("%d: %ul: <unknown>", level, ip);
 		}
 
 		level++;

--- a/src/libserver/worker_util.c
+++ b/src/libserver/worker_util.c
@@ -1639,8 +1639,8 @@ rspamd_print_crash(ucontext_t *uap)
 		ret = unw_get_proc_name(&cursor, name, sizeof(name), &off);
 
 		if (ret == 0) {
-			msg_err("%d: %ul: %s()+0x%xl",
-					level, ip, name, (uintptr_t) off);
+			msg_err("%d: 0x%xl: %s()+0x%xl",
+					level, (unsigned long)ip, name, (unsigned long)off);
 		}
 		else {
 			msg_err("%d: %ul: <unknown>", level, ip);


### PR DESCRIPTION
On x86_64 unw_word_t is uint64_t.

NOTE: Possibly incorrect for !x86_64.

Triggered by -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DENABLE_CLANG_PLUGIN=ON -DENABLE_LIBUNWIND=ON.

