### PR TITLE
[Minor] Add missing <algorithm> include for gcc 14

### DIFF
--- a/src/libmime/mime_string.hxx
+++ b/src/libmime/mime_string.hxx
@@ -17,6 +17,7 @@
 #define RSPAMD_MIME_STRING_HXX
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <memory>

--- a/src/libstat/backends/http_backend.cxx
+++ b/src/libstat/backends/http_backend.cxx
@@ -20,6 +20,7 @@
 #include "libserver/mempool_vars_internal.h"
 #include "upstream.h"
 #include "contrib/ankerl/unordered_dense.h"
+#include <algorithm>
 #include <vector>
 
 namespace rspamd::stat::http {


### PR DESCRIPTION
This commit addresses a compilation issue when using GCC 14. According to [GCC 14's porting guide](https://gcc.gnu.org/gcc-14/porting_to.html), some C++ Standard Library headers no longer include other headers they used to use internally. Specifically, <algorithm> must now be explicitly included.

The issue was first reported in [Gentoo Bug 916438](https://bugs.gentoo.org/916438)