### PR TITLE
[Rework] Resolve rdns in a separate function

### DIFF
--- a/conf/modules.d/once_received.conf
+++ b/conf/modules.d/once_received.conf
@@ -14,8 +14,7 @@
 
 once_received {
   good_host = "mail";
-  bad_host = "static";
-  bad_host = "dynamic";
+  bad_host = ["static", "dynamic"];
   symbol_strict = "ONCE_RECEIVED_STRICT";
   symbol = "ONCE_RECEIVED";
   symbol_mx = "DIRECT_TO_MX";

--- a/conf/scores.d/headers_group.conf
+++ b/conf/scores.d/headers_group.conf
@@ -50,14 +50,6 @@ symbols = {
         weight = 0.1;
         description = "One received header in a message";
     }
-    "RDNS_NONE" {
-        weight = 2.0;
-        description = "Cannot resolve reverse DNS for sender's IP";
-    }
-    "RDNS_DNSFAIL" {
-        weight = 0.0;
-        description = "PTR verification DNS error";
-    }
     "ONCE_RECEIVED_STRICT" {
         weight = 4.0;
         description = "One received header with 'bad' patterns inside";

--- a/conf/scores.d/hfilter_group.conf
+++ b/conf/scores.d/hfilter_group.conf
@@ -130,4 +130,12 @@ symbols = {
         weight = 2.5;
         description = "One line URL and text in body";
     }
+    "RDNS_NONE" {
+        weight = 2.0;
+        description = "Cannot resolve reverse DNS for sender's IP";
+    }
+    "RDNS_DNSFAIL" {
+        weight = 0.0;
+        description = "PTR verification DNS error";
+    }
 }

--- a/rules/misc.lua
+++ b/rules/misc.lua
@@ -896,7 +896,8 @@ local rnds_check_id = rspamd_config:register_symbol {
     end
   end,
   type = 'prefilter',
-  priority = lua_util.symbols_priorities.top,
+  -- TODO: settings might need to use this symbol if they depend on hostname...
+  priority = lua_util.symbols_priorities.top - 1,
   description = 'Check if hostname has been resolved by MTA',
 }
 


### PR DESCRIPTION
Historically, it was done in `once_received` module, however, that check must
be done early, even before settings (as they could rely on hostname).

Hence, it was discussed to move this code to a separate rule.
