### PR TITLE
[Fix] Add url_encode function and encode filename in ICAP Request headers, which if contains space invalidate header

### DIFF
--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -243,7 +243,8 @@ local function icap_check(task, content, digest, rule, maybe_part)
         local in_client_ip = task:get_from_ip()
         local req_hlen = 2
         if maybe_part then
-          table.insert(req_headers, string.format('GET http://%s/%s HTTP/1.0\r\n', in_client_ip, maybe_part:get_filename()))
+          table.insert(req_headers, string.format('GET http://%s/%s HTTP/1.0\r\n',
+            in_client_ip, lua_util.url_encode(maybe_part:get_filename())))
           table.insert(http_headers, string.format('Content-Type: %s/%s\r\n', maybe_part:get_detected_type()))
         else
           table.insert(req_headers, string.format('GET %s HTTP/1.0\r\n', rule.req_fake_url))

--- a/lualib/lua_util.lua
+++ b/lualib/lua_util.lua
@@ -1621,6 +1621,39 @@ local function join_path(...)
 end
 exports.join_path = join_path
 
+---[[[
+--- @function lua_util.url_encode(str)
+-- URL encode string according to RFC 3986
+--
+-- @param str The string to URL encode.
+-- @return The URL encoded string.
+--
+---]]]
+
+local function url_encode (str)
+   str = string.gsub (str, "([^0-9a-zA-Z! '&/:()*._~-])", -- locale independent
+      function (c) return string.format ("%%%02X", string.byte(c)) end)
+   str = string.gsub (str, " ", "+")
+   return str
+end
+exports.url_encode = url_encode
+
+---[[[
+--- @function lua_util.url_decode(str)
+-- URL decode string according to RFC 3986
+--
+-- @param str The string to URL decode.
+-- @return The URL decoded string.
+--
+---]]]
+
+local function url_decode (str)
+   str = string.gsub (str, "+", " ")
+   str = string.gsub (str, "%%(%x%x)", function(h) return string.char(tonumber(h,16)) end)
+   return str
+end
+exports.url_decode = url_decode
+
 -- Short unit test for sanity
 if path_sep == '/' then
   assert(join_path('/path', 'to', 'file') == '/path/to/file')


### PR DESCRIPTION
Add url_encode (and url_decode) functions to lua_util, as url encode function was not found. Add url_encode to ICAP REQ Headers filename, becuase if raw data contain spaces header becomes invalid.