### PR TITLE
[Fix] Replace comment types

### DIFF
--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -561,9 +561,9 @@ exports.rspamd_maybe_check_map = rspamd_maybe_check_map
 --     optional = true,
 --   }
 -- }
--- --[[ Then this function will look for opts.my_map parameter and try to replace it's with
--- a map with the specific type, description but not failing if it was empty.
--- It will also set options.my_map_orig to the original value defined in the map --]]
+-- -- Then this function will look for opts.my_map parameter and try to replace it's with
+-- -- a map with the specific type, description but not failing if it was empty.
+-- -- It will also set options.my_map_orig to the original value defined in the map.
 --]]
 exports.fill_config_maps = function(mname, opts, map_defs)
   assert(type(opts) == 'table')

--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -561,7 +561,7 @@ exports.rspamd_maybe_check_map = rspamd_maybe_check_map
 --     optional = true,
 --   }
 -- }
--- -- Then this function will look for opts.my_map parameter and try to replace it's with
+-- -- Then this function will look for opts.my_map parameter and try to replace it with
 -- -- a map with the specific type, description but not failing if it was empty.
 -- -- It will also set options.my_map_orig to the original value defined in the map.
 --]]


### PR DESCRIPTION
Rspamd fails to start with lua 5-1 without this change.

Bug: https://bugs.gentoo.org/922522
Fixes: b189c9fea633 ("[Minor] lua_maps docs: apply formatting")
Fixes: https://github.com/rspamd/rspamd/issues/4784