### PR TITLE
Update URIBL_RED/GREY scores

### DIFF
--- a/conf/scores.d/surbl_group.conf
+++ b/conf/scores.d/surbl_group.conf
@@ -214,13 +214,13 @@ symbols = {
         groups = ["uribl"];
     }
     "URIBL_RED" {
-        weight = 3.5;
+        weight = 0.5;
         description = "A domain in the message is listed in URIBL.com red";
         one_shot = true;
         groups = ["uribl"];
     }
     "URIBL_GREY" {
-        weight = 1.5;
+        weight = 2.5;
         description = "A domain in the message is listed in URIBL.com grey";
         one_shot = true;
         groups = ["uribl"];


### PR DESCRIPTION
The ``URIBL_RED`` is automated, informative list, the ``URIBL_GREY`` is declared as "possible false positives"