### PR TITLE
[Rework] Change the logic of skipping symbols

### DIFF
--- a/src/libmime/lang_detection.c
+++ b/src/libmime/lang_detection.c
@@ -1828,7 +1828,7 @@ rspamd_language_detector_detect(struct rspamd_task *task,
 	unsigned int cand_len;
 	enum rspamd_language_category cat;
 	struct rspamd_lang_detector_res *cand;
-	enum rspamd_language_detected_type r;
+	enum rspamd_language_detected_type r = rs_detect_none;
 	struct rspamd_frequency_sort_cbdata cbd;
 	/* Check if we have sorted candidates based on frequency */
 	gboolean frequency_heuristic_applied = FALSE, ret = FALSE, internal_heuristic_applied = FALSE;

--- a/src/libserver/symcache/symcache_runtime.hxx
+++ b/src/libserver/symcache/symcache_runtime.hxx
@@ -60,6 +60,11 @@ class symcache_runtime {
 		enabled = 1,
 		disabled = 2,
 	} slow_status;
+	enum class check_status {
+		allow,
+		limit_reached,
+		passthrough,
+	};
 	bool profile;
 
 	double profile_start;
@@ -77,7 +82,7 @@ class symcache_runtime {
 	/* Specific stages of the processing */
 	auto process_pre_postfilters(struct rspamd_task *task, symcache &cache, int start_events, unsigned int stage) -> bool;
 	auto process_filters(struct rspamd_task *task, symcache &cache, int start_events) -> bool;
-	auto check_metric_limit(struct rspamd_task *task) -> bool;
+	auto check_process_status(struct rspamd_task *task) -> check_status;
 	auto check_item_deps(struct rspamd_task *task, symcache &cache, cache_item *item,
 						 cache_dynamic_item *dyn_item, bool check_only) -> bool;
 


### PR DESCRIPTION
We now do not skip pre/post filters even if the task result has reached
threshold.
