### PR TITLE
[Fix] Skip extra RBL checks when Received IP same as From IP

### DIFF
--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -693,12 +693,12 @@ local function gen_rbl_callback(rule)
 
     for pos, rh in ipairs(received) do
       if check_conditions(rh, pos) then
-        if rh.real_ip ~= from_ip then
+        if rh.real_ip ~= from_ip or (rh.real_ip == from_ip and not rule.from) then
           add_dns_request(task, rh.real_ip, false, true,
               requests_table, 'received',
               whitelist)
         else
-          lua_util.debugm(N, task, 'Received IP same as From IP, skipping extra check')
+          lua_util.debugm(N, task, 'rbl %s; skip check_received for %s: Received IP same as From IP and will be checked only in check_from function', rule.symbol, rh.real_ip)
         end
       end
     end

--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -689,12 +689,17 @@ local function gen_rbl_callback(rule)
 
     local received_total = #received
     local check_conditions = gen_check_rcvd_conditions(rule, received_total)
+    local from_ip = task:get_from_ip()
 
     for pos, rh in ipairs(received) do
       if check_conditions(rh, pos) then
-        add_dns_request(task, rh.real_ip, false, true,
-            requests_table, 'received',
-            whitelist)
+        if rh.real_ip ~= from_ip then
+          add_dns_request(task, rh.real_ip, false, true,
+              requests_table, 'received',
+              whitelist)
+        else
+          lua_util.debugm(N, task, 'Received IP same as From IP, skipping extra check')
+        end
       end
     end
 

--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -698,7 +698,9 @@ local function gen_rbl_callback(rule)
               requests_table, 'received',
               whitelist)
         else
-          lua_util.debugm(N, task, 'rbl %s; skip check_received for %s: Received IP same as From IP and will be checked only in check_from function', rule.symbol, rh.real_ip)
+          lua_util.debugm(N, task, 'rbl %s; skip check_received for %s:' .. 
+          'Received IP same as From IP and will be checked only in check_from function', 
+          rule.symbol, rh.real_ip)
         end
       end
     end


### PR DESCRIPTION
Some mail server (MTA) add a Received header with their own IP address to the message. For example:
```
Received: from neovet-base.ru (neovet-base.ru [82.202.243.114])
        by mail.example.com (Postfix) with ESMTPS id 466F14034A
        for <user@example.com>; Sun, 24 Nov 2024 00:12:24 +0300 (MSK)
        
Received: from neovet-base.ru ([82.202.243.114])
        by neovet-base.ru with esmtpa (Exim 4.97.1)
        (envelope-from <robot@neovet-base.ru>)
        id 1tExQP-00000008rN5-017q
        for user@example.com;
        Sun, 24 Nov 2024 00:12:17 +0300
```

In this case IP address can be checked in some RBL twice,  first as From and then as Received ( for RBL that use `checks = ['received', 'from']`)

If sender IP is blacklisted, this will give the extra scores to email message:
```
Symbol: RBL_SPAMHAUS_SBL (4.00)[82.202.243.114:from]
Symbol: RECEIVED_SPAMHAUS_SBL (3.00)[82.202.243.114:received]
```

This patch corrects this behavior — if the IP in the 'Received' header matches the IP from which the message was sent, then IP is excluded from checks in the `check_received` function, since it has already been checked by the `check_from` function.