### PR TITLE
[Fix] rspamadm mime: arguments beginning with letter `t`

### DIFF
--- a/lualib/rspamadm/mime.lua
+++ b/lualib/rspamadm/mime.lua
@@ -179,7 +179,7 @@ sign:option "-k --key"
     :description "Use specific key of file"
     :argname "<key>"
     :count "1"
-sign:option "-t type"
+sign:option "-t --type"
     :description "ARC or DKIM signing"
     :argname("<arc|dkim>")
     :convert {


### PR DESCRIPTION
Makes `rspamadm mime ex test.eml` work