### PR TITLE
Fix error in headers_checks.lua

### DIFF
--- a/rules/headers_checks.lua
+++ b/rules/headers_checks.lua
@@ -254,7 +254,7 @@ local check_replyto_id = rspamd_config:register_symbol({
         then
           task:insert_result('REPLYTO_EQ_TO_ADDR', 1.0)
         end
-      elseif to[1].domain and rt[1].domain then
+      elseif (to and to[1] and to[1].domain and rt[1].domain) then
         if (util.strequal_caseless(to[1].domain, rt[1].domain)) then
           task:insert_result('REPLYTO_DOM_EQ_TO_DOM', 1.0)
         else


### PR DESCRIPTION
Fix errors like:
```lua
task; lua_metric_symbol_callback: call to (CHECK_REPLYTO) failed (2): /usr/share/rspamd/rules/headers_checks.lua:257: attempt to index local 'to' (a nil value); trace: [1]:{/usr/share/rspamd/rules/headers_checks.lua:257 - <unknown> [Lua]};
```