### PR TITLE
[Fix] Change Date: header location to conform with RFC

### DIFF
--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -242,7 +242,6 @@ local function icap_check(task, content, digest, rule, maybe_part)
 
         local in_client_ip = task:get_from_ip()
         local req_hlen = 2
-        table.insert(req_headers, string.format('Date: %s\r\n', rspamd_util.time_to_string(rspamd_util.get_time())))
         if maybe_part then
           table.insert(req_headers, string.format('GET http://%s/%s HTTP/1.0\r\n', in_client_ip, maybe_part:get_filename()))
           table.insert(http_headers, string.format('Content-Type: %s/%s\r\n', maybe_part:get_detected_type()))
@@ -250,6 +249,7 @@ local function icap_check(task, content, digest, rule, maybe_part)
           table.insert(req_headers, string.format('GET %s HTTP/1.0\r\n', rule.req_fake_url))
           table.insert(http_headers, string.format('Content-Type: application/octet-stream\r\n'))
         end
+        table.insert(req_headers, string.format('Date: %s\r\n', rspamd_util.time_to_string(rspamd_util.get_time())))
         if rule.user_agent ~= "none" then
           table.insert(req_headers, string.format("User-Agent: %s\r\n", rule.user_agent))
         end


### PR DESCRIPTION
Re-arrange the Date: header to be in appropriate order and conform to RFC. Otherwise, the functionality for populating filename, client_ip, content type and sub_type is not working as expected.