### PR TITLE
[Fix] Use correct type for keylen in lua_ucl_newindex

### DIFF
--- a/contrib/libucl/lua_ucl.c
+++ b/contrib/libucl/lua_ucl.c
@@ -1426,7 +1426,7 @@ lua_ucl_newindex(lua_State *L)
 
 	if (ucl_object_type(obj) == UCL_OBJECT) {
 		if (key_type == LUA_TSTRING) {
-			lua_Integer keylen;
+			size_t keylen;
 			const char *key = lua_tolstring(L, 2, &keylen);
 
 			ucl_object_t *value_obj = lua_ucl_object_get(L, 3);
@@ -1539,7 +1539,7 @@ lua_ucl_newindex(lua_State *L)
 			obj->value.av = NULL;
 			obj->type = UCL_OBJECT;
 
-			lua_Integer keylen;
+			size_t keylen;
 			const char *key = lua_tolstring(L, 2, &keylen);
 
 			ucl_object_t *value_obj = lua_ucl_object_get(L, 3);


### PR DESCRIPTION
The keylen variable used in `lua_ucl_newindex` function should use `size_t` type instead of `lua_Integer`, because all functions that use `keylen` expect it to be of `size_t` type. This mismatch leads to incompatible pointer types, and modern versions of GCC fail to compile the code.

Fixes: 9e87597ceb05 ("[Project] Allow manipulations with opaque UCL objects")
Closes: #5163