### PR TITLE
[Minor] Add selector to get rspamd_hostname

### DIFF
--- a/lualib/lua_selectors/extractors.lua
+++ b/lualib/lua_selectors/extractors.lua
@@ -17,6 +17,7 @@ limitations under the License.
 local fun = require 'fun'
 local meta_functions = require "lua_meta"
 local lua_util = require "lua_util"
+local rspamd_util = require "rspamd_util"
 local rspamd_url = require "rspamd_url"
 local common = require "lua_selectors/common"
 local ts = require("tableshape").types
@@ -559,6 +560,12 @@ The first argument must be header name.]],
       return res, 'string_list'
     end,
     ['description'] = 'Get metatokens for a message as strings',
+  },
+  ['rspamd_hostname'] = {
+    ['get_value'] = function(task)
+      return rspamd_util.get_hostname(), 'string'
+    end,
+    ['description'] = 'Get hostname of the filter server',
   },
 }
 

--- a/lualib/lua_selectors/extractors.lua
+++ b/lualib/lua_selectors/extractors.lua
@@ -25,6 +25,8 @@ local maps = require "lua_selectors/maps"
 local E = {}
 local M = "selectors"
 
+local HOSTNAME = rspamd_util.get_hostname()
+
 local url_flags_ts = ts.array_of(ts.one_of(lua_util.keys(rspamd_url.flags))):is_optional()
 
 local function gen_exclude_flags_filter(exclude_flags)
@@ -563,7 +565,7 @@ The first argument must be header name.]],
   },
   ['rspamd_hostname'] = {
     ['get_value'] = function(task)
-      return rspamd_util.get_hostname(), 'string'
+      return HOSTNAME, 'string'
     end,
     ['description'] = 'Get hostname of the filter server',
   },


### PR DESCRIPTION
Instead of extending the clickhouse `rspamd` table directly, this allows using `rspamd_hostname` as a selector with `extra_columns`, such as:

```lua
extra_columns = {
        RspamdServer = {
                selector = "rspamd_hostname";
                type = "String";
        }
}
```