### PR TITLE
[Fix] Fix dealing with happy eyeballs in SPF

### DIFF
--- a/src/libserver/spf.c
+++ b/src/libserver/spf.c
@@ -1,16 +1,18 @@
-// Copyright 2024 Vsevolod Stakhov
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "config.h"
 #include "dns.h"

--- a/src/libserver/spf.h
+++ b/src/libserver/spf.h
@@ -142,15 +142,15 @@ struct rspamd_spf_cred *rspamd_spf_get_cred(struct rspamd_task *task);
 /*
  * Increase refcount
  */
-struct spf_resolved *_spf_record_ref(struct spf_resolved *rec, const char *loc);
+struct spf_resolved *spf_record_ref_internal(struct spf_resolved *rec, const char *loc);
 #define spf_record_ref(rec) \
-	_spf_record_ref((rec), G_STRLOC)
+	spf_record_ref_internal((rec), G_STRLOC)
 /*
  * Decrease refcount
  */
-void _spf_record_unref(struct spf_resolved *rec, const char *loc);
+void spf_record_unref_internal(struct spf_resolved *rec, const char *loc);
 #define spf_record_unref(rec) \
-	_spf_record_unref((rec), G_STRLOC)
+	spf_record_unref_internal((rec), G_STRLOC)
 
 /**
  * Prints address + mask in a freshly allocated string (must be freed)


### PR DESCRIPTION
Rspamd could incorrectly resolve some records where additional DNS checks are initiated, e.g. for `mx` elements.

For each `mx` name Rspamd emits 2 DNS requests: A for IPv4 and AAAA for IPv6. Previously, it was possible to have an error in the situation where one of these requests was successful and another one is not. There was some protection against it but it was not sufficient at all.

This PR introduces subrequests count and trigger errors merely if all subrequests have failed. Similarly, if MX returns multiple names, and only some of them are resolvable it is still a case where we could actually resolve SPF element.

At the same time, I have added tracking count of all subrequests to ensure that we don't emit more DNS requests than allowed.