### PR TITLE
Rework grow factor

### DIFF
--- a/src/libmime/scan_result.c
+++ b/src/libmime/scan_result.c
@@ -231,7 +231,7 @@ insert_metric_result(struct rspamd_task *task,
 					 bool *new_sym)
 {
 	struct rspamd_symbol_result *symbol_result = NULL;
-	double final_score, *gr_score = NULL, next_gf = 1.0, diff;
+	double final_score, *gr_score = NULL, diff;
 	struct rspamd_symbol *sdef;
 	struct rspamd_symbols_group *gr = NULL;
 	const ucl_object_t *mobj, *sobj;
@@ -368,17 +368,6 @@ insert_metric_result(struct rspamd_task *task,
 		}
 
 		if (diff) {
-			/* Handle grow factor */
-			if (metric_res->grow_factor && diff > 0) {
-				diff *= metric_res->grow_factor;
-				next_gf *= task->cfg->grow_factor;
-			}
-			else if (diff > 0) {
-				next_gf = task->cfg->grow_factor;
-			}
-
-			msg_debug_metric("adjust grow factor to %.2f for symbol %s (%.2f final)",
-							 next_gf, symbol, diff);
 
 			if (sdef) {
 				PTR_ARRAY_FOREACH(sdef->groups, i, gr)
@@ -418,8 +407,6 @@ insert_metric_result(struct rspamd_task *task,
 			}
 
 			if (!isnan(diff)) {
-				metric_res->score += diff;
-				metric_res->grow_factor = next_gf;
 
 				if (single) {
 					msg_debug_metric("final score for single symbol %s = %.2f; %.2f diff",
@@ -446,18 +433,6 @@ insert_metric_result(struct rspamd_task *task,
 		g_assert(ret > 0);
 		symbol_result = rspamd_mempool_alloc0(task->task_pool, sizeof(*symbol_result));
 		kh_value(metric_res->symbols, k) = symbol_result;
-
-		/* Handle grow factor */
-		if (metric_res->grow_factor && final_score > 0) {
-			final_score *= metric_res->grow_factor;
-			next_gf *= task->cfg->grow_factor;
-		}
-		else if (final_score > 0) {
-			next_gf = task->cfg->grow_factor;
-		}
-
-		msg_debug_metric("adjust grow factor to %.2f for symbol %s (%.2f final)",
-						 next_gf, symbol, final_score);
 
 		symbol_result->name = sym_cpy;
 		symbol_result->sym = sdef;
@@ -503,7 +478,6 @@ insert_metric_result(struct rspamd_task *task,
 			const double epsilon = DBL_EPSILON;
 
 			metric_res->score += final_score;
-			metric_res->grow_factor = next_gf;
 			symbol_result->score = final_score;
 
 			if (final_score > epsilon) {

--- a/src/libmime/scan_result.h
+++ b/src/libmime/scan_result.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vsevolod Stakhov
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,8 +99,7 @@ struct kh_rspamd_symbols_group_hash_s;
 
 
 struct rspamd_scan_result {
-	double score;       /**< total score							*/
-	double grow_factor; /**< current grow factor					*/
+	double score; /**< total score							*/
 	struct rspamd_passthrough_result *passthrough_result;
 	double positive_score;
 	double negative_score;
@@ -220,16 +219,11 @@ void rspamd_task_symbol_result_foreach(struct rspamd_task *task,
 									   gpointer ud);
 
 /**
- * Default consolidation function for metric, it get all symbols and multiply symbol
- * weight by some factor that is specified in config. Default factor is 1.
- * @param task worker's task that present message from user
- * @param metric_name name of metric
- * @return result metric weight
+ * Adjust symbol results to the grow factor for a specific task; should be called after postfilters
  */
-double rspamd_factor_consolidation_func(struct rspamd_task *task,
-										const char *metric_name,
-										const char *unused);
-
+void rspamd_task_result_adjust_grow_factor(struct rspamd_task *task,
+										   struct rspamd_scan_result *result,
+										   double grow_factor);
 
 /**
  * Check thresholds and return action for a task

--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -1322,15 +1322,13 @@ rspamd_scan_result_ucl(struct rspamd_task *task,
 			sobj = rspamd_metric_symbol_ucl(task, sym);
 			ucl_object_insert_key(obj, sobj, sym->name, 0, false);
 		}
-	})
+	});
 
-		if (task->cmd != CMD_CHECK)
-	{
+	if (task->cmd != CMD_CHECK) {
 		/* For checkv2 we insert symbols as a separate object */
 		ucl_object_insert_key(top, obj, "symbols", 0, false);
 	}
-	else
-	{
+	else {
 		/* For legacy check we just insert it as "default" all together */
 		ucl_object_insert_key(top, obj, DEFAULT_METRIC, 0, false);
 	}

--- a/src/libserver/task.c
+++ b/src/libserver/task.c
@@ -758,6 +758,10 @@ rspamd_task_process(struct rspamd_task *task, unsigned int stages)
 		all_done = rspamd_symcache_process_symbols(task, task->cfg->cache,
 												   st);
 
+		if (all_done) {
+			rspamd_task_result_adjust_grow_factor(task, task->result, task->cfg->grow_factor);
+		}
+
 		if (all_done && (task->flags & RSPAMD_TASK_FLAG_LEARN_AUTO) &&
 			!RSPAMD_TASK_IS_EMPTY(task) &&
 			!(task->flags & (RSPAMD_TASK_FLAG_LEARN_SPAM | RSPAMD_TASK_FLAG_LEARN_HAM))) {


### PR DESCRIPTION
Currently, `grow_factor` setting is totally bogus:

* It is increased with every symbol with positive score being added
* As symbols are added in undefined order, the weight of symbol X might be different depending if there were different amount of **other** symbols being inserted before
* Symbols with low score (like 0.01) are as significant in grow factor calculations as symbols with high scores

This PR fixes all the issues above. `grow_factor` is just a value that will be used to multiply weights of **all** positive score symbols after the postfilters phase. This factor will be calculated by checking each individual symbol contribution to the final result, so symbols with 1/2 of rejection (or any other highest score metric threshold) score will multiply grow_factor by `1.0 + (grow_factor - 1.0) * 0.5`, and symbol with 0.1 of rejection threshold will increase grow_factor by `1.0 + (grow_factor - 1.0) * 0.1`. After all symbols are examined, the adjusted grow factor is applied to all symbols with positive scores.

This logic will provide consistent and reasonable (to me) result.