### PR TITLE
[Fix] Relearn messages in bayes filter

### DIFF
--- a/lualib/redis_scripts/bayes_cache_learn.lua
+++ b/lualib/redis_scripts/bayes_cache_learn.lua
@@ -15,7 +15,8 @@ for i = 0, conf.cache_max_keys do
   local have = redis.call('HGET', prefix, cache_id)
 
   if have then
-    -- Already in cache
+    -- Already in cache, but is_spam changes when relearning
+    redis.call('HSET', prefix, cache_id, is_spam)
     return false
   end
 end

--- a/lualib/redis_scripts/bayes_learn.lua
+++ b/lualib/redis_scripts/bayes_learn.lua
@@ -26,7 +26,7 @@ redis.call('HSET', prefix, 'version', '2') -- new schema
 redis.call('HINCRBY', prefix, learned_key, is_unlearn and -1 or 1) -- increase or decrease learned count
 
 for i, token in ipairs(input_tokens) do
-  redis.call('HINCRBY', token, hash_key, 1)
+  redis.call('HINCRBY', token, hash_key, is_unlearn and -1 or 1)
   if text_tokens then
     local tok1 = text_tokens[i * 2 - 1]
     local tok2 = text_tokens[i * 2]

--- a/src/libstat/learn_cache/redis_cache.cxx
+++ b/src/libstat/learn_cache/redis_cache.cxx
@@ -170,7 +170,7 @@ rspamd_stat_cache_checked(lua_State *L)
 						  (task->flags & RSPAMD_TASK_FLAG_LEARN_SPAM) ? "spam" : "ham");
 			task->flags |= RSPAMD_TASK_FLAG_ALREADY_LEARNED;
 		}
-		else if (val != 0) {
+		else {
 			/* Unlearn flag */
 			task->flags |= RSPAMD_TASK_FLAG_UNLEARN;
 		}


### PR DESCRIPTION
Relearning a message should have the same result as learning a message the first time. #4928, #3600
The following should have the same result:
- learn as spam
- learn as ham, then relearn as spam

The same should be true for the opposite direction:

- learn as ham
- learn as spam, then relearn as ham

With these changes, we were able to successfully relearn a message in both ways. The score always shows the same result, regardless of whether it is a relearn or first learn.