### PR TITLE
[Rework] Breaking: Do not report module as action

### DIFF
--- a/lualib/lua_verdict.lua
+++ b/lualib/lua_verdict.lua
@@ -186,23 +186,4 @@ exports.describe = function(verdict, what)
   return nil
 end
 
----[[[
--- @function lua_verdict.adjust_passthrough_action(task)
--- If an action is `soft reject` then this function extracts a module that has set this action
--- and returns an adjusted action (e.g. 'greylist' or 'ratelimit').
--- Otherwise an action is returned as is.
---]]
-exports.adjust_passthrough_action = function(task)
-  local action = task:get_metric_action()
-  if action == 'soft reject' then
-    local has_pr, _, _, module = task:has_pre_result()
-
-    if has_pr and module then
-      action = module
-    end
-  end
-
-  return action
-end
-
 return exports

--- a/src/plugins/lua/history_redis.lua
+++ b/src/plugins/lua/history_redis.lua
@@ -47,7 +47,6 @@ local lua_redis = require "lua_redis"
 local fun = require "fun"
 local ucl = require "ucl"
 local ts = (require "tableshape").types
-local lua_verdict = require "lua_verdict"
 local E = {}
 local N = "history_redis"
 local hostname = rspamd_util.get_hostname()
@@ -115,7 +114,7 @@ local function normalise_results(tbl, task)
   tbl.rmilter = nil
   tbl.messages = nil
   tbl.urls = nil
-  tbl.action = lua_verdict.adjust_passthrough_action(task)
+  tbl.action = task:get_metric_action()
 
   local seconds = task:get_timeval()['tv_sec']
   tbl.unix_time = seconds


### PR DESCRIPTION
in the /history response since we have the `passthrough_module` key for that purpose.

While that might be handy in some situations,
mixing actions and module names is confusing in general.