### PR TITLE
Update greylist.conf

### DIFF
--- a/conf/modules.d/greylist.conf
+++ b/conf/modules.d/greylist.conf
@@ -19,7 +19,7 @@ greylist {
     "$LOCAL_CONFDIR/local.d/maps.d/greylist-whitelist-domains.inc",
   ];
 
-  expire = 1d; # 1 day by default
+  expire = 86400; # 86400 (1 day by default)
   timeout = 5min; # 5 minutes by default
   key_prefix = "rg"; # default hash name
   max_data_len = 10k; # default data limit to hash


### PR DESCRIPTION
Hi, there should be **numeric** value.
Or it die with error and another processing after this error.
`2024-01-03 00:16:47 #682935(normal) <7e95eb>; task; lua_metric_symbol_callback: call to (GREYLIST_SAVE) failed (2): /usr/share/rspamd/plugins/greylist.lua:447: bad argument #1 to 'toint' (number expected, got string); trace: [1]:{[C]:-1 - toint [C]}; [2]:{/usr/share/rspamd/plugins/greylist.lua:447 - <unknown> [Lua]};`



Easily to test for example here:
https://www.tutorialspoint.com/execute_lua_online.php
Sample code with the same error:
```
local toint = math.ifloor or math.floor
print(toint("1 day"))
```

![image](https://github.com/rspamd/rspamd/assets/8518736/81f4013e-4e3e-44eb-af6a-2ec4060d8788)

