### PR TITLE
[Feature] Support reply in message pack format

### DIFF
--- a/contrib/libucl/ucl_parser.c
+++ b/contrib/libucl/ucl_parser.c
@@ -2984,7 +2984,7 @@ ucl_parser_add_chunk_full (struct ucl_parser *parser, const unsigned char *data,
 
 		if (parse_type == UCL_PARSE_AUTO && len > 0) {
 			/* We need to detect parse type by the first symbol */
-			if ((*data & 0x80) == 0x80 && (*data >= 0xdc && *data <= 0xdf)) {
+			if ((*data & 0x80) == 0x80) {
 				parse_type = UCL_PARSE_MSGPACK;
 			}
 			else if (*data == '(') {

--- a/src/client/rspamdclient.c
+++ b/src/client/rspamdclient.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -232,7 +232,9 @@ rspamd_client_finish_handler(struct rspamd_http_connection *conn,
 		}
 
 		parser = ucl_parser_new(0);
-		if (!ucl_parser_add_chunk(parser, start, len)) {
+		if (!ucl_parser_add_chunk_full(parser, start, len,
+									   ucl_parser_get_default_priority(parser),
+									   UCL_DUPLICATE_APPEND, UCL_PARSE_AUTO)) {
 			err = g_error_new(RCLIENT_ERROR, msg->code, "Cannot parse UCL: %s",
 							  ucl_parser_get_error(parser));
 			ucl_parser_free(parser);
@@ -453,6 +455,11 @@ rspamd_client_command(struct rspamd_client_connection *conn,
 	if (filename) {
 		rspamd_http_message_add_header(req->msg, "Filename", filename);
 	}
+
+	/*
+	 * Allow messagepack reply if supported
+	 */
+	rspamd_http_message_add_header(req->msg, "Accept", "application/msgpack");
 
 	req->msg->url = rspamd_fstring_append(req->msg->url, "/", 1);
 	req->msg->url = rspamd_fstring_append(req->msg->url, command, strlen(command));

--- a/src/controller.c
+++ b/src/controller.c
@@ -2008,7 +2008,7 @@ rspamd_controller_scan_reply(struct rspamd_task *task)
 	const rspamd_ftok_t *accept_hdr = rspamd_task_get_request_header(task, "Accept");
 
 	if (accept_hdr && rspamd_substring_search(accept_hdr->begin, accept_hdr->len,
-											  "application/msgpack", sizeof("application/msgpack") - 1)) {
+											  "application/msgpack", sizeof("application/msgpack") - 1) != -1) {
 		ctype = "application/msgpack";
 		out_type = UCL_EMIT_MSGPACK;
 	}

--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -2116,7 +2116,7 @@ void rspamd_protocol_write_reply(struct rspamd_task *task, ev_tstamp timeout)
 	accept_hdr = rspamd_task_get_request_header(task, "Accept");
 
 	if (accept_hdr && rspamd_substring_search(accept_hdr->begin, accept_hdr->len,
-											  "application/msgpack", sizeof("application/msgpack") - 1)) {
+											  "application/msgpack", sizeof("application/msgpack") - 1) != -1) {
 		ctype = "application/msgpack";
 		out_type = UCL_EMIT_MSGPACK;
 	}

--- a/src/libserver/protocol.h
+++ b/src/libserver/protocol.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * @file protocol.h
  * Rspamd protocol definition
@@ -70,7 +86,8 @@ gboolean rspamd_protocol_handle_request(struct rspamd_task *task,
  * @param task
  */
 void rspamd_protocol_http_reply(struct rspamd_http_message *msg,
-								struct rspamd_task *task, ucl_object_t **pobj);
+								struct rspamd_task *task, ucl_object_t **pobj,
+								int how);
 
 /**
  * Write data to log pipes

--- a/src/lua/lua_common.c
+++ b/src/lua/lua_common.c
@@ -1974,8 +1974,7 @@ rspamd_lua_check_udata_common(lua_State *L, gint pos, const gchar *classname,
 							  gboolean fatal)
 {
 	void *p = lua_touserdata(L, pos);
-	guint i, top = lua_gettop(L);
-	khiter_t k;
+	gint i, top = lua_gettop(L);
 
 	if (p == NULL) {
 		goto err;

--- a/src/rspamd_proxy.c
+++ b/src/rspamd_proxy.c
@@ -1718,7 +1718,7 @@ rspamd_proxy_scan_self_reply(struct rspamd_task *task)
 	const rspamd_ftok_t *accept_hdr = rspamd_task_get_request_header(task, "Accept");
 
 	if (accept_hdr && rspamd_substring_search(accept_hdr->begin, accept_hdr->len,
-											  "application/msgpack", sizeof("application/msgpack") - 1)) {
+											  "application/msgpack", sizeof("application/msgpack") - 1) != -1) {
 		ctype = "application/msgpack";
 		out_type = UCL_EMIT_MSGPACK;
 	}


### PR DESCRIPTION
Rspamd currently sends reply in JSON format. However, message pack seems to be a better choice for a compatible client. It is faster and does not need escaping or even UTF8 validation. This is a surface for further updates.