### PR TITLE
[minor] log queue id with cloudmark analysis string

### DIFF
--- a/lualib/lua_scanners/cloudmark.lua
+++ b/lualib/lua_scanners/cloudmark.lua
@@ -263,7 +263,8 @@ local function parse_cloudmark_reply(task, rule, body)
 
   if obj.analysis then
     -- Report analysis string
-    rspamd_logger.infox(task, 'cloudmark report string: %s', obj.analysis)
+    local qid = task:get_queue_id() or 'unknown'
+    rspamd_logger.infox(task, 'qid: <%s>, cloudmark report string: %s', qid, obj.analysis)
   end
 
   local score = tonumber(obj.score) or 0


### PR DESCRIPTION
This is a minor and slightly subjective patch. We do a lot of log entries per day for mail and it's impossible to link a cloudmark analysis string to a specific email without the queue id. Trivial patch but would allow for better debugging of cloudmark specific problems, especially FP/FN remediation. The analysis strings are used to report issues with CM. 