### PR TITLE
[Minor] Improve FREEMAIL_AFF catch rate

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -165,7 +165,7 @@ composites {
     group = "scams";
   }
   FREEMAIL_AFF {
-    expression = "(FREEMAIL_FROM | FREEMAIL_ENVFROM | FREEMAIL_REPLYTO | FREEMAIL_MDN) & (TO_DN_RECIPIENTS | R_UNDISC_RCPT) & (INTRODUCTION | FROM_NAME_HAS_TITLE | FREEMAIL_REPLYTO_NEQ_FROM_DOM | SUBJECT_HAS_CURRENCY)";
+    expression = "(FREEMAIL_FROM | FREEMAIL_ENVFROM | FREEMAIL_REPLYTO | FREEMAIL_MDN) & (TO_DN_RECIPIENTS | R_UNDISC_RCPT | CD_MM_BODY) & (INTRODUCTION | FROM_NAME_HAS_TITLE | FREEMAIL_REPLYTO_NEQ_FROM_DOM | SUBJECT_HAS_CURRENCY)";
     score = 4.0;
     policy = "leave";
     description = "Message exhibits strong characteristics of advance fee fraud (AFF a/k/a '419' spam) involving freemail addresses";


### PR DESCRIPTION
This "Mail message body" Content-Description header appears to be a common quirk of advance fee fraud e-mails leveraging freemail services.