### PR TITLE
add EOF to openmetrics response in proxy and server

### DIFF
--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -2091,6 +2091,7 @@ void rspamd_protocol_write_reply(struct rspamd_task *task, ev_tstamp timeout, st
 			memcpy(&stat_copy, srv->stat, sizeof(stat_copy));
 			output = rspamd_metrics_to_prometheus_string(
 				rspamd_worker_metrics_object(srv->cfg, &stat_copy, now - srv->start_time));
+			rspamd_printf_fstring(&output, "# EOF\n");
 			rspamd_http_message_set_body_from_fstring_steal(msg, output);
 			ctype = "application/openmetrics-text; version=1.0.0; charset=utf-8";
 			break;

--- a/src/rspamd_proxy.c
+++ b/src/rspamd_proxy.c
@@ -1768,6 +1768,7 @@ rspamd_proxy_scan_self_reply(struct rspamd_task *task)
 		memcpy(&stat_copy, session->ctx->srv->stat, sizeof(stat_copy));
 		output = rspamd_metrics_to_prometheus_string(
 			rspamd_worker_metrics_object(task->cfg, &stat_copy, ev_time() - session->ctx->srv->start_time));
+		rspamd_printf_fstring(&output, "# EOF\n");
 		rspamd_http_message_set_body_from_fstring_steal(msg, output);
 		ctype = "application/openmetrics-text; version=1.0.0; charset=utf-8";
 		break;


### PR DESCRIPTION
We provide a `/metrics` endpoint for controller, proxy and worker in open metrics format.

Openmetrics format demands that the end is signalled by the following marker "# EOF".

However we only send this marker for the controller metrics endpoint.

Scraping worker /metrics endpoint results in the following error message "data does not end with # EOF" and scraping fails.

This PR adds EOF marker for proxy and worker endpoint.

I tested this and after this change prometheus can successfully scrape the endpoint.

```text
...
rspamd_actions_total{type="soft reject"} 0
rspamd_actions_total{type="rewrite subject"} 0
rspamd_actions_total{type="add header"} 0
rspamd_actions_total{type="greylist"} 0
rspamd_actions_total{type="no action"} 1
# EOF
```