### PR TITLE
Check tld in url_redirector in addition to exact host

### DIFF
--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -348,6 +348,11 @@ local function url_redirector_handler(task)
     task = task,
     limit = settings.max_urls,
     filter = function(url)
+      local tld = url:get_tld()
+      if settings.redirector_hosts_map:get_key(tld) then
+        lua_util.debugm(N, task, 'check url %s', tostring(url))
+        return true
+      end
       local host = url:get_host()
       if settings.redirector_hosts_map:get_key(host) then
         lua_util.debugm(N, task, 'check url %s', tostring(url))


### PR DESCRIPTION
This align logic between `redirector` symbol in `multimap.conf` and `url_redirector.lua`