### PR TITLE
[Minor] Add "User" HELO in Received headers to ABUSE_FROM_INJECTOR

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -191,7 +191,7 @@ composites {
     description = "Message authenticated, but from a suspicios origin (potentially an injector)";
   }
   ABUSE_FROM_INJECTOR {
-    expression = "SUSPICIOUS_AUTH_ORIGIN & (FAKE_REPLY | HAS_IPFS_GATEWAY_URL | HTML_SHORT_LINK_IMG_1)";
+    expression = "SUSPICIOUS_AUTH_ORIGIN & (RCVD_HELO_USER | FAKE_REPLY | HAS_IPFS_GATEWAY_URL | HTML_SHORT_LINK_IMG_1)";
     score = 2.0;
     policy = "leave";
     description = "Message is sent from a suspicios origin and showing signs of abuse, likely spam injected in compromised account";


### PR DESCRIPTION
This pattern often surfaces in spam (frequently advance fee fraud) disseminated via compromised accounts, adding it to ABUSE_FROM_INJECTOR to increase the likelihood of such spam getting rejected.