### PR TITLE
Verify `l=` tag in DKIM signatures

### DIFF
--- a/contrib/kann/kautodiff.c
+++ b/contrib/kann/kautodiff.c
@@ -1061,12 +1061,12 @@ bool kad_ssyev_simple(int N, float *A, float *eigenvals)
 	ssyev("Vectors", "Upper", &n, A, &lda, eigenvals, work, &lwork, &info);
 	/* Check for convergence */
 	if (info > 0) {
-		g_g_free(work);
+		g_free(work);
 
 		return false;
 	}
 
-	g_g_free(work);
+	g_free(work);
 
 	return true;
 #endif

--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -2733,7 +2733,7 @@ rspamd_dkim_check(rspamd_dkim_context_t *ctx,
 
 		if (!cached_bh->digest_normal) {
 			/* Start canonization of body part */
-			if (!rspamd_dkim_canonize_body(&ctx->common, body_start, body_end,
+			if (!rspamd_dkim_canonize_body(task, &ctx->common, body_start, body_end,
 										   FALSE)) {
 				res->rcode = DKIM_RECORD_ERROR;
 				return res;
@@ -3356,7 +3356,7 @@ rspamd_dkim_sign(struct rspamd_task *task, const char *selector,
 
 		if (!cached_bh->digest_normal) {
 			/* Start canonization of body part */
-			if (!rspamd_dkim_canonize_body(&ctx->common, body_start, body_end,
+			if (!rspamd_dkim_canonize_body(task, &ctx->common, body_start, body_end,
 										   TRUE)) {
 				return NULL;
 			}


### PR DESCRIPTION
We want to reject signatures that do not cover enough of the body and some absurd values as well.