### PR TITLE
Fix Thunderbird for Android marked with FORGED_MUA_THUNDERBIRD_MSGID_UNKNOWN

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -460,7 +460,7 @@ local user_agent_mozilla = string.format('(%s) & !(%s) & !(%s) & !(%s)', user_ag
     user_agent_seamonkey, user_agent_postbox)
 -- Mozilla based common Message-ID template
 local mozilla_msgid_common = 'Message-ID=/^\\s*<[\\dA-F]{8}\\.\\d{1,7}\\@([^>\\.]+\\.)+[^>\\.]+>$/H'
-local mozilla_msgid_common_sec = 'Message-ID=/^\\s*<[\\da-f]{8}-([\\da-f]{4}-){3}[\\da-f]{12}\\@([^>\\.]+\\.)+[^>\\.]+>$/H'
+local mozilla_msgid_common_sec = 'Message-ID=/^\\s*<[\\da-f]{8}-([\\da-f]{4}-){3}[\\da-f]{12}\\@([^>\\.]+\\.)+[^>\\.]+>$/Hi'
 local mozilla_msgid = 'Message-ID=/^\\s*<(3[3-9A-F]|[4-9A-F][\\dA-F])[\\dA-F]{6}\\.(\\d0){1,4}\\d\\@([^>\\.]+\\.)+[^>\\.]+>$/H'
 -- Summary rule for forged Mozilla Mail Message-ID header
 reconf['FORGED_MUA_MOZILLA_MAIL_MSGID'] = {


### PR DESCRIPTION
This small change fixes Thunderbird for Android being marked as `FORGED_MUA_THUNDERBIRD_MSGID_UNKNOWN` due to uppercase UUID format for message IDs.

Alternative would be overcomplicating the regular expression with a special exemption for Thunderbird for Android that only applies then.