### PR TITLE
[FIX] call get_words_count method on the textpart in AV Scan

### DIFF
--- a/lualib/lua_scanners/common.lua
+++ b/lualib/lua_scanners/common.lua
@@ -459,7 +459,7 @@ local function check_parts_match(task, rule)
 
     -- check text_part has more words than text_part_min_words_check
     if rule.scan_text_mime and rule.text_part_min_words and p:is_text() and
-        p:get_words_count() >= tonumber(rule.text_part_min_words) then
+        p:get_text():get_words_count() >= tonumber(rule.text_part_min_words) then
       return true
     end
 


### PR DESCRIPTION
When AV Scanning is active, and the following settings are applied in the antivirus.conf:
  scan_mime_parts = true;
  scan_text_mime = true;
  text_part_min_words = 1;

the Antivirus scan fails in the lualib/lua_scanners/common.lua file, because the get_words_count is called in the mimepart object (which does not implement the method) instead of the textpart.

With this fix the get_words_count is called on the correct object

this should really close #3503 

