### PR TITLE
Set expiration for history_redis to 5 days by default

### DIFF
--- a/src/plugins/lua/history_redis.lua
+++ b/src/plugins/lua/history_redis.lua
@@ -22,7 +22,7 @@ redis_history {
   # History key name
   key_prefix = 'rs_history{{HOSTNAME}}{{COMPRESS}}';
   # History expire in seconds
-  expire = 0;
+  expire = 432000;
   # History rows limit
   nrows = 200;
   # Use zstd compression when storing data in redis

--- a/src/plugins/lua/history_redis.lua
+++ b/src/plugins/lua/history_redis.lua
@@ -21,7 +21,7 @@ if confighelp then
 redis_history {
   # History key name
   key_prefix = 'rs_history{{HOSTNAME}}{{COMPRESS}}';
-  # History expire in seconds
+  # Expire in seconds for inactive keys, default to 5 days
   expire = 432000;
   # History rows limit
   nrows = 200;


### PR DESCRIPTION
If somebody using docker with random hostname generation (or k8s deployment which by default pseudo-random for each new pod) with current default settings each recreation of docker container will create new hostname which lead in new and new list of rs_history, I think putting `expire = 432000;` which is 5 days will not hurt anyone, but will protect from totally uncleanable keys in such cases.

Expire will touch only that keys that was not updated over 5 days, so it really safe.

Update to documentation: https://github.com/rspamd/rspamd.com/pull/778/files - and I removed `key_prefix` from doc as it was obsolite and false statement.