### PR TITLE
Support libarchive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ ENDIF ()
 FIND_PACKAGE(PkgConfig REQUIRED)
 FIND_PACKAGE(Perl REQUIRED)
 
+
 option(SANITIZE "Enable sanitizer: address, memory, undefined, leak (comma separated list)" "")
 INCLUDE(Toolset)
 INCLUDE(Sanitizer)
@@ -240,6 +241,8 @@ ProcessPackage(LIBZ LIBRARY z INCLUDE zlib.h INCLUDE_SUFFIXES include/zlib
 ProcessPackage(SODIUM LIBRARY sodium INCLUDE sodium.h
         INCLUDE_SUFFIXES include/libsodium include/sodium
         ROOT ${LIBSODIUM_ROOT_DIR} MODULES libsodium>=1.0.0)
+ProcessPackage(LIBARCHIVE LIBRARY archive INCLUDE archive.h
+        ROOT ${LIBARCHIVE_ROOT_DIR} MODULES libarchive>=3.0.0)
 
 if (ENABLE_FASTTEXT MATCHES "ON")
     ProcessPackage(FASTTEXT LIBRARY fasttext INCLUDE fasttext/fasttext.h

--- a/src/libmime/archives.c
+++ b/src/libmime/archives.c
@@ -1683,7 +1683,7 @@ rspamd_7zip_read_next_section(struct rspamd_task *task,
 			struct archive_entry *ae;
 
 			while (archive_read_next_header(a, &ae) == ARCHIVE_OK) {
-				const char *name = archive_entry_pathname(ae);
+				const char *name = archive_entry_pathname_utf8(ae);
 				if (name) {
 					msg_debug_archive("7zip: found file %s", name);
 					struct rspamd_archive_file *f = g_malloc0(sizeof(*f));

--- a/src/libmime/archives.c
+++ b/src/libmime/archives.c
@@ -1135,6 +1135,7 @@ rspamd_7zip_read_folder(struct rspamd_task *task,
 		msg_debug_archive("7zip: read codec id: %L", tmp);
 
 		if (IS_SZ_ENCRYPTED(tmp)) {
+			msg_debug_archive("7zip: encrypted codec: %L", tmp);
 			arch->flags |= RSPAMD_ARCHIVE_ENCRYPTED;
 		}
 
@@ -1691,6 +1692,12 @@ rspamd_7zip_read_next_section(struct rspamd_task *task,
 				}
 				archive_read_data_skip(a);
 			}
+
+			if (archive_read_has_encrypted_entries(a) > 0) {
+				msg_debug_archive("7zip: found encrypted stuff");
+				arch->flags |= RSPAMD_ARCHIVE_ENCRYPTED;
+			}
+
 			archive_read_free(a);
 			p = NULL; /* Stop internal processor, as we rely on libarchive here */
 			break;


### PR DESCRIPTION
Rspamd historically tried not to use heavy external dependencies and used some own code. Unfortunately, archives formats are now so complicated and it is much easier to use a robust library when the internal support is not enough. Libarchive seems to be a good option for that task, as it supports just files reading without decompression of everything. 