### PR TITLE
[Rework] Remove some of the GLib types in lieu of standard ones

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -108,7 +108,7 @@ INIT_LOG_MODULE(controller)
 #define COLOR_REJECT "#CB4B4B"
 #define COLOR_TOTAL "#9440ED"
 
-static const guint64 rspamd_controller_ctx_magic = 0xf72697805e6941faULL;
+static const uint64_t rspamd_controller_ctx_magic = 0xf72697805e6941faULL;
 
 extern void fuzzy_stat_command(struct rspamd_task *task);
 
@@ -128,7 +128,7 @@ worker_t controller_worker = {
  * Worker's context
  */
 struct rspamd_controller_worker_ctx {
-	guint64 magic;
+	uint64_t magic;
 	/* Events base */
 	struct ev_loop *event_loop;
 	/* DNS resolver */
@@ -203,7 +203,7 @@ rspamd_is_encrypted_password(const gchar *password,
 							 struct rspamd_controller_pbkdf const **pbkdf)
 {
 	const gchar *start, *end;
-	gint64 id;
+	int64_t id;
 	gsize size, i;
 	gboolean ret = FALSE;
 	const struct rspamd_controller_pbkdf *p;
@@ -2590,7 +2590,7 @@ struct rspamd_stat_cbdata {
 	ucl_object_t *top;
 	ucl_object_t *stat;
 	struct rspamd_task *task;
-	guint64 learned;
+	uint64_t learned;
 };
 
 static gboolean
@@ -2660,7 +2660,7 @@ rspamd_controller_handle_stat_common(
 	ucl_object_t *top, *sub;
 	gint i;
 	int64_t uptime;
-	guint64 spam = 0, ham = 0;
+	uint64_t spam = 0, ham = 0;
 	rspamd_mempool_stat_t mem_st;
 	struct rspamd_stat *stat, stat_copy;
 	struct rspamd_controller_worker_ctx *ctx;
@@ -3097,7 +3097,7 @@ rspamd_controller_handle_metrics_common(
 	ucl_object_t *top, *sub;
 	gint i;
 	int64_t uptime;
-	guint64 spam = 0, ham = 0;
+	uint64_t spam = 0, ham = 0;
 	rspamd_mempool_stat_t mem_st;
 	struct rspamd_stat *stat, stat_copy;
 	struct rspamd_controller_worker_ctx *ctx;

--- a/src/hs_helper.c
+++ b/src/hs_helper.c
@@ -39,13 +39,13 @@ worker_t hs_helper_worker = {
 
 static const gdouble default_max_time = 1.0;
 static const gdouble default_recompile_time = 60.0;
-static const guint64 rspamd_hs_helper_magic = 0x22d310157a2288a0ULL;
+static const uint64_t rspamd_hs_helper_magic = 0x22d310157a2288a0ULL;
 
 /*
  * Worker's context
  */
 struct hs_helper_ctx {
-	guint64 magic;
+	uint64_t magic;
 	/* Events base */
 	struct ev_loop *event_loop;
 	/* DNS resolver */

--- a/src/libcryptobox/chacha20/ref.c
+++ b/src/libcryptobox/chacha20/ref.c
@@ -5,7 +5,7 @@
 #if defined(HAVE_INT32)
 typedef uint32_t chacha_int32;
 #else
-typedef guint32 chacha_int32;
+typedef uint32_t chacha_int32;
 #endif
 
 /* interpret four 8 bit unsigned integers as a 32 bit unsigned integer in little endian */

--- a/src/libcryptobox/cryptobox.c
+++ b/src/libcryptobox/cryptobox.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -72,7 +72,7 @@ static const guchar n0[16] = {0};
 static void
 rspamd_cryptobox_cpuid(gint cpu[4], gint info)
 {
-	guint32 __attribute__((unused)) eax, __attribute__((unused)) ecx = 0, __attribute__((unused)) ebx = 0, __attribute__((unused)) edx = 0;
+	uint32_t __attribute__((unused)) eax, __attribute__((unused)) ecx = 0, __attribute__((unused)) ebx = 0, __attribute__((unused)) edx = 0;
 
 	eax = info;
 #if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
@@ -111,7 +111,7 @@ static gboolean
 rspamd_cryptobox_test_instr(gint instr)
 {
 	void (*old_handler)(int);
-	guint32 rd;
+	uint32_t rd;
 
 #if defined(__GNUC__)
 	ok = 1;
@@ -187,9 +187,9 @@ struct rspamd_cryptobox_library_ctx *
 rspamd_cryptobox_init(void)
 {
 	gint cpu[4], nid;
-	const guint32 osxsave_mask = (1 << 27);
-	const guint32 fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
-	const guint32 avx2_bmi12_mask = (1 << 5) | (1 << 3) | (1 << 8);
+	const uint32_t osxsave_mask = (1 << 27);
+	const uint32_t fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
+	const uint32_t avx2_bmi12_mask = (1 << 5) | (1 << 3) | (1 << 8);
 	gulong bit;
 	static struct rspamd_cryptobox_library_ctx *ctx;
 	GString *buf;
@@ -207,32 +207,32 @@ rspamd_cryptobox_init(void)
 	rspamd_cryptobox_cpuid(cpu, 1);
 
 	if (nid > 1) {
-		if ((cpu[3] & ((guint32) 1 << 26))) {
+		if ((cpu[3] & ((uint32_t) 1 << 26))) {
 			if (rspamd_cryptobox_test_instr(CPUID_SSE2)) {
 				cpu_config |= CPUID_SSE2;
 			}
 		}
-		if ((cpu[2] & ((guint32) 1 << 0))) {
+		if ((cpu[2] & ((uint32_t) 1 << 0))) {
 			if (rspamd_cryptobox_test_instr(CPUID_SSE3)) {
 				cpu_config |= CPUID_SSE3;
 			}
 		}
-		if ((cpu[2] & ((guint32) 1 << 9))) {
+		if ((cpu[2] & ((uint32_t) 1 << 9))) {
 			if (rspamd_cryptobox_test_instr(CPUID_SSSE3)) {
 				cpu_config |= CPUID_SSSE3;
 			}
 		}
-		if ((cpu[2] & ((guint32) 1 << 19))) {
+		if ((cpu[2] & ((uint32_t) 1 << 19))) {
 			if (rspamd_cryptobox_test_instr(CPUID_SSE41)) {
 				cpu_config |= CPUID_SSE41;
 			}
 		}
-		if ((cpu[2] & ((guint32) 1 << 20))) {
+		if ((cpu[2] & ((uint32_t) 1 << 20))) {
 			if (rspamd_cryptobox_test_instr(CPUID_SSE42)) {
 				cpu_config |= CPUID_SSE42;
 			}
 		}
-		if ((cpu[2] & ((guint32) 1 << 30))) {
+		if ((cpu[2] & ((uint32_t) 1 << 30))) {
 			if (rspamd_cryptobox_test_instr(CPUID_RDRAND)) {
 				cpu_config |= CPUID_RDRAND;
 			}
@@ -240,7 +240,7 @@ rspamd_cryptobox_init(void)
 
 		/* OSXSAVE */
 		if ((cpu[2] & osxsave_mask) == osxsave_mask) {
-			if ((cpu[2] & ((guint32) 1 << 28))) {
+			if ((cpu[2] & ((uint32_t) 1 << 28))) {
 				if (rspamd_cryptobox_test_instr(CPUID_AVX)) {
 					cpu_config |= CPUID_AVX;
 				}
@@ -1529,10 +1529,10 @@ G_STATIC_ASSERT(sizeof(struct XXH3_state_s) <=
 
 struct RSPAMD_ALIGNED(16) _mum_iuf {
 	union {
-		gint64 ll;
-		unsigned char b[sizeof(guint64)];
+		int64_t ll;
+		unsigned char b[sizeof(uint64_t)];
 	} buf;
-	gint64 h;
+	int64_t h;
 	unsigned rem;
 };
 
@@ -1556,7 +1556,7 @@ void rspamd_cryptobox_fast_hash_free(rspamd_cryptobox_fast_hash_state_t *st)
 }
 
 void rspamd_cryptobox_fast_hash_init(rspamd_cryptobox_fast_hash_state_t *st,
-									 guint64 seed)
+									 uint64_t seed)
 {
 	XXH3_state_t *xst = (XXH3_state_t *) st->opaque;
 	st->type = RSPAMD_CRYPTOBOX_XXHASH3;
@@ -1566,7 +1566,7 @@ void rspamd_cryptobox_fast_hash_init(rspamd_cryptobox_fast_hash_state_t *st,
 
 void rspamd_cryptobox_fast_hash_init_specific(rspamd_cryptobox_fast_hash_state_t *st,
 											  enum rspamd_cryptobox_fast_hash_type type,
-											  guint64 seed)
+											  uint64_t seed)
 {
 	switch (type) {
 	case RSPAMD_CRYPTOBOX_T1HA:
@@ -1664,7 +1664,7 @@ void rspamd_cryptobox_fast_hash_update(rspamd_cryptobox_fast_hash_state_t *st,
 
 			/* Leftover */
 			if (drem > 0) {
-				iuf->rem = sizeof(guint64) - drem;
+				iuf->rem = sizeof(uint64_t) - drem;
 				iuf->buf.ll = 0;
 				memcpy(iuf->buf.b, p, drem);
 			}
@@ -1681,10 +1681,10 @@ void rspamd_cryptobox_fast_hash_update(rspamd_cryptobox_fast_hash_state_t *st,
 	}
 }
 
-guint64
+uint64_t
 rspamd_cryptobox_fast_hash_final(rspamd_cryptobox_fast_hash_state_t *st)
 {
-	guint64 ret;
+	uint64_t ret;
 
 	if (st->type == RSPAMD_CRYPTOBOX_T1HA) {
 		t1ha_context_t *rst = (t1ha_context_t *) st->opaque;
@@ -1731,32 +1731,32 @@ rspamd_cryptobox_fast_hash_final(rspamd_cryptobox_fast_hash_state_t *st)
 /**
  * One in all function
  */
-static inline guint64
+static inline uint64_t
 rspamd_cryptobox_fast_hash_machdep(const void *data,
-								   gsize len, guint64 seed)
+								   gsize len, uint64_t seed)
 {
 	return XXH3_64bits_withSeed(data, len, seed);
 }
 
-static inline guint64
+static inline uint64_t
 rspamd_cryptobox_fast_hash_indep(const void *data,
-								 gsize len, guint64 seed)
+								 gsize len, uint64_t seed)
 {
 	return XXH3_64bits_withSeed(data, len, seed);
 }
 
-guint64
+uint64_t
 rspamd_cryptobox_fast_hash(const void *data,
-						   gsize len, guint64 seed)
+						   gsize len, uint64_t seed)
 {
 	return rspamd_cryptobox_fast_hash_machdep(data, len, seed);
 }
 
-guint64
+uint64_t
 rspamd_cryptobox_fast_hash_specific(
 	enum rspamd_cryptobox_fast_hash_type type,
 	const void *data,
-	gsize len, guint64 seed)
+	gsize len, uint64_t seed)
 {
 	switch (type) {
 	case RSPAMD_CRYPTOBOX_XXHASH32:

--- a/src/libcryptobox/cryptobox.h
+++ b/src/libcryptobox/cryptobox.h
@@ -375,7 +375,7 @@ void rspamd_cryptobox_fast_hash_free(rspamd_cryptobox_fast_hash_state_t *st);
  * non-keyed hash is generated
  */
 void rspamd_cryptobox_fast_hash_init(rspamd_cryptobox_fast_hash_state_t *st,
-									 guint64 seed);
+									 uint64_t seed);
 
 /**
  * Init cryptobox hash state using key if needed, `st` must point to the buffer
@@ -384,7 +384,7 @@ void rspamd_cryptobox_fast_hash_init(rspamd_cryptobox_fast_hash_state_t *st,
  */
 void rspamd_cryptobox_fast_hash_init_specific(rspamd_cryptobox_fast_hash_state_t *st,
 											  enum rspamd_cryptobox_fast_hash_type type,
-											  guint64 seed);
+											  uint64_t seed);
 
 /**
  * Update hash with data portion
@@ -395,21 +395,21 @@ void rspamd_cryptobox_fast_hash_update(rspamd_cryptobox_fast_hash_state_t *st,
 /**
  * Output hash to the buffer of rspamd_cryptobox_HASHBYTES length
  */
-guint64 rspamd_cryptobox_fast_hash_final(rspamd_cryptobox_fast_hash_state_t *st);
+uint64_t rspamd_cryptobox_fast_hash_final(rspamd_cryptobox_fast_hash_state_t *st);
 
 /**
  * One in all function
  */
-guint64 rspamd_cryptobox_fast_hash(const void *data,
-								   gsize len, guint64 seed);
+uint64_t rspamd_cryptobox_fast_hash(const void *data,
+									gsize len, uint64_t seed);
 
 /**
  * Platform independent version
  */
-guint64 rspamd_cryptobox_fast_hash_specific(
+uint64_t rspamd_cryptobox_fast_hash_specific(
 	enum rspamd_cryptobox_fast_hash_type type,
 	const void *data,
-	gsize len, guint64 seed);
+	gsize len, uint64_t seed);
 
 /**
  * Decode base64 using platform optimized code

--- a/src/libcryptobox/keypair.c
+++ b/src/libcryptobox/keypair.c
@@ -447,7 +447,7 @@ rspamd_pubkey_get_nm(struct rspamd_cryptobox_pubkey *p,
 	g_assert(p != NULL);
 
 	if (p->nm) {
-		if (memcmp(kp->id, (const guchar *) &p->nm->sk_id, sizeof(guint64)) == 0) {
+		if (memcmp(kp->id, (const guchar *) &p->nm->sk_id, sizeof(uint64_t)) == 0) {
 			return p->nm->nm;
 		}
 
@@ -472,7 +472,7 @@ rspamd_pubkey_calculate_nm(struct rspamd_cryptobox_pubkey *p,
 			abort();
 		}
 
-		memcpy(&p->nm->sk_id, kp->id, sizeof(guint64));
+		memcpy(&p->nm->sk_id, kp->id, sizeof(uint64_t));
 		REF_INIT_RETAIN(p->nm, rspamd_cryptobox_nm_dtor);
 	}
 

--- a/src/libcryptobox/keypair_private.h
+++ b/src/libcryptobox/keypair_private.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 struct rspamd_cryptobox_nm {
 	guchar nm[rspamd_cryptobox_MAX_NMBYTES];
-	guint64 sk_id; /* Used to store secret key id */
+	uint64_t sk_id; /* Used to store secret key id */
 	ref_entry_t ref;
 };
 

--- a/src/libcryptobox/keypairs_cache.c
+++ b/src/libcryptobox/keypairs_cache.c
@@ -104,7 +104,7 @@ void rspamd_keypair_cache_process(struct rspamd_keypair_cache *c,
 		memcpy(new->pair, rk->id, rspamd_cryptobox_HASHBYTES);
 		memcpy(&new->pair[rspamd_cryptobox_HASHBYTES], lk->id,
 			   rspamd_cryptobox_HASHBYTES);
-		memcpy(&new->nm->sk_id, lk->id, sizeof(guint64));
+		memcpy(&new->nm->sk_id, lk->id, sizeof(uint64_t));
 
 		if (rk->alg == RSPAMD_CRYPTOBOX_MODE_25519) {
 			struct rspamd_cryptobox_pubkey_25519 *rk_25519 =

--- a/src/libmime/archives.c
+++ b/src/libmime/archives.c
@@ -68,7 +68,7 @@ rspamd_archive_file_try_utf(struct rspamd_task *task,
 	if (charset) {
 		UChar *tmp;
 		UErrorCode uc_err = U_ZERO_ERROR;
-		gint32 r, clen, dlen;
+		int32_t r, clen, dlen;
 		struct rspamd_charset_converter *conv;
 		UConverter *utf8_converter;
 
@@ -174,10 +174,10 @@ rspamd_archive_process_zip(struct rspamd_task *task,
 						   struct rspamd_mime_part *part)
 {
 	const guchar *p, *start, *end, *eocd = NULL, *cd;
-	const guint32 eocd_magic = 0x06054b50, cd_basic_len = 46;
+	const uint32_t eocd_magic = 0x06054b50, cd_basic_len = 46;
 	const guchar cd_magic[] = {0x50, 0x4b, 0x01, 0x02};
 	const guint max_processed = 1024;
-	guint32 cd_offset, cd_size, comp_size, uncomp_size, processed = 0;
+	uint32_t cd_offset, cd_size, comp_size, uncomp_size, processed = 0;
 	guint16 extra_len, fname_len, comment_len;
 	struct rspamd_archive *arch;
 	struct rspamd_archive_file *f = NULL;
@@ -193,8 +193,8 @@ rspamd_archive_process_zip(struct rspamd_task *task,
 	 */
 	p -= 21;
 
-	while (p > start + sizeof(guint32)) {
-		guint32 t;
+	while (p > start + sizeof(uint32_t)) {
+		uint32_t t;
 
 		if (processed > max_processed) {
 			break;
@@ -263,9 +263,9 @@ rspamd_archive_process_zip(struct rspamd_task *task,
 
 		memcpy(&flags, cd + 8, sizeof(guint16));
 		flags = GUINT16_FROM_LE(flags);
-		memcpy(&comp_size, cd + 20, sizeof(guint32));
+		memcpy(&comp_size, cd + 20, sizeof(uint32_t));
 		comp_size = GUINT32_FROM_LE(comp_size);
-		memcpy(&uncomp_size, cd + 24, sizeof(guint32));
+		memcpy(&uncomp_size, cd + 24, sizeof(uint32_t));
 		uncomp_size = GUINT32_FROM_LE(uncomp_size);
 		memcpy(&fname_len, cd + 28, sizeof(fname_len));
 		fname_len = GUINT16_FROM_LE(fname_len);
@@ -333,7 +333,7 @@ rspamd_archive_process_zip(struct rspamd_task *task,
 }
 
 static inline gint
-rspamd_archive_rar_read_vint(const guchar *start, gsize remain, guint64 *res)
+rspamd_archive_rar_read_vint(const guchar *start, gsize remain, uint64_t *res)
 {
 	/*
 	 * From http://www.rarlab.com/technote.htm:
@@ -344,16 +344,16 @@ rspamd_archive_rar_read_vint(const guchar *start, gsize remain, guint64 *res)
 	 * So first byte contains 7 least significant bits of integer and
 	 * continuation flag. Second byte, if present, contains next 7 bits and so on.
 	 */
-	guint64 t = 0;
+	uint64_t t = 0;
 	guint shift = 0;
 	const guchar *p = start;
 
 	while (remain > 0 && shift <= 57) {
 		if (*p & 0x80) {
-			t |= ((guint64) (*p & 0x7f)) << shift;
+			t |= ((uint64_t) (*p & 0x7f)) << shift;
 		}
 		else {
-			t |= ((guint64) (*p & 0x7f)) << shift;
+			t |= ((uint64_t) (*p & 0x7f)) << shift;
 			p++;
 			break;
 		}
@@ -420,12 +420,12 @@ rspamd_archive_rar_read_vint(const guchar *start, gsize remain, guint64 *res)
 
 #define RAR_READ_UINT32(n)                                                                    \
 	do {                                                                                      \
-		if (end - p < (glong) sizeof(guint32)) {                                              \
+		if (end - p < (glong) sizeof(uint32_t)) {                                             \
 			msg_debug_archive("rar archive is invalid (bad int32)");                          \
 			return;                                                                           \
 		}                                                                                     \
 		n = (guint) p[0] + ((guint) p[1] << 8) + ((guint) p[2] << 16) + ((guint) p[3] << 24); \
-		p += sizeof(guint32);                                                                 \
+		p += sizeof(uint32_t);                                                                \
 	} while (0)
 
 static void
@@ -435,7 +435,7 @@ rspamd_archive_process_rar_v4(struct rspamd_task *task, const guchar *start,
 	const guchar *p = start, *start_section;
 	guint8 type;
 	guint flags;
-	guint64 sz, comp_sz = 0, uncomp_sz = 0;
+	uint64_t sz, comp_sz = 0, uncomp_sz = 0;
 	struct rspamd_archive *arch;
 	struct rspamd_archive_file *f;
 
@@ -468,7 +468,7 @@ rspamd_archive_process_rar_v4(struct rspamd_task *task, const guchar *start,
 
 		if (flags & 0x8000) {
 			/* We also need to read ADD_SIZE element */
-			guint32 tmp;
+			uint32_t tmp;
 
 			RAR_READ_UINT32(tmp);
 			sz += tmp;
@@ -505,7 +505,7 @@ rspamd_archive_process_rar_v4(struct rspamd_task *task, const guchar *start,
 
 			if (flags & 0x100) {
 				/* We also need to read HIGH_PACK_SIZE */
-				guint32 tmp;
+				uint32_t tmp;
 
 				RAR_READ_UINT32(tmp);
 				sz += tmp;
@@ -579,8 +579,8 @@ rspamd_archive_process_rar(struct rspamd_task *task,
 				 rar_v4_magic[] = {0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00};
 	const guint rar_encrypted_header = 4, rar_main_header = 1,
 				rar_file_header = 2;
-	guint64 vint, sz, comp_sz = 0, uncomp_sz = 0, flags = 0, type = 0,
-					  extra_sz = 0;
+	uint64_t vint, sz, comp_sz = 0, uncomp_sz = 0, flags = 0, type = 0,
+					   extra_sz = 0;
 	struct rspamd_archive *arch;
 	struct rspamd_archive_file *f;
 	gint r;
@@ -621,7 +621,7 @@ rspamd_archive_process_rar(struct rspamd_task *task,
 
 	/* Now we can have either encryption header or archive header */
 	/* Crc 32 */
-	RAR_SKIP_BYTES(sizeof(guint32));
+	RAR_SKIP_BYTES(sizeof(uint32_t));
 	/* Size */
 	RAR_READ_VINT_SKIP();
 	sz = vint;
@@ -662,7 +662,7 @@ rspamd_archive_process_rar(struct rspamd_task *task,
 		gboolean has_extra = FALSE;
 		/* Read the next header */
 		/* Crc 32 */
-		RAR_SKIP_BYTES(sizeof(guint32));
+		RAR_SKIP_BYTES(sizeof(uint32_t));
 		/* Size */
 		RAR_READ_VINT_SKIP();
 
@@ -702,7 +702,7 @@ rspamd_archive_process_rar(struct rspamd_task *task,
 		}
 		else {
 			/* We have a file header, go forward */
-			guint64 fname_len;
+			uint64_t fname_len;
 			bool is_directory = false;
 
 			/* File header specific flags */
@@ -717,11 +717,11 @@ rspamd_archive_process_rar(struct rspamd_task *task,
 
 			if (flags & 0x2) {
 				/* Unix mtime */
-				RAR_SKIP_BYTES(sizeof(guint32));
+				RAR_SKIP_BYTES(sizeof(uint32_t));
 			}
 			if (flags & 0x4) {
 				/* Crc32 */
-				RAR_SKIP_BYTES(sizeof(guint32));
+				RAR_SKIP_BYTES(sizeof(uint32_t));
 			}
 			if (flags & 0x1) {
 				/* Ignore directories for sanity purposes */
@@ -768,7 +768,7 @@ rspamd_archive_process_rar(struct rspamd_task *task,
 
 					while (ex < p + extra_sz) {
 						const guchar *t;
-						gint64 cur_sz = 0, sec_type = 0;
+						int64_t cur_sz = 0, sec_type = 0;
 
 						r = rspamd_archive_rar_read_vint(ex, extra_sz, &cur_sz);
 						if (r == -1) {
@@ -808,7 +808,7 @@ end:
 }
 
 static inline gint
-rspamd_archive_7zip_read_vint(const guchar *start, gsize remain, guint64 *res)
+rspamd_archive_7zip_read_vint(const guchar *start, gsize remain, uint64_t *res)
 {
 	/*
 	 * REAL_UINT64 means real UINT64.
@@ -839,17 +839,17 @@ rspamd_archive_7zip_read_vint(const guchar *start, gsize remain, guint64 *res)
 		return 1;
 	}
 	else if (t == 0xFF) {
-		if (remain >= sizeof(guint64) + 1) {
-			memcpy(res, start + 1, sizeof(guint64));
+		if (remain >= sizeof(uint64_t) + 1) {
+			memcpy(res, start + 1, sizeof(uint64_t));
 			*res = GUINT64_FROM_LE(*res);
 
-			return sizeof(guint64) + 1;
+			return sizeof(uint64_t) + 1;
 		}
 	}
 	else {
 		gint cur_bit = 6, intlen = 1;
 		const guchar bmask = 0xFF;
-		guint64 tgt;
+		uint64_t tgt;
 
 		while (cur_bit > 0) {
 			if (!isset(&t, cur_bit)) {
@@ -859,7 +859,7 @@ rspamd_archive_7zip_read_vint(const guchar *start, gsize remain, guint64 *res)
 					/* Shift back */
 					tgt >>= sizeof(tgt) - NBBY * intlen;
 					/* Add masked value */
-					tgt += (guint64) (t & (bmask >> (NBBY - cur_bit)))
+					tgt += (uint64_t) (t & (bmask >> (NBBY - cur_bit)))
 						   << (NBBY * intlen);
 					*res = tgt;
 
@@ -896,13 +896,13 @@ rspamd_archive_7zip_read_vint(const guchar *start, gsize remain, guint64 *res)
 
 #define SZ_READ_UINT64(n)                                                            \
 	do {                                                                             \
-		if (end - p < (goffset) sizeof(guint64)) {                                   \
+		if (end - p < (goffset) sizeof(uint64_t)) {                                  \
 			msg_debug_archive("7zip archive is invalid (bad uint64): %s", G_STRLOC); \
 			return;                                                                  \
 		}                                                                            \
-		memcpy(&(n), p, sizeof(guint64));                                            \
+		memcpy(&(n), p, sizeof(uint64_t));                                           \
 		n = GUINT64_FROM_LE(n);                                                      \
-		p += sizeof(guint64);                                                        \
+		p += sizeof(uint64_t);                                                       \
 	} while (0)
 #define SZ_SKIP_BYTES(n)                                                                                                                             \
 	do {                                                                                                                                             \
@@ -985,11 +985,11 @@ static const guchar *
 rspamd_7zip_read_digest(struct rspamd_task *task,
 						const guchar *p, const guchar *end,
 						struct rspamd_archive *arch,
-						guint64 num_streams,
+						uint64_t num_streams,
 						guint *pdigest_read)
 {
 	guchar all_defined = *p;
-	guint64 i;
+	uint64_t i;
 	guint num_defined = 0;
 	/*
 	 * BYTE AllAreDefined
@@ -1019,7 +1019,7 @@ rspamd_7zip_read_digest(struct rspamd_task *task,
 	}
 
 	for (i = 0; i < num_defined; i++) {
-		SZ_SKIP_BYTES(sizeof(guint32));
+		SZ_SKIP_BYTES(sizeof(uint32_t));
 	}
 
 	if (pdigest_read) {
@@ -1034,7 +1034,7 @@ rspamd_7zip_read_pack_info(struct rspamd_task *task,
 						   const guchar *p, const guchar *end,
 						   struct rspamd_archive *arch)
 {
-	guint64 pack_pos = 0, pack_streams = 0, i, cur_sz;
+	uint64_t pack_pos = 0, pack_streams = 0, i, cur_sz;
 	guint num_digests = 0;
 	guchar t;
 	/*
@@ -1094,12 +1094,12 @@ rspamd_7zip_read_folder(struct rspamd_task *task,
 						const guchar *p, const guchar *end,
 						struct rspamd_archive *arch, guint *pnstreams, guint *ndigests)
 {
-	guint64 ncoders = 0, i, j, noutstreams = 0, ninstreams = 0;
+	uint64_t ncoders = 0, i, j, noutstreams = 0, ninstreams = 0;
 
 	SZ_READ_VINT(ncoders);
 
 	for (i = 0; i < ncoders && p != NULL && p < end; i++) {
-		guint64 sz, tmp;
+		uint64_t sz, tmp;
 		guchar t;
 		/*
 		 * BYTE
@@ -1163,21 +1163,21 @@ rspamd_7zip_read_folder(struct rspamd_task *task,
 	if (noutstreams > 1) {
 		/* BindPairs, WTF, huh */
 		for (i = 0; i < noutstreams - 1; i++) {
-			guint64 tmp;
+			uint64_t tmp;
 
 			SZ_READ_VINT(tmp);
 			SZ_READ_VINT(tmp);
 		}
 	}
 
-	gint64 npacked = (gint64) ninstreams - (gint64) noutstreams + 1;
+	int64_t npacked = (int64_t) ninstreams - (int64_t) noutstreams + 1;
 	msg_debug_archive("7zip: instreams=%L, outstreams=%L, packed=%L",
 					  ninstreams, noutstreams, npacked);
 
 	if (npacked > 1) {
 		/* Gah... */
 		for (i = 0; i < npacked; i++) {
-			guint64 tmp;
+			uint64_t tmp;
 
 			SZ_READ_VINT(tmp);
 		}
@@ -1195,7 +1195,7 @@ rspamd_7zip_read_coders_info(struct rspamd_task *task,
 							 struct rspamd_archive *arch,
 							 guint *pnum_folders, guint *pnum_nodigest)
 {
-	guint64 num_folders = 0, i, tmp;
+	uint64_t num_folders = 0, i, tmp;
 	guchar t;
 	guint *folder_nstreams = NULL, num_digests = 0, digests_read = 0;
 
@@ -1323,15 +1323,15 @@ rspamd_7zip_read_substreams_info(struct rspamd_task *task,
 {
 	guchar t;
 	guint i;
-	guint64 *folder_nstreams;
+	uint64_t *folder_nstreams;
 
 	if (num_folders > 8192) {
 		/* Gah */
 		return NULL;
 	}
 
-	folder_nstreams = g_alloca(sizeof(guint64) * num_folders);
-	memset(folder_nstreams, 0, sizeof(guint64) * num_folders);
+	folder_nstreams = g_alloca(sizeof(uint64_t) * num_folders);
+	memset(folder_nstreams, 0, sizeof(uint64_t) * num_folders);
 
 	while (p != NULL && p < end) {
 		/*
@@ -1360,7 +1360,7 @@ rspamd_7zip_read_substreams_info(struct rspamd_task *task,
 		switch (t) {
 		case kNumUnPackStream:
 			for (i = 0; i < num_folders; i++) {
-				guint64 tmp;
+				uint64_t tmp;
 
 				SZ_READ_VINT(tmp);
 				folder_nstreams[i] = tmp;
@@ -1381,7 +1381,7 @@ rspamd_7zip_read_substreams_info(struct rspamd_task *task,
 			 */
 			for (i = 0; i < num_folders; i++) {
 				for (guint j = 0; j < folder_nstreams[i]; j++) {
-					guint64 tmp;
+					uint64_t tmp;
 
 					SZ_READ_VINT(tmp); /* Who cares indeed */
 				}
@@ -1465,7 +1465,7 @@ rspamd_7zip_read_archive_props(struct rspamd_task *task,
 							   struct rspamd_archive *arch)
 {
 	guchar proptype;
-	guint64 proplen;
+	uint64_t proplen;
 
 	/*
 	 * for (;;)
@@ -1543,7 +1543,7 @@ rspamd_7zip_read_files_info(struct rspamd_task *task,
 							const guchar *p, const guchar *end,
 							struct rspamd_archive *arch)
 {
-	guint64 nfiles = 0, sz, i;
+	uint64_t nfiles = 0, sz, i;
 	guchar t, b;
 	struct rspamd_archive_file *fentry;
 
@@ -1584,7 +1584,7 @@ rspamd_7zip_read_files_info(struct rspamd_task *task,
 				/* TODO: for the god sake, do something about external
 				 * filenames...
 				 */
-				guint64 tmp;
+				uint64_t tmp;
 
 				SZ_READ_VINT(tmp);
 			}
@@ -1734,13 +1734,13 @@ rspamd_archive_process_7zip(struct rspamd_task *task,
 	struct rspamd_archive *arch;
 	const guchar *start, *p, *end;
 	const guchar sz_magic[] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
-	guint64 section_offset = 0, section_length = 0;
+	uint64_t section_offset = 0, section_length = 0;
 
 	start = part->parsed_data.begin;
 	p = start;
 	end = p + part->parsed_data.len;
 
-	if (end - p <= sizeof(guint64) + sizeof(guint32) ||
+	if (end - p <= sizeof(uint64_t) + sizeof(uint32_t) ||
 		memcmp(p, sz_magic, sizeof(sz_magic)) != 0) {
 		msg_debug_archive("7z archive is invalid (no 7z magic)");
 
@@ -1754,13 +1754,13 @@ rspamd_archive_process_7zip(struct rspamd_task *task,
 								  arch);
 
 	/* Magic (6 bytes) + version (2 bytes) + crc32 (4 bytes) */
-	p += sizeof(guint64) + sizeof(guint32);
+	p += sizeof(uint64_t) + sizeof(uint32_t);
 
 	SZ_READ_UINT64(section_offset);
 	SZ_READ_UINT64(section_length);
 
-	if (end - p > sizeof(guint32)) {
-		p += sizeof(guint32);
+	if (end - p > sizeof(uint32_t)) {
+		p += sizeof(uint32_t);
 	}
 	else {
 		msg_debug_archive("7z archive is invalid (truncated crc)");

--- a/src/libmime/content_type.c
+++ b/src/libmime/content_type.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -163,7 +163,7 @@ rspamd_param_maybe_rfc2231_process(rspamd_mempool_t *pool,
 	return TRUE;
 }
 
-static gint32
+static int32_t
 rspamd_cmp_pieces(struct rspamd_content_type_param *p1, struct rspamd_content_type_param *p2)
 {
 	return p1->rfc2231_id - p2->rfc2231_id;

--- a/src/libmime/images.c
+++ b/src/libmime/images.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -107,7 +107,7 @@ static struct rspamd_image *
 process_png_image(rspamd_mempool_t *pool, rspamd_ftok_t *data)
 {
 	struct rspamd_image *img;
-	guint32 t;
+	uint32_t t;
 	const guint8 *p;
 
 	if (data->len < 24) {
@@ -128,10 +128,10 @@ process_png_image(rspamd_mempool_t *pool, rspamd_ftok_t *data)
 	img->data = data;
 
 	p += 4;
-	memcpy(&t, p, sizeof(guint32));
+	memcpy(&t, p, sizeof(uint32_t));
 	img->width = ntohl(t);
 	p += 4;
-	memcpy(&t, p, sizeof(guint32));
+	memcpy(&t, p, sizeof(uint32_t));
 	img->height = ntohl(t);
 
 	return img;
@@ -209,7 +209,7 @@ static struct rspamd_image *
 process_bmp_image(rspamd_mempool_t *pool, rspamd_ftok_t *data)
 {
 	struct rspamd_image *img;
-	gint32 t;
+	int32_t t;
 	const guint8 *p;
 
 	if (data->len < 28) {
@@ -221,9 +221,9 @@ process_bmp_image(rspamd_mempool_t *pool, rspamd_ftok_t *data)
 	img->type = IMAGE_TYPE_BMP;
 	img->data = data;
 	p = data->begin + 18;
-	memcpy(&t, p, sizeof(guint32));
+	memcpy(&t, p, sizeof(uint32_t));
 	img->width = GUINT32_FROM_LE(t);
-	memcpy(&t, p + 4, sizeof(gint32));
+	memcpy(&t, p + 4, sizeof(int32_t));
 	img->height = GUINT32_FROM_LE(t);
 
 	return img;
@@ -373,7 +373,7 @@ rspamd_image_cache_entry_dtor(gpointer p)
 	g_free(entry);
 }
 
-static guint32
+static uint32_t
 rspamd_image_dct_hash(gconstpointer p)
 {
 	return rspamd_cryptobox_fast_hash(p, rspamd_cryptobox_HASHBYTES,

--- a/src/libmime/images.h
+++ b/src/libmime/images.h
@@ -28,8 +28,8 @@ struct rspamd_image {
 	rspamd_ftok_t *filename;
 	struct html_image *html_image;
 	enum rspamd_image_type type;
-	guint32 width;
-	guint32 height;
+	uint32_t width;
+	uint32_t height;
 	gboolean is_normalized;
 	guchar *dct;
 };

--- a/src/libmime/lang_detection.c
+++ b/src/libmime/lang_detection.c
@@ -938,10 +938,10 @@ end:
 static void
 rspamd_language_detector_random_select(GArray *ucs_tokens, guint nwords,
 									   goffset *offsets_out,
-									   guint64 *seed)
+									   uint64_t *seed)
 {
 	guint step_len, remainder, i, out_idx;
-	guint64 coin, sel;
+	uint64_t coin, sel;
 	rspamd_stat_token_t *tok;
 
 	g_assert(nwords != 0);
@@ -1232,7 +1232,7 @@ rspamd_language_detector_detect_type(struct rspamd_task *task,
 	goffset *selected_words;
 	rspamd_stat_token_t *tok;
 	guint i;
-	guint64 seed;
+	uint64_t seed;
 
 	/* Seed PRNG with part digest to provide some sort of determinism */
 	memcpy(&seed, part->mime_part->digest, sizeof(seed));
@@ -1411,14 +1411,14 @@ rspamd_language_detector_unicode_scripts(struct rspamd_task *task,
 	const gchar *p = part->utf_stripped_content->data, *end;
 	guint i = 0, cnt = 0;
 	end = p + part->utf_stripped_content->len;
-	gint32 uc, sc;
+	int32_t uc, sc;
 	guint nlatin = 0, nchinese = 0, nspecial = 0;
 	const guint cutoff_limit = 32;
 
 	while (p + i < end) {
 		U8_NEXT(p, i, part->utf_stripped_content->len, uc);
 
-		if (((gint32) uc) < 0) {
+		if (((int32_t) uc) < 0) {
 			break;
 		}
 

--- a/src/libmime/message.c
+++ b/src/libmime/message.c
@@ -55,7 +55,7 @@ static const gchar gtube_pattern_rewrite_subject[] = "ZJS*C4JDBQADN1.NSBN3*2IDNE
 static const gchar gtube_pattern_no_action[] = "AJS*C4JDBQADN1.NSBN3*2IDNEN*"
 											   "GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X";
 struct rspamd_multipattern *gtube_matcher = NULL;
-static const guint64 words_hash_seed = 0xdeadbabe;
+static const uint64_t words_hash_seed = 0xdeadbabe;
 
 static void
 free_byte_array_callback(void *pointer)
@@ -76,7 +76,7 @@ rspamd_mime_part_extract_words(struct rspamd_task *task,
 						  task->lang_det);
 
 		for (i = 0; i < part->utf_words->len; i++) {
-			guint64 h;
+			uint64_t h;
 
 			w = &g_array_index(part->utf_words, rspamd_stat_token_t, i);
 
@@ -155,14 +155,14 @@ rspamd_mime_part_create_words(struct rspamd_task *task,
 		const gchar *p = part->utf_stripped_content->data, *end;
 		guint i = 0;
 		end = p + part->utf_stripped_content->len;
-		gint32 uc, sc;
+		int32_t uc, sc;
 
 		tok_type = RSPAMD_TOKENIZE_UTF;
 
 		while (p + i < end) {
 			U8_NEXT(p, i, part->utf_stripped_content->len, uc);
 
-			if (((gint32) uc) < 0) {
+			if (((int32_t) uc) < 0) {
 				tok_type = RSPAMD_TOKENIZE_RAW;
 				break;
 			}
@@ -198,7 +198,7 @@ rspamd_mime_part_create_words(struct rspamd_task *task,
 
 	if (part->utf_words) {
 		part->normalized_hashes = g_array_sized_new(FALSE, FALSE,
-													sizeof(guint64), part->utf_words->len);
+													sizeof(uint64_t), part->utf_words->len);
 		rspamd_normalize_words(part->utf_words, task->task_pool);
 	}
 }
@@ -241,7 +241,7 @@ rspamd_strip_newlines_parse(struct rspamd_task *task,
 
 	while (p < pe) {
 		if (U8_IS_LEAD(*p) && is_utf) {
-			gint32 off = p - begin;
+			int32_t off = p - begin;
 			U8_NEXT(begin, off, pe - begin, uc);
 
 			if (uc != -1) {
@@ -575,7 +575,7 @@ rspamd_words_levenshtein_distance(struct rspamd_task *task,
 {
 	guint s1len, s2len, x, y, lastdiag, olddiag;
 	guint *column, ret;
-	guint64 h1, h2;
+	uint64_t h1, h2;
 	gint eq;
 	static const guint max_words = 8192;
 
@@ -607,8 +607,8 @@ rspamd_words_levenshtein_distance(struct rspamd_task *task,
 
 		for (y = 1, lastdiag = x - 1; y <= s1len; y++) {
 			olddiag = column[y];
-			h1 = g_array_index(w1, guint64, y - 1);
-			h2 = g_array_index(w2, guint64, x - 1);
+			h1 = g_array_index(w1, uint64_t, y - 1);
+			h2 = g_array_index(w2, uint64_t, x - 1);
 			eq = (h1 == h2) ? 1 : 0;
 			/*
 			 * Cost of replacement is twice higher than cost of add/delete
@@ -1150,7 +1150,7 @@ rspamd_message_parse(struct rspamd_task *task)
 	gsize len;
 	guint i;
 	GError *err = NULL;
-	guint64 n[2], seed;
+	uint64_t n[2], seed;
 
 	if (RSPAMD_TASK_IS_EMPTY(task)) {
 		/* Don't do anything with empty task */
@@ -1722,7 +1722,7 @@ void rspamd_message_unref(struct rspamd_message *msg)
 void rspamd_message_update_digest(struct rspamd_message *msg,
 								  const void *input, gsize len)
 {
-	guint64 n[2];
+	uint64_t n[2];
 	/* Sanity */
 	G_STATIC_ASSERT(sizeof(n) == sizeof(msg->digest));
 

--- a/src/libmime/message.h
+++ b/src/libmime/message.h
@@ -138,7 +138,7 @@ struct rspamd_mime_text_part {
 	rspamd_ftok_t utf_content;        /* utf8 encoded processed content */
 	GByteArray *utf_raw_content;      /* utf raw content */
 	GByteArray *utf_stripped_content; /* utf content with no newlines */
-	GArray *normalized_hashes;        /* Array of guint64 */
+	GArray *normalized_hashes;        /* Array of uint64_t */
 	GArray *utf_words;                /* Array of rspamd_stat_token_t */
 	UText utf_stripped_text;          /* Used by libicu to represent the utf8 content */
 

--- a/src/libmime/mime_encoding.c
+++ b/src/libmime/mime_encoding.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -327,7 +327,7 @@ rspamd_mime_text_to_utf8(rspamd_mempool_t *pool,
 						 gsize *olen, GError **err)
 {
 	gchar *d;
-	gint32 r, clen, dlen;
+	int32_t r, clen, dlen;
 	UChar *tmp_buf;
 
 	UErrorCode uc_err = U_ZERO_ERROR;
@@ -407,7 +407,7 @@ rspamd_mime_text_part_utf8_convert(struct rspamd_task *task,
 								   GError **err)
 {
 	gchar *d;
-	gint32 r, clen, dlen, uc_len;
+	int32_t r, clen, dlen, uc_len;
 	UChar *tmp_buf;
 	UErrorCode uc_err = U_ZERO_ERROR;
 	UConverter *utf8_converter;
@@ -484,7 +484,7 @@ rspamd_mime_to_utf8_byte_array(GByteArray *in,
 							   rspamd_mempool_t *pool,
 							   const gchar *enc)
 {
-	gint32 r, clen, dlen;
+	int32_t r, clen, dlen;
 	UChar *tmp_buf;
 	UErrorCode uc_err = U_ZERO_ERROR;
 	UConverter *utf8_converter;
@@ -568,10 +568,10 @@ void rspamd_mime_charset_utf_enforce(gchar *in, gsize len)
 
 	while (p < end && len > 0 && (err_offset = rspamd_fast_utf8_validate(p, len)) > 0) {
 		err_offset--; /* As it returns it 1 indexed */
-		gint32 cur_offset = err_offset;
+		int32_t cur_offset = err_offset;
 
 		while (cur_offset < len) {
-			gint32 tmp = cur_offset;
+			int32_t tmp = cur_offset;
 
 			U8_NEXT(p, cur_offset, len, uc);
 

--- a/src/libmime/mime_encoding.h
+++ b/src/libmime/mime_encoding.h
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -124,12 +124,12 @@ struct rspamd_charset_converter *rspamd_mime_get_converter_cached(
  * @param pErrorCode
  * @return
  */
-gint32
+int32_t
 rspamd_converter_to_uchars(struct rspamd_charset_converter *cnv,
 						   UChar *dest,
-						   gint32 destCapacity,
+						   int32_t destCapacity,
 						   const char *src,
-						   gint32 srcLength,
+						   int32_t srcLength,
 						   UErrorCode *pErrorCode);
 
 /**

--- a/src/libmime/mime_expressions.c
+++ b/src/libmime/mime_expressions.c
@@ -175,8 +175,8 @@ const struct rspamd_atom_subr mime_expr_subr = {
 	.destroy = rspamd_mime_expr_destroy};
 
 static struct _fl *list_ptr = &rspamd_functions_list[0];
-static guint32 functions_number = sizeof(rspamd_functions_list) /
-								  sizeof(struct _fl);
+static uint32_t functions_number = sizeof(rspamd_functions_list) /
+								   sizeof(struct _fl);
 static gboolean list_allocated = FALSE;
 
 /* Bsearch routine */

--- a/src/libmime/mime_headers.c
+++ b/src/libmime/mime_headers.c
@@ -37,7 +37,7 @@ static void
 rspamd_mime_header_check_special(struct rspamd_task *task,
 								 struct rspamd_mime_header *rh)
 {
-	guint64 h;
+	uint64_t h;
 	const gchar *p, *end;
 	gchar *id;
 	gint max_recipients = -1, len;
@@ -819,7 +819,7 @@ gchar *
 rspamd_mime_header_encode(const gchar *in, gsize len)
 {
 	const gchar *p = in, *end = in + len;
-	gchar *out, encode_buf[80 * sizeof(guint32)];
+	gchar *out, encode_buf[80 * sizeof(uint32_t)];
 	GString *res;
 	gboolean need_encoding = FALSE;
 
@@ -902,15 +902,15 @@ gchar *
 rspamd_mime_message_id_generate(const gchar *fqdn)
 {
 	GString *out;
-	guint64 rnd, clk;
+	uint64_t rnd, clk;
 
 	out = g_string_sized_new(strlen(fqdn) + 22);
 	rnd = ottery_rand_uint64();
 	clk = rspamd_get_calendar_ticks() * 1e6;
 
 	rspamd_printf_gstring(out, "%*bs.%*bs@%s",
-						  (gint) sizeof(guint64) - 3, (guchar *) &clk,
-						  (gint) sizeof(guint64), (gchar *) &rnd,
+						  (gint) sizeof(uint64_t) - 3, (guchar *) &clk,
+						  (gint) sizeof(uint64_t), (gchar *) &rnd,
 						  fqdn);
 
 	return g_string_free(out, FALSE);

--- a/src/libmime/mime_parser.c
+++ b/src/libmime/mime_parser.c
@@ -51,8 +51,8 @@ INIT_LOG_MODULE(mime)
 struct rspamd_mime_boundary {
 	goffset boundary;
 	goffset start;
-	guint64 hash;
-	guint64 closed_hash;
+	uint64_t hash;
+	uint64_t closed_hash;
 	gint flags;
 };
 
@@ -180,7 +180,7 @@ rspamd_mime_parser_init_lib(void)
 static enum rspamd_cte
 rspamd_mime_parse_cte(const gchar *in, gsize len)
 {
-	guint64 h;
+	uint64_t h;
 	enum rspamd_cte ret = RSPAMD_CTE_UNKNOWN;
 
 	in = rspamd_string_len_strip(in, &len, " \t;,.+-#!`~'");
@@ -851,7 +851,7 @@ struct rspamd_mime_multipart_cbdata {
 	struct rspamd_mime_parser_ctx *st;
 	const gchar *part_start;
 	rspamd_ftok_t *cur_boundary;
-	guint64 bhash;
+	uint64_t bhash;
 	GError **err;
 };
 

--- a/src/libmime/smtp_parsers.h
+++ b/src/libmime/smtp_parsers.h
@@ -42,7 +42,7 @@ rspamd_rfc2047_parser(const gchar *in, gsize len, gint *pencoding,
 rspamd_inet_addr_t *rspamd_parse_smtp_ip(const char *data, size_t len,
 										 rspamd_mempool_t *pool);
 
-guint64 rspamd_parse_smtp_date(const unsigned char *data, size_t len, GError **err);
+uint64_t rspamd_parse_smtp_date(const unsigned char *data, size_t len, GError **err);
 
 #ifdef __cplusplus
 }

--- a/src/libserver/async_session.c
+++ b/src/libserver/async_session.c
@@ -61,7 +61,7 @@ rspamd_event_equal(const struct rspamd_async_event *ev1, const struct rspamd_asy
 	return ev1->fin == ev2->fin && ev1->user_data == ev2->user_data;
 }
 
-static inline guint64
+static inline uint64_t
 rspamd_event_hash(const struct rspamd_async_event *ev)
 {
 	union _pointer_fp_thunk {

--- a/src/libserver/cfg_file.h
+++ b/src/libserver/cfg_file.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,8 +174,8 @@ struct rspamd_classifier_config {
 	GList *learn_conditions;                   /**< list of learn condition callbacks					*/
 	GList *classify_conditions;                /**< list of classify condition callbacks					*/
 	gchar *name;                               /**< unique name of classifier							*/
-	guint32 min_tokens;                        /**< minimal number of tokens to process classifier 	*/
-	guint32 max_tokens;                        /**< maximum number of tokens							*/
+	uint32_t min_tokens;                       /**< minimal number of tokens to process classifier 	*/
+	uint32_t max_tokens;                       /**< maximum number of tokens							*/
 	guint min_token_hits;                      /**< minimum number of hits for a token to be considered */
 	gdouble min_prob_strength;                 /**< use only tokens with probability in [0.5 - MPS, 0.5 + MPS] */
 	guint min_learns;                          /**< minimum number of learns for each statfile			*/
@@ -205,8 +205,8 @@ struct rspamd_worker_conf {
 	struct rspamd_worker_bind_conf *bind_conf; /**< bind configuration									*/
 	gint16 count;                              /**< number of workers									*/
 	GList *listen_socks;                       /**< listening sockets descriptors						*/
-	guint64 rlimit_nofile;                     /**< max files limit									*/
-	guint64 rlimit_maxcore;                    /**< maximum core file size								*/
+	uint64_t rlimit_nofile;                    /**< max files limit									*/
+	uint64_t rlimit_maxcore;                   /**< maximum core file size								*/
 	GHashTable *params;                        /**< params for worker									*/
 	GQueue *active_workers;                    /**< linked list of spawned workers						*/
 	gpointer ctx;                              /**< worker's context									*/
@@ -319,7 +319,7 @@ enum rspamd_gtube_patterns_policy {
 };
 
 struct rspamd_config_settings_elt {
-	guint32 id;
+	uint32_t id;
 	enum rspamd_config_settings_policy policy;
 	const gchar *name;
 	ucl_object_t *symbols_enabled;
@@ -367,16 +367,16 @@ struct rspamd_config {
 	enum rspamd_gtube_patterns_policy gtube_patterns_policy; /**< Enable test patterns								*/
 	gboolean enable_css_parser;                              /**< Enable css parsing in HTML							*/
 
-	gsize max_cores_size;       /**< maximum size occupied by rspamd core files			*/
-	gsize max_cores_count;      /**< maximum number of core files						*/
-	gchar *cores_dir;           /**< directory for core files							*/
-	gsize max_message;          /**< maximum size for messages							*/
-	gsize max_pic_size;         /**< maximum size for a picture to process				*/
-	gsize images_cache_size;    /**< size of LRU cache for DCT data from images			*/
-	gdouble task_timeout;       /**< maximum message processing time					*/
-	gint default_max_shots;     /**< default maximum count of symbols hits permitted (-1 for unlimited) */
-	gint32 heartbeats_loss_max; /**< number of heartbeats lost to consider worker's termination */
-	gdouble heartbeat_interval; /**< interval for heartbeats for workers				*/
+	gsize max_cores_size;        /**< maximum size occupied by rspamd core files			*/
+	gsize max_cores_count;       /**< maximum number of core files						*/
+	gchar *cores_dir;            /**< directory for core files							*/
+	gsize max_message;           /**< maximum size for messages							*/
+	gsize max_pic_size;          /**< maximum size for a picture to process				*/
+	gsize images_cache_size;     /**< size of LRU cache for DCT data from images			*/
+	gdouble task_timeout;        /**< maximum message processing time					*/
+	gint default_max_shots;      /**< default maximum count of symbols hits permitted (-1 for unlimited) */
+	int32_t heartbeats_loss_max; /**< number of heartbeats lost to consider worker's termination */
+	gdouble heartbeat_interval;  /**< interval for heartbeats for workers				*/
 
 	enum rspamd_log_type log_type;                      /**< log type											*/
 	gint log_facility;                                  /**< log facility in case of syslog						*/
@@ -384,7 +384,7 @@ struct rspamd_config {
 	gchar *log_file;                                    /**< path to logfile in case of file logging			*/
 	gboolean log_buffered;                              /**< whether logging is buffered						*/
 	gboolean log_silent_workers;                        /**< silence info messages from workers					*/
-	guint32 log_buf_size;                               /**< length of log buffer								*/
+	uint32_t log_buf_size;                              /**< length of log buffer								*/
 	const ucl_object_t *debug_ip_map;                   /**< turn on debugging for specified ip addresses       */
 	gboolean log_urls;                                  /**< whether we should log URLs                         */
 	GHashTable *debug_modules;                          /**< logging modules to debug							*/
@@ -440,10 +440,10 @@ struct rspamd_config {
 	gchar *events_backend; /**< string representation of the events backend used	*/
 
 	gdouble dns_timeout;             /**< timeout in milliseconds for waiting for dns reply	*/
-	guint32 dns_retransmits;         /**< maximum retransmits count							*/
-	guint32 dns_io_per_server;       /**< number of sockets per DNS server					*/
+	uint32_t dns_retransmits;        /**< maximum retransmits count							*/
+	uint32_t dns_io_per_server;      /**< number of sockets per DNS server					*/
 	const ucl_object_t *nameservers; /**< list of nameservers or NULL to parse resolv.conf	*/
-	guint32 dns_max_requests;        /**< limit of DNS requests per task 					*/
+	uint32_t dns_max_requests;       /**< limit of DNS requests per task 					*/
 	gboolean enable_dnssec;          /**< enable dnssec stub resolver						*/
 
 	guint upstream_max_errors;                /**< upstream max errors before shutting off			*/
@@ -760,7 +760,7 @@ void rspamd_config_register_settings_id(struct rspamd_config *cfg,
  * @param namelen
  * @return
  */
-guint32 rspamd_config_name_to_id(const gchar *name, gsize namelen);
+uint32_t rspamd_config_name_to_id(const gchar *name, gsize namelen);
 
 /**
  * Finds settings id element and obtain reference count (must be unrefed by caller)
@@ -770,7 +770,7 @@ guint32 rspamd_config_name_to_id(const gchar *name, gsize namelen);
  */
 struct rspamd_config_settings_elt *rspamd_config_find_settings_id_ref(
 	struct rspamd_config *cfg,
-	guint32 id);
+	uint32_t id);
 
 /**
  * Finds settings id element and obtain reference count (must be unrefed by callee)

--- a/src/libserver/cfg_rcl.cxx
+++ b/src/libserver/cfg_rcl.cxx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2792,16 +2792,16 @@ rspamd_rcl_parse_struct_integer(rspamd_mempool_t *pool,
 	auto *pd = (struct rspamd_rcl_struct_parser *) ud;
 	union {
 		gint *ip;
-		gint32 *i32p;
+		int32_t *i32p;
 		gint16 *i16p;
-		gint64 *i64p;
+		int64_t *i64p;
 		guint *up;
 		gsize *sp;
 	} target;
 	int64_t val;
 
 	if (pd->flags == RSPAMD_CL_FLAG_INT_32) {
-		target.i32p = (gint32 *) (((gchar *) pd->user_struct) + pd->offset);
+		target.i32p = (int32_t *) (((gchar *) pd->user_struct) + pd->offset);
 		if (!ucl_object_toint_safe(obj, &val)) {
 			g_set_error(err,
 						CFG_RCL_ERROR,
@@ -2814,7 +2814,7 @@ rspamd_rcl_parse_struct_integer(rspamd_mempool_t *pool,
 		*target.i32p = val;
 	}
 	else if (pd->flags == RSPAMD_CL_FLAG_INT_64) {
-		target.i64p = (gint64 *) (((gchar *) pd->user_struct) + pd->offset);
+		target.i64p = (int64_t *) (((gchar *) pd->user_struct) + pd->offset);
 		if (!ucl_object_toint_safe(obj, &val)) {
 			g_set_error(err,
 						CFG_RCL_ERROR,
@@ -2917,7 +2917,7 @@ rspamd_rcl_parse_struct_time(rspamd_mempool_t *pool,
 	auto *pd = (struct rspamd_rcl_struct_parser *) ud;
 	union {
 		gint *psec;
-		guint32 *pu32;
+		uint32_t *pu32;
 		gdouble *pdv;
 		struct timeval *ptv;
 		struct timespec *pts;
@@ -2955,7 +2955,7 @@ rspamd_rcl_parse_struct_time(rspamd_mempool_t *pool,
 		*target.psec = val * 1000;
 	}
 	else if (pd->flags == RSPAMD_CL_FLAG_TIME_UINT_32) {
-		target.pu32 = (guint32 *) (((gchar *) pd->user_struct) + pd->offset);
+		target.pu32 = (uint32_t *) (((gchar *) pd->user_struct) + pd->offset);
 		*target.pu32 = val * 1000;
 	}
 	else {
@@ -3385,7 +3385,7 @@ static int
 rspamd_rcl_emitter_append_c(unsigned char c, size_t nchars, void *ud)
 {
 	auto *hs = (rspamd_cryptobox_hash_state_t *) ud;
-	guint64 d[2];
+	uint64_t d[2];
 
 	d[0] = nchars;
 	d[1] = c;

--- a/src/libserver/cfg_utils.cxx
+++ b/src/libserver/cfg_utils.cxx
@@ -2399,20 +2399,20 @@ rspamd_config_settings_elt_dtor(struct rspamd_config_settings_elt *e)
 	}
 }
 
-guint32
+uint32_t
 rspamd_config_name_to_id(const gchar *name, gsize namelen)
 {
-	guint64 h;
+	uint64_t h;
 
 	h = rspamd_cryptobox_fast_hash_specific(RSPAMD_CRYPTOBOX_XXHASH64,
 											name, namelen, 0x0);
 	/* Take the lower part of hash as LE number */
-	return ((guint32) GUINT64_TO_LE(h));
+	return ((uint32_t) GUINT64_TO_LE(h));
 }
 
 struct rspamd_config_settings_elt *
 rspamd_config_find_settings_id_ref(struct rspamd_config *cfg,
-								   guint32 id)
+								   uint32_t id)
 {
 	struct rspamd_config_settings_elt *cur;
 
@@ -2431,7 +2431,7 @@ struct rspamd_config_settings_elt *rspamd_config_find_settings_name_ref(
 	struct rspamd_config *cfg,
 	const gchar *name, gsize namelen)
 {
-	guint32 id;
+	uint32_t id;
 
 	id = rspamd_config_name_to_id(name, namelen);
 
@@ -2445,7 +2445,7 @@ void rspamd_config_register_settings_id(struct rspamd_config *cfg,
 										enum rspamd_config_settings_policy policy)
 {
 	struct rspamd_config_settings_elt *elt;
-	guint32 id;
+	uint32_t id;
 
 	id = rspamd_config_name_to_id(name, strlen(name));
 	elt = rspamd_config_find_settings_id_ref(cfg, id);

--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -97,12 +97,12 @@ union rspamd_dkim_header_stat {
 		guint16 count;
 		guint16 flags;
 	} s;
-	guint32 n;
+	uint32_t n;
 };
 
 struct rspamd_dkim_common_ctx {
 	rspamd_mempool_t *pool;
-	guint64 sig_hash;
+	uint64_t sig_hash;
 	gsize len;
 	GPtrArray *hlist;
 	GHashTable *htable; /* header -> count mapping */
@@ -2469,7 +2469,7 @@ rspamd_dkim_canonize_header(struct rspamd_dkim_common_ctx *ctx,
 				}
 
 				if ((rh->flags & RSPAMD_HEADER_UNIQUE) && hdr_cnt > 1) {
-					guint64 random_cookie = ottery_rand_uint64();
+					uint64_t random_cookie = ottery_rand_uint64();
 
 					msg_warn_dkim("header %s is intended to be unique by"
 								  " email standards, but we have %d headers of this"
@@ -2586,8 +2586,8 @@ rspamd_dkim_canonize_header(struct rspamd_dkim_common_ctx *ctx,
 
 				DL_FOREACH(rh, cur)
 				{
-					guint64 th = rspamd_cryptobox_fast_hash(cur->decoded,
-															strlen(cur->decoded), rspamd_hash_seed());
+					uint64_t th = rspamd_cryptobox_fast_hash(cur->decoded,
+															 strlen(cur->decoded), rspamd_hash_seed());
 
 					if (th == ctx->sig_hash) {
 						rspamd_dkim_signature_update(ctx, cur->raw_value,

--- a/src/libserver/dns.c
+++ b/src/libserver/dns.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ struct rspamd_dns_request_ud {
 
 struct rspamd_dns_fail_cache_entry {
 	const char *name;
-	gint32 namelen;
+	int32_t namelen;
 	enum rdns_request_type type;
 };
 

--- a/src/libserver/fuzzy_backend/fuzzy_backend.c
+++ b/src/libserver/fuzzy_backend/fuzzy_backend.c
@@ -215,7 +215,7 @@ rspamd_fuzzy_backend_count_sqlite(struct rspamd_fuzzy_backend *bk,
 								  void *subr_ud)
 {
 	struct rspamd_fuzzy_backend_sqlite *sq = subr_ud;
-	guint64 nhashes;
+	uint64_t nhashes;
 
 	nhashes = rspamd_fuzzy_backend_sqlite_count(sq);
 
@@ -231,7 +231,7 @@ rspamd_fuzzy_backend_version_sqlite(struct rspamd_fuzzy_backend *bk,
 									void *subr_ud)
 {
 	struct rspamd_fuzzy_backend_sqlite *sq = subr_ud;
-	guint64 rev;
+	uint64_t rev;
 
 	rev = rspamd_fuzzy_backend_sqlite_version(sq, src);
 

--- a/src/libserver/fuzzy_backend/fuzzy_backend.h
+++ b/src/libserver/fuzzy_backend/fuzzy_backend.h
@@ -39,9 +39,9 @@ typedef void (*rspamd_fuzzy_update_cb)(gboolean success,
 									   guint nignored,
 									   void *ud);
 
-typedef void (*rspamd_fuzzy_version_cb)(guint64 rev, void *ud);
+typedef void (*rspamd_fuzzy_version_cb)(uint64_t rev, void *ud);
 
-typedef void (*rspamd_fuzzy_count_cb)(guint64 count, void *ud);
+typedef void (*rspamd_fuzzy_count_cb)(uint64_t count, void *ud);
 
 typedef gboolean (*rspamd_fuzzy_periodic_cb)(void *ud);
 

--- a/src/libserver/fuzzy_backend/fuzzy_backend_redis.c
+++ b/src/libserver/fuzzy_backend/fuzzy_backend_redis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1094,7 +1094,7 @@ rspamd_fuzzy_update_append_command(struct rspamd_fuzzy_backend *bk,
 		g_string_append(key, session->backend->redis_object);
 		g_string_append_len(key, cmd->digest, sizeof(cmd->digest));
 		value = g_string_sized_new(sizeof("18446744073709551616"));
-		rspamd_printf_gstring(value, "%L", (gint64) rspamd_get_calendar_ticks());
+		rspamd_printf_gstring(value, "%L", (int64_t) rspamd_get_calendar_ticks());
 		session->argv[cur_shift] = g_strdup("HSETNX");
 		session->argv_lens[cur_shift++] = sizeof("HSETNX") - 1;
 		session->argv[cur_shift] = key->str;

--- a/src/libserver/fuzzy_backend/fuzzy_backend_sqlite.h
+++ b/src/libserver/fuzzy_backend/fuzzy_backend_sqlite.h
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,7 +44,7 @@ struct rspamd_fuzzy_backend_sqlite *rspamd_fuzzy_backend_sqlite_open(const gchar
 struct rspamd_fuzzy_reply rspamd_fuzzy_backend_sqlite_check(
 	struct rspamd_fuzzy_backend_sqlite *backend,
 	const struct rspamd_fuzzy_cmd *cmd,
-	gint64 expire);
+	int64_t expire);
 
 /**
  * Prepare storage for updates (by starting transaction)
@@ -83,7 +83,7 @@ gboolean rspamd_fuzzy_backend_sqlite_finish_update(struct rspamd_fuzzy_backend_s
  * @return
  */
 gboolean rspamd_fuzzy_backend_sqlite_sync(struct rspamd_fuzzy_backend_sqlite *backend,
-										  gint64 expire,
+										  int64_t expire,
 										  gboolean clean_orphaned);
 
 /**

--- a/src/libserver/fuzzy_wire.h
+++ b/src/libserver/fuzzy_wire.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,8 @@ RSPAMD_PACKED(rspamd_fuzzy_cmd)
 	guint8 cmd;
 	guint8 shingles_count;
 	guint8 flag;
-	gint32 value;
-	guint32 tag;
+	int32_t value;
+	uint32_t tag;
 	gchar digest[rspamd_cryptobox_HASHBYTES];
 };
 
@@ -71,9 +71,9 @@ RSPAMD_PACKED(rspamd_fuzzy_shingle_cmd)
 
 RSPAMD_PACKED(rspamd_fuzzy_reply_v1)
 {
-	gint32 value;
-	guint32 flag;
-	guint32 tag;
+	int32_t value;
+	uint32_t flag;
+	uint32_t tag;
 	float prob;
 };
 
@@ -81,7 +81,7 @@ RSPAMD_PACKED(rspamd_fuzzy_reply)
 {
 	struct rspamd_fuzzy_reply_v1 v1;
 	gchar digest[rspamd_cryptobox_HASHBYTES];
-	guint32 ts;
+	uint32_t ts;
 	guchar reserved[12];
 };
 
@@ -135,12 +135,12 @@ struct rspamd_fuzzy_cmd_extension {
 
 struct rspamd_fuzzy_stat_entry {
 	const gchar *name;
-	guint64 fuzzy_cnt;
+	uint64_t fuzzy_cnt;
 };
 
 RSPAMD_PACKED(fuzzy_peer_cmd)
 {
-	gint32 is_shingle;
+	int32_t is_shingle;
 	union {
 		struct rspamd_fuzzy_cmd normal;
 		struct rspamd_fuzzy_shingle_cmd shingle;

--- a/src/libserver/http/http_context.c
+++ b/src/libserver/http/http_context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -361,7 +361,7 @@ rspamd_http_context_default(void)
 	return default_ctx;
 }
 
-gint32
+int32_t
 rspamd_keep_alive_key_hash(struct rspamd_keepalive_hash_key *k)
 {
 	rspamd_cryptobox_fast_hash_state_t hst;

--- a/src/libserver/http/http_private.h
+++ b/src/libserver/http/http_private.h
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -91,7 +91,7 @@ struct rspamd_keepalive_hash_key {
 	GQueue conns;
 };
 
-gint32 rspamd_keep_alive_key_hash(struct rspamd_keepalive_hash_key *k);
+int32_t rspamd_keep_alive_key_hash(struct rspamd_keepalive_hash_key *k);
 
 bool rspamd_keep_alive_key_equal(struct rspamd_keepalive_hash_key *k1,
 								 struct rspamd_keepalive_hash_key *k2);

--- a/src/libserver/http/http_util.c
+++ b/src/libserver/http/http_util.c
@@ -34,7 +34,7 @@ rspamd_http_parse_date(const gchar *header, gsize len)
 	const gchar *p, *end;
 	gint month;
 	guint day, year, hour, min, sec;
-	guint64 time;
+	uint64_t time;
 	enum {
 		no = 0,
 		rfc822, /* Tue, 10 Nov 2002 23:50:13   */
@@ -257,7 +257,7 @@ rspamd_http_parse_date(const gchar *header, gsize len)
 
 	/* Gauss' formula for Gregorian days since March 1, 1 BC */
 
-	time = (guint64) (
+	time = (uint64_t) (
 			   /* days in years including leap years since March 1, 1 BC */
 
 			   365 * year + year / 4 - year / 100 + year / 400

--- a/src/libserver/logger.h
+++ b/src/libserver/logger.h
@@ -189,7 +189,7 @@ bool rspamd_conditional_debug_fast(rspamd_logger_t *logger,
 bool rspamd_conditional_debug_fast_num_id(rspamd_logger_t *logger,
 										  rspamd_inet_addr_t *addr,
 										  gint mod_id,
-										  const gchar *module, guint64 id,
+										  const gchar *module, uint64_t id,
 										  const gchar *function, const gchar *fmt, ...);
 gboolean rspamd_logger_need_log(rspamd_logger_t *rspamd_log,
 								GLogLevelFlags log_level,
@@ -234,7 +234,7 @@ void rspamd_log_nodebug(rspamd_logger_t *logger);
  * 2 - info messages
  * 3 - debug messages
  */
-const guint64 *rspamd_log_counters(rspamd_logger_t *logger);
+const uint64_t *rspamd_log_counters(rspamd_logger_t *logger);
 
 /**
  * Returns errors ring buffer as ucl array

--- a/src/libserver/logger/logger.c
+++ b/src/libserver/logger/logger.c
@@ -373,7 +373,7 @@ rspamd_log_write_ringbuffer(rspamd_logger_t *rspamd_log,
 							const gchar *module, const gchar *id,
 							const gchar *data, glong len)
 {
-	guint32 row_num;
+	uint32_t row_num;
 	struct rspamd_logger_error_log *elog;
 	struct rspamd_logger_error_elt *elt;
 
@@ -644,7 +644,7 @@ bool rspamd_conditional_debug_fast(rspamd_logger_t *rspamd_log,
 
 bool rspamd_conditional_debug_fast_num_id(rspamd_logger_t *rspamd_log,
 										  rspamd_inet_addr_t *addr,
-										  gint mod_id, const gchar *module, guint64 id,
+										  gint mod_id, const gchar *module, uint64_t id,
 										  const gchar *function, const gchar *fmt, ...)
 {
 	static gchar logbuf[LOGBUF_LEN], idbuf[64];
@@ -725,7 +725,7 @@ void rspamd_log_nodebug(rspamd_logger_t *rspamd_log)
 	rspamd_log->is_debug = FALSE;
 }
 
-const guint64 *
+const uint64_t *
 rspamd_log_counters(rspamd_logger_t *logger)
 {
 	if (logger) {
@@ -905,7 +905,7 @@ rspamd_log_line_hex_escape(const guchar *src, gsize srclen,
 	static const gchar hexdigests[16] = "0123456789ABCDEF";
 	gchar *d = dst;
 
-	static guint32 escape[] = {
+	static uint32_t escape[] = {
 		0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
 
 		/* ?>=< ;:98 7654 3210  /.-, +*)( '&%$ #"!  */
@@ -952,7 +952,7 @@ rspamd_log_line_hex_escape(const guchar *src, gsize srclen,
 
 gsize rspamd_log_line_need_escape(const guchar *src, gsize srclen)
 {
-	static guint32 escape[] = {
+	static uint32_t escape[] = {
 		0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
 
 		/* ?>=< ;:98 7654 3210  /.-, +*)( '&%$ #"!  */

--- a/src/libserver/logger/logger_file.c
+++ b/src/libserver/logger/logger_file.c
@@ -27,8 +27,8 @@
 struct rspamd_file_logger_priv {
 	gint fd;
 	struct {
-		guint32 size;
-		guint32 used;
+		uint32_t size;
+		uint32_t used;
 		u_char *buf;
 	} io_buf;
 	gboolean throttling;
@@ -36,8 +36,8 @@ struct rspamd_file_logger_priv {
 	gboolean is_buffered;
 	gboolean log_severity;
 	time_t throttling_time;
-	guint32 repeats;
-	guint64 last_line_cksum;
+	uint32_t repeats;
+	uint64_t last_line_cksum;
 	gchar *saved_message;
 	gsize saved_mlen;
 	gchar *saved_function;
@@ -49,7 +49,7 @@ struct rspamd_file_logger_priv {
 /**
  * Calculate checksum for log line (used for repeating logic)
  */
-static inline guint64
+static inline uint64_t
 rspamd_log_calculate_cksum(const gchar *message, size_t mlen)
 {
 	return rspamd_cryptobox_fast_hash(message, mlen, rspamd_hash_seed());
@@ -376,7 +376,7 @@ bool rspamd_log_file_log(const gchar *module, const gchar *id,
 {
 	struct rspamd_file_logger_priv *priv = (struct rspamd_file_logger_priv *) arg;
 	gdouble now;
-	guint64 cksum;
+	uint64_t cksum;
 	gboolean got_time = FALSE;
 
 

--- a/src/libserver/logger/logger_private.h
+++ b/src/libserver/logger/logger_private.h
@@ -48,10 +48,10 @@ struct rspamd_logger_error_elt {
 struct rspamd_logger_error_log {
 	struct rspamd_logger_error_elt *elts;
 	rspamd_mempool_t *pool;
-	guint32 max_elts;
-	guint32 elt_len;
+	uint32_t max_elts;
+	uint32_t elt_len;
 	/* Avoid false cache sharing */
-	guchar __padding[64 - sizeof(gpointer) * 2 - sizeof(guint64)];
+	guchar __padding[64 - sizeof(gpointer) * 2 - sizeof(uint64_t)];
 	guint cur_row;
 };
 
@@ -78,7 +78,7 @@ struct rspamd_logger_s {
 	struct rspamd_radix_map_helper *debug_ip;
 	rspamd_mempool_mutex_t *mtx;
 	rspamd_mempool_t *pool;
-	guint64 log_cnt[4];
+	uint64_t log_cnt[4];
 };
 
 /*

--- a/src/libserver/maps/map_helpers.c
+++ b/src/libserver/maps/map_helpers.c
@@ -35,7 +35,7 @@
 #endif
 
 
-static const guint64 map_hash_seed = 0xdeadbabeULL;
+static const uint64_t map_hash_seed = 0xdeadbabeULL;
 static const gchar *const hash_fill = "1";
 
 struct rspamd_map_helper_value {

--- a/src/libserver/maps/map_private.h
+++ b/src/libserver/maps/map_private.h
@@ -72,7 +72,7 @@ struct rspamd_http_map_cached_cbdata {
 	struct rspamd_storage_shmem *shm;
 	struct rspamd_map *map;
 	struct http_map_data *data;
-	guint64 gen;
+	uint64_t gen;
 	time_t last_checked;
 };
 
@@ -99,7 +99,7 @@ struct http_map_data {
 	time_t last_modified;
 	time_t last_checked;
 	gboolean request_sent;
-	guint64 gen;
+	uint64_t gen;
 	guint16 port;
 };
 
@@ -124,7 +124,7 @@ struct rspamd_map_backend {
 	gboolean is_fallback;
 	struct rspamd_map *map;
 	struct ev_loop *event_loop;
-	guint32 id;
+	uint32_t id;
 	struct rspamd_cryptobox_pubkey *trusted_pubkey;
 	union rspamd_map_backend_data data;
 	gchar *uri;
@@ -146,7 +146,7 @@ struct rspamd_map {
 	struct rspamd_worker *wrk;
 	gchar *description;
 	gchar *name;
-	guint32 id;
+	uint32_t id;
 	struct map_periodic_cbdata *scheduled_check;
 	rspamd_map_tmp_dtor tmp_dtor;
 	gpointer tmp_dtor_data;
@@ -156,7 +156,7 @@ struct rspamd_map {
 	GDestroyNotify on_load_ud_dtor;
 	gpointer lua_map;
 	gsize nelts;
-	guint64 digest;
+	uint64_t digest;
 	/* Should we check HTTP or just load cached data */
 	ev_tstamp timeout;
 	gdouble poll_timeout;

--- a/src/libserver/milter.c
+++ b/src/libserver/milter.c
@@ -331,7 +331,7 @@ rspamd_milter_process_command(struct rspamd_milter_session *session,
 	rspamd_fstring_t *buf;
 	const guchar *pos, *end, *zero;
 	guint cmdlen;
-	guint32 version, actions, protocol;
+	uint32_t version, actions, protocol;
 
 	buf = priv->parser.buf;
 	pos = buf->str + priv->parser.cmd_start;
@@ -689,7 +689,7 @@ rspamd_milter_process_command(struct rspamd_milter_session *session,
 												 "\r\n", 2);
 		break;
 	case RSPAMD_MILTER_CMD_OPTNEG:
-		if (cmdlen != sizeof(guint32) * 3) {
+		if (cmdlen != sizeof(uint32_t) * 3) {
 			err = g_error_new(rspamd_milter_quark(), EINVAL, "invalid "
 															 "optneg command");
 			rspamd_milter_on_protocol_error(session, priv, err);
@@ -1268,7 +1268,7 @@ rspamd_milter_set_reply(struct rspamd_milter_session *session,
 
 #define SET_COMMAND(cmd, sz, reply, pos)                         \
 	do {                                                         \
-		guint32 _len;                                            \
+		uint32_t _len;                                           \
 		_len = (sz) + 1;                                         \
 		(reply) = rspamd_fstring_sized_new(sizeof(_len) + _len); \
 		(reply)->len = sizeof(_len) + _len;                      \
@@ -1282,7 +1282,7 @@ gboolean
 rspamd_milter_send_action(struct rspamd_milter_session *session,
 						  enum rspamd_milter_reply act, ...)
 {
-	guint32 ver, actions, protocol, idx;
+	uint32_t ver, actions, protocol, idx;
 	va_list ap;
 	guchar cmd, *pos;
 	rspamd_fstring_t *reply = NULL;
@@ -1331,14 +1331,14 @@ rspamd_milter_send_action(struct rspamd_milter_session *session,
 		break;
 	case RSPAMD_MILTER_CHGHEADER:
 	case RSPAMD_MILTER_INSHEADER:
-		idx = va_arg(ap, guint32);
+		idx = va_arg(ap, uint32_t);
 		name = va_arg(ap, GString *);
 		value = va_arg(ap, GString *);
 
 		msg_debug_milter("change/insert header command pos = %d- \"%v\"=\"%v\"",
 						 idx, name, value);
 		/* Name and value must be zero terminated */
-		SET_COMMAND(cmd, name->len + value->len + 2 + sizeof(guint32),
+		SET_COMMAND(cmd, name->len + value->len + 2 + sizeof(uint32_t),
 					reply, pos);
 		idx = htonl(idx);
 		memcpy(pos, &idx, sizeof(idx));
@@ -1366,16 +1366,16 @@ rspamd_milter_send_action(struct rspamd_milter_session *session,
 		memcpy(pos, value->str, value->len + 1);
 		break;
 	case RSPAMD_MILTER_OPTNEG:
-		ver = va_arg(ap, guint32);
-		actions = va_arg(ap, guint32);
-		protocol = va_arg(ap, guint32);
+		ver = va_arg(ap, uint32_t);
+		actions = va_arg(ap, uint32_t);
+		protocol = va_arg(ap, uint32_t);
 
 		msg_debug_milter("optneg reply: ver=%d, actions=%d, protocol=%d",
 						 ver, actions, protocol);
 		ver = htonl(ver);
 		actions = htonl(actions);
 		protocol = htonl(protocol);
-		SET_COMMAND(cmd, sizeof(guint32) * 3, reply, pos);
+		SET_COMMAND(cmd, sizeof(uint32_t) * 3, reply, pos);
 		memcpy(pos, &ver, sizeof(ver));
 		pos += sizeof(ver);
 		memcpy(pos, &actions, sizeof(actions));
@@ -1416,7 +1416,7 @@ rspamd_milter_del_header(struct rspamd_milter_session *session,
 						 GString *name)
 {
 	GString value;
-	guint32 idx = 1;
+	uint32_t idx = 1;
 
 	value.str = (gchar *) "";
 	value.len = 0;
@@ -1960,7 +1960,7 @@ rspamd_milter_process_milter_block(struct rspamd_milter_session *session,
 				hname = g_string_new(milter_ctx->spam_header);
 				hvalue = g_string_new(ucl_object_tostring(elt));
 				rspamd_milter_send_action(session, RSPAMD_MILTER_CHGHEADER,
-										  (guint32) 1, hname, hvalue);
+										  (uint32_t) 1, hname, hvalue);
 				g_string_free(hname, TRUE);
 				g_string_free(hvalue, TRUE);
 				rspamd_milter_send_action(session, RSPAMD_MILTER_ACCEPT);
@@ -1978,7 +1978,7 @@ rspamd_milter_process_milter_block(struct rspamd_milter_session *session,
 					hname = g_string_new(ucl_object_key(cur));
 					hvalue = g_string_new(ucl_object_tostring(cur));
 					rspamd_milter_send_action(session, RSPAMD_MILTER_CHGHEADER,
-											  (guint32) 1, hname, hvalue);
+											  (uint32_t) 1, hname, hvalue);
 					g_string_free(hname, TRUE);
 					g_string_free(hvalue, TRUE);
 				}
@@ -2169,7 +2169,7 @@ void rspamd_milter_send_task_results(struct rspamd_milter_session *session,
 			hvalue = g_string_new(ucl_object_tostring(elt));
 
 			rspamd_milter_send_action(session, RSPAMD_MILTER_CHGHEADER,
-									  (guint32) 1, hname, hvalue);
+									  (uint32_t) 1, hname, hvalue);
 			g_string_free(hname, TRUE);
 			g_string_free(hvalue, TRUE);
 		}
@@ -2186,7 +2186,7 @@ void rspamd_milter_send_task_results(struct rspamd_milter_session *session,
 		hname = g_string_new(milter_ctx->spam_header);
 		hvalue = g_string_new("Yes");
 		rspamd_milter_send_action(session, RSPAMD_MILTER_CHGHEADER,
-								  (guint32) 1, hname, hvalue);
+								  (uint32_t) 1, hname, hvalue);
 		g_string_free(hname, TRUE);
 		g_string_free(hvalue, TRUE);
 		rspamd_milter_send_action(session, RSPAMD_MILTER_ACCEPT);

--- a/src/libserver/monitored.c
+++ b/src/libserver/monitored.c
@@ -365,7 +365,7 @@ rspamd_monitored_dns_cb(struct rdns_reply *reply, void *arg)
 					LL_FOREACH(reply->entries, cur)
 					{
 						if (cur->type == RDNS_REQUEST_A) {
-							if ((guint32) cur->content.a.addr.s_addr ==
+							if ((uint32_t) cur->content.a.addr.s_addr ==
 								htonl(INADDR_LOOPBACK)) {
 								is_special_reply = TRUE;
 							}

--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -1867,7 +1867,7 @@ end:
 #endif
 
 		/* Set average processing time */
-		guint32 slot;
+		uint32_t slot;
 		float processing_time = task->time_real_finish - task->task_timestamp;
 
 #ifndef HAVE_ATOMIC_BUILTINS
@@ -1890,7 +1890,7 @@ void rspamd_protocol_write_log_pipe(struct rspamd_task *task)
 	struct rspamd_scan_result *mres;
 	struct rspamd_symbol_result *sym;
 	gint id, i;
-	guint32 n = 0, nextra = 0;
+	uint32_t n = 0, nextra = 0;
 	gsize sz;
 	GArray *extra;
 	struct rspamd_protocol_log_symbol_result er;

--- a/src/libserver/protocol.h
+++ b/src/libserver/protocol.h
@@ -39,13 +39,13 @@ extern "C" {
 #define RSPAMD_STATFILE_ERROR RSPAMD_BASE_ERROR + 5
 
 struct rspamd_protocol_log_symbol_result {
-	guint32 id;
+	uint32_t id;
 	float score;
 };
 struct rspamd_protocol_log_message_sum {
-	guint32 nresults;
-	guint32 nextra;
-	guint32 settings_id;
+	uint32_t nresults;
+	uint32_t nextra;
+	uint32_t settings_id;
 	gdouble score;
 	gdouble required_score;
 	struct rspamd_protocol_log_symbol_result results[];

--- a/src/libserver/re_cache.c
+++ b/src/libserver/re_cache.c
@@ -84,7 +84,7 @@ static const guchar rspamd_hs_magic[] = {'r', 's', 'h', 's', 'r', 'e', '1', '1'}
 
 
 struct rspamd_re_class {
-	guint64 id;
+	uint64_t id;
 	enum rspamd_re_type type;
 	gboolean has_utf8; /* if there are any utf8 regexps */
 	gpointer type_data;
@@ -157,7 +157,7 @@ rspamd_re_cache_quark(void)
 	return g_quark_from_static_string("re_cache");
 }
 
-static guint64
+static uint64_t
 rspamd_re_cache_class_id(enum rspamd_re_type type,
 						 gconstpointer type_data,
 						 gsize datalen)
@@ -279,7 +279,7 @@ rspamd_re_cache_add(struct rspamd_re_cache *cache,
 					gconstpointer type_data, gsize datalen,
 					gint lua_cbref)
 {
-	guint64 class_id;
+	uint64_t class_id;
 	struct rspamd_re_class *re_class;
 	rspamd_regexp_t *nre;
 	struct rspamd_re_cache_elt *elt;
@@ -334,7 +334,7 @@ void rspamd_re_cache_replace(struct rspamd_re_cache *cache,
 							 rspamd_regexp_t *what,
 							 rspamd_regexp_t *with)
 {
-	guint64 re_id;
+	uint64_t re_id;
 	struct rspamd_re_class *re_class;
 	rspamd_regexp_t *src;
 	struct rspamd_re_cache_elt *elt;
@@ -590,7 +590,7 @@ rspamd_re_cache_process_pcre(struct rspamd_re_runtime *rt,
 	guint r = 0;
 	const gchar *start = NULL, *end = NULL;
 	guint max_hits = rspamd_regexp_get_maxhits(re);
-	guint64 id = rspamd_regexp_get_cache_id(re);
+	uint64_t id = rspamd_regexp_get_cache_id(re);
 	gdouble t1 = NAN, t2, pr;
 	const gdouble slow_time = 1e8;
 
@@ -736,7 +736,7 @@ rspamd_re_cache_process_regexp_data(struct rspamd_re_runtime *rt,
 									gboolean *processed_hyperscan)
 {
 
-	guint64 re_id;
+	uint64_t re_id;
 	guint ret = 0;
 	guint i;
 	struct rspamd_re_cache_elt *cache_elt;
@@ -834,7 +834,7 @@ rspamd_re_cache_finish_class(struct rspamd_task *task,
 {
 #ifdef WITH_HYPERSCAN
 	guint i;
-	guint64 re_id;
+	uint64_t re_id;
 	guint found = 0;
 
 	/* Set all bits that are not checked and included in hyperscan to 1 */
@@ -1504,7 +1504,7 @@ gint rspamd_re_cache_process(struct rspamd_task *task,
 							 gsize datalen,
 							 gboolean is_strong)
 {
-	guint64 re_id;
+	uint64_t re_id;
 	struct rspamd_re_class *re_class;
 	struct rspamd_re_cache *cache;
 	struct rspamd_re_runtime *rt;
@@ -1678,7 +1678,7 @@ enum rspamd_re_type
 rspamd_re_cache_type_from_string(const char *str)
 {
 	enum rspamd_re_type ret;
-	guint64 h;
+	uint64_t h;
 
 	/*
 	 * To optimize this function, we apply hash to input string and
@@ -1889,7 +1889,7 @@ rspamd_re_cache_compile_timer_cb(EV_P_ ev_timer *w, int revents)
 	hs_database_t *test_db;
 	gint fd, i, n, *hs_ids = NULL, pcre_flags, re_flags;
 	rspamd_cryptobox_fast_hash_state_t crc_st;
-	guint64 crc;
+	uint64_t crc;
 	rspamd_regexp_t *re;
 	hs_compile_error_t *hs_errors = NULL;
 	guint *hs_flags = NULL;
@@ -2273,7 +2273,7 @@ rspamd_re_cache_is_valid_hyperscan_file(struct rspamd_re_cache *cache,
 	hs_database_t *test_db = NULL;
 	guchar *map, *p, *end;
 	rspamd_cryptobox_fast_hash_state_t crc_st;
-	guint64 crc, valid_crc;
+	uint64_t crc, valid_crc;
 
 	len = strlen(path);
 
@@ -2406,7 +2406,7 @@ rspamd_re_cache_is_valid_hyperscan_file(struct rspamd_re_cache *cache,
 				p += sizeof(gint);
 
 				if (n <= 0 || 2 * n * sizeof(gint) +        /* IDs + flags */
-									  sizeof(guint64) +     /* crc */
+									  sizeof(uint64_t) +    /* crc */
 									  RSPAMD_HS_MAGIC_LEN + /* header */
 									  sizeof(cache->plt) >
 								  len) {
@@ -2437,7 +2437,7 @@ rspamd_re_cache_is_valid_hyperscan_file(struct rspamd_re_cache *cache,
 				rspamd_cryptobox_fast_hash_update(&crc_st, p + n * sizeof(gint),
 												  n * sizeof(gint));
 				/* HS database */
-				p += n * sizeof(gint) * 2 + sizeof(guint64);
+				p += n * sizeof(gint) * 2 + sizeof(uint64_t);
 				rspamd_cryptobox_fast_hash_update(&crc_st, p, end - p);
 				valid_crc = rspamd_cryptobox_fast_hash_final(&crc_st);
 
@@ -2539,7 +2539,7 @@ rspamd_re_cache_load_hyperscan(struct rspamd_re_cache *cache,
 			n = *(gint *) p;
 
 			if (n <= 0 || 2 * n * sizeof(gint) +        /* IDs + flags */
-								  sizeof(guint64) +     /* crc */
+								  sizeof(uint64_t) +    /* crc */
 								  RSPAMD_HS_MAGIC_LEN + /* header */
 								  sizeof(cache->plt) >
 							  (gsize) st.st_size) {
@@ -2567,7 +2567,7 @@ rspamd_re_cache_load_hyperscan(struct rspamd_re_cache *cache,
 			memcpy(hs_flags, p, n * sizeof(*hs_flags));
 
 			/* Skip crc */
-			p += n * sizeof(*hs_ids) + sizeof(guint64);
+			p += n * sizeof(*hs_ids) + sizeof(uint64_t);
 
 			/* Cleanup */
 			if (re_class->hs_scratch != NULL) {

--- a/src/libserver/re_cache.h
+++ b/src/libserver/re_cache.h
@@ -48,8 +48,8 @@ enum rspamd_re_type {
 };
 
 struct rspamd_re_cache_stat {
-	guint64 bytes_scanned;
-	guint64 bytes_scanned_pcre;
+	uint64_t bytes_scanned;
+	uint64_t bytes_scanned_pcre;
 	guint regexp_checked;
 	guint regexp_matched;
 	guint regexp_total;

--- a/src/libserver/rspamd_control.h
+++ b/src/libserver/rspamd_control.h
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -55,7 +55,7 @@ enum rspamd_srv_type {
 enum rspamd_log_pipe_type {
 	RSPAMD_LOG_PIPE_SYMBOLS = 0,
 };
-#define CONTROL_PATHLEN MIN(PATH_MAX, PIPE_BUF - sizeof(int) * 2 - sizeof(gint64) * 2)
+#define CONTROL_PATHLEN MIN(PATH_MAX, PIPE_BUF - sizeof(int) * 2 - sizeof(int64_t) * 2)
 struct rspamd_control_command {
 	enum rspamd_control_type type;
 	union {
@@ -154,7 +154,7 @@ struct rspamd_control_reply {
 
 struct rspamd_srv_command {
 	enum rspamd_srv_type type;
-	guint64 id;
+	uint64_t id;
 	union {
 		struct {
 			gint af;
@@ -206,7 +206,7 @@ struct rspamd_srv_command {
 
 struct rspamd_srv_reply {
 	enum rspamd_srv_type type;
-	guint64 id;
+	uint64_t id;
 	union {
 		struct {
 			gint code;

--- a/src/libserver/rspamd_symcache.h
+++ b/src/libserver/rspamd_symcache.h
@@ -66,7 +66,7 @@ enum rspamd_symbol_type {
  * Abstract structure for saving callback data for symbols
  */
 struct rspamd_abstract_callback_data {
-	guint64 magic;
+	uint64_t magic;
 	char data[];
 };
 
@@ -78,7 +78,7 @@ struct rspamd_symcache_item_stat {
 	gdouble avg_time;
 	gdouble weight;
 	guint hits;
-	guint64 total_hits;
+	uint64_t total_hits;
 	struct rspamd_counter_data frequency_counter;
 	gdouble avg_frequency;
 	gdouble stddev_frequency;
@@ -297,7 +297,7 @@ gboolean rspamd_symcache_is_checked(struct rspamd_task *task,
  * @param cache
  * @return
  */
-guint64 rspamd_symcache_get_cksum(struct rspamd_symcache *cache);
+uint64_t rspamd_symcache_get_cksum(struct rspamd_symcache *cache);
 
 /**
  * Checks if a symbols is enabled (not checked and conditions return true if present)
@@ -452,7 +452,7 @@ void rspamd_symcache_composites_foreach(struct rspamd_task *task,
  */
 bool rspamd_symcache_set_allowed_settings_ids(struct rspamd_symcache *cache,
 											  const gchar *symbol,
-											  const guint32 *ids,
+											  const uint32_t *ids,
 											  guint nids);
 /**
  * Sets denied settings ids for a symbol
@@ -463,7 +463,7 @@ bool rspamd_symcache_set_allowed_settings_ids(struct rspamd_symcache *cache,
  */
 bool rspamd_symcache_set_forbidden_settings_ids(struct rspamd_symcache *cache,
 												const gchar *symbol,
-												const guint32 *ids,
+												const uint32_t *ids,
 												guint nids);
 
 /**
@@ -473,9 +473,9 @@ bool rspamd_symcache_set_forbidden_settings_ids(struct rspamd_symcache *cache,
  * @param nids
  * @return
  */
-const guint32 *rspamd_symcache_get_allowed_settings_ids(struct rspamd_symcache *cache,
-														const gchar *symbol,
-														guint *nids);
+const uint32_t *rspamd_symcache_get_allowed_settings_ids(struct rspamd_symcache *cache,
+														 const gchar *symbol,
+														 guint *nids);
 
 /**
  * Returns denied ids for a symbol as a constant array
@@ -484,9 +484,9 @@ const guint32 *rspamd_symcache_get_allowed_settings_ids(struct rspamd_symcache *
  * @param nids
  * @return
  */
-const guint32 *rspamd_symcache_get_forbidden_settings_ids(struct rspamd_symcache *cache,
-														  const gchar *symbol,
-														  guint *nids);
+const uint32_t *rspamd_symcache_get_forbidden_settings_ids(struct rspamd_symcache *cache,
+														   const gchar *symbol,
+														   guint *nids);
 
 
 /**

--- a/src/libserver/spf.c
+++ b/src/libserver/spf.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -181,7 +181,7 @@ spf_record_cached_unref_dtor(gpointer p)
 void spf_library_config(const ucl_object_t *obj)
 {
 	const ucl_object_t *value;
-	gint64 ival;
+	int64_t ival;
 	bool bval;
 
 	if (obj == NULL) {
@@ -569,14 +569,14 @@ rspamd_spf_record_postprocess(struct spf_resolved *rec, struct rspamd_task *task
 		struct spf_addr *cur_addr = &g_array_index(rec->elts, struct spf_addr, i);
 
 		if (cur_addr->flags & RSPAMD_SPF_FLAG_IPV6) {
-			guint64 t[3];
+			uint64_t t[3];
 
 			/*
 			 * Fill hash entry for ipv6 addr with 2 int64 from ipv6 address,
 			 * the remaining int64 has mech + mask
 			 */
-			memcpy(t, cur_addr->addr6, sizeof(guint64) * 2);
-			t[2] = ((guint64) (cur_addr->mech)) << 48u;
+			memcpy(t, cur_addr->addr6, sizeof(uint64_t) * 2);
+			t[2] = ((uint64_t) (cur_addr->mech)) << 48u;
 			t[2] |= cur_addr->m.dual.mask_v6;
 
 			for (guint j = 0; j < G_N_ELEMENTS(t); j++) {
@@ -584,11 +584,11 @@ rspamd_spf_record_postprocess(struct spf_resolved *rec, struct rspamd_task *task
 			}
 		}
 		else if (cur_addr->flags & RSPAMD_SPF_FLAG_IPV4) {
-			guint64 t = 0;
+			uint64_t t = 0;
 
-			memcpy(&t, cur_addr->addr4, sizeof(guint32));
-			t |= ((guint64) (cur_addr->mech)) << 48u;
-			t |= ((guint64) cur_addr->m.dual.mask_v4) << 32u;
+			memcpy(&t, cur_addr->addr4, sizeof(uint32_t));
+			t |= ((uint64_t) (cur_addr->mech)) << 48u;
+			t |= ((uint64_t) cur_addr->m.dual.mask_v4) << 32u;
 
 			rec->digest = mum_hash_step(rec->digest, t);
 		}
@@ -1433,8 +1433,8 @@ parse_spf_ip4(struct spf_record *rec, struct spf_addr *addr)
 	const gchar *semicolon, *slash;
 	gsize len;
 	gchar ipbuf[INET_ADDRSTRLEN + 1];
-	guint32 mask;
-	static const guint32 min_valid_mask = 8;
+	uint32_t mask;
+	static const uint32_t min_valid_mask = 8;
 
 	semicolon = strchr(addr->spf_string, ':');
 
@@ -1509,8 +1509,8 @@ parse_spf_ip6(struct spf_record *rec, struct spf_addr *addr)
 	const gchar *semicolon, *slash;
 	gsize len;
 	gchar ipbuf[INET6_ADDRSTRLEN + 1];
-	guint32 mask;
-	static const guint32 min_valid_mask = 8;
+	uint32_t mask;
+	static const uint32_t min_valid_mask = 8;
 
 	semicolon = strchr(addr->spf_string, ':');
 

--- a/src/libserver/spf.h
+++ b/src/libserver/spf.h
@@ -75,7 +75,7 @@ struct spf_addr {
 			guint16 mask_v4;
 			guint16 mask_v6;
 		} dual;
-		guint32 idx;
+		uint32_t idx;
 	} m;
 	guint flags;
 	spf_mech_t mech;
@@ -96,7 +96,7 @@ struct spf_resolved {
 	guint ttl;
 	gint flags;
 	gdouble timestamp;
-	guint64 digest;
+	uint64_t digest;
 	GArray *elts;    /* Flat list of struct spf_addr */
 	ref_entry_t ref; /* Refcounting */
 };

--- a/src/libserver/symcache/symcache_c.cxx
+++ b/src/libserver/symcache/symcache_c.cxx
@@ -181,7 +181,7 @@ guint rspamd_symcache_stats_symbols_count(struct rspamd_symcache *cache)
 	return real_cache->get_stats_symbols_count();
 }
 
-guint64
+uint64_t
 rspamd_symcache_get_cksum(struct rspamd_symcache *cache)
 {
 	auto *real_cache = C_API_SYMCACHE(cache);
@@ -362,7 +362,7 @@ void rspamd_symcache_process_settings_elt(struct rspamd_symcache *cache,
 
 bool rspamd_symcache_set_allowed_settings_ids(struct rspamd_symcache *cache,
 											  const gchar *symbol,
-											  const guint32 *ids,
+											  const uint32_t *ids,
 											  guint nids)
 {
 	auto *real_cache = C_API_SYMCACHE(cache);
@@ -379,7 +379,7 @@ bool rspamd_symcache_set_allowed_settings_ids(struct rspamd_symcache *cache,
 
 bool rspamd_symcache_set_forbidden_settings_ids(struct rspamd_symcache *cache,
 												const gchar *symbol,
-												const guint32 *ids,
+												const uint32_t *ids,
 												guint nids)
 {
 	auto *real_cache = C_API_SYMCACHE(cache);
@@ -394,7 +394,7 @@ bool rspamd_symcache_set_forbidden_settings_ids(struct rspamd_symcache *cache,
 	return true;
 }
 
-const guint32 *
+const uint32_t *
 rspamd_symcache_get_allowed_settings_ids(struct rspamd_symcache *cache,
 										 const gchar *symbol,
 										 guint *nids)
@@ -405,7 +405,7 @@ rspamd_symcache_get_allowed_settings_ids(struct rspamd_symcache *cache,
 	return item->allowed_ids.get_ids(*nids);
 }
 
-const guint32 *
+const uint32_t *
 rspamd_symcache_get_forbidden_settings_ids(struct rspamd_symcache *cache,
 										   const gchar *symbol,
 										   guint *nids)

--- a/src/libserver/symcache/symcache_impl.cxx
+++ b/src/libserver/symcache/symcache_impl.cxx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -856,7 +856,7 @@ auto symcache::validate(bool strict) -> bool
 
 	for (auto &pair: items_by_symbol) {
 		auto &item = pair.second;
-		auto ghost = item->st->weight == 0 ? true : false;
+		auto ghost = item->st->weight == 0;
 		auto skipped = !ghost;
 
 		if (item->is_scoreable() && g_hash_table_lookup(cfg->symbols, item->symbol.c_str()) == nullptr) {

--- a/src/libserver/task.h
+++ b/src/libserver/task.h
@@ -171,10 +171,10 @@ struct rspamd_task {
 	struct rspamd_worker *worker; /**< pointer to worker object						*/
 	enum rspamd_command cmd;      /**< command										*/
 	gint sock;                    /**< socket descriptor								*/
-	guint32 dns_requests;         /**< number of DNS requests per this task			*/
-	guint32 flags;                /**< Bit flags										*/
-	guint32 protocol_flags;
-	guint32 processed_stages;                           /**< bits of stages that are processed			*/
+	uint32_t dns_requests;        /**< number of DNS requests per this task			*/
+	uint32_t flags;               /**< Bit flags										*/
+	uint32_t protocol_flags;
+	uint32_t processed_stages;                          /**< bits of stages that are processed			*/
 	gchar *helo;                                        /**< helo header value								*/
 	gchar *queue_id;                                    /**< queue id if specified							*/
 	rspamd_inet_addr_t *from_addr;                      /**< from addr for a task							*/

--- a/src/libserver/url.c
+++ b/src/libserver/url.c
@@ -1802,7 +1802,7 @@ rspamd_url_maybe_regenerate_from_ip(struct rspamd_url *uri, rspamd_mempool_t *po
 	struct in_addr in4;
 	struct in6_addr in6;
 	gboolean ret = FALSE, check_num = TRUE;
-	guint32 n, dots, t = 0, i = 0, shift, nshift;
+	uint32_t n, dots, t = 0, i = 0, shift, nshift;
 
 	p = rspamd_url_host_unsafe(uri);
 	end = p + uri->hostlen;
@@ -2360,7 +2360,7 @@ rspamd_url_parse(struct rspamd_url *uri,
 	}
 
 	UChar *utf16_hostname, *norm_utf16;
-	gint32 utf16_len, norm_utf16_len, norm_utf8_len;
+	int32_t utf16_len, norm_utf16_len, norm_utf8_len;
 	UParseError parse_error;
 
 	utf16_hostname = rspamd_mempool_alloc(pool, uri->hostlen * sizeof(UChar));

--- a/src/libserver/worker_util.c
+++ b/src/libserver/worker_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -726,8 +726,8 @@ rspamd_worker_set_limits(struct rspamd_main *rspamd_main,
 		}
 		else {
 			msg_info_main("set max file descriptors limit: %HL cur and %HL max",
-						  (guint64) rlmt.rlim_cur,
-						  (guint64) rlmt.rlim_max);
+						  (uint64_t) rlmt.rlim_cur,
+						  (uint64_t) rlmt.rlim_max);
 		}
 	}
 	else {
@@ -739,8 +739,8 @@ rspamd_worker_set_limits(struct rspamd_main *rspamd_main,
 		}
 		else {
 			msg_info_main("use system max file descriptors limit: %HL cur and %HL max",
-						  (guint64) rlmt.rlim_cur,
-						  (guint64) rlmt.rlim_max);
+						  (uint64_t) rlmt.rlim_cur,
+						  (uint64_t) rlmt.rlim_max);
 		}
 	}
 
@@ -780,13 +780,13 @@ rspamd_worker_set_limits(struct rspamd_main *rspamd_main,
 								  "%HL was wanted, "
 								  "but we have %HL cur and %HL max",
 								  cf->rlimit_maxcore,
-								  (guint64) rlmt.rlim_cur,
-								  (guint64) rlmt.rlim_max);
+								  (uint64_t) rlmt.rlim_cur,
+								  (uint64_t) rlmt.rlim_max);
 				}
 				else {
 					msg_info_main("set max core size limit: %HL cur and %HL max",
-								  (guint64) rlmt.rlim_cur,
-								  (guint64) rlmt.rlim_max);
+								  (uint64_t) rlmt.rlim_cur,
+								  (uint64_t) rlmt.rlim_max);
 				}
 			}
 		}
@@ -799,8 +799,8 @@ rspamd_worker_set_limits(struct rspamd_main *rspamd_main,
 			}
 			else {
 				msg_info_main("use system max core size limit: %HL cur and %HL max",
-							  (guint64) rlmt.rlim_cur,
-							  (guint64) rlmt.rlim_max);
+							  (uint64_t) rlmt.rlim_cur,
+							  (uint64_t) rlmt.rlim_max);
 			}
 		}
 	}
@@ -1808,8 +1808,8 @@ rspamd_check_termination_clause(struct rspamd_main *rspamd_main,
 					WEXITSTATUS(res),
 					g_strsignal(WTERMSIG(res)),
 					wrk->cores_throttled ? "yes" : "no",
-					(gint64) rlmt.rlim_cur,
-					(gint64) rlmt.rlim_max);
+					(int64_t) rlmt.rlim_cur,
+					(int64_t) rlmt.rlim_max);
 #else
 				msg_warn_main(
 					"%s process %P terminated abnormally with exit code %d by signal: %s"
@@ -1884,7 +1884,7 @@ rspamd_worker_hyperscan_ready(struct rspamd_main *rspamd_main,
 #endif /* With Hyperscan */
 
 gboolean
-rspamd_worker_check_context(gpointer ctx, guint64 magic)
+rspamd_worker_check_context(gpointer ctx, uint64_t magic)
 {
 	struct rspamd_abstract_worker_ctx *actx = (struct rspamd_abstract_worker_ctx *) ctx;
 

--- a/src/libserver/worker_util.h
+++ b/src/libserver/worker_util.h
@@ -65,7 +65,7 @@ rspamd_prepare_worker(struct rspamd_worker *worker, const char *name,
  * @param magic
  * @return
  */
-gboolean rspamd_worker_check_context(gpointer ctx, guint64 magic);
+gboolean rspamd_worker_check_context(gpointer ctx, uint64_t magic);
 
 /**
  * Set special signal handler for a worker

--- a/src/libstat/backends/mmaped_file.c
+++ b/src/libstat/backends/mmaped_file.c
@@ -26,33 +26,33 @@
  * Common statfile header
  */
 struct stat_file_header {
-	u_char magic[3];            /**< magic signature ('r' 's' 'd')      */
-	u_char version[2];          /**< version of statfile				*/
-	u_char padding[3];          /**< padding							*/
-	guint64 create_time;        /**< create time (time_t->guint64)		*/
-	guint64 revision;           /**< revision number					*/
-	guint64 rev_time;           /**< revision time						*/
-	guint64 used_blocks;        /**< used blocks number					*/
-	guint64 total_blocks;       /**< total number of blocks				*/
-	guint64 tokenizer_conf_len; /**< length of tokenizer configuration	*/
-	u_char unused[231];         /**< some bytes that can be used in future */
+	u_char magic[3];             /**< magic signature ('r' 's' 'd')      */
+	u_char version[2];           /**< version of statfile				*/
+	u_char padding[3];           /**< padding							*/
+	uint64_t create_time;        /**< create time (time_t->uint64_t)		*/
+	uint64_t revision;           /**< revision number					*/
+	uint64_t rev_time;           /**< revision time						*/
+	uint64_t used_blocks;        /**< used blocks number					*/
+	uint64_t total_blocks;       /**< total number of blocks				*/
+	uint64_t tokenizer_conf_len; /**< length of tokenizer configuration	*/
+	u_char unused[231];          /**< some bytes that can be used in future */
 };
 
 /**
  * Section header
  */
 struct stat_file_section {
-	guint64 code;   /**< section's code						*/
-	guint64 length; /**< section's length in blocks			*/
+	uint64_t code;   /**< section's code						*/
+	uint64_t length; /**< section's length in blocks			*/
 };
 
 /**
  * Block of data in statfile
  */
 struct stat_file_block {
-	guint32 hash1; /**< hash1 (also acts as index)			*/
-	guint32 hash2; /**< hash2								*/
-	double value;  /**< double value                       */
+	uint32_t hash1; /**< hash1 (also acts as index)			*/
+	uint32_t hash2; /**< hash2								*/
+	double value;   /**< double value                       */
 };
 
 /**
@@ -91,7 +91,7 @@ typedef struct {
 
 static void rspamd_mmaped_file_set_block_common(rspamd_mempool_t *pool,
 												rspamd_mmaped_file_t *file,
-												guint32 h1, guint32 h2, double value);
+												uint32_t h1, uint32_t h2, double value);
 
 rspamd_mmaped_file_t *rspamd_mmaped_file_open(rspamd_mempool_t *pool,
 											  const gchar *filename, size_t size,
@@ -104,8 +104,8 @@ gint rspamd_mmaped_file_close_file(rspamd_mempool_t *pool,
 
 double
 rspamd_mmaped_file_get_block(rspamd_mmaped_file_t *file,
-							 guint32 h1,
-							 guint32 h2)
+							 uint32_t h1,
+							 uint32_t h2)
 {
 	struct stat_file_block *block;
 	guint i, blocknum;
@@ -137,7 +137,7 @@ rspamd_mmaped_file_get_block(rspamd_mmaped_file_t *file,
 static void
 rspamd_mmaped_file_set_block_common(rspamd_mempool_t *pool,
 									rspamd_mmaped_file_t *file,
-									guint32 h1, guint32 h2, double value)
+									uint32_t h1, uint32_t h2, double value)
 {
 	struct stat_file_block *block, *to_expire = NULL;
 	struct stat_file_header *header;
@@ -215,15 +215,15 @@ rspamd_mmaped_file_set_block_common(rspamd_mempool_t *pool,
 
 void rspamd_mmaped_file_set_block(rspamd_mempool_t *pool,
 								  rspamd_mmaped_file_t *file,
-								  guint32 h1,
-								  guint32 h2,
+								  uint32_t h1,
+								  uint32_t h2,
 								  double value)
 {
 	rspamd_mmaped_file_set_block_common(pool, file, h1, h2, value);
 }
 
 gboolean
-rspamd_mmaped_file_set_revision(rspamd_mmaped_file_t *file, guint64 rev, time_t time)
+rspamd_mmaped_file_set_revision(rspamd_mmaped_file_t *file, uint64_t rev, time_t time)
 {
 	struct stat_file_header *header;
 
@@ -273,7 +273,7 @@ rspamd_mmaped_file_dec_revision(rspamd_mmaped_file_t *file)
 
 
 gboolean
-rspamd_mmaped_file_get_revision(rspamd_mmaped_file_t *file, guint64 *rev, time_t *time)
+rspamd_mmaped_file_get_revision(rspamd_mmaped_file_t *file, uint64_t *rev, time_t *time)
 {
 	struct stat_file_header *header;
 
@@ -293,13 +293,13 @@ rspamd_mmaped_file_get_revision(rspamd_mmaped_file_t *file, guint64 *rev, time_t
 	return TRUE;
 }
 
-guint64
+uint64_t
 rspamd_mmaped_file_get_used(rspamd_mmaped_file_t *file)
 {
 	struct stat_file_header *header;
 
 	if (file == NULL || file->map == NULL) {
-		return (guint64) -1;
+		return (uint64_t) -1;
 	}
 
 	header = (struct stat_file_header *) file->map;
@@ -307,13 +307,13 @@ rspamd_mmaped_file_get_used(rspamd_mmaped_file_t *file)
 	return header->used_blocks;
 }
 
-guint64
+uint64_t
 rspamd_mmaped_file_get_total(rspamd_mmaped_file_t *file)
 {
 	struct stat_file_header *header;
 
 	if (file == NULL || file->map == NULL) {
-		return (guint64) -1;
+		return (uint64_t) -1;
 	}
 
 	header = (struct stat_file_header *) file->map;
@@ -752,14 +752,14 @@ create:
 					 0,
 					 sizeof(header) + sizeof(section) + sizeof(block) * nblocks);
 
-	header.create_time = (guint64) time(NULL);
+	header.create_time = (uint64_t) time(NULL);
 	g_assert(stcf->clcf != NULL);
 	g_assert(stcf->clcf->tokenizer != NULL);
 	tokenizer = rspamd_stat_get_tokenizer(stcf->clcf->tokenizer->name);
 	g_assert(tokenizer != NULL);
 	tok_conf = tokenizer->get_config(pool, stcf->clcf->tokenizer, &tok_conf_len);
 	header.tokenizer_conf_len = tok_conf_len;
-	g_assert(tok_conf_len < sizeof(header.unused) - sizeof(guint64));
+	g_assert(tok_conf_len < sizeof(header.unused) - sizeof(uint64_t));
 	memcpy(header.unused, tok_conf, tok_conf_len);
 
 	if (write(fd, &header, sizeof(header)) == -1) {
@@ -775,7 +775,7 @@ create:
 		return -1;
 	}
 
-	section.length = (guint64) nblocks;
+	section.length = (uint64_t) nblocks;
 	if (write(fd, &section, sizeof(section)) == -1) {
 		msg_info_pool("cannot write section header to file %s, error %d, %s",
 					  filename,
@@ -944,7 +944,7 @@ rspamd_mmaped_file_process_tokens(struct rspamd_task *task, GPtrArray *tokens,
 								  gpointer p)
 {
 	rspamd_mmaped_file_t *mf = p;
-	guint32 h1, h2;
+	uint32_t h1, h2;
 	rspamd_token_t *tok;
 	guint i;
 
@@ -974,7 +974,7 @@ rspamd_mmaped_file_learn_tokens(struct rspamd_task *task, GPtrArray *tokens,
 								gpointer p)
 {
 	rspamd_mmaped_file_t *mf = p;
-	guint32 h1, h2;
+	uint32_t h1, h2;
 	rspamd_token_t *tok;
 	guint i;
 
@@ -997,7 +997,7 @@ rspamd_mmaped_file_total_learns(struct rspamd_task *task, gpointer runtime,
 								gpointer ctx)
 {
 	rspamd_mmaped_file_t *mf = (rspamd_mmaped_file_t *) runtime;
-	guint64 rev = 0;
+	uint64_t rev = 0;
 	time_t t;
 
 	if (mf != NULL) {
@@ -1012,7 +1012,7 @@ rspamd_mmaped_file_inc_learns(struct rspamd_task *task, gpointer runtime,
 							  gpointer ctx)
 {
 	rspamd_mmaped_file_t *mf = (rspamd_mmaped_file_t *) runtime;
-	guint64 rev = 0;
+	uint64_t rev = 0;
 	time_t t;
 
 	if (mf != NULL) {
@@ -1028,7 +1028,7 @@ rspamd_mmaped_file_dec_learns(struct rspamd_task *task, gpointer runtime,
 							  gpointer ctx)
 {
 	rspamd_mmaped_file_t *mf = (rspamd_mmaped_file_t *) runtime;
-	guint64 rev = 0;
+	uint64_t rev = 0;
 	time_t t;
 
 	if (mf != NULL) {
@@ -1045,7 +1045,7 @@ rspamd_mmaped_file_get_stat(gpointer runtime,
 							gpointer ctx)
 {
 	ucl_object_t *res = NULL;
-	guint64 rev;
+	uint64_t rev;
 	rspamd_mmaped_file_t *mf = (rspamd_mmaped_file_t *) runtime;
 
 	if (mf != NULL) {

--- a/src/libstat/backends/sqlite3_backend.c
+++ b/src/libstat/backends/sqlite3_backend.c
@@ -43,8 +43,8 @@ struct rspamd_stat_sqlite3_rt {
 	struct rspamd_task *task;
 	struct rspamd_stat_sqlite3_db *db;
 	struct rspamd_statfile_config *cf;
-	gint64 user_id;
-	gint64 lang_id;
+	int64_t user_id;
+	int64_t lang_id;
 };
 
 static const char *create_tables_sql =
@@ -156,11 +156,11 @@ rspamd_sqlite3_backend_quark(void)
 	return g_quark_from_static_string("sqlite3-stat-backend");
 }
 
-static gint64
+static int64_t
 rspamd_sqlite3_get_user(struct rspamd_stat_sqlite3_db *db,
 						struct rspamd_task *task, gboolean learn)
 {
-	gint64 id = 0; /* Default user is 0 */
+	int64_t id = 0; /* Default user is 0 */
 	gint rc, err_idx;
 	const gchar *user = NULL;
 	struct rspamd_task **ptask;
@@ -215,11 +215,11 @@ rspamd_sqlite3_get_user(struct rspamd_stat_sqlite3_db *db,
 	return id;
 }
 
-static gint64
+static int64_t
 rspamd_sqlite3_get_language(struct rspamd_stat_sqlite3_db *db,
 							struct rspamd_task *task, gboolean learn)
 {
-	gint64 id = 0; /* Default language is 0 */
+	int64_t id = 0; /* Default language is 0 */
 	gint rc, err_idx;
 	guint i;
 	const gchar *language = NULL;
@@ -293,7 +293,7 @@ rspamd_sqlite3_opendb(rspamd_mempool_t *pool,
 	struct rspamd_stat_tokenizer *tokenizer;
 	gpointer tk_conf;
 	gsize sz = 0;
-	gint64 sz64 = 0;
+	int64_t sz64 = 0;
 	gchar *tok_conf_encoded;
 	gint ret, ntries = 0;
 	const gint max_tries = 100;
@@ -347,7 +347,7 @@ rspamd_sqlite3_opendb(rspamd_mempool_t *pool,
 
 		if (rspamd_sqlite3_run_prstmt(pool, bk->sqlite, bk->prstmt,
 									  RSPAMD_STAT_BACKEND_SAVE_TOKENIZER,
-									  (gint64) strlen(tok_conf_encoded),
+									  (int64_t) strlen(tok_conf_encoded),
 									  tok_conf_encoded) != SQLITE_OK) {
 			sqlite3_close(bk->sqlite);
 			g_free(bk);
@@ -526,7 +526,7 @@ rspamd_sqlite3_process_tokens(struct rspamd_task *task,
 {
 	struct rspamd_stat_sqlite3_db *bk;
 	struct rspamd_stat_sqlite3_rt *rt = p;
-	gint64 iv = 0;
+	int64_t iv = 0;
 	guint i;
 	rspamd_token_t *tok;
 
@@ -629,7 +629,7 @@ rspamd_sqlite3_learn_tokens(struct rspamd_task *task, GPtrArray *tokens,
 {
 	struct rspamd_stat_sqlite3_db *bk;
 	struct rspamd_stat_sqlite3_rt *rt = p;
-	gint64 iv = 0;
+	int64_t iv = 0;
 	guint i;
 	rspamd_token_t *tok;
 
@@ -735,7 +735,7 @@ rspamd_sqlite3_total_learns(struct rspamd_task *task, gpointer runtime,
 {
 	struct rspamd_stat_sqlite3_rt *rt = runtime;
 	struct rspamd_stat_sqlite3_db *bk;
-	guint64 res;
+	uint64_t res;
 
 	g_assert(rt != NULL);
 	bk = rt->db;
@@ -751,7 +751,7 @@ rspamd_sqlite3_inc_learns(struct rspamd_task *task, gpointer runtime,
 {
 	struct rspamd_stat_sqlite3_rt *rt = runtime;
 	struct rspamd_stat_sqlite3_db *bk;
-	guint64 res;
+	uint64_t res;
 
 	g_assert(rt != NULL);
 	bk = rt->db;
@@ -780,7 +780,7 @@ rspamd_sqlite3_dec_learns(struct rspamd_task *task, gpointer runtime,
 {
 	struct rspamd_stat_sqlite3_rt *rt = runtime;
 	struct rspamd_stat_sqlite3_db *bk;
-	guint64 res;
+	uint64_t res;
 
 	g_assert(rt != NULL);
 	bk = rt->db;
@@ -809,7 +809,7 @@ rspamd_sqlite3_learns(struct rspamd_task *task, gpointer runtime,
 {
 	struct rspamd_stat_sqlite3_rt *rt = runtime;
 	struct rspamd_stat_sqlite3_db *bk;
-	guint64 res;
+	uint64_t res;
 
 	g_assert(rt != NULL);
 	bk = rt->db;
@@ -828,7 +828,7 @@ rspamd_sqlite3_get_stat(gpointer runtime,
 	struct rspamd_stat_sqlite3_db *bk;
 	rspamd_mempool_t *pool;
 	struct stat st;
-	gint64 rev;
+	int64_t rev;
 
 	g_assert(rt != NULL);
 	bk = rt->db;
@@ -873,7 +873,7 @@ rspamd_sqlite3_load_tokenizer_config(gpointer runtime,
 									 gsize *len)
 {
 	gpointer tk_conf, copied_conf;
-	guint64 sz;
+	uint64_t sz;
 	struct rspamd_stat_sqlite3_rt *rt = runtime;
 	struct rspamd_stat_sqlite3_db *bk;
 

--- a/src/libstat/classifiers/bayes.c
+++ b/src/libstat/classifiers/bayes.c
@@ -97,9 +97,9 @@ struct bayes_task_closure {
 	double ham_prob;
 	double spam_prob;
 	gdouble meta_skip_prob;
-	guint64 processed_tokens;
-	guint64 total_hits;
-	guint64 text_tokens;
+	uint64_t processed_tokens;
+	uint64_t total_hits;
+	uint64_t text_tokens;
 	struct rspamd_task *task;
 };
 

--- a/src/libstat/classifiers/lua_classifier.c
+++ b/src/libstat/classifiers/lua_classifier.c
@@ -136,7 +136,7 @@ lua_classifier_classify(struct rspamd_classifier *cl,
 	lua_State *L;
 	rspamd_token_t *tok;
 	guint i;
-	guint64 v;
+	uint64_t v;
 
 	ctx = g_hash_table_lookup(lua_classifiers, cl->subrs->name);
 	g_assert(ctx != NULL);
@@ -157,9 +157,9 @@ lua_classifier_classify(struct rspamd_classifier *cl,
 		v = tok->data;
 		lua_createtable(L, 3, 0);
 		/* High word, low word, order */
-		lua_pushinteger(L, (guint32) (v >> 32));
+		lua_pushinteger(L, (uint32_t) (v >> 32));
 		lua_rawseti(L, -2, 1);
-		lua_pushinteger(L, (guint32) (v));
+		lua_pushinteger(L, (uint32_t) (v));
 		lua_rawseti(L, -2, 2);
 		lua_pushinteger(L, tok->window_idx);
 		lua_rawseti(L, -2, 3);
@@ -191,7 +191,7 @@ lua_classifier_learn_spam(struct rspamd_classifier *cl,
 	lua_State *L;
 	rspamd_token_t *tok;
 	guint i;
-	guint64 v;
+	uint64_t v;
 
 	ctx = g_hash_table_lookup(lua_classifiers, cl->subrs->name);
 	g_assert(ctx != NULL);
@@ -213,9 +213,9 @@ lua_classifier_learn_spam(struct rspamd_classifier *cl,
 		v = tok->data;
 		lua_createtable(L, 3, 0);
 		/* High word, low word, order */
-		lua_pushinteger(L, (guint32) (v >> 32));
+		lua_pushinteger(L, (uint32_t) (v >> 32));
 		lua_rawseti(L, -2, 1);
-		lua_pushinteger(L, (guint32) (v));
+		lua_pushinteger(L, (uint32_t) (v));
 		lua_rawseti(L, -2, 2);
 		lua_pushinteger(L, tok->window_idx);
 		lua_rawseti(L, -2, 3);

--- a/src/libstat/learn_cache/sqlite3_cache.c
+++ b/src/libstat/learn_cache/sqlite3_cache.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -165,7 +165,7 @@ gint rspamd_stat_cache_sqlite3_check(struct rspamd_task *task,
 	gchar *user = NULL;
 	guint i;
 	gint rc;
-	gint64 flag;
+	int64_t flag;
 
 	if (task->tokens == NULL || task->tokens->len == 0) {
 		return RSPAMD_LEARN_IGNORE;
@@ -193,7 +193,7 @@ gint rspamd_stat_cache_sqlite3_check(struct rspamd_task *task,
 		rspamd_sqlite3_run_prstmt(task->task_pool, ctx->db, ctx->prstmt,
 								  RSPAMD_STAT_CACHE_TRANSACTION_START_DEF);
 		rc = rspamd_sqlite3_run_prstmt(task->task_pool, ctx->db, ctx->prstmt,
-									   RSPAMD_STAT_CACHE_GET_LEARN, (gint64) rspamd_cryptobox_HASHBYTES,
+									   RSPAMD_STAT_CACHE_GET_LEARN, (int64_t) rspamd_cryptobox_HASHBYTES,
 									   out, &flag);
 		rspamd_sqlite3_run_prstmt(task->task_pool, ctx->db, ctx->prstmt,
 								  RSPAMD_STAT_CACHE_TRANSACTION_COMMIT);
@@ -226,7 +226,7 @@ gint rspamd_stat_cache_sqlite3_learn(struct rspamd_task *task,
 	struct rspamd_stat_sqlite3_ctx *ctx = runtime;
 	gboolean unlearn = !!(task->flags & RSPAMD_TASK_FLAG_UNLEARN);
 	guchar *h;
-	gint64 flag;
+	int64_t flag;
 
 	h = rspamd_mempool_get_variable(task->task_pool, "words_hash");
 
@@ -242,7 +242,7 @@ gint rspamd_stat_cache_sqlite3_learn(struct rspamd_task *task,
 								  RSPAMD_STAT_CACHE_TRANSACTION_START_IM);
 		rspamd_sqlite3_run_prstmt(task->task_pool, ctx->db, ctx->prstmt,
 								  RSPAMD_STAT_CACHE_ADD_LEARN,
-								  (gint64) rspamd_cryptobox_HASHBYTES, h, flag);
+								  (int64_t) rspamd_cryptobox_HASHBYTES, h, flag);
 		rspamd_sqlite3_run_prstmt(task->task_pool, ctx->db, ctx->prstmt,
 								  RSPAMD_STAT_CACHE_TRANSACTION_COMMIT);
 	}
@@ -252,7 +252,7 @@ gint rspamd_stat_cache_sqlite3_learn(struct rspamd_task *task,
 		rspamd_sqlite3_run_prstmt(task->task_pool, ctx->db, ctx->prstmt,
 								  RSPAMD_STAT_CACHE_UPDATE_LEARN,
 								  flag,
-								  (gint64) rspamd_cryptobox_HASHBYTES, h);
+								  (int64_t) rspamd_cryptobox_HASHBYTES, h);
 		rspamd_sqlite3_run_prstmt(task->task_pool, ctx->db, ctx->prstmt,
 								  RSPAMD_STAT_CACHE_TRANSACTION_COMMIT);
 	}

--- a/src/libstat/stat_api.h
+++ b/src/libstat/stat_api.h
@@ -55,7 +55,7 @@ typedef struct rspamd_stat_token_s {
 
 #define RSPAMD_TOKEN_VALUE_TYPE float
 typedef struct token_node_s {
-	guint64 data;
+	uint64_t data;
 	guint window_idx;
 	guint flags;
 	rspamd_stat_token_t *t1;
@@ -136,7 +136,7 @@ rspamd_stat_result_t rspamd_stat_learn(struct rspamd_task *task,
  */
 rspamd_stat_result_t rspamd_stat_statistics(struct rspamd_task *task,
 											struct rspamd_config *cfg,
-											guint64 *total_learns,
+											uint64_t *total_learns,
 											ucl_object_t **res);
 
 void rspamd_stat_unload(void);

--- a/src/libstat/stat_internal.h
+++ b/src/libstat/stat_internal.h
@@ -31,8 +31,8 @@ extern "C" {
 struct rspamd_statfile_runtime {
 	struct rspamd_statfile_config *st;
 	gpointer backend_runtime;
-	guint64 hits;
-	guint64 total_hits;
+	uint64_t hits;
+	uint64_t total_hits;
 };
 
 /* Common classifier structure */

--- a/src/libstat/stat_process.c
+++ b/src/libstat/stat_process.c
@@ -1189,7 +1189,7 @@ rspamd_stat_check_autolearn(struct rspamd_task *task)
 rspamd_stat_result_t
 rspamd_stat_statistics(struct rspamd_task *task,
 					   struct rspamd_config *cfg,
-					   guint64 *total_learns,
+					   uint64_t *total_learns,
 					   ucl_object_t **target)
 {
 	struct rspamd_stat_ctx *st_ctx;
@@ -1197,7 +1197,7 @@ rspamd_stat_statistics(struct rspamd_task *task,
 	struct rspamd_statfile *st;
 	gpointer backend_runtime;
 	ucl_object_t *res = NULL, *elt;
-	guint64 learns = 0;
+	uint64_t learns = 0;
 	guint i, j;
 	gint id;
 

--- a/src/libstat/tokenizers/osb.c
+++ b/src/libstat/tokenizers/osb.c
@@ -62,7 +62,7 @@ struct rspamd_osb_tokenizer_config {
 	gshort version;
 	gshort window_size;
 	enum rspamd_osb_hash_type ht;
-	guint64 seed;
+	uint64_t seed;
 	rspamd_sipkey_t sk;
 };
 
@@ -262,7 +262,7 @@ rspamd_tokenizer_osb_is_compat (struct rspamd_tokenizer_runtime *rt)
 #endif
 
 struct token_pipe_entry {
-	guint64 h;
+	uint64_t h;
 	rspamd_stat_token_t *t;
 };
 
@@ -276,9 +276,9 @@ gint rspamd_tokenizer_osb(struct rspamd_stat_ctx *ctx,
 	rspamd_token_t *new_tok = NULL;
 	rspamd_stat_token_t *token;
 	struct rspamd_osb_tokenizer_config *osb_cf;
-	guint64 cur, seed;
+	uint64_t cur, seed;
 	struct token_pipe_entry *hashpipe;
-	guint32 h1, h2;
+	uint32_t h1, h2;
 	gsize token_size;
 	guint processed = 0, i, w, window_size, token_flags = 0;
 
@@ -369,10 +369,10 @@ gint rspamd_tokenizer_osb(struct rspamd_stat_ctx *ctx,
 		new_tok->t1 = hashpipe[0].t;                                                    \
 		new_tok->t2 = hashpipe[i].t;                                                    \
 		if (osb_cf->ht == RSPAMD_OSB_HASH_COMPAT) {                                     \
-			h1 = ((guint32) hashpipe[0].h) * primes[0] +                                \
-				 ((guint32) hashpipe[i].h) * primes[i << 1];                            \
-			h2 = ((guint32) hashpipe[0].h) * primes[1] +                                \
-				 ((guint32) hashpipe[i].h) * primes[(i << 1) - 1];                      \
+			h1 = ((uint32_t) hashpipe[0].h) * primes[0] +                               \
+				 ((uint32_t) hashpipe[i].h) * primes[i << 1];                           \
+			h2 = ((uint32_t) hashpipe[0].h) * primes[1] +                               \
+				 ((uint32_t) hashpipe[i].h) * primes[(i << 1) - 1];                     \
 			memcpy((guchar *) &new_tok->data, &h1, sizeof(h1));                         \
 			memcpy(((guchar *) &new_tok->data) + sizeof(h1), &h2, sizeof(h2));          \
 		}                                                                               \

--- a/src/libstat/tokenizers/tokenizers.c
+++ b/src/libstat/tokenizers/tokenizers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,8 +162,8 @@ static inline gboolean
 rspamd_tokenize_check_limit(gboolean decay,
 							guint word_decay,
 							guint nwords,
-							guint64 *hv,
-							guint64 *prob,
+							uint64_t *hv,
+							uint64_t *prob,
 							const rspamd_stat_token_t *token,
 							gssize remain,
 							gssize total)
@@ -171,8 +171,8 @@ rspamd_tokenize_check_limit(gboolean decay,
 	static const gdouble avg_word_len = 6.0;
 
 	if (!decay) {
-		if (token->original.len >= sizeof(guint64)) {
-			guint64 tmp;
+		if (token->original.len >= sizeof(uint64_t)) {
+			uint64_t tmp;
 			memcpy(&tmp, token->original.begin, sizeof(tmp));
 			*hv = mum_hash_step(*hv, tmp);
 		}
@@ -192,7 +192,7 @@ rspamd_tokenize_check_limit(gboolean decay,
 				*prob = G_MAXUINT64;
 			}
 			else {
-				*prob = (guint64) (decay_prob * (double) G_MAXUINT64);
+				*prob = (uint64_t) (decay_prob * (double) G_MAXUINT64);
 			}
 
 			return TRUE;
@@ -213,7 +213,7 @@ rspamd_tokenize_check_limit(gboolean decay,
 
 static inline gboolean
 rspamd_utf_word_valid(const guchar *text, const guchar *end,
-					  gint32 start, gint32 finish)
+					  int32_t start, int32_t finish)
 {
 	const guchar *st = text + start, *fin = text + finish;
 	UChar32 c;
@@ -283,7 +283,7 @@ rspamd_tokenize_text(const gchar *text, gsize len,
 					 enum rspamd_tokenize_type how,
 					 struct rspamd_config *cfg,
 					 GList *exceptions,
-					 guint64 *hash,
+					 uint64_t *hash,
 					 GArray *cur_words,
 					 rspamd_mempool_t *pool)
 {
@@ -293,9 +293,9 @@ rspamd_tokenize_text(const gchar *text, gsize len,
 	GArray *res;
 	GList *cur = exceptions;
 	guint min_len = 0, max_len = 0, word_decay = 0, initial_size = 128;
-	guint64 hv = 0;
+	uint64_t hv = 0;
 	gboolean decay = FALSE, long_text_mode = FALSE;
-	guint64 prob = 0;
+	uint64_t prob = 0;
 	static UBreakIterator *bi = NULL;
 	static const gsize long_text_limit = 1 * 1024 * 1024;
 	static const ev_tstamp max_exec_time = 0.2; /* 200 ms */
@@ -422,7 +422,7 @@ rspamd_tokenize_text(const gchar *text, gsize len,
 							if (last > p) {
 								/* Exception spread over the boundaries */
 								while (last > p && p != UBRK_DONE) {
-									gint32 old_p = p;
+									int32_t old_p = p;
 									p = ubrk_next(bi);
 
 									if (p != UBRK_DONE && p <= old_p) {
@@ -462,7 +462,7 @@ rspamd_tokenize_text(const gchar *text, gsize len,
 							if (last > p) {
 								/* Exception spread over the boundaries */
 								while (last > p && p != UBRK_DONE) {
-									gint32 old_p = p;
+									int32_t old_p = p;
 									p = ubrk_next(bi);
 									if (p != UBRK_DONE && p <= old_p) {
 										msg_warn_pool_check(
@@ -607,14 +607,14 @@ rspamd_add_metawords_from_str(const gchar *beg, gsize len,
 	while (i < len) {
 		U8_NEXT(beg, i, len, uc);
 
-		if (((gint32) uc) < 0) {
+		if (((int32_t) uc) < 0) {
 			valid_utf = FALSE;
 			break;
 		}
 
 #if U_ICU_VERSION_MAJOR_NUM < 50
 		if (u_isalpha(uc)) {
-			gint32 sc = ublock_getCode(uc);
+			int32_t sc = ublock_getCode(uc);
 
 			if (sc == UBLOCK_THAI) {
 				valid_utf = FALSE;
@@ -697,7 +697,7 @@ rspamd_uchars_to_ucs32(const UChar *src, gsize srclen,
 					   rspamd_mempool_t *pool)
 {
 	UChar32 *dest, t, *d;
-	gint32 i = 0;
+	int32_t i = 0;
 
 	dest = rspamd_mempool_alloc(pool, srclen * sizeof(UChar32));
 	d = dest;
@@ -787,7 +787,7 @@ void rspamd_normalize_single_word(rspamd_stat_token_t *tok, rspamd_mempool_t *po
 		else {
 #if U_ICU_VERSION_MAJOR_NUM >= 44
 			const UNormalizer2 *norm = rspamd_get_unicode_normalizer();
-			gint32 end;
+			int32_t end;
 
 			/* We can now check if we need to decompose */
 			end = unorm2_spanQuickCheckYes(norm, tmpbuf, ulen, &uc_err);

--- a/src/libstat/tokenizers/tokenizers.h
+++ b/src/libstat/tokenizers/tokenizers.h
@@ -65,7 +65,7 @@ GArray *rspamd_tokenize_text(const gchar *text, gsize len,
 							 enum rspamd_tokenize_type how,
 							 struct rspamd_config *cfg,
 							 GList *exceptions,
-							 guint64 *hash,
+							 uint64_t *hash,
 							 GArray *cur_words,
 							 rspamd_mempool_t *pool);
 

--- a/src/libutil/addr.c
+++ b/src/libutil/addr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -460,7 +460,7 @@ rspamd_parse_inet_address_ip4(const guchar *text, gsize len, gpointer target)
 {
 	const guchar *p;
 	guchar c;
-	guint32 addr = 0, *addrptr = target;
+	uint32_t addr = 0, *addrptr = target;
 	guint octet = 0, n = 0;
 
 	g_assert(text != NULL);
@@ -1728,7 +1728,7 @@ rspamd_inet_address_from_rnds(const struct rdns_reply_entry *rep)
 
 void rspamd_inet_address_apply_mask(rspamd_inet_addr_t *addr, guint mask)
 {
-	guint32 umsk, *p;
+	uint32_t umsk, *p;
 
 	if (mask > 0 && addr != NULL) {
 		if (addr->af == AF_INET && mask <= 32) {
@@ -1890,7 +1890,7 @@ guint rspamd_inet_address_hash(gconstpointer a)
 		int af;
 	} layout;
 
-	gint32 k;
+	int32_t k;
 
 	if (addr->af == AF_UNIX && addr->u.un) {
 		rspamd_cryptobox_fast_hash_state_t st;
@@ -1931,7 +1931,7 @@ guint rspamd_inet_address_port_hash(gconstpointer a)
 		int af;
 	} layout;
 
-	gint32 k;
+	int32_t k;
 
 	if (addr->af == AF_UNIX && addr->u.un) {
 		rspamd_cryptobox_fast_hash_state_t st;

--- a/src/libutil/expression.c
+++ b/src/libutil/expression.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -864,7 +864,7 @@ rspamd_parse_expression(const gchar *line, gsize len,
 	e->evals = 0;
 	e->next_resort = ottery_rand_range(MAX_RESORT_EVALS) + MIN_RESORT_EVALS;
 	e->log_id = g_malloc0(RSPAMD_LOG_ID_LEN + 1);
-	guint64 h = rspamd_cryptobox_fast_hash(line, len, 0xdeadbabe);
+	uint64_t h = rspamd_cryptobox_fast_hash(line, len, 0xdeadbabe);
 	rspamd_snprintf(e->log_id, RSPAMD_LOG_ID_LEN + 1, "%xL", h);
 	msg_debug_expression("start to parse expression '%*s'", (int) len, line);
 
@@ -1538,8 +1538,8 @@ rspamd_ast_string_traverse(GNode *n, gpointer d)
 							  (int) elt->p.atom->len, elt->p.atom->str);
 	}
 	else if (elt->type == ELT_LIMIT) {
-		if (elt->p.lim == (double) (gint64) elt->p.lim) {
-			rspamd_printf_gstring(res, "%L", (gint64) elt->p.lim);
+		if (elt->p.lim == (double) (int64_t) elt->p.lim) {
+			rspamd_printf_gstring(res, "%L", (int64_t) elt->p.lim);
 		}
 		else {
 			rspamd_printf_gstring(res, "%f", elt->p.lim);

--- a/src/libutil/fstring.c
+++ b/src/libutil/fstring.c
@@ -229,8 +229,8 @@ void rspamd_fstring_erase(rspamd_fstring_t *str, gsize pos, gsize len)
 }
 
 /* Compat code */
-static guint64
-fstrhash_c(guint64 c, guint64 hval)
+static uint64_t
+fstrhash_c(uint64_t c, uint64_t hval)
 {
 	return mum_hash_step(hval, c);
 }
@@ -239,11 +239,11 @@ fstrhash_c(guint64 c, guint64 hval)
 /*
  * Return hash value for a string
  */
-guint32
+uint32_t
 rspamd_fstrhash_lc(const rspamd_ftok_t *str, gboolean is_utf)
 {
 	gsize i;
-	guint64 hval;
+	uint64_t hval;
 	const gchar *p, *end = NULL;
 	gunichar uc;
 
@@ -266,20 +266,20 @@ rspamd_fstrhash_lc(const rspamd_ftok_t *str, gboolean is_utf)
 		}
 	}
 	else {
-		gsize large_steps = str->len / sizeof(guint64);
-		for (i = 0; i < large_steps; i++, p += sizeof(guint64)) {
+		gsize large_steps = str->len / sizeof(uint64_t);
+		for (i = 0; i < large_steps; i++, p += sizeof(uint64_t)) {
 			/* Copy to the uint64 lowercasing each byte */
 			union {
-				char c[sizeof(guint64)];
-				guint64 iu64;
+				char c[sizeof(uint64_t)];
+				uint64_t iu64;
 			} t;
-			for (int j = 0; j < sizeof(guint64); j++) {
+			for (int j = 0; j < sizeof(uint64_t); j++) {
 				t.c[j] = g_ascii_tolower(p[j]);
 			}
 			hval = fstrhash_c(t.iu64, hval);
 		}
 
-		gsize remain = str->len % sizeof(guint64);
+		gsize remain = str->len % sizeof(uint64_t);
 		for (i = 0; i < remain; i++, p++) {
 			hval = fstrhash_c(g_ascii_tolower(*p), hval);
 		}

--- a/src/libutil/fstring.h
+++ b/src/libutil/fstring.h
@@ -114,7 +114,7 @@ char *rspamd_ftok_cstr(const rspamd_ftok_t *str)
 /*
  * Return fast hash value for fixed string converted to lowercase
  */
-guint32 rspamd_fstrhash_lc(const rspamd_ftok_t *str, gboolean is_utf);
+uint32_t rspamd_fstrhash_lc(const rspamd_ftok_t *str, gboolean is_utf);
 
 /**
  * Return true if two strings are equal

--- a/src/libutil/mem_pool.c
+++ b/src/libutil/mem_pool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,9 +94,9 @@ static gboolean always_malloc = FALSE;
 static gsize
 pool_chain_free(struct _pool_chain *chain)
 {
-	gint64 occupied = chain->pos - chain->begin + MIN_MEM_ALIGNMENT;
+	int64_t occupied = chain->pos - chain->begin + MIN_MEM_ALIGNMENT;
 
-	return (occupied < (gint64) chain->slice_size ? chain->slice_size - occupied : 0);
+	return (occupied < (int64_t) chain->slice_size ? chain->slice_size - occupied : 0);
 }
 
 /* By default allocate 4Kb chunks of memory */

--- a/src/libutil/mem_pool_internal.h
+++ b/src/libutil/mem_pool_internal.h
@@ -33,15 +33,15 @@ enum rspamd_mempool_chain_type {
 #define ENTRY_NELTS 64
 
 struct entry_elt {
-	guint32 fragmentation;
-	guint32 leftover;
+	uint32_t fragmentation;
+	uint32_t leftover;
 };
 
 struct rspamd_mempool_entry_point {
 	gchar src[ENTRY_LEN];
-	guint32 cur_suggestion;
-	guint32 cur_elts;
-	guint32 cur_vars;
+	uint32_t cur_suggestion;
+	uint32_t cur_elts;
+	uint32_t cur_vars;
 	struct entry_elt elts[ENTRY_NELTS];
 };
 
@@ -63,7 +63,7 @@ struct rspamd_mempool_variable {
 };
 
 KHASH_INIT(rspamd_mempool_vars_hash,
-		   guint32, struct rspamd_mempool_variable, 1,
+		   uint32_t, struct rspamd_mempool_variable, 1,
 		   kh_int_hash_func, kh_int_hash_equal);
 
 struct rspamd_mempool_specific {

--- a/src/libutil/printf.c
+++ b/src/libutil/printf.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -50,11 +50,11 @@ static const gchar _hex[] = "0123456789abcdef";
 static const gchar _HEX[] = "0123456789ABCDEF";
 
 static gchar *
-rspamd_humanize_number(gchar *buf, gchar *last, gint64 num, gboolean bytes)
+rspamd_humanize_number(gchar *buf, gchar *last, int64_t num, gboolean bytes)
 {
 	const gchar *prefixes;
 	int i, r, remainder, sign;
-	gint64 divisor;
+	int64_t divisor;
 	gsize len = last - buf;
 
 	remainder = 0;
@@ -107,9 +107,9 @@ rspamd_humanize_number(gchar *buf, gchar *last, gint64 num, gboolean bytes)
 
 
 static inline unsigned
-rspamd_decimal_digits32(guint32 val)
+rspamd_decimal_digits32(uint32_t val)
 {
-	static const guint32 powers_of_10[] = {
+	static const uint32_t powers_of_10[] = {
 		0,
 		10,
 		100,
@@ -134,7 +134,7 @@ rspamd_decimal_digits32(guint32 val)
 											  11, 14, 16, 18, 22, 25, 3, 30,
 											  8, 12, 20, 28, 15, 17, 24, 7,
 											  19, 27, 23, 6, 26, 5, 4, 31};
-	guint32 v = val | 1;
+	uint32_t v = val | 1;
 
 	v |= v >> 1;
 	v |= v >> 2;
@@ -147,9 +147,9 @@ rspamd_decimal_digits32(guint32 val)
 }
 
 static inline unsigned
-rspamd_decimal_digits64(guint64 val)
+rspamd_decimal_digits64(uint64_t val)
 {
-	static const guint64 powers_of_10[] = {
+	static const uint64_t powers_of_10[] = {
 		0,
 		10ULL,
 		100ULL,
@@ -175,7 +175,7 @@ rspamd_decimal_digits64(guint64 val)
 #if defined(_MSC_VER)
 #if _M_IX86
 	unsigned long r = 0;
-	guint64 m = val | 1;
+	uint64_t m = val | 1;
 	if (_BitScanReverse(&r, m >> 32)) {
 		r += 32;
 	}
@@ -195,7 +195,7 @@ rspamd_decimal_digits64(guint64 val)
 											  11, 14, 16, 18, 22, 25, 3, 30,
 											  8, 12, 20, 28, 15, 17, 24, 7,
 											  19, 27, 23, 6, 26, 5, 4, 31};
-	guint32 v = val >> 32;
+	uint32_t v = val >> 32;
 
 	if (v) {
 		v |= 1;
@@ -256,7 +256,7 @@ static const char int_lookup_table[200] = {
 	'9', '5', '9', '6', '9', '7', '9', '8', '9', '9'};
 
 static inline guint
-rspamd_uint32_print(guint32 in, gchar *out)
+rspamd_uint32_print(uint32_t in, gchar *out)
 {
 	guint ndigits = rspamd_decimal_digits32(in);
 	gchar *p;
@@ -287,17 +287,17 @@ rspamd_uint32_print(guint32 in, gchar *out)
 }
 
 static inline guint
-rspamd_uint64_print(guint64 in, gchar *out)
+rspamd_uint64_print(uint64_t in, gchar *out)
 {
 	guint ndigits = rspamd_decimal_digits64(in);
-	guint32 v32;
+	uint32_t v32;
 	gchar *p;
 
 	p = out + ndigits - 1;
 
 	while (in >= 100000000) {
-		v32 = (guint32) (in % 100000000);
-		guint32 a, b, a1, a2, b1, b2;
+		v32 = (uint32_t) (in % 100000000);
+		uint32_t a, b, a1, a2, b1, b2;
 
 		/* Initial spill */
 		a = v32 / 10000;
@@ -321,7 +321,7 @@ rspamd_uint64_print(guint64 in, gchar *out)
 	}
 
 	/* Remaining 32 bit */
-	v32 = (guint32) in;
+	v32 = (uint32_t) in;
 
 	while (v32 >= 100) {
 		unsigned idx = (v32 % 100) << 1;
@@ -377,7 +377,7 @@ rspamd_ffsll(long long n)
 }
 
 static gchar *
-rspamd_sprintf_num(gchar *buf, gchar *last, guint64 ui64, gchar zero,
+rspamd_sprintf_num(gchar *buf, gchar *last, uint64_t ui64, gchar zero,
 				   guint hexadecimal, guint binary, guint width)
 {
 	gchar *p, temp[64];
@@ -387,7 +387,7 @@ rspamd_sprintf_num(gchar *buf, gchar *last, guint64 ui64, gchar zero,
 		p = temp;
 
 		if (ui64 < G_MAXUINT32) {
-			len = rspamd_uint32_print((guint32) ui64, temp);
+			len = rspamd_uint32_print((uint32_t) ui64, temp);
 		}
 		else {
 			len = rspamd_uint64_print(ui64, temp);
@@ -396,7 +396,7 @@ rspamd_sprintf_num(gchar *buf, gchar *last, guint64 ui64, gchar zero,
 	else if (hexadecimal == 1) {
 		p = temp + sizeof(temp);
 		do {
-			*--p = _hex[(guint32) (ui64 & 0xf)];
+			*--p = _hex[(uint32_t) (ui64 & 0xf)];
 		} while (ui64 >>= 4);
 
 		len = (temp + sizeof(temp)) - p;
@@ -404,7 +404,7 @@ rspamd_sprintf_num(gchar *buf, gchar *last, guint64 ui64, gchar zero,
 	else if (hexadecimal == 2) { /* hexadecimal == 2 */
 		p = temp + sizeof(temp);
 		do {
-			*--p = _HEX[(guint32) (ui64 & 0xf)];
+			*--p = _HEX[(uint32_t) (ui64 & 0xf)];
 		} while (ui64 >>= 4);
 
 		len = (temp + sizeof(temp)) - p;
@@ -625,8 +625,8 @@ glong rspamd_vprintf_common(rspamd_printf_append_func func,
 	gint d;
 	gdouble f;
 	glong written = 0, wr, slen;
-	gint64 i64;
-	guint64 ui64;
+	int64_t i64;
+	uint64_t ui64;
 	guint width, sign, hex, humanize, bytes, frac_width, b32, b64;
 	rspamd_fstring_t *v;
 	rspamd_ftok_t *tok;
@@ -917,62 +917,62 @@ glong rspamd_vprintf_common(rspamd_printf_append_func func,
 				continue;
 
 			case 'O':
-				i64 = (gint64) va_arg(args, off_t);
+				i64 = (int64_t) va_arg(args, off_t);
 				sign = 1;
 				break;
 
 			case 'P':
-				i64 = (gint64) va_arg(args, pid_t);
+				i64 = (int64_t) va_arg(args, pid_t);
 				sign = 1;
 				break;
 
 			case 't':
-				i64 = (gint64) va_arg(args, time_t);
+				i64 = (int64_t) va_arg(args, time_t);
 				sign = 1;
 				break;
 
 			case 'z':
 				if (sign) {
-					i64 = (gint64) va_arg(args, ssize_t);
+					i64 = (int64_t) va_arg(args, ssize_t);
 				}
 				else {
-					ui64 = (guint64) va_arg(args, size_t);
+					ui64 = (uint64_t) va_arg(args, size_t);
 				}
 				break;
 
 			case 'd':
 				if (sign) {
-					i64 = (gint64) va_arg(args, gint);
+					i64 = (int64_t) va_arg(args, gint);
 				}
 				else {
-					ui64 = (guint64) va_arg(args, guint);
+					ui64 = (uint64_t) va_arg(args, guint);
 				}
 				break;
 
 			case 'l':
 				if (sign) {
-					i64 = (gint64) va_arg(args, glong);
+					i64 = (int64_t) va_arg(args, glong);
 				}
 				else {
-					ui64 = (guint64) va_arg(args, gulong);
+					ui64 = (uint64_t) va_arg(args, gulong);
 				}
 				break;
 
 			case 'D':
 				if (sign) {
-					i64 = (gint64) va_arg(args, gint32);
+					i64 = (int64_t) va_arg(args, int32_t);
 				}
 				else {
-					ui64 = (guint64) va_arg(args, guint32);
+					ui64 = (uint64_t) va_arg(args, uint32_t);
 				}
 				break;
 
 			case 'L':
 				if (sign) {
-					i64 = va_arg(args, gint64);
+					i64 = va_arg(args, int64_t);
 				}
 				else {
-					ui64 = va_arg(args, guint64);
+					ui64 = va_arg(args, uint64_t);
 				}
 				break;
 
@@ -1062,10 +1062,10 @@ glong rspamd_vprintf_common(rspamd_printf_append_func func,
 			if (sign) {
 				if (i64 < 0) {
 					*p++ = '-';
-					ui64 = (guint64) -i64;
+					ui64 = (uint64_t) -i64;
 				}
 				else {
-					ui64 = (guint64) i64;
+					ui64 = (uint64_t) i64;
 				}
 			}
 

--- a/src/libutil/printf.h
+++ b/src/libutil/printf.h
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,8 +29,8 @@ extern "C" {
  *	%[0][width][u][x|X|h|H|b|B]z	    ssize_t/size_t
  *	%[0][width][u][x|X|h|H|b|B]d	    gint/guint
  *	%[0][width][u][x|X|h|H|b|B]l	    long
- *	%[0][width][u][x|X|h|H|b|B]D	    gint32/guint32
- *	%[0][width][u][x|X|h|H|b|B]L	    gint64/guint64
+ *	%[0][width][u][x|X|h|H|b|B]D	    int32_t/uint32_t
+ *	%[0][width][u][x|X|h|H|b|B]L	    int64_t/uint64_t
  *	%[0][width][.width]f	    double
  *	%[0][width][.width]F	    long double
  *	%[0][width][.width]g	    double

--- a/src/libutil/regexp.c
+++ b/src/libutil/regexp.c
@@ -65,7 +65,7 @@ struct rspamd_regexp_s {
 	ref_entry_t ref;
 	gpointer ud;
 	gpointer re_class;
-	guint64 cache_id;
+	uint64_t cache_id;
 	gsize match_limit;
 	guint max_hits;
 	gint flags;
@@ -901,7 +901,7 @@ guint rspamd_regexp_set_maxhits(rspamd_regexp_t *re, guint new_maxhits)
 	return old_hits;
 }
 
-guint64
+uint64_t
 rspamd_regexp_get_cache_id(const rspamd_regexp_t *re)
 {
 	g_assert(re != NULL);
@@ -909,10 +909,10 @@ rspamd_regexp_get_cache_id(const rspamd_regexp_t *re)
 	return re->cache_id;
 }
 
-guint64
-rspamd_regexp_set_cache_id(rspamd_regexp_t *re, guint64 id)
+uint64_t
+rspamd_regexp_set_cache_id(rspamd_regexp_t *re, uint64_t id)
 {
-	guint64 old;
+	uint64_t old;
 
 	g_assert(re != NULL);
 	old = re->cache_id;
@@ -999,11 +999,11 @@ rspamd_regexp_equal(gconstpointer a, gconstpointer b)
 	return (memcmp(ia, ib, sizeof(regexp_id_t)) == 0);
 }
 
-guint32
+uint32_t
 rspamd_regexp_hash(gconstpointer a)
 {
 	const guchar *ia = a;
-	guint32 res;
+	uint32_t res;
 
 	memcpy(&res, ia, sizeof(res));
 

--- a/src/libutil/regexp.h
+++ b/src/libutil/regexp.h
@@ -27,7 +27,7 @@
 #define PCRE_FLAG(x) G_PASTE(PCRE2_, x)
 #endif
 
-#define RSPAMD_INVALID_ID ((guint64) -1LL)
+#define RSPAMD_INVALID_ID ((uint64_t) -1LL)
 #define RSPAMD_REGEXP_FLAG_RAW (1 << 1)
 #define RSPAMD_REGEXP_FLAG_NOOPT (1 << 2)
 #define RSPAMD_REGEXP_FLAG_FULL_MATCH (1 << 3)
@@ -164,12 +164,12 @@ guint rspamd_regexp_set_maxhits(rspamd_regexp_t *re, guint new_maxhits);
 /**
  * Returns cache id for a regexp
  */
-guint64 rspamd_regexp_get_cache_id(const rspamd_regexp_t *re);
+uint64_t rspamd_regexp_get_cache_id(const rspamd_regexp_t *re);
 
 /**
  * Sets cache id for a regexp
  */
-guint64 rspamd_regexp_set_cache_id(rspamd_regexp_t *re, guint64 id);
+uint64_t rspamd_regexp_set_cache_id(rspamd_regexp_t *re, uint64_t id);
 
 /**
  * Returns match limit for a regexp
@@ -241,7 +241,7 @@ void rspamd_regexp_cache_destroy(struct rspamd_regexp_cache *cache);
  * @param a
  * @return
  */
-guint32 rspamd_regexp_hash(gconstpointer a);
+uint32_t rspamd_regexp_hash(gconstpointer a);
 
 /**
  * Compare two regexp objects based on theirs ID

--- a/src/libutil/shingles.c
+++ b/src/libutil/shingles.c
@@ -120,11 +120,11 @@ struct rspamd_shingle *RSPAMD_OPTIMIZE("unroll-loops")
 							  enum rspamd_shingle_alg alg)
 {
 	struct rspamd_shingle *res;
-	guint64 **hashes;
+	uint64_t **hashes;
 	guchar **keys;
 	rspamd_fstring_t *row;
 	rspamd_stat_token_t *word;
-	guint64 val;
+	uint64_t val;
 	gint i, j, k;
 	gsize hlen, ilen = 0, beg = 0, widx = 0;
 	enum rspamd_cryptobox_fast_hash_type ht;
@@ -152,7 +152,7 @@ struct rspamd_shingle *RSPAMD_OPTIMIZE("unroll-loops")
 	keys = rspamd_shingles_get_keys_cached(key);
 
 	for (i = 0; i < RSPAMD_SHINGLE_SIZE; i++) {
-		hashes[i] = g_malloc(hlen * sizeof(guint64));
+		hashes[i] = g_malloc(hlen * sizeof(uint64_t));
 	}
 
 	/* Now parse input words into a vector of hashes using rolling window */
@@ -210,7 +210,7 @@ struct rspamd_shingle *RSPAMD_OPTIMIZE("unroll-loops")
 		}
 	}
 	else {
-		guint64 window[SHINGLES_WINDOW * RSPAMD_SHINGLE_SIZE], seed;
+		uint64_t window[SHINGLES_WINDOW * RSPAMD_SHINGLE_SIZE], seed;
 
 		switch (alg) {
 		case RSPAMD_SHINGLES_XXHASH:
@@ -309,14 +309,14 @@ struct rspamd_shingle *RSPAMD_OPTIMIZE("unroll-loops")
 							   enum rspamd_shingle_alg alg)
 {
 	struct rspamd_shingle *shingle;
-	guint64 **hashes;
+	uint64_t **hashes;
 	guchar **keys;
-	guint64 d;
-	guint64 val;
+	uint64_t d;
+	uint64_t val;
 	gint i, j;
 	gsize hlen, beg = 0;
 	enum rspamd_cryptobox_fast_hash_type ht;
-	guint64 res[SHINGLES_WINDOW * RSPAMD_SHINGLE_SIZE], seed;
+	uint64_t res[SHINGLES_WINDOW * RSPAMD_SHINGLE_SIZE], seed;
 
 	if (pool != NULL) {
 		shingle = rspamd_mempool_alloc(pool, sizeof(*shingle));
@@ -331,7 +331,7 @@ struct rspamd_shingle *RSPAMD_OPTIMIZE("unroll-loops")
 	keys = rspamd_shingles_get_keys_cached(key);
 
 	for (i = 0; i < RSPAMD_SHINGLE_SIZE; i++) {
-		hashes[i] = g_malloc(hlen * sizeof(guint64));
+		hashes[i] = g_malloc(hlen * sizeof(uint64_t));
 	}
 
 	switch (alg) {
@@ -380,11 +380,11 @@ struct rspamd_shingle *RSPAMD_OPTIMIZE("unroll-loops")
 	return shingle;
 }
 
-guint64
-rspamd_shingles_default_filter(guint64 *input, gsize count,
+uint64_t
+rspamd_shingles_default_filter(uint64_t *input, gsize count,
 							   gint shno, const guchar *key, gpointer ud)
 {
-	guint64 minimal = G_MAXUINT64;
+	uint64_t minimal = G_MAXUINT64;
 	gsize i;
 
 	for (i = 0; i < count; i++) {

--- a/src/libutil/shingles.h
+++ b/src/libutil/shingles.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 struct rspamd_shingle {
-	guint64 hashes[RSPAMD_SHINGLE_SIZE];
+	uint64_t hashes[RSPAMD_SHINGLE_SIZE];
 };
 
 enum rspamd_shingle_alg {
@@ -42,8 +42,8 @@ enum rspamd_shingle_alg {
  * @param count number of hashes in the vector
  * @return shingle value
  */
-typedef guint64 (*rspamd_shingles_filter)(guint64 *input, gsize count,
-										  gint shno, const guchar *key, gpointer ud);
+typedef uint64_t (*rspamd_shingles_filter)(uint64_t *input, gsize count,
+										   gint shno, const guchar *key, gpointer ud);
 
 /**
  * Generate shingles from the input of fixed size strings using lemmatizer
@@ -91,8 +91,8 @@ gdouble rspamd_shingles_compare(const struct rspamd_shingle *a,
 /**
  * Default filtering function
  */
-guint64 rspamd_shingles_default_filter(guint64 *input, gsize count,
-									   gint shno, const guchar *key, gpointer ud);
+uint64_t rspamd_shingles_default_filter(uint64_t *input, gsize count,
+										gint shno, const guchar *key, gpointer ud);
 
 #ifdef __cplusplus
 }

--- a/src/libutil/sqlite_utils.c
+++ b/src/libutil/sqlite_utils.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -64,7 +64,7 @@ int rspamd_sqlite3_run_prstmt(rspamd_mempool_t *pool, sqlite3 *db, GArray *stmts
 	va_list ap;
 	sqlite3_stmt *stmt;
 	gint i, rowid, nargs, j;
-	gint64 len;
+	int64_t len;
 	gpointer p;
 	struct rspamd_sqlite3_prstmt *nst;
 	const char *argtypes;
@@ -101,7 +101,7 @@ int rspamd_sqlite3_run_prstmt(rspamd_mempool_t *pool, sqlite3 *db, GArray *stmts
 		case 'B':
 
 			for (j = 0; j < nargs; j++, rowid++) {
-				len = va_arg(ap, gint64);
+				len = va_arg(ap, int64_t);
 				sqlite3_bind_text(stmt, rowid, va_arg(ap, const char *), len,
 								  SQLITE_STATIC);
 			}
@@ -111,7 +111,7 @@ int rspamd_sqlite3_run_prstmt(rspamd_mempool_t *pool, sqlite3 *db, GArray *stmts
 		case 'I':
 
 			for (j = 0; j < nargs; j++, rowid++) {
-				sqlite3_bind_int64(stmt, rowid, va_arg(ap, gint64));
+				sqlite3_bind_int64(stmt, rowid, va_arg(ap, int64_t));
 			}
 
 			nargs = 1;
@@ -141,20 +141,20 @@ int rspamd_sqlite3_run_prstmt(rspamd_mempool_t *pool, sqlite3 *db, GArray *stmts
 				*va_arg(ap, char **) = g_strdup(sqlite3_column_text(stmt, i));
 				break;
 			case 'I':
-				*va_arg(ap, gint64 *) = sqlite3_column_int64(stmt, i);
+				*va_arg(ap, int64_t *) = sqlite3_column_int64(stmt, i);
 				break;
 			case 'S':
 				*va_arg(ap, int *) = sqlite3_column_int(stmt, i);
 				break;
 			case 'L':
-				*va_arg(ap, gint64 *) = sqlite3_last_insert_rowid(db);
+				*va_arg(ap, int64_t *) = sqlite3_last_insert_rowid(db);
 				break;
 			case 'B':
 				len = sqlite3_column_bytes(stmt, i);
 				g_assert(len >= 0);
 				p = g_malloc(len);
 				memcpy(p, sqlite3_column_blob(stmt, i), len);
-				*va_arg(ap, gint64 *) = len;
+				*va_arg(ap, int64_t *) = len;
 				*va_arg(ap, gpointer *) = p;
 				break;
 			}
@@ -464,7 +464,7 @@ rspamd_sqlite3_open_or_create(rspamd_mempool_t *pool, const gchar *path, const g
 	else if (has_lock && version > 0) {
 		/* Check user version */
 		sqlite3_stmt *stmt = NULL;
-		guint32 db_ver;
+		uint32_t db_ver;
 		GString *new_ver_sql;
 
 		if (sqlite3_prepare(sqlite, db_version, -1, &stmt, NULL) != SQLITE_OK) {

--- a/src/libutil/sqlite_utils.h
+++ b/src/libutil/sqlite_utils.h
@@ -74,7 +74,7 @@ void rspamd_sqlite3_close_prstmt(sqlite3 *db, GArray *stmts);
  */
 sqlite3 *rspamd_sqlite3_open_or_create(rspamd_mempool_t *pool,
 									   const gchar *path, const gchar *create_sql,
-									   guint32 version, GError **err);
+									   uint32_t version, GError **err);
 
 
 /**

--- a/src/libutil/str_util.c
+++ b/src/libutil/str_util.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -143,7 +143,7 @@ gint rspamd_lc_cmp(const gchar *s, const gchar *d, gsize l)
 	guchar c1, c2, c3, c4;
 	union {
 		guchar c[4];
-		guint32 n;
+		uint32_t n;
 	} cmp1, cmp2;
 	gsize leftover = l % 4;
 	gint ret = 0;
@@ -188,7 +188,7 @@ gint rspamd_lc_cmp(const gchar *s, const gchar *d, gsize l)
 guint rspamd_str_lc_utf8(gchar *str, guint size)
 {
 	guchar *d = (guchar *) str, tst[6];
-	gint32 i = 0, prev = 0;
+	int32_t i = 0, prev = 0;
 	UChar32 uc;
 
 	while (i < size) {
@@ -197,7 +197,7 @@ guint rspamd_str_lc_utf8(gchar *str, guint size)
 		U8_NEXT((guint8 *) str, i, size, uc);
 		uc = u_tolower(uc);
 
-		gint32 olen = 0;
+		int32_t olen = 0;
 		U8_APPEND_UNSAFE(tst, olen, uc);
 
 		if (olen <= (i - prev)) {
@@ -223,19 +223,19 @@ rspamd_strcase_equal(gconstpointer v, gconstpointer v2)
 	return FALSE;
 }
 
-guint64
-rspamd_icase_hash(const gchar *in, gsize len, guint64 seed)
+uint64_t
+rspamd_icase_hash(const gchar *in, gsize len, uint64_t seed)
 {
-	guint leftover = len % sizeof(guint64);
+	guint leftover = len % sizeof(uint64_t);
 	guint fp, i;
 	const uint8_t *s = (const uint8_t *) in;
 	union {
 		struct {
 			guchar c1, c2, c3, c4, c5, c6, c7, c8;
 		} c;
-		guint64 pp;
+		uint64_t pp;
 	} u;
-	guint64 h = seed;
+	uint64_t h = seed;
 
 	fp = len - leftover;
 
@@ -346,10 +346,10 @@ guint rspamd_gstring_icase_hash(gconstpointer key)
 /* https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord */
 #define MEM_ALIGN (sizeof(gsize) - 1)
 #if defined(__LP64__) || defined(_LP64)
-#define WORD_TYPE guint64
+#define WORD_TYPE uint64_t
 #define ZEROMASK 0x7F7F7F7F7F7F7F7FLLU
 #else
-#define WORD_TYPE guint32
+#define WORD_TYPE uint32_t
 #define ZEROMASK 0x7F7F7F7FU
 #endif
 
@@ -535,12 +535,12 @@ rspamd_strtoul(const gchar *s, gsize len, gulong *value)
 }
 
 gboolean
-rspamd_strtou64(const gchar *s, gsize len, guint64 *value)
+rspamd_strtou64(const gchar *s, gsize len, uint64_t *value)
 {
 	const gchar *p = s, *end = s + len;
 	gchar c;
-	guint64 v = 0;
-	const guint64 cutoff = G_MAXUINT64 / 10, cutlim = G_MAXUINT64 % 10;
+	uint64_t v = 0;
+	const uint64_t cutoff = G_MAXUINT64 / 10, cutlim = G_MAXUINT64 % 10;
 
 	/* Some preparations for range errors */
 	CONV_STR_LIM_DECIMAL(G_MAXUINT64);
@@ -1265,8 +1265,8 @@ rspamd_encode_base64_common(const guchar *in, gsize inlen, gint str_len,
 
 	gsize allocated_len = (inlen / 3) * 4 + 5;
 	gchar *out, *o;
-	guint64 n;
-	guint32 rem, t, carry;
+	uint64_t n;
+	uint32_t rem, t, carry;
 	gint cols, shift;
 	static const char b64_enc[] =
 		"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -3508,7 +3508,7 @@ rspamd_str_regexp_escape(const gchar *pattern, gsize slen,
 				else {
 					if (flags & (RSPAMD_REGEXP_ESCAPE_RE | RSPAMD_REGEXP_ESCAPE_GLOB)) {
 						UChar32 uc;
-						gint32 off = p - pattern - 1;
+						int32_t off = p - pattern - 1;
 						U8_NEXT(pattern, off, slen, uc);
 
 						if (uc > 0) {
@@ -3821,11 +3821,11 @@ rspamd_str_has_8bit_u64(const guchar *beg, gsize len)
 	guint8 orb = 0;
 
 	if (len >= 16) {
-		const guchar *nextd = beg + sizeof(guint64);
-		guint64 n1 = 0, n2 = 0;
+		const guchar *nextd = beg + sizeof(uint64_t);
+		uint64_t n1 = 0, n2 = 0;
 
 		do {
-			guint64 t;
+			uint64_t t;
 			memcpy(&t, beg, sizeof(t));
 			n1 |= t;
 			memcpy(&t, nextd, sizeof(t));

--- a/src/libutil/str_util.h
+++ b/src/libutil/str_util.h
@@ -59,7 +59,7 @@ guint rspamd_str_lc_utf8(gchar *str, guint size);
 /*
  * Hash table utility functions for case insensitive hashing
  */
-guint64 rspamd_icase_hash(const gchar *in, gsize len, guint64 seed);
+uint64_t rspamd_icase_hash(const gchar *in, gsize len, uint64_t seed);
 
 guint rspamd_strcase_hash(gconstpointer key);
 
@@ -140,7 +140,7 @@ gboolean rspamd_strtol(const gchar *s, gsize len, glong *value);
  * Try to convert a string of length to unsigned long
  */
 gboolean rspamd_strtoul(const gchar *s, gsize len, gulong *value);
-gboolean rspamd_strtou64(const gchar *s, gsize len, guint64 *value);
+gboolean rspamd_strtou64(const gchar *s, gsize len, uint64_t *value);
 
 /*
  * Try to convert a hex string of length to unsigned long

--- a/src/libutil/upstream.c
+++ b/src/libutil/upstream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ struct upstream_list {
 	GPtrArray *ups;
 	GPtrArray *alive;
 	struct upstream_list_watcher *watchers;
-	guint64 hash_seed;
+	uint64_t hash_seed;
 	const struct upstream_limits *limits;
 	enum rspamd_upstream_flag flags;
 	guint cur_elt;
@@ -1492,10 +1492,10 @@ rspamd_upstream_get_round_robin(struct upstream_list *ups,
  *
  * http://arxiv.org/abs/1406.2294
  */
-static guint32
-rspamd_consistent_hash(guint64 key, guint32 nbuckets)
+static uint32_t
+rspamd_consistent_hash(uint64_t key, uint32_t nbuckets)
 {
-	gint64 b = -1, j = 0;
+	int64_t b = -1, j = 0;
 
 	while (j < nbuckets) {
 		b = j;
@@ -1511,8 +1511,8 @@ rspamd_upstream_get_hashed(struct upstream_list *ups,
 						   struct upstream *except,
 						   const guint8 *key, guint keylen)
 {
-	guint64 k;
-	guint32 idx;
+	uint64_t k;
+	uint32_t idx;
 	static const guint max_tries = 20;
 	struct upstream *up = NULL;
 

--- a/src/libutil/util.c
+++ b/src/libutil/util.c
@@ -1091,11 +1091,11 @@ void g_ptr_array_unref(GPtrArray *array)
 gboolean
 g_int64_equal(gconstpointer v1, gconstpointer v2)
 {
-	return *((const gint64 *) v1) == *((const gint64 *) v2);
+	return *((const int64_t *) v1) == *((const int64_t *) v2);
 }
 guint g_int64_hash(gconstpointer v)
 {
-	guint64 v64 = *(guint64 *) v;
+	uint64_t v64 = *(uint64_t *) v;
 
 	return (guint) (v ^ (v >> 32));
 }
@@ -1467,7 +1467,7 @@ rspamd_get_ticks(gboolean rdtsc_ok)
 
 #ifdef HAVE_RDTSC
 #ifdef __x86_64__
-	guint64 r64;
+	uint64_t r64;
 
 	if (rdtsc_ok) {
 		__builtin_ia32_lfence();
@@ -1586,16 +1586,16 @@ rspamd_get_calendar_ticks(void)
 	return res;
 }
 
-void rspamd_random_hex(gchar *buf, guint64 len)
+void rspamd_random_hex(gchar *buf, uint64_t len)
 {
 	static const gchar hexdigests[16] = "0123456789abcdef";
-	gint64 i;
+	int64_t i;
 
 	g_assert(len > 0);
 
 	ottery_rand_bytes((void *) buf, ceil(len / 2.0));
 
-	for (i = (gint64) len - 1; i >= 0; i -= 2) {
+	for (i = (int64_t) len - 1; i >= 0; i -= 2) {
 		buf[i] = hexdigests[buf[i / 2] & 0xf];
 
 		if (i > 0) {
@@ -1698,11 +1698,11 @@ RSPAMD_CONSTRUCTOR(blis_thread_fix_ctor)
 }
 #endif
 
-guint64
+uint64_t
 rspamd_hash_seed(void)
 {
 #if 0
-	static guint64 seed;
+	static uint64_t seed;
 
 	if (seed == 0) {
 		seed = ottery_rand_uint64 ();
@@ -1719,10 +1719,10 @@ rspamd_hash_seed(void)
 }
 
 static inline gdouble
-rspamd_double_from_int64(guint64 x)
+rspamd_double_from_int64(uint64_t x)
 {
 	const union {
-		guint64 i;
+		uint64_t i;
 		double d;
 	} u = {
 		.i = G_GUINT64_CONSTANT(0x3FF) << 52 | x >> 12};
@@ -1733,7 +1733,7 @@ rspamd_double_from_int64(guint64 x)
 gdouble
 rspamd_random_double(void)
 {
-	guint64 rnd_int;
+	uint64_t rnd_int;
 
 	rnd_int = ottery_rand_uint64();
 
@@ -1741,10 +1741,10 @@ rspamd_random_double(void)
 }
 
 
-static guint64 *
+static uint64_t *
 rspamd_fast_random_seed(void)
 {
-	static guint64 seed;
+	static uint64_t seed;
 
 	if (G_UNLIKELY(seed == 0)) {
 		ottery_rand_bytes((void *) &seed, sizeof(seed));
@@ -1799,12 +1799,12 @@ rspamd_random_double_fast(void)
 
 /* xoshiro256+ */
 inline gdouble
-rspamd_random_double_fast_seed(guint64 *seed)
+rspamd_random_double_fast_seed(uint64_t *seed)
 {
 	return rspamd_double_from_int64(rspamd_random_uint64_fast_seed(seed));
 }
 
-guint64
+uint64_t
 rspamd_random_uint64_fast(void)
 {
 	return rspamd_random_uint64_fast_seed(rspamd_fast_random_seed());
@@ -1852,7 +1852,7 @@ rspamd_constant_memcmp(const void *a, const void *b, gsize len)
 		r |= (d & m);
 	}
 
-	return (((gint32) (guint16) ((guint32) r + 0x8000) - 0x8000) == 0);
+	return (((int32_t) (guint16) ((uint32_t) r + 0x8000) - 0x8000) == 0);
 }
 
 int rspamd_file_xopen(const char *fname, int oflags, guint mode,
@@ -2032,10 +2032,10 @@ rspamd_normalize_probability(gdouble x, gdouble bias)
 /*
  * Calculations from musl libc
  */
-guint64
+uint64_t
 rspamd_tm_to_time(const struct tm *tm, glong tz)
 {
-	guint64 result;
+	uint64_t result;
 	gboolean is_leap = FALSE;
 	gint leaps, y = tm->tm_year, cycles, rem, centuries;
 	glong offset = (tz / 100) * 3600 + (tz % 100) * 60;
@@ -2125,19 +2125,19 @@ rspamd_tm_to_time(const struct tm *tm, glong tz)
 }
 
 
-void rspamd_gmtime(gint64 ts, struct tm *dest)
+void rspamd_gmtime(int64_t ts, struct tm *dest)
 {
-	guint64 days, secs, years;
+	uint64_t days, secs, years;
 	int remdays, remsecs, remyears;
 	int leap_400_cycles, leap_100_cycles, leap_4_cycles;
 	int months;
 	int wday, yday, leap;
 	/* From March */
 	static const uint8_t days_in_month[] = {31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31, 29};
-	static const guint64 leap_epoch = 946684800ULL + 86400 * (31 + 29);
-	static const guint64 days_per_400y = 365 * 400 + 97;
-	static const guint64 days_per_100y = 365 * 100 + 24;
-	static const guint64 days_per_4y = 365 * 4 + 1;
+	static const uint64_t leap_epoch = 946684800ULL + 86400 * (31 + 29);
+	static const uint64_t days_per_400y = 365 * 400 + 97;
+	static const uint64_t days_per_100y = 365 * 100 + 24;
+	static const uint64_t days_per_4y = 365 * 4 + 1;
 
 	secs = ts - leap_epoch;
 	days = secs / 86400;
@@ -2218,7 +2218,7 @@ void rspamd_gmtime(gint64 ts, struct tm *dest)
 #endif
 }
 
-void rspamd_localtime(gint64 ts, struct tm *dest)
+void rspamd_localtime(int64_t ts, struct tm *dest)
 {
 	time_t t = ts;
 	localtime_r(&t, dest);

--- a/src/libutil/util.h
+++ b/src/libutil/util.h
@@ -370,14 +370,14 @@ void rspamd_gstring_free_soft(gpointer p);
  * Returns some statically initialized random hash seed
  * @return hash seed
  */
-guint64 rspamd_hash_seed(void);
+uint64_t rspamd_hash_seed(void);
 
 /**
  * Returns random hex string of the specified length
  * @param buf
  * @param len
  */
-void rspamd_random_hex(gchar *buf, guint64 len);
+void rspamd_random_hex(gchar *buf, uint64_t len);
 
 /**
  * Returns
@@ -402,9 +402,9 @@ gdouble rspamd_random_double(void);
  * @return
  */
 gdouble rspamd_random_double_fast(void);
-gdouble rspamd_random_double_fast_seed(guint64 *seed);
+gdouble rspamd_random_double_fast_seed(uint64_t *seed);
 uint64_t rspamd_random_uint64_fast_seed(uint64_t *seed);
-guint64 rspamd_random_uint64_fast(void);
+uint64_t rspamd_random_uint64_fast(void);
 
 /**
  * Seed fast rng
@@ -459,21 +459,21 @@ gdouble rspamd_normalize_probability(gdouble x, gdouble bias);
  * @param tz timezone in format (hours * 100) + minutes
  * @return
  */
-guint64 rspamd_tm_to_time(const struct tm *tm, glong tz);
+uint64_t rspamd_tm_to_time(const struct tm *tm, glong tz);
 
 /**
  * Splits unix timestamp into struct tm using GMT timezone
  * @param ts
  * @param dest
  */
-void rspamd_gmtime(gint64 ts, struct tm *dest);
+void rspamd_gmtime(int64_t ts, struct tm *dest);
 
 /**
  * Split unix timestamp into struct tm using local timezone
  * @param ts
  * @param dest
  */
-void rspamd_localtime(gint64 ts, struct tm *dest);
+void rspamd_localtime(int64_t ts, struct tm *dest);
 
 #define PTR_ARRAY_FOREACH(ar, i, cur) for ((i) = 0; (ar) != NULL && (i) < (ar)->len && (((cur) = (__typeof__(cur)) g_ptr_array_index((ar), (i))) || 1); ++(i))
 
@@ -509,7 +509,7 @@ GPtrArray *rspamd_glob_path(const gchar *dir,
 struct rspamd_counter_data {
 	float mean;
 	float stddev;
-	guint64 number;
+	uint64_t number;
 };
 
 /**

--- a/src/lua/lua_cdb.c
+++ b/src/lua/lua_cdb.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -144,7 +144,7 @@ lua_cdb_get_input(lua_State *L, int pos, gsize *olen)
 
 		p = rspamd_lua_check_udata_maybe(L, pos, rspamd_int64_classname);
 		if (p) {
-			static char numbuf[sizeof(gint64)];
+			static char numbuf[sizeof(int64_t)];
 
 			memcpy(numbuf, p, sizeof(numbuf));
 			*olen = sizeof(numbuf);

--- a/src/lua/lua_common.c
+++ b/src/lua/lua_common.c
@@ -471,7 +471,7 @@ set:
 static int
 rspamd_lua_rspamd_version_numeric(lua_State *L)
 {
-	static gint64 version_num = RSPAMD_VERSION_NUM;
+	static int64_t version_num = RSPAMD_VERSION_NUM;
 	const gchar *type;
 
 	if (lua_gettop(L) >= 2 && lua_type(L, 1) == LUA_TSTRING) {
@@ -1428,15 +1428,15 @@ rspamd_lua_parse_table_arguments(lua_State *L, gint pos,
 
 			case 'I':
 				if (t == LUA_TNUMBER) {
-					*(va_arg(ap, gint64 *)) = lua_tointeger(L, idx);
+					*(va_arg(ap, int64_t *)) = lua_tointeger(L, idx);
 				}
 				else if (t == LUA_TNIL || t == LUA_TNONE) {
 					failed = TRUE;
 					if (how != RSPAMD_LUA_PARSE_ARGUMENTS_IGNORE_MISSING) {
-						*(va_arg(ap, gint64 *)) = 0;
+						*(va_arg(ap, int64_t *)) = 0;
 					}
 					else {
-						(void) va_arg(ap, gint64 *);
+						(void) va_arg(ap, int64_t *);
 					}
 				}
 				else {
@@ -1460,15 +1460,15 @@ rspamd_lua_parse_table_arguments(lua_State *L, gint pos,
 
 			case 'i':
 				if (t == LUA_TNUMBER) {
-					*(va_arg(ap, gint32 *)) = lua_tointeger(L, idx);
+					*(va_arg(ap, int32_t *)) = lua_tointeger(L, idx);
 				}
 				else if (t == LUA_TNIL || t == LUA_TNONE) {
 					failed = TRUE;
 					if (how != RSPAMD_LUA_PARSE_ARGUMENTS_IGNORE_MISSING) {
-						*(va_arg(ap, gint32 *)) = 0;
+						*(va_arg(ap, int32_t *)) = 0;
 					}
 					else {
-						(void) va_arg(ap, gint32 *);
+						(void) va_arg(ap, int32_t *);
 					}
 				}
 				else {
@@ -2575,7 +2575,7 @@ bool rspamd_lua_universal_pcall(lua_State *L, gint cbref, const gchar *strloc,
 	}
 	/*
 	 * Possible arguments
-	 * - i - lua_integer, argument - gint64
+	 * - i - lua_integer, argument - int64_t
 	 * - n - lua_number, argument - gdouble
 	 * - s - lua_string, argument - const gchar * (zero terminated)
 	 * - l - lua_lstring, argument - (size_t + const gchar *) pair
@@ -2587,7 +2587,7 @@ bool rspamd_lua_universal_pcall(lua_State *L, gint cbref, const gchar *strloc,
 	while (*argp) {
 		switch (*argp) {
 		case 'i':
-			lua_pushinteger(L, va_arg(ap, gint64));
+			lua_pushinteger(L, va_arg(ap, int64_t));
 			nargs++;
 			break;
 		case 'n':

--- a/src/lua/lua_common.h
+++ b/src/lua/lua_common.h
@@ -464,7 +464,7 @@ enum rspamd_lua_parse_arguments_flags {
 * Extract an arguments from lua table according to format string. Supported arguments are:
 * [*]key=S|I|N|B|V|U{a-z};[key=...]
 * - S - const char *
-* - I - gint64_t
+* - I - int64_t_t
 * - i - int32_t
 * - N - double
 * - B - gboolean
@@ -654,7 +654,7 @@ gchar *rspamd_lua_get_module_name(lua_State *L);
 
 /**
 * Call Lua function in a universal way. Arguments string:
-* - i - lua_integer, argument - gint64
+* - i - lua_integer, argument - int64_t
 * - n - lua_number, argument - gdouble
 * - s - lua_string, argument - const gchar * (zero terminated)
 * - l - lua_lstring, argument - (size_t + const gchar *) pair

--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -942,7 +942,7 @@ static const struct luaL_reg monitoredlib_m[] = {
 	{"__tostring", rspamd_lua_class_tostring},
 	{NULL, NULL}};
 
-static const guint64 rspamd_lua_callback_magic = 0x32c118af1e3263c7ULL;
+static const uint64_t rspamd_lua_callback_magic = 0x32c118af1e3263c7ULL;
 
 struct rspamd_config *
 lua_check_config(lua_State *L, gint pos)
@@ -1171,7 +1171,7 @@ lua_config_get_classifier(lua_State *L)
 }
 
 struct lua_callback_data {
-	guint64 magic;
+	uint64_t magic;
 	lua_State *L;
 	gchar *symbol;
 
@@ -1513,10 +1513,10 @@ rspamd_process_id_list(const gchar *entries)
 
 	sym_elts = g_strsplit_set(entries, ",;", -1);
 	guint nids = g_strv_length(sym_elts);
-	ret = g_array_sized_new(FALSE, FALSE, sizeof(guint32), nids);
+	ret = g_array_sized_new(FALSE, FALSE, sizeof(uint32_t), nids);
 
 	for (guint i = 0; i < nids; i++) {
-		guint32 v = rspamd_config_name_to_id(sym_elts[i], strlen(sym_elts[i]));
+		uint32_t v = rspamd_config_name_to_id(sym_elts[i], strlen(sym_elts[i]));
 		g_array_append_val(ret, v);
 	}
 
@@ -1613,12 +1613,12 @@ rspamd_register_symbol_fromlua(lua_State *L,
 
 	if (allowed_ids) {
 		rspamd_symcache_set_allowed_settings_ids(cfg->cache, name,
-												 &g_array_index(allowed_ids, guint32, 0), allowed_ids->len);
+												 &g_array_index(allowed_ids, uint32_t, 0), allowed_ids->len);
 	}
 
 	if (forbidden_ids) {
 		rspamd_symcache_set_forbidden_settings_ids(cfg->cache, name,
-												   &g_array_index(forbidden_ids, guint32, 0), forbidden_ids->len);
+												   &g_array_index(forbidden_ids, uint32_t, 0), forbidden_ids->len);
 	}
 
 	return ret;
@@ -1968,7 +1968,7 @@ lua_config_register_symbol(lua_State *L)
 	gboolean one_shot = FALSE;
 	gint ret = -1, cbref = -1;
 	guint type = 0, flags = 0;
-	gint64 parent = 0, priority = 0, nshots = 0;
+	int64_t parent = 0, priority = 0, nshots = 0;
 	GArray *allowed_ids = NULL, *forbidden_ids = NULL;
 	GError *err = NULL;
 	int prev_top = lua_gettop(L);
@@ -2007,10 +2007,10 @@ lua_config_register_symbol(lua_State *L)
 			allowed_ids = rspamd_process_id_list(lua_tostring(L, -1));
 		}
 		else if (lua_type(L, -1) == LUA_TTABLE) {
-			allowed_ids = g_array_sized_new(FALSE, FALSE, sizeof(guint32),
+			allowed_ids = g_array_sized_new(FALSE, FALSE, sizeof(uint32_t),
 											rspamd_lua_table_size(L, -1));
 			for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
-				guint32 v = lua_tointeger(L, -1);
+				uint32_t v = lua_tointeger(L, -1);
 				g_array_append_val(allowed_ids, v);
 			}
 		}
@@ -2022,10 +2022,10 @@ lua_config_register_symbol(lua_State *L)
 			forbidden_ids = rspamd_process_id_list(lua_tostring(L, -1));
 		}
 		else if (lua_type(L, -1) == LUA_TTABLE) {
-			forbidden_ids = g_array_sized_new(FALSE, FALSE, sizeof(guint32),
+			forbidden_ids = g_array_sized_new(FALSE, FALSE, sizeof(uint32_t),
 											  rspamd_lua_table_size(L, -1));
 			for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
-				guint32 v = lua_tointeger(L, -1);
+				uint32_t v = lua_tointeger(L, -1);
 				g_array_append_val(forbidden_ids, v);
 			}
 		}
@@ -2396,7 +2396,7 @@ lua_config_set_metric_symbol(lua_State *L)
 	GError *err = NULL;
 	gdouble priority = 0.0;
 	guint flags = 0;
-	gint64 nshots = 0;
+	int64_t nshots = 0;
 
 	if (cfg) {
 
@@ -2754,10 +2754,10 @@ lua_config_newindex(lua_State *L)
 				allowed_ids = rspamd_process_id_list(lua_tostring(L, -1));
 			}
 			else if (lua_type(L, -1) == LUA_TTABLE) {
-				allowed_ids = g_array_sized_new(FALSE, FALSE, sizeof(guint32),
+				allowed_ids = g_array_sized_new(FALSE, FALSE, sizeof(uint32_t),
 												rspamd_lua_table_size(L, -1));
 				for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
-					guint32 v = lua_tointeger(L, -1);
+					uint32_t v = lua_tointeger(L, -1);
 					g_array_append_val(allowed_ids, v);
 				}
 			}
@@ -2769,10 +2769,10 @@ lua_config_newindex(lua_State *L)
 				forbidden_ids = rspamd_process_id_list(lua_tostring(L, -1));
 			}
 			else if (lua_type(L, -1) == LUA_TTABLE) {
-				forbidden_ids = g_array_sized_new(FALSE, FALSE, sizeof(guint32),
+				forbidden_ids = g_array_sized_new(FALSE, FALSE, sizeof(uint32_t),
 												  rspamd_lua_table_size(L, -1));
 				for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
-					guint32 v = lua_tointeger(L, -1);
+					uint32_t v = lua_tointeger(L, -1);
 					g_array_append_val(forbidden_ids, v);
 				}
 			}
@@ -3521,7 +3521,7 @@ lua_config_get_symbols_cksum(lua_State *L)
 {
 	LUA_TRACE_POINT;
 	struct rspamd_config *cfg = lua_check_config(L, 1);
-	guint64 res = 0, *pres;
+	uint64_t res = 0, *pres;
 
 	if (cfg != NULL) {
 		res = rspamd_symcache_get_cksum(cfg->cache);

--- a/src/lua/lua_cryptobox.c
+++ b/src/lua/lua_cryptobox.c
@@ -1124,35 +1124,35 @@ rspamd_lua_hash_create(const gchar *type, const gchar *key, gsize keylen)
 			h->content.fh = rspamd_cryptobox_fast_hash_new();
 			rspamd_cryptobox_fast_hash_init_specific(h->content.fh,
 													 RSPAMD_CRYPTOBOX_XXHASH64, 0);
-			h->out_len = sizeof(guint64);
+			h->out_len = sizeof(uint64_t);
 		}
 		else if (g_ascii_strcasecmp(type, "xxh32") == 0) {
 			h->type = LUA_CRYPTOBOX_HASH_XXHASH32;
 			h->content.fh = rspamd_cryptobox_fast_hash_new();
 			rspamd_cryptobox_fast_hash_init_specific(h->content.fh,
 													 RSPAMD_CRYPTOBOX_XXHASH32, 0);
-			h->out_len = sizeof(guint32);
+			h->out_len = sizeof(uint32_t);
 		}
 		else if (g_ascii_strcasecmp(type, "xxh3") == 0) {
 			h->type = LUA_CRYPTOBOX_HASH_XXHASH3;
 			h->content.fh = rspamd_cryptobox_fast_hash_new();
 			rspamd_cryptobox_fast_hash_init_specific(h->content.fh,
 													 RSPAMD_CRYPTOBOX_XXHASH3, 0);
-			h->out_len = sizeof(guint64);
+			h->out_len = sizeof(uint64_t);
 		}
 		else if (g_ascii_strcasecmp(type, "mum") == 0) {
 			h->type = LUA_CRYPTOBOX_HASH_MUM;
 			h->content.fh = rspamd_cryptobox_fast_hash_new();
 			rspamd_cryptobox_fast_hash_init_specific(h->content.fh,
 													 RSPAMD_CRYPTOBOX_MUMHASH, 0);
-			h->out_len = sizeof(guint64);
+			h->out_len = sizeof(uint64_t);
 		}
 		else if (g_ascii_strcasecmp(type, "t1ha") == 0) {
 			h->type = LUA_CRYPTOBOX_HASH_T1HA;
 			h->content.fh = rspamd_cryptobox_fast_hash_new();
 			rspamd_cryptobox_fast_hash_init_specific(h->content.fh,
 													 RSPAMD_CRYPTOBOX_T1HA, 0);
-			h->out_len = sizeof(guint64);
+			h->out_len = sizeof(uint64_t);
 		}
 		else if (g_ascii_strcasecmp(type, "blake2") == 0) {
 			rspamd_lua_hash_init_default(h, key, keylen);
@@ -1500,7 +1500,7 @@ lua_cryptobox_hash_reset(lua_State *L)
 static void
 lua_cryptobox_hash_finish(struct rspamd_lua_cryptobox_hash *h)
 {
-	guint64 ll;
+	uint64_t ll;
 	guchar out[rspamd_cryptobox_HASHBYTES];
 	guint ssl_outlen = sizeof(out);
 
@@ -2288,7 +2288,7 @@ lua_cryptobox_encrypt_cookie(lua_State *L)
 	guchar nonce[RSPAMD_CRYPTOBOX_AES_BLOCKSIZE];
 	guchar aes_key[RSPAMD_CRYPTOBOX_AES_KEYSIZE];
 	guchar result[RSPAMD_CRYPTOBOX_AES_BLOCKSIZE * 2];
-	guint32 ts;
+	uint32_t ts;
 
 	const gchar *sk, *cookie;
 	gsize sklen, cookie_len;
@@ -2315,10 +2315,10 @@ lua_cryptobox_encrypt_cookie(lua_State *L)
 		}
 
 		/* Fill nonce */
-		ottery_rand_bytes(nonce, sizeof(guint64) + sizeof(guint32));
-		ts = (guint32) rspamd_get_calendar_ticks();
+		ottery_rand_bytes(nonce, sizeof(uint64_t) + sizeof(uint32_t));
+		ts = (uint32_t) rspamd_get_calendar_ticks();
 		ts = GUINT32_TO_LE(ts);
-		memcpy(nonce + sizeof(guint64) + sizeof(guint32), &ts, sizeof(ts));
+		memcpy(nonce + sizeof(uint64_t) + sizeof(uint32_t), &ts, sizeof(ts));
 
 		/* Prepare padded cookie */
 		memset(padded_cookie, 0, sizeof(padded_cookie));
@@ -2379,7 +2379,7 @@ lua_cryptobox_decrypt_cookie(lua_State *L)
 	guchar nonce[RSPAMD_CRYPTOBOX_AES_BLOCKSIZE];
 	guchar aes_key[RSPAMD_CRYPTOBOX_AES_KEYSIZE];
 	guchar *src;
-	guint32 ts;
+	uint32_t ts;
 
 	const gchar *sk, *cookie;
 	gsize sklen, cookie_len;
@@ -2420,7 +2420,7 @@ lua_cryptobox_decrypt_cookie(lua_State *L)
 		EVP_CIPHER_CTX_set_padding(ctx, 0);
 
 		/* Copy time */
-		memcpy(&ts, src + sizeof(guint64) + sizeof(guint32), sizeof(ts));
+		memcpy(&ts, src + sizeof(uint64_t) + sizeof(uint32_t), sizeof(ts));
 		ts = GUINT32_FROM_LE(ts);
 		bklen = sizeof(nonce);
 		blk = nonce;

--- a/src/lua/lua_ip.c
+++ b/src/lua/lua_ip.c
@@ -402,7 +402,7 @@ lua_ip_to_number(lua_State *L)
 {
 	LUA_TRACE_POINT;
 	struct rspamd_lua_ip *ip = lua_check_ip(L, 1);
-	guint32 c;
+	uint32_t c;
 	guint max, i;
 	guchar *ptr;
 

--- a/src/lua/lua_kann.c
+++ b/src/lua/lua_kann.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1052,9 +1052,9 @@ lua_kann_train1(lua_State *L)
 
 	/* Default train params */
 	double lr = 0.001;
-	gint64 mini_size = 64;
-	gint64 max_epoch = 25;
-	gint64 max_drop_streak = 10;
+	int64_t mini_size = 64;
+	int64_t max_epoch = 25;
+	int64_t max_drop_streak = 10;
 	double frac_val = 0.1;
 	gint cbref = -1;
 

--- a/src/lua/lua_map.c
+++ b/src/lua/lua_map.c
@@ -878,7 +878,7 @@ lua_map_get_key(lua_State *L)
 	const gchar *key, *value = NULL;
 	gpointer ud;
 	gsize len;
-	guint32 key_num = 0;
+	uint32_t key_num = 0;
 	gboolean ret = FALSE;
 
 	if (map) {

--- a/src/lua/lua_mempool.c
+++ b/src/lua/lua_mempool.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -452,10 +452,10 @@ lua_mempool_get_variable(lua_State *L)
 					}
 					else if (len == sizeof("int64") - 1 &&
 							 g_ascii_strncasecmp(pt, "int64", len) == 0) {
-						gint64 num;
-						memcpy(&num, pv, sizeof(gint64));
+						int64_t num;
+						memcpy(&num, pv, sizeof(int64_t));
 						lua_pushinteger(L, num);
-						pv += sizeof(gint64);
+						pv += sizeof(int64_t);
 					}
 					else if (len == sizeof("bool") - 1 &&
 							 g_ascii_strncasecmp(pt, "bool", len) == 0) {

--- a/src/lua/lua_mimepart.c
+++ b/src/lua/lua_mimepart.c
@@ -1183,7 +1183,7 @@ lua_textpart_get_languages(lua_State *L)
 }
 
 struct lua_shingle_data {
-	guint64 hash;
+	uint64_t hash;
 	rspamd_ftok_t t1;
 	rspamd_ftok_t t2;
 	rspamd_ftok_t t3;
@@ -1203,11 +1203,11 @@ struct lua_shingle_filter_cbdata {
 		}                                                                     \
 	} while (0)
 
-static guint64
-lua_shingles_filter(guint64 *input, gsize count,
+static uint64_t
+lua_shingles_filter(uint64_t *input, gsize count,
 					gint shno, const guchar *key, gpointer ud)
 {
-	guint64 minimal = G_MAXUINT64;
+	uint64_t minimal = G_MAXUINT64;
 	gsize i, min_idx = 0;
 	struct lua_shingle_data *sd;
 	rspamd_stat_token_t *word;

--- a/src/lua/lua_redis.c
+++ b/src/lua/lua_redis.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -110,9 +110,9 @@ struct lua_redis_userdata {
 };
 
 #define msg_debug_lua_redis(...) rspamd_conditional_debug_fast(NULL, NULL,                                        \
-																 rspamd_lua_redis_log_id, "lua_redis", ud->log_tag, \
-																 G_STRFUNC,                                         \
-																 __VA_ARGS__)
+															   rspamd_lua_redis_log_id, "lua_redis", ud->log_tag, \
+															   G_STRFUNC,                                         \
+															   __VA_ARGS__)
 INIT_LOG_MODULE(lua_redis)
 
 #define LUA_REDIS_SPECIFIC_REPLIED (1 << 0)
@@ -830,9 +830,9 @@ lua_redis_parse_args(lua_State *L, gint idx, const gchar *cmd,
 				gint r;
 				gchar numbuf[64];
 
-				if (val == (gdouble) ((gint64) val)) {
+				if (val == (gdouble) ((int64_t) val)) {
 					r = rspamd_snprintf(numbuf, sizeof(numbuf), "%L",
-										(gint64) val);
+										(int64_t) val);
 				}
 				else {
 					r = rspamd_snprintf(numbuf, sizeof(numbuf), "%f",

--- a/src/lua/lua_regexp.c
+++ b/src/lua/lua_regexp.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -393,7 +393,7 @@ lua_regexp_set_limit(lua_State *L)
 {
 	LUA_TRACE_POINT;
 	struct rspamd_lua_regexp *re = lua_check_regexp(L, 1);
-	gint64 lim;
+	int64_t lim;
 
 	lim = lua_tointeger(L, 2);
 

--- a/src/lua/lua_sqlite3.c
+++ b/src/lua/lua_sqlite3.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -133,7 +133,7 @@ lua_sqlite3_bind_statements(lua_State *L, gint start, gint end,
 		case LUA_TNUMBER:
 			n = lua_tonumber(L, i);
 
-			if (n == (gdouble) ((gint64) n)) {
+			if (n == (gdouble) ((int64_t) n)) {
 				sqlite3_bind_int64(stmt, num, n);
 			}
 			else {
@@ -214,7 +214,7 @@ lua_sqlite3_push_row(lua_State *L, sqlite3_stmt *stmt)
 {
 	const gchar *str;
 	gsize slen;
-	gint64 num;
+	int64_t num;
 	gchar numbuf[32];
 	gint nresults, i, type;
 

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -3356,7 +3356,7 @@ lua_task_str_to_get_type(lua_State *L, struct rspamd_task *task, gint pos, gint 
 {
 	const gchar *type = NULL;
 	gint ret = LUA_ADDRESS_ANY;
-	guint64 h;
+	uint64_t h;
 	gsize sz;
 
 	/* Get what value */
@@ -5982,7 +5982,7 @@ lua_task_set_settings_id(lua_State *L)
 {
 	LUA_TRACE_POINT;
 	struct rspamd_task *task = lua_check_task(L, 1);
-	guint32 id = lua_tointeger(L, 2);
+	uint32_t id = lua_tointeger(L, 2);
 
 	if (task != NULL && id != 0) {
 

--- a/src/lua/lua_tcp.c
+++ b/src/lua/lua_tcp.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -1539,7 +1539,7 @@ lua_tcp_request(lua_State *L)
 	struct iovec *iov = NULL;
 	struct upstream *up = NULL;
 	guint niov = 0, total_out;
-	guint64 h;
+	uint64_t h;
 	gdouble timeout = default_tcp_timeout;
 	gboolean partial = FALSE, do_shutdown = FALSE, do_read = TRUE,
 			 ssl = FALSE, ssl_noverify = FALSE;
@@ -1973,11 +1973,11 @@ lua_tcp_connect_sync(lua_State *L)
 	LUA_TRACE_POINT;
 	GError *err = NULL;
 
-	gint64 port = -1;
+	int64_t port = -1;
 	gdouble timeout = default_tcp_timeout;
 	const gchar *host = NULL;
 	gint ret;
-	guint64 h;
+	uint64_t h;
 
 	struct rspamd_task *task = NULL;
 	struct rspamd_async_session *session = NULL;

--- a/src/lua/lua_text.c
+++ b/src/lua/lua_text.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2019 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -667,7 +667,7 @@ lua_text_span(lua_State *L)
 {
 	LUA_TRACE_POINT;
 	struct rspamd_lua_text *t = lua_check_text(L, 1);
-	gint64 start = lua_tointeger(L, 2), len = -1;
+	int64_t start = lua_tointeger(L, 2), len = -1;
 
 	if (t && start >= 1 && start <= t->len) {
 		if (lua_isnumber(L, 3)) {
@@ -760,16 +760,16 @@ lua_text_sub(lua_State *L)
 	return 1;
 }
 
-static gint64
+static int64_t
 rspamd_lua_text_push_line(lua_State *L,
 						  struct rspamd_lua_text *t,
-						  gint64 start_offset,
+						  int64_t start_offset,
 						  const gchar *sep_pos,
 						  gboolean stringify)
 {
 	const gchar *start;
 	gsize len;
-	gint64 ret;
+	int64_t ret;
 
 	start = t->start + start_offset;
 	len = sep_pos ? (sep_pos - start) : (t->len - start_offset);
@@ -806,7 +806,7 @@ rspamd_lua_text_readline(lua_State *L)
 {
 	struct rspamd_lua_text *t = lua_touserdata(L, lua_upvalueindex(1));
 	gboolean stringify = lua_toboolean(L, lua_upvalueindex(2));
-	gint64 pos = lua_tointeger(L, lua_upvalueindex(3));
+	int64_t pos = lua_tointeger(L, lua_upvalueindex(3));
 
 	if (pos < 0) {
 		return luaL_error(L, "invalid pos: %d", (gint) pos);
@@ -878,7 +878,7 @@ rspamd_lua_text_regexp_split(lua_State *L)
 	struct rspamd_lua_regexp *re = *(struct rspamd_lua_regexp **)
 									   lua_touserdata(L, lua_upvalueindex(2));
 	gboolean stringify = lua_toboolean(L, lua_upvalueindex(3));
-	gint64 pos = lua_tointeger(L, lua_upvalueindex(4));
+	int64_t pos = lua_tointeger(L, lua_upvalueindex(4));
 	gboolean matched;
 
 	if (pos < 0) {
@@ -1447,7 +1447,7 @@ lua_text_find(lua_State *L)
 }
 
 #define BITOP(a, b, op) \
-	((a)[(guint64) (b) / (8u * sizeof *(a))] op(guint64) 1 << ((guint64) (b) % (8u * sizeof *(a))))
+	((a)[(uint64_t) (b) / (8u * sizeof *(a))] op(uint64_t) 1 << ((uint64_t) (b) % (8u * sizeof *(a))))
 
 static gint
 lua_text_exclude_chars(lua_State *L)
@@ -1457,7 +1457,7 @@ lua_text_exclude_chars(lua_State *L)
 	gssize patlen;
 	const gchar *pat = lua_tolstring(L, 2, &patlen), *p, *end;
 	gchar *dest, *d;
-	guint64 byteset[32 / sizeof(guint64)]; /* Bitset for ascii */
+	uint64_t byteset[32 / sizeof(uint64_t)]; /* Bitset for ascii */
 	gboolean copy = TRUE;
 	guint *plen;
 
@@ -1569,7 +1569,7 @@ lua_text_oneline(lua_State *L)
 	struct rspamd_lua_text *t = lua_check_text(L, 1);
 	const gchar *p, *end;
 	gchar *dest, *d;
-	guint64 byteset[32 / sizeof(guint64)]; /* Bitset for ascii */
+	uint64_t byteset[32 / sizeof(uint64_t)]; /* Bitset for ascii */
 	gboolean copy = TRUE, seen_8bit = FALSE;
 	guint *plen;
 

--- a/src/lua/lua_url.h
+++ b/src/lua/lua_url.h
@@ -37,7 +37,7 @@ struct lua_tree_cb_data {
 	gboolean sort;
 	gsize max_urls;
 	gdouble skip_prob;
-	guint64 random_seed;
+	uint64_t random_seed;
 };
 
 void lua_tree_url_callback(gpointer key, gpointer value, gpointer ud);

--- a/src/lua/lua_util.c
+++ b/src/lua/lua_util.c
@@ -760,12 +760,12 @@ static const struct luaL_reg ev_baselib_m[] = {
 	{"__tostring", rspamd_lua_class_tostring},
 	{NULL, NULL}};
 
-static gint64
+static int64_t
 lua_check_int64(lua_State *L, gint pos)
 {
 	void *ud = rspamd_lua_check_udata(L, pos, rspamd_int64_classname);
 	luaL_argcheck(L, ud != NULL, pos, "'int64' expected");
-	return ud ? *((gint64 *) ud) : 0LL;
+	return ud ? *((int64_t *) ud) : 0LL;
 }
 
 
@@ -1419,7 +1419,7 @@ static gint
 lua_util_is_uppercase(lua_State *L)
 {
 	LUA_TRACE_POINT;
-	gint32 i = 0;
+	int32_t i = 0;
 	UChar32 uc;
 	guint nlc = 0, nuc = 0;
 
@@ -1455,7 +1455,7 @@ static gint
 lua_util_humanize_number(lua_State *L)
 {
 	LUA_TRACE_POINT;
-	gint64 number = luaL_checkinteger(L, 1);
+	int64_t number = luaL_checkinteger(L, 1);
 	gchar numbuf[32];
 
 
@@ -1543,7 +1543,7 @@ lua_util_strlen_utf8(lua_State *L)
 	t = lua_check_text_or_string(L, 1);
 
 	if (t) {
-		gint32 i = 0, nchars = 0;
+		int32_t i = 0, nchars = 0;
 		UChar32 uc;
 
 		while (i < t->len) {
@@ -1569,7 +1569,7 @@ lua_util_lower_utf8(lua_State *L)
 	gchar *dst;
 	UChar32 uc;
 	UBool err = 0;
-	gint32 i = 0, j = 0;
+	int32_t i = 0, j = 0;
 
 	t = lua_check_text_or_string(L, 1);
 
@@ -2057,9 +2057,9 @@ static gint
 lua_util_caseless_hash(lua_State *L)
 {
 	LUA_TRACE_POINT;
-	guint64 seed = 0xdeadbabe, h;
+	uint64_t seed = 0xdeadbabe, h;
 	struct rspamd_lua_text *t = NULL;
-	gint64 *r;
+	int64_t *r;
 
 	t = lua_check_text_or_string(L, 1);
 
@@ -2086,10 +2086,10 @@ static gint
 lua_util_caseless_hash_fast(lua_State *L)
 {
 	LUA_TRACE_POINT;
-	guint64 seed = 0xdeadbabe, h;
+	uint64_t seed = 0xdeadbabe, h;
 	struct rspamd_lua_text *t = NULL;
 	union {
-		guint64 i;
+		uint64_t i;
 		double d;
 	} u;
 
@@ -2293,8 +2293,8 @@ lua_util_is_utf_outside_range(lua_State *L)
 	LUA_TRACE_POINT;
 	gint ret;
 	struct rspamd_lua_text *t = lua_check_text_or_string(L, 1);
-	guint32 range_start = lua_tointeger(L, 2);
-	guint32 range_end = lua_tointeger(L, 3);
+	uint32_t range_start = lua_tointeger(L, 2);
+	uint32_t range_end = lua_tointeger(L, 3);
 
 	static rspamd_lru_hash_t *validators;
 
@@ -2303,7 +2303,7 @@ lua_util_is_utf_outside_range(lua_State *L)
 	}
 
 	if (t) {
-		guint64 hash_key = (guint64) range_end << 32 || range_start;
+		uint64_t hash_key = (uint64_t) range_end << 32 || range_start;
 
 		USpoofChecker *validator = rspamd_lru_hash_lookup(validators, &hash_key, 0);
 
@@ -2311,7 +2311,7 @@ lua_util_is_utf_outside_range(lua_State *L)
 
 		if (validator == NULL) {
 			USet *allowed_chars;
-			guint64 *creation_hash_key = g_malloc(sizeof(guint64));
+			uint64_t *creation_hash_key = g_malloc(sizeof(uint64_t));
 			*creation_hash_key = hash_key;
 
 			validator = uspoof_open(&uc_err);
@@ -2344,7 +2344,7 @@ lua_util_is_utf_outside_range(lua_State *L)
 								   0, 0);
 		}
 
-		gint32 pos = 0;
+		int32_t pos = 0;
 		ret = uspoof_checkUTF8(validator, t->start, t->len, &pos,
 							   &uc_err);
 	}
@@ -2439,7 +2439,7 @@ static gint
 lua_util_has_obscured_unicode(lua_State *L)
 {
 	LUA_TRACE_POINT;
-	gint32 i = 0, prev_i;
+	int32_t i = 0, prev_i;
 	UChar32 uc;
 
 	struct rspamd_lua_text *t = lua_check_text_or_string(L, 1);
@@ -3411,7 +3411,7 @@ lua_util_unpack(lua_State *L)
 static int
 lua_util_btc_polymod(lua_State *L)
 {
-	guint64 c = 1;
+	uint64_t c = 1;
 
 	if (lua_type(L, 1) != LUA_TTABLE) {
 		return luaL_error(L, "invalid arguments");
@@ -3419,7 +3419,7 @@ lua_util_btc_polymod(lua_State *L)
 
 	for (lua_pushnil(L); lua_next(L, 1); lua_pop(L, 1)) {
 		guint8 c0 = c >> 35;
-		guint64 d = lua_tointeger(L, -1);
+		uint64_t d = lua_tointeger(L, -1);
 
 		c = ((c & 0x07ffffffff) << 5) ^ d;
 
@@ -3479,7 +3479,7 @@ void luaopen_util(lua_State *L)
 static int
 lua_int64_tostring(lua_State *L)
 {
-	gint64 n = lua_check_int64(L, 1);
+	int64_t n = lua_check_int64(L, 1);
 	gchar buf[32];
 	bool is_signed = false;
 
@@ -3504,7 +3504,7 @@ lua_int64_fromstring(lua_State *L)
 	struct rspamd_lua_text *t = lua_check_text_or_string(L, 1);
 
 	if (t && t->len > 0) {
-		guint64 u64;
+		uint64_t u64;
 		const char *p = t->start;
 		gsize len = t->len;
 		bool neg = false;
@@ -3529,7 +3529,7 @@ lua_int64_fromstring(lua_State *L)
 			return 2;
 		}
 
-		gint64 *i64_p = lua_newuserdata(L, sizeof(gint64));
+		int64_t *i64_p = lua_newuserdata(L, sizeof(int64_t));
 		rspamd_lua_setclass(L, rspamd_int64_classname, -1);
 		memcpy(i64_p, &u64, sizeof(u64));
 
@@ -3546,7 +3546,7 @@ lua_int64_fromstring(lua_State *L)
 static int
 lua_int64_tonumber(lua_State *L)
 {
-	gint64 n = lua_check_int64(L, 1);
+	int64_t n = lua_check_int64(L, 1);
 	gdouble d;
 
 	d = n;
@@ -3558,7 +3558,7 @@ lua_int64_tonumber(lua_State *L)
 static int
 lua_int64_hex(lua_State *L)
 {
-	gint64 n = lua_check_int64(L, 1);
+	int64_t n = lua_check_int64(L, 1);
 	gchar buf[32];
 
 	rspamd_snprintf(buf, sizeof(buf), "%XL", n);

--- a/src/lua/lua_worker.c
+++ b/src/lua/lua_worker.c
@@ -78,7 +78,7 @@ lua_worker_get_stat(lua_State *L)
 		struct rspamd_stat *stat, stat_copy;
 		ucl_object_t *top, *sub;
 		gint i;
-		guint64 spam = 0, ham = 0;
+		uint64_t spam = 0, ham = 0;
 
 		memset(&mem_st, 0, sizeof(mem_st));
 		rspamd_mempool_stat(&mem_st);
@@ -481,7 +481,7 @@ struct rspamd_lua_process_cbdata {
 	gboolean is_error;
 	pid_t cpid;
 	lua_State *L;
-	guint64 sz;
+	uint64_t sz;
 	GString *io_buf;
 	GString *out_buf;
 	goffset out_pos;
@@ -495,7 +495,7 @@ rspamd_lua_execute_lua_subprocess(lua_State *L,
 								  struct rspamd_lua_process_cbdata *cbdata)
 {
 	gint err_idx, r;
-	guint64 wlen = 0;
+	uint64_t wlen = 0;
 
 	lua_pushcfunction(L, &rspamd_lua_traceback);
 	err_idx = lua_gettop(L);
@@ -639,12 +639,12 @@ rspamd_lua_subprocess_io(EV_P_ ev_io *w, int revents)
 		(struct rspamd_lua_process_cbdata *) w->data;
 	gssize r;
 
-	if (cbdata->sz == (guint64) -1) {
-		guint64 sz;
+	if (cbdata->sz == (uint64_t) -1) {
+		uint64_t sz;
 
 		/* We read size of reply + flags first */
 		r = read(cbdata->sp[0], cbdata->io_buf->str + cbdata->io_buf->len,
-				 sizeof(guint64) - cbdata->io_buf->len);
+				 sizeof(uint64_t) - cbdata->io_buf->len);
 
 		if (r == 0) {
 			ev_io_stop(cbdata->event_loop, &cbdata->ev);
@@ -672,7 +672,7 @@ rspamd_lua_subprocess_io(EV_P_ ev_io *w, int revents)
 
 		cbdata->io_buf->len += r;
 
-		if (cbdata->io_buf->len == sizeof(guint64)) {
+		if (cbdata->io_buf->len == sizeof(uint64_t)) {
 			memcpy((guchar *) &sz, cbdata->io_buf->str, sizeof(sz));
 
 			if (sz & (1ULL << 63)) {
@@ -790,7 +790,7 @@ lua_worker_spawn_process(lua_State *L)
 	cbdata->wrk = w;
 	cbdata->L = L;
 	cbdata->event_loop = actx->event_loop;
-	cbdata->sz = (guint64) -1;
+	cbdata->sz = (uint64_t) -1;
 
 	pid = fork();
 

--- a/src/plugins/chartable.cxx
+++ b/src/plugins/chartable.cxx
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -1725,7 +1725,7 @@ rspamd_chartable_process_word_utf(struct rspamd_task *task,
 	while (p < end) {
 		uc = *p++;
 
-		if (((gint32) uc) < 0) {
+		if (((int32_t) uc) < 0) {
 			break;
 		}
 

--- a/src/plugins/dkim_check.c
+++ b/src/plugins/dkim_check.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -695,7 +695,7 @@ static gint
 lua_dkim_sign_handler(lua_State *L)
 {
 	struct rspamd_task *task = lua_check_task(L, 1);
-	gint64 arc_idx = 0, expire = 0;
+	int64_t arc_idx = 0, expire = 0;
 	enum rspamd_dkim_type sign_type = RSPAMD_DKIM_NORMAL;
 	GError *err = NULL;
 	GString *hdr;

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -63,7 +63,7 @@ static const gchar *M = "fuzzy check";
 struct fuzzy_ctx;
 
 struct fuzzy_mapping {
-	guint64 fuzzy_flag;
+	uint64_t fuzzy_flag;
 	const gchar *symbol;
 	double weight;
 };
@@ -89,7 +89,7 @@ struct fuzzy_rule {
 	gboolean no_share;
 	gboolean no_subject;
 	gint learn_condition_cb;
-	guint32 retransmits;
+	uint32_t retransmits;
 	struct rspamd_hash_map_helper *skip_map;
 	struct fuzzy_ctx *ctx;
 	gint lua_id;
@@ -109,7 +109,7 @@ struct fuzzy_ctx {
 	gint check_mime_part_ref; /* Lua callback */
 	gint process_rule_ref;    /* Lua callback */
 	gint cleanup_rules_ref;
-	guint32 retransmits;
+	uint32_t retransmits;
 	gboolean enabled;
 };
 
@@ -170,8 +170,8 @@ struct fuzzy_learn_session {
 #define FUZZY_CHECK_FLAG_NOTEXT (1 << 2)
 
 struct fuzzy_cmd_io {
-	guint32 tag;
-	guint32 flags;
+	uint32_t tag;
+	uint32_t flags;
 	struct iovec io;
 	struct rspamd_mime_part *part;
 	struct rspamd_fuzzy_cmd cmd;
@@ -297,7 +297,7 @@ parse_fuzzy_headers(struct rspamd_config *cfg, const gchar *str)
 }
 
 static double
-fuzzy_normalize(gint32 in, double weight)
+fuzzy_normalize(int32_t in, double weight)
 {
 	if (weight == 0) {
 		return 0;
@@ -1335,7 +1335,7 @@ static struct fuzzy_cmd_io *
 fuzzy_cmd_stat(struct fuzzy_rule *rule,
 			   int c,
 			   gint flag,
-			   guint32 weight,
+			   uint32_t weight,
 			   rspamd_mempool_t *pool)
 {
 	struct rspamd_fuzzy_cmd *cmd;
@@ -1431,7 +1431,7 @@ fuzzy_cmd_hash(struct fuzzy_rule *rule,
 			   int c,
 			   const rspamd_ftok_t *hash,
 			   gint flag,
-			   guint32 weight,
+			   uint32_t weight,
 			   rspamd_mempool_t *pool)
 {
 	struct rspamd_fuzzy_cmd *cmd;
@@ -1708,7 +1708,7 @@ fuzzy_cmd_from_text_part(struct rspamd_task *task,
 						 struct fuzzy_rule *rule,
 						 int c,
 						 gint flag,
-						 guint32 weight,
+						 uint32_t weight,
 						 gboolean short_text,
 						 struct rspamd_mime_text_part *part,
 						 struct rspamd_mime_part *mp)
@@ -1940,7 +1940,7 @@ static struct fuzzy_cmd_io *
 fuzzy_cmd_from_image_part (struct fuzzy_rule *rule,
 						   int c,
 						   gint flag,
-						   guint32 weight,
+						   uint32_t weight,
 						   struct rspamd_task *task,
 						   struct rspamd_image *img,
 						   struct rspamd_mime_part *mp)
@@ -2038,7 +2038,7 @@ static struct fuzzy_cmd_io *
 fuzzy_cmd_from_data_part(struct fuzzy_rule *rule,
 						 int c,
 						 gint flag,
-						 guint32 weight,
+						 uint32_t weight,
 						 struct rspamd_task *task,
 						 guchar digest[rspamd_cryptobox_HASHBYTES],
 						 struct rspamd_mime_part *mp)
@@ -2477,7 +2477,7 @@ fuzzy_check_try_read(struct fuzzy_client_session *session)
 						g_hash_table_insert(stats_hash, (char *) pval->name, pval);
 					}
 
-					pval->fuzzy_cnt = (((guint64) rep->v1.value) << 32) + rep->v1.flag;
+					pval->fuzzy_cnt = (((uint64_t) rep->v1.value) << 32) + rep->v1.flag;
 				}
 			}
 			else if (rep->v1.value == 403) {
@@ -3089,7 +3089,7 @@ cleanup:
 
 static GPtrArray *
 fuzzy_generate_commands(struct rspamd_task *task, struct fuzzy_rule *rule,
-						gint c, gint flag, guint32 value, guint flags)
+						gint c, gint flag, uint32_t value, guint flags)
 {
 	struct rspamd_mime_text_part *part;
 	struct rspamd_mime_part *mime_part;

--- a/src/plugins/regexp.c
+++ b/src/plugins/regexp.c
@@ -25,10 +25,10 @@
 #include "libserver/maps/map.h"
 #include "lua/lua_common.h"
 
-static const guint64 rspamd_regexp_cb_magic = 0xca9d9649fc3e2659ULL;
+static const uint64_t rspamd_regexp_cb_magic = 0xca9d9649fc3e2659ULL;
 
 struct regexp_module_item {
-	guint64 magic;
+	uint64_t magic;
 	struct rspamd_expression *expr;
 	const gchar *symbol;
 	struct ucl_lua_funcdata *lua_function;

--- a/src/ragel/smtp_date_parser.rl
+++ b/src/ragel/smtp_date_parser.rl
@@ -13,7 +13,7 @@
 
 %% write data;
 
-guint64
+uint64_t
 rspamd_parse_smtp_date (const unsigned char *data, size_t len, GError **err)
 {
   const unsigned char *p = data, *pe = data + len, *eof = data + len, *tmp = data;
@@ -40,7 +40,7 @@ rspamd_parse_smtp_date (const unsigned char *data, size_t len, GError **err)
   if ( cs < %%{ write first_final; }%% ) {
     g_set_error (err, g_quark_from_static_string ("smtp_date"), cs, "invalid date at offset %d (%c), state %d",
 			(int)(p - data), (*p > 0 && *p < 128) ? *p : '?', cs);
-    return (guint64)(-1);
+    return (uint64_t)(-1);
   }
 
   return rspamd_tm_to_time (&tm, tz);

--- a/src/rspamadm/configtest.c
+++ b/src/rspamadm/configtest.c
@@ -87,7 +87,7 @@ rspamadm_configtest(gint argc, gchar **argv, const struct rspamadm_command *cmd)
 	struct rspamd_config *cfg = rspamd_main->cfg;
 	gboolean ret = TRUE;
 	worker_t **pworker;
-	const guint64 *log_cnt;
+	const uint64_t *log_cnt;
 
 	context = g_option_context_new(
 		"configtest - perform configuration file test");

--- a/src/rspamd.h
+++ b/src/rspamd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ typedef void (*rspamd_worker_term_cb)(EV_P_ ev_child *, struct rspamd_main *,
 struct rspamd_worker_heartbeat {
 	ev_timer heartbeat_ev; /**< used by main for checking heartbeats and by workers to send heartbeats */
 	ev_tstamp last_event;  /**< last heartbeat received timestamp */
-	gint64 nbeats;         /**< positive for beats received, negative for beats missed */
+	int64_t nbeats;        /**< positive for beats received, negative for beats missed */
 };
 
 enum rspamd_worker_state {
@@ -128,7 +128,7 @@ struct rspamd_worker {
 };
 
 struct rspamd_abstract_worker_ctx {
-	guint64 magic;
+	uint64_t magic;
 	/* Events base */
 	struct ev_loop *event_loop;
 	/* DNS resolver */
@@ -221,7 +221,7 @@ typedef struct module_s {
 										 GHashTable *custom_commands);
 
 	guint module_version;
-	guint64 rspamd_version;
+	uint64_t rspamd_version;
 	const gchar *rspamd_features;
 	guint ctx_offset;
 } module_t;
@@ -249,7 +249,7 @@ typedef struct worker_s {
 	int flags;
 	int listen_type;
 	guint worker_version;
-	guint64 rspamd_version;
+	uint64_t rspamd_version;
 	const gchar *rspamd_features;
 } worker_t;
 
@@ -281,7 +281,7 @@ struct rspamd_cryptobox_library_ctx;
 
 #define MAX_AVG_TIME_SLOTS 31
 struct RSPAMD_ALIGNED(64) rspamd_avg_time {
-	guint32 cur_slot;
+	uint32_t cur_slot;
 	float avg_time[MAX_AVG_TIME_SLOTS];
 };
 /**

--- a/src/rspamd_proxy.c
+++ b/src/rspamd_proxy.c
@@ -110,10 +110,10 @@ struct rspamd_http_mirror {
 	gboolean compress;
 };
 
-static const guint64 rspamd_rspamd_proxy_magic = 0xcdeb4fd1fc351980ULL;
+static const uint64_t rspamd_rspamd_proxy_magic = 0xcdeb4fd1fc351980ULL;
 
 struct rspamd_proxy_ctx {
-	guint64 magic;
+	uint64_t magic;
 	/* Events base */
 	struct ev_loop *event_loop;
 	/* DNS resolver */

--- a/src/worker.c
+++ b/src/worker.c
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2016 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -67,7 +67,7 @@ worker_t normal_worker = {
 													  __VA_ARGS__)
 
 struct rspamd_worker_session {
-	gint64 magic;
+	int64_t magic;
 	struct rspamd_task *task;
 	gint fd;
 	rspamd_inet_addr_t *addr;
@@ -226,7 +226,7 @@ rspamd_worker_error_handler(struct rspamd_http_connection *conn, GError *err)
 	 * Hence, we need to distinguish our arguments...
 	 *
 	 * The approach here is simple:
-	 * - struct rspamd_worker_session starts with gint64 `magic` and we set it to
+	 * - struct rspamd_worker_session starts with int64_t `magic` and we set it to
 	 * MAX_INT64
 	 * - struct rspamd_task starts with a pointer (or pointer + command on 32 bit system)
 	 *

--- a/src/worker_private.h
+++ b/src/worker_private.h
@@ -27,12 +27,12 @@
 extern "C" {
 #endif
 
-static const guint64 rspamd_worker_magic = 0xb48abc69d601dc1dULL;
+static const uint64_t rspamd_worker_magic = 0xb48abc69d601dc1dULL;
 
 struct rspamd_lang_detector;
 
 struct rspamd_worker_ctx {
-	guint64 magic;
+	uint64_t magic;
 	/* Events base */
 	struct ev_loop *event_loop;
 	/* DNS resolver */
@@ -46,7 +46,7 @@ struct rspamd_worker_ctx {
 	/* Allow encrypted requests only using network */
 	gboolean encrypted_only;
 	/* Limit of tasks */
-	guint32 max_tasks;
+	uint32_t max_tasks;
 	/* Maximum time for task processing */
 	ev_tstamp task_timeout;
 	/* Encryption key */

--- a/test/rspamd_cryptobox_test.c
+++ b/test/rspamd_cryptobox_test.c
@@ -49,12 +49,12 @@ static void
 check_result(const rspamd_nm_t key, const rspamd_nonce_t nonce,
 			 const rspamd_mac_t mac, guchar *begin, guchar *end)
 {
-	guint64 *t = (guint64 *) begin;
+	uint64_t *t = (uint64_t *) begin;
 
 	g_assert(rspamd_cryptobox_decrypt_nm_inplace(begin, end - begin, nonce, key,
 												 mac, mode));
 
-	while (t < (guint64 *) end) {
+	while (t < (uint64_t *) end) {
 		g_assert(*t == 0);
 		t++;
 	}

--- a/test/rspamd_radix_test.c
+++ b/test/rspamd_radix_test.c
@@ -38,7 +38,7 @@ struct _tv {
 	const char *ip;
 	const char *nip;
 	const char *m;
-	guint32 mask;
+	uint32_t mask;
 	guint8 *addr;
 	guint8 *naddr;
 	gsize len;
@@ -207,10 +207,10 @@ void rspamd_radix_test_func(void)
 	struct btrie *btrie;
 	rspamd_mempool_t *pool;
 	struct {
-		guint32 addr;
-		guint32 mask;
+		uint32_t addr;
+		uint32_t mask;
 		guint8 addr6[16];
-		guint32 mask6;
+		uint32_t mask6;
 		guint8 addr64[16];
 	} *addrs;
 	gsize nelts, i, check;

--- a/test/rspamd_shingles_test.c
+++ b/test/rspamd_shingles_test.c
@@ -136,7 +136,7 @@ test_case(gsize cnt, gsize max_len, gdouble perm_factor,
 	g_free(sgl_permuted);
 }
 
-static const guint64 expected_old[RSPAMD_SHINGLE_SIZE] = {
+static const uint64_t expected_old[RSPAMD_SHINGLE_SIZE] = {
 	0x2a97e024235cedc5,
 	0x46238acbcc55e9e0,
 	0x2378ff151af075b3,
@@ -171,7 +171,7 @@ static const guint64 expected_old[RSPAMD_SHINGLE_SIZE] = {
 	0x99fbca9f8563080,
 };
 
-static const guint64 expected_xxhash[RSPAMD_SHINGLE_SIZE] = {
+static const uint64_t expected_xxhash[RSPAMD_SHINGLE_SIZE] = {
 	0x33b134be11a705a,
 	0x36e2ea657aa36903,
 	0x6547b57f7470ce9d,
@@ -206,7 +206,7 @@ static const guint64 expected_xxhash[RSPAMD_SHINGLE_SIZE] = {
 	0x68454ef43da9c748,
 };
 
-static const guint64 expected_mumhash[RSPAMD_SHINGLE_SIZE] = {
+static const uint64_t expected_mumhash[RSPAMD_SHINGLE_SIZE] = {
 	0x38d35473b80a7fc3,
 	0x1300531adc2d16a1,
 	0x26883bc89f78f4bd,
@@ -241,7 +241,7 @@ static const guint64 expected_mumhash[RSPAMD_SHINGLE_SIZE] = {
 	0x33cb9190905e049a,
 };
 
-static const guint64 expected_fasthash[RSPAMD_SHINGLE_SIZE] = {
+static const uint64_t expected_fasthash[RSPAMD_SHINGLE_SIZE] = {
 	0x3843a716f94828a6,
 	0x13fd5386dda3b28d,
 	0x71cb09de527c40a,

--- a/utils/rspamd_http_bench.c
+++ b/utils/rspamd_http_bench.c
@@ -42,10 +42,10 @@ static gboolean csv_output = FALSE;
 
 /* Dynamic vars */
 static rspamd_inet_addr_t *addr;
-static guint32 workers_left = 0;
-static guint32 *conns_done = NULL;
+static uint32_t workers_left = 0;
+static uint32_t *conns_done = NULL;
 static const guint store_latencies = 1000;
-static guint32 conns_pending = 0;
+static uint32_t conns_pending = 0;
 
 static GOptionEntry entries[] = {
 	{"port", 'p', 0, G_OPTION_ARG_INT, &port,
@@ -91,7 +91,7 @@ rspamd_client_body(struct rspamd_http_connection *conn,
 
 struct client_cbdata {
 	struct lat_elt *lat;
-	guint32 *wconns;
+	uint32_t *wconns;
 	gdouble ts;
 	struct ev_loop *ev_base;
 };
@@ -130,7 +130,7 @@ rspamd_client_finish(struct rspamd_http_connection *conn,
 
 static void
 rspamd_http_client_func(struct ev_loop *ev_base, struct lat_elt *latency,
-						guint32 *wconns,
+						uint32_t *wconns,
 						struct rspamd_cryptobox_pubkey *peer_key,
 						struct rspamd_cryptobox_keypair *client_key,
 						struct rspamd_keypair_cache *c)
@@ -174,7 +174,7 @@ rspamd_http_client_func(struct ev_loop *ev_base, struct lat_elt *latency,
 }
 
 static void
-rspamd_worker_func(struct lat_elt *plat, guint32 *wconns)
+rspamd_worker_func(struct lat_elt *plat, uint32_t *wconns)
 {
 	guint i, j;
 	struct ev_loop *ev_base;
@@ -314,7 +314,7 @@ int main(int argc, char **argv)
 	struct ev_loop *ev_base;
 	rspamd_mempool_t *pool = rspamd_mempool_new(8192, "http-bench");
 	struct event term_ev, int_ev, cld_ev;
-	guint64 total_done;
+	uint64_t total_done;
 	FILE *lat_file;
 	gdouble mean, std;
 	guint i;
@@ -341,8 +341,8 @@ int main(int argc, char **argv)
 	latencies = rspamd_mempool_alloc_shared(pool,
 											nworkers * pconns * store_latencies * sizeof(*latencies));
 	sfd = g_malloc(sizeof(*sfd) * nworkers);
-	conns_done = rspamd_mempool_alloc_shared(pool, sizeof(guint32) * nworkers);
-	memset(conns_done, 0, sizeof(guint32) * nworkers);
+	conns_done = rspamd_mempool_alloc_shared(pool, sizeof(uint32_t) * nworkers);
+	memset(conns_done, 0, sizeof(uint32_t) * nworkers);
 
 	rspamd_http_start_workers(sfd);
 


### PR DESCRIPTION
This types have constant conflicts with the system ones especially on OSX.