### PR TITLE
[Fix] connIp is not correctly added to request

### DIFF
--- a/lualib/lua_scanners/cloudmark.lua
+++ b/lualib/lua_scanners/cloudmark.lua
@@ -345,7 +345,9 @@ local function cloudmark_check(task, content, digest, rule, maybe_part)
 
     local fip = task:get_from_ip()
     if fip and fip:is_valid() then
-      request['connIp'] = tostring(fip)
+      request['connIp'] = {
+        data = tostring(fip)
+      }
     end
 
     local hostname = task:get_hostname()


### PR DESCRIPTION
This fixes an issue where the cloudmark module does not correctly add connIp to the request. This prevents cloudmark from using the remote ip for white and blacklist checks. 