### PR TITLE
[Fix] SUBJ_ALL_CAPS is overkill with some unicase scripts

### DIFF
--- a/src/lua/lua_util.c
+++ b/src/lua/lua_util.c
@@ -1421,7 +1421,7 @@ lua_util_is_uppercase(lua_State *L)
 	LUA_TRACE_POINT;
 	int32_t i = 0;
 	UChar32 uc;
-	unsigned int nlc = 0, nuc = 0;
+	bool is_upper = false, is_lower = false, is_other = false;
 
 	struct rspamd_lua_text *t = lua_check_text_or_string(L, 1);
 	if (t) {
@@ -1433,15 +1433,20 @@ lua_util_is_uppercase(lua_State *L)
 			}
 
 			if (u_isupper(uc)) {
-				nuc++;
+				is_upper = true;
 			}
 			else if (u_islower(uc)) {
-				nlc++;
+				is_lower = true;
+				break;
+			}
+			else if (u_charType(uc) == U_OTHER_LETTER) {
+				is_other = true;
+				break;
 			}
 		}
 	}
 
-	if (nuc > 0 && nlc == 0) {
+	if (is_upper && !is_lower && !is_other) {
 		lua_pushboolean(L, TRUE);
 	}
 	else {


### PR DESCRIPTION
For example, a subject header field with following content is determined to be all uppercase.
```
ツイスター、世界王者がAIロボットに完敗　得意技「関節外し」も及ばず
```
Ideographs and letters in unicase scripts which have Unicode general category `Lo` should be considered being not uppercase.
