### PR TITLE
[Minor] Decrease XM_UA_NO_VERSION score to 0.0

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -973,7 +973,7 @@ reconf['XM_UA_NO_VERSION'] = {
       'X-Mailer=/^[^0-9]+$/H',
       'User-Agent=/^[^0-9]+$/H'),
   description = 'X-Mailer/User-Agent header has no version number',
-  score = 0.01,
+  score = 0.0,
   group = 'experimental'
 }
 


### PR DESCRIPTION
My rspamd is always getting a score due to XM_UA_NO_VERSION. That's because Thunderbird's default settings send a minimal user-agent.

* [Thunderbird Release Notes](https://www.thunderbird.net/en-US/thunderbird/115.0/releasenotes/)
> Thunderbird will now send a minimal user-agent header by default

The disclosure of the sender's OS and Thunderbird version to the recipient and any intermediaries raises security and privacy concerns.

Based on the above, the score should be reduced from 0.01 to 0.0. Setting it to 0.0 will allow detection of XM_UA_NO_VERSION without affecting actions.