### PR TITLE
[Feature] Add ICAP Content-Type and Filename from TODO List

### DIFF
--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -241,13 +241,15 @@ local function icap_check(task, content, digest, rule, maybe_part)
       local function get_req_headers()
 
         local in_client_ip = task:get_from_ip()
-        lua_util.debugm(rule.name, task, 'URL: http://%s/%s | Content-Type: %s/%s',
-            in_client_ip, maybe_part[1], maybe_part[2], maybe_part[3])
-
         local req_hlen = 2
-        table.insert(req_headers, string.format('GET http://%s/%s HTTP/1.0\r\n', in_client_ip, maybe_part[1]))
         table.insert(req_headers, string.format('Date: %s\r\n', rspamd_util.time_to_string(rspamd_util.get_time())))
-        table.insert(http_headers, string.format('Content-Type: %s/%s\r\n', maybe_part[2], maybe_part[3]))
+        if maybe_part then
+          table.insert(req_headers, string.format('GET http://%s/%s HTTP/1.0\r\n', in_client_ip, maybe_part:get_filename()))
+          table.insert(http_headers, string.format('Content-Type: %s/%s\r\n', maybe_part:get_detected_type()))
+        else
+          table.insert(req_headers, string.format('GET %s HTTP/1.0\r\n', rule.req_fake_url))
+          table.insert(http_headers, string.format('Content-Type: application/octet-stream\r\n'))
+        end
         if rule.user_agent ~= "none" then
           table.insert(req_headers, string.format("User-Agent: %s\r\n", rule.user_agent))
         end

--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -240,10 +240,14 @@ local function icap_check(task, content, digest, rule, maybe_part)
 
       local function get_req_headers()
 
+        local in_client_ip = task:get_from_ip()
+        lua_util.debugm(rule.name, task, 'URL: http://%s/%s | Content-Type: %s/%s',
+            in_client_ip, maybe_part[1], maybe_part[2], maybe_part[3])
+
         local req_hlen = 2
-        table.insert(req_headers, string.format('GET %s HTTP/1.0\r\n', rule.req_fake_url))
+        table.insert(req_headers, string.format('GET http://%s/%s HTTP/1.0\r\n', in_client_ip, maybe_part[1]))
         table.insert(req_headers, string.format('Date: %s\r\n', rspamd_util.time_to_string(rspamd_util.get_time())))
-        --table.insert(http_headers, string.format('Content-Type: %s\r\n', 'text/html'))
+        table.insert(http_headers, string.format('Content-Type: %s/%s\r\n', maybe_part[2], maybe_part[3]))
         if rule.user_agent ~= "none" then
           table.insert(req_headers, string.format("User-Agent: %s\r\n", rule.user_agent))
         end

--- a/src/plugins/lua/external_services.lua
+++ b/src/plugins/lua/external_services.lua
@@ -181,12 +181,19 @@ local function add_scanner_rule(sym, opts)
       fun.each(function(p)
         local content = p:get_content()
         if content and #content > 0 then
-          cfg.check(task, content, p:get_digest(), rule)
+          local in_fname = p:get_filename()
+          local in_type, in_stype = p:get_detected_type()
+          local part_info = {in_fname,in_type,in_stype}
+          cfg.check(task, content, p:get_digest(), rule, part_info)
         end
       end, common.check_parts_match(task, rule))
 
     else
-      cfg.check(task, task:get_content(), task:get_digest(), rule)
+      local in_fname = "mail"
+      local in_type = "application"
+      local in_stype = "octet-stream"
+      local part_info = {in_fname,in_type,in_stype}
+      cfg.check(task, task:get_content(), task:get_digest(), rule, part_info)
     end
   end
 

--- a/src/plugins/lua/external_services.lua
+++ b/src/plugins/lua/external_services.lua
@@ -181,19 +181,12 @@ local function add_scanner_rule(sym, opts)
       fun.each(function(p)
         local content = p:get_content()
         if content and #content > 0 then
-          local in_fname = p:get_filename()
-          local in_type, in_stype = p:get_detected_type()
-          local part_info = {in_fname,in_type,in_stype}
-          cfg.check(task, content, p:get_digest(), rule, part_info)
+          cfg.check(task, content, p:get_digest(), rule, p)
         end
       end, common.check_parts_match(task, rule))
 
     else
-      local in_fname = "mail"
-      local in_type = "application"
-      local in_stype = "octet-stream"
-      local part_info = {in_fname,in_type,in_stype}
-      cfg.check(task, task:get_content(), task:get_digest(), rule, part_info)
+      cfg.check(task, task:get_content(), task:get_digest(), rule, nil)
     end
   end
 


### PR DESCRIPTION
It turns out, that external_services plugin is not submitting maybe_part parameter at all when calling icap services check method. In order to avoid expensive operations in icap.lua scanner, I am just getting the filename and content-type/subtype in the external_services plugin and submitting that as maybe_part parameter. Of course, a new parameter can be introduced should maybe_part is used, but I wasn't able to find any usage of it at least related to the ICAP functionality.