### PR TITLE
Implement backpressure for fuzzy check

### DIFF
--- a/src/libutil/libev_helper.h
+++ b/src/libutil/libev_helper.h
@@ -1,11 +1,11 @@
-/*-
- * Copyright 2019 Vsevolod Stakhov
+/*
+ * Copyright 2024 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -78,6 +78,17 @@ void rspamd_ev_watcher_stop(struct ev_loop *loop,
 void rspamd_ev_watcher_reschedule(struct ev_loop *loop,
 								  struct rspamd_io_ev *ev,
 								  short what);
+
+/**
+ * Convenience function to reschedule watcher with different events and different timeout
+ * @param loop
+ * @param ev
+ * @param what
+ */
+void rspamd_ev_watcher_reschedule_at(struct ev_loop *loop,
+									 struct rspamd_io_ev *ev,
+									 short what,
+									 ev_tstamp at);
 
 #ifdef __cplusplus
 }

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -2682,6 +2682,7 @@ fuzzy_check_timer_callback(int fd, short what, void *arg)
 			/* Do not make delay more than 500ms for performance considerations */
 			backpressure_time = MIN(backpressure_time, 0.5);
 			backpressure_time = rspamd_time_jitter(backpressure_time * 0.5, 0.0);
+			backpressure_time = MAX(backpressure_time, 0.1);
 			/* Inverse to distinguish */
 			msg_debug_fuzzy_check("backpressure for %.2f milliseconds (server=%s), retransmits: %d;",
 								  backpressure_time * 1000,
@@ -2870,6 +2871,7 @@ fuzzy_controller_timer_callback(int fd, short what, void *arg)
 			/* Do not make delay more than 500ms for performance considerations */
 			backpressure_time = MIN(backpressure_time, 0.5);
 			backpressure_time = rspamd_time_jitter(backpressure_time * 0.5, 0.0);
+			backpressure_time = MAX(backpressure_time, 0.1);
 			/* Inverse to distinguish */
 			msg_debug_fuzzy_check("backpressure for %.2f milliseconds (server=%s), retransmits: %d;",
 								  backpressure_time * 1000,

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -59,7 +59,7 @@
 #define RSPAMD_FUZZY_PLUGIN_VERSION RSPAMD_FUZZY_VERSION
 
 static const int rspamd_fuzzy_hash_len = 5;
-static const char *M = "fuzzy check";
+static const char *M = "fuzzy_check";
 struct fuzzy_ctx;
 
 struct fuzzy_mapping {
@@ -207,6 +207,13 @@ module_t fuzzy_check_module = {
 	RSPAMD_MODULE_VER,
 	(unsigned int) -1,
 };
+
+INIT_LOG_MODULE(N)
+#define msg_debug_fuzzy_check(...) rspamd_conditional_debug_fast(NULL,                                                          \
+																 task ? task->from_addr : NULL,                                 \
+																 rspamd_task_log_id, M, task ? task->task_pool->tag.uid : NULL, \
+																 RSPAMD_LOG_FUNC,                                               \
+																 __VA_ARGS__)
 
 static inline struct fuzzy_ctx *
 fuzzy_get_context(struct rspamd_config *cfg)
@@ -1842,9 +1849,9 @@ fuzzy_cmd_from_text_part(struct rspamd_task *task,
 
 			rspamd_cryptobox_hash_final(&st, shcmd->basic.digest);
 
-			msg_debug_task("loading shingles of type %s with key %*xs",
-						   rule->algorithm_str,
-						   16, rule->shingles_key->str);
+			msg_debug_fuzzy_check("loading shingles of type %s with key %*xs",
+								  rule->algorithm_str,
+								  16, rule->shingles_key->str);
 			sh = rspamd_shingles_from_text(words,
 										   rule->shingles_key->str, task->task_pool,
 										   rspamd_shingles_default_filter, NULL,
@@ -1987,7 +1994,7 @@ fuzzy_cmd_from_image_part (struct fuzzy_rule *rule,
 				(const unsigned char *)img->dct, RSPAMD_DCT_LEN / NBBY,
 				rule->hash_key->str, rule->hash_key->len);
 
-		msg_debug_task ("loading shingles of type %s with key %*xs",
+		msg_debug_fuzzy_check ("loading shingles of type %s with key %*xs",
 				rule->algorithm_str,
 				16, rule->shingles_key->str);
 
@@ -4228,9 +4235,9 @@ fuzzy_lua_hex_hashes_handler(lua_State *L)
 		/* Check for flag */
 		if (g_hash_table_lookup(rule->mappings,
 								GINT_TO_POINTER(flag)) == NULL) {
-			msg_debug_task("skip rule %s as it has no flag %d defined"
-						   " false",
-						   rule->name, flag);
+			msg_debug_fuzzy_check("skip rule %s as it has no flag %d defined"
+								  " false",
+								  rule->name, flag);
 			continue;
 		}
 

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -2681,6 +2681,7 @@ fuzzy_check_timer_callback(int fd, short what, void *arg)
 			double backpressure_time = MAX(session->rule->io_timeout * 0.1, 0.1) * session->retransmits;
 			/* Do not make delay more than 500ms for performance considerations */
 			backpressure_time = MIN(backpressure_time, 0.5);
+			backpressure_time = rspamd_time_jitter(backpressure_time * 0.5, 0.0);
 			/* Inverse to distinguish */
 			msg_debug_fuzzy_check("backpressure for %.2f milliseconds (server=%s), retransmits: %d;",
 								  backpressure_time * 1000,
@@ -2868,6 +2869,7 @@ fuzzy_controller_timer_callback(int fd, short what, void *arg)
 			double backpressure_time = MAX(session->rule->io_timeout * 0.1, 0.1) * session->retransmits;
 			/* Do not make delay more than 500ms for performance considerations */
 			backpressure_time = MIN(backpressure_time, 0.5);
+			backpressure_time = rspamd_time_jitter(backpressure_time * 0.5, 0.0);
 			/* Inverse to distinguish */
 			msg_debug_fuzzy_check("backpressure for %.2f milliseconds (server=%s), retransmits: %d;",
 								  backpressure_time * 1000,


### PR DESCRIPTION
We don't want to retransmits requests immediately as if we have some networking issues it won't help anything and will likely make troubles even worse.

The logic is to apply linear backpressure on each retransmit from 100 to 500ms.