### PR TITLE
[Enhancement] Add composite rule for suspicious URLs in suspicious messages

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -181,6 +181,12 @@ composites {
     description = "Fake reply exhibiting characteristics of being injected into a compromised mail server, possibly e-mail thread hijacking";
     group = "compromised_hosts";
   }
+  SUSPICIOUS_URL_IN_SUSPICIOUS_MESSAGE {
+    expression = "(REDIRECTOR_URL | HAS_ANON_DOMAIN | HAS_IPFS_GATEWAY_URL) & (-g+:fuzzy | -g+:statistics | -g+:surbl | -g+:rbl)";
+    score = 1.0;
+    policy = "leave";
+    description = "Message contains redirector, anonymous or IPFS gateway URL and is marked by fuzzy/bayes/SURBL/RBL";
+  }
 
   .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/composites.conf"
   .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/composites.conf"


### PR DESCRIPTION
This rule aims at improving rspamd's catch rates for messages already exhibiting indicators of spam, containing often abused services such as redirectors. With regards to the latter, it's presence currently (and, IMO, rightly) receives +/- 0 points, but in conjunction with a message that is likely spam, redirector usage is suspicions.