### PR TITLE
[Minor] Treat *.cue attachments as harmful

### DIFF
--- a/src/plugins/lua/mime_types.lua
+++ b/src/plugins/lua/mime_types.lua
@@ -55,6 +55,7 @@ local settings = {
     bat = 2,
     chm = 4,
     com = 2,
+    cue = 2,
     exe = 1,
     hta = 2,
     iso = 4,


### PR DESCRIPTION
Rationale: https://arstechnica.com/information-technology/2023/10/one-click-remote-code-exploit-in-cd-cue-files-affects-most-gnome-based-linux-distros/