### PR TITLE
Rework composites for spam injected into compromised accounts

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -83,12 +83,14 @@ composites {
     expression = "(HAS_X_POS | HAS_PHPMAILER_SIG) & HAS_WP_URI & (PHISHING | CRACKED_SURBL | PH_SURBL_MULTI | DBL_PHISH | DBL_ABUSE_PHISH | URIBL_BLACK | PHISHED_OPENPHISH | PHISHED_PHISHTANK)";
     description = "Phish message sent by hacked Wordpress instance";
     policy = "leave";
+    group = "compromised_hosts";
   }
   COMPROMISED_ACCT_BULK {
     expression = "(HAS_XOIP | RCVD_FROM_SMTP_AUTH) & DCC_BULK";
     description = "Likely to be from a compromised account";
     score = 3.0;
     policy = "leave";
+    group = "compromised_hosts";
   }
   UNDISC_RCPTS_BULK {
     expression = "DCC_BULK & (MISSING_TO | R_UNDISC_RCPT)";
@@ -167,6 +169,7 @@ composites {
     score = 4.0;
     policy = "leave";
     description = "Message exhibits strong characteristics of advance fee fraud (AFF a/k/a '419' spam) involving freemail addresses";
+    group = "scams";
   }
   REDIRECTOR_URL_ONLY {
     expression = "HFILTER_URL_ONLY & REDIRECTOR_URL";

--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -174,11 +174,17 @@ composites {
     policy = "leave";
     description = "Message only contains a redirector URL";
   }
-  THREAD_HIJACKING_FROM_INJECTOR {
-    expression = "FAKE_REPLY & RCVD_VIA_SMTP_AUTH & (!RECEIVED_SPAMHAUS_PBL | RECEIVED_SPAMHAUS_XBL | RECEIVED_SPAMHAUS_SBL)";
+  SUSPICIOUS_AUTH_ORIGIN {
+    expression = "RCVD_VIA_SMTP_AUTH & (!RECEIVED_SPAMHAUS_PBL | RECEIVED_SPAMHAUS_XBL | RECEIVED_SPAMHAUS_SBL | RECEIVED_BLOCKLISTDE)";
+    score = 0.0;
+    policy = "leave";
+    description = "Message authenticated, but from a suspicios origin (potentially an injector)";
+  }
+  ABUSE_FROM_INJECTOR {
+    expression = "SUSPICIOUS_AUTH_ORIGIN & (FAKE_REPLY | HAS_IPFS_GATEWAY_URL | HTML_SHORT_LINK_IMG_1)";
     score = 2.0;
     policy = "leave";
-    description = "Fake reply exhibiting characteristics of being injected into a compromised mail server, possibly e-mail thread hijacking";
+    description = "Message is sent from a suspicios origin and showing signs of abuse, likely spam injected in compromised account";
     group = "compromised_hosts";
   }
   SUSPICIOUS_URL_IN_SUSPICIOUS_MESSAGE {

--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -178,7 +178,7 @@ composites {
     description = "Message only contains a redirector URL";
   }
   SUSPICIOUS_AUTH_ORIGIN {
-    expression = "RCVD_VIA_SMTP_AUTH & (!RECEIVED_SPAMHAUS_PBL | RECEIVED_SPAMHAUS_XBL | RECEIVED_SPAMHAUS_SBL | RECEIVED_BLOCKLISTDE)";
+    expression = "(HAS_XOIP | RCVD_FROM_SMTP_AUTH) & (!RECEIVED_SPAMHAUS_PBL | RECEIVED_SPAMHAUS_XBL | RECEIVED_SPAMHAUS_SBL | RECEIVED_BLOCKLISTDE)";
     score = 0.0;
     policy = "leave";
     description = "Message authenticated, but from a suspicios origin (potentially an injector)";


### PR DESCRIPTION
This pull request aims at separating the composite logic for a suspicious origin from the rule actually scoring in case a message also carries signs of abuse. The goal of this is to allow for machine learning to pick up such nuances better, and to make the latter rule more flexible, since it is not limited to threat hijacking.

IPFS gateway URLs and `HTML_SHORT_LINK_IMG_1` have been added, since these are currently commonly seen in spam messages disseminated via compromised accounts.

As a minor detail, some missing groups have been added to existing composite rules.