### PR TITLE
[Minor] Add HAS_FILE_URL rule for messages containing a file:// URL

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -938,6 +938,13 @@ reconf['HAS_GOOGLE_FIREBASE_URL'] = {
   group = 'url'
 }
 
+reconf['HAS_FILE_URL'] = {
+  re = '/^file:\\/\\//{url}i',
+  description = 'Contains file:// URL',
+  score = 2.0,
+  group = 'url'
+}
+
 reconf['XM_UA_NO_VERSION'] = {
   re = string.format('(!%s && !%s) && (%s || %s)',
       'X-Mailer=/https?:/H',


### PR DESCRIPTION
These are frequently abused for distributing malware via non-HTTP protocols, such as public Samba servers. file:// URLs may also be abused for including files from the victims' machine in a message. Either way, a legitimate usecase is unlikely.

Unfortunately, I was not able to figure out how to include the URL(s) matched in rspamd's results. This applies to other rules in this file as well, such as `HAS_GOOGLE_REDIR` and `HAS_GOOGLE_FIREBASE_URL`: For forensic reasons, it might be useful to log the URLs these were triggering on.

Is this something that can be achieved easily?