### PR TITLE
Add ability to not send response_format in gpt plugin in order to support gpt4all

### DIFF
--- a/src/plugins/lua/gpt.lua
+++ b/src/plugins/lua/gpt.lua
@@ -48,6 +48,8 @@ gpt {
   allow_passthrough = false;
   # Check messages that are apparent ham (no action and negative score)
   allow_ham = false;
+  # default send response_format field { type = "json_object" }
+  include_response_format = true,
 }
   ]])
   return
@@ -393,7 +395,6 @@ local function default_llm_check(task)
     model = settings.model,
     max_tokens = settings.max_tokens,
     temperature = settings.temperature,
-    response_format = { type = "json_object" },
     messages = {
       {
         role = 'system',
@@ -417,6 +418,11 @@ local function default_llm_check(task)
       }
     }
   }
+
+  -- Conditionally add response_format
+  if settings.include_response_format then
+    body.response_format = { type = "json_object" }
+  end
 
   upstream = settings.upstreams:get_upstream_round_robin()
   local http_params = {
@@ -498,7 +504,6 @@ local function ollama_check(task)
     model = settings.model,
     max_tokens = settings.max_tokens,
     temperature = settings.temperature,
-    response_format = { type = "json_object" },
     messages = {
       {
         role = 'system',
@@ -522,6 +527,11 @@ local function ollama_check(task)
       }
     }
   }
+
+  -- Conditionally add response_format
+  if settings.include_response_format then
+    body.response_format = { type = "json_object" }
+  end
 
   upstream = settings.upstreams:get_upstream_round_robin()
   local http_params = {


### PR DESCRIPTION
GPT4All API is openai compatible but does not support response_format. The API does respond back as a json object with out sending response_format in the API request. This changes allows the ability to add

 include_response_format = false;

In gpt.conf to suppress sending response_format which resolves the error:

 gpt.lua:365: got reply: {"error":{"code":null,"message":"'response_format' is not supported","param":null,"type":"invalid_request_error"}}

The change defaults to response_format being with no setting set.
