### PR TITLE
[Fix] multimap: rawtext: use decoded parts

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -460,7 +460,7 @@ local function apply_content_filter(task, filter)
   elseif filter == 'rawtext' then
     local ret = {}
     for _, p in ipairs(task:get_text_parts()) do
-      table.insert(ret, p:get_raw_content())
+      table.insert(ret, p:get_content('raw_parsed'))
     end
     return ret
   elseif filter == 'oneline' then


### PR DESCRIPTION
Adjust behaviour of `rawtext` filter inline with documentation.

Reported by `George B` on Telegram.