### PR TITLE
[Feature] Allow to add templates to redis history prefix

### DIFF
--- a/conf/modules.d/history_redis.conf
+++ b/conf/modules.d/history_redis.conf
@@ -14,7 +14,7 @@
 
 history_redis {
   #servers = 127.0.0.1:6379; # Redis server to store history
-  key_prefix = "rs_history"; # Default key name
+  key_prefix = "rs_history{{HOSTNAME}}{{COMPRESS}}"; # Default key name template
   nrows = 200; # Default rows limit
   compress = true; # Use zstd compression when storing data in redis
   subject_privacy = false; # subject privacy is off


### PR DESCRIPTION
We allow two things for now - `HOSTNAME` and `COMPRESS`. Hence, the default prefix will be the same, but the configuration default is now different to match the existing behaviour: `rs_history{{HOSTNAME}}{{COMPRESS}}`.

Issue: #4793
Closes: #4793