### PR TITLE
[Fix] Rework DMARC grammar to correctly handle spaces in values

### DIFF
--- a/lualib/plugins/dmarc.lua
+++ b/lualib/plugins/dmarc.lua
@@ -241,10 +241,10 @@ local function gen_dmarc_grammar()
   local space = lpeg.space ^ 0
   local name = lpeg.C(lpeg.alpha ^ 1)
   local sep = space * lpeg.S("\\;") * space
-  local value = lpeg.C(lpeg.P(lpeg.P((lpeg.space ^ 1) * lpeg.graph + lpeg.P(lpeg.graph)) - sep) ^ 1)
+  local value = lpeg.C(((lpeg.space ^ 1 * lpeg.graph + lpeg.graph) - sep) ^ 1)
   local pair = lpeg.Cg(name * "=" * space * value) * sep ^ -1
   local list = lpeg.Cf(lpeg.Ct("") * pair ^ 0, rawset)
-  local version = lpeg.P("v") * space * lpeg.P("=") * space * lpeg.P("DMARC1")
+  local version = "v" * space * "=" * space * "DMARC1"
   local record = version * sep * list
 
   return record

--- a/lualib/plugins/dmarc.lua
+++ b/lualib/plugins/dmarc.lua
@@ -239,9 +239,9 @@ local function gen_dmarc_grammar()
   local lpeg = require "lpeg"
   lpeg.locale(lpeg)
   local space = lpeg.space ^ 0
-  local name = lpeg.C(lpeg.alpha ^ 1) * space
-  local sep = space * (lpeg.S("\\;") * space) + (lpeg.P(lpeg.graph - lpeg.P(',')) * lpeg.space ^ 1)
-  local value = lpeg.C(lpeg.P(lpeg.P(lpeg.graph + lpeg.space) - sep) ^ 1)
+  local name = lpeg.C(lpeg.alpha ^ 1)
+  local sep = space * lpeg.S("\\;") * space
+  local value = lpeg.C(lpeg.P(lpeg.P((lpeg.space ^ 1) * lpeg.graph + lpeg.P(lpeg.graph)) - sep) ^ 1)
   local pair = lpeg.Cg(name * "=" * space * value) * sep ^ -1
   local list = lpeg.Cf(lpeg.Ct("") * pair ^ 0, rawset)
   local version = lpeg.P("v") * space * lpeg.P("=") * space * lpeg.P("DMARC1")


### PR DESCRIPTION
Issue: #4906

According to [RFC7489 section 6.3](https://www.rfc-editor.org/rfc/rfc7489#section-6.3) and [RFC6376 section 3.2](https://www.rfc-editor.org/rfc/rfc6376.html#section-3.2), white space around tags is allowed.
But in particular, any white space after the "=" and any white space before the terminating ";" is not part of the value.
However, white space inside the value is significant.

This PR fixes the DMARC grammar to parse the values correctly.