### PR TITLE
[Fix] Logging regression 3.9.1 to 3.10.0

### DIFF
--- a/src/libserver/milter.c
+++ b/src/libserver/milter.c
@@ -1473,16 +1473,12 @@ rspamd_milter_macro_http(struct rspamd_milter_session *session,
 	{
 		rspamd_http_message_add_header_len(msg, QUEUE_ID_HEADER,
 										   found->begin, found->len);
-		rspamd_http_message_add_header_len(msg, LOG_TAG_HEADER,
-										   found->begin, found->len);
 	}
 	else
 	{
 		IF_MACRO("i")
 		{
 			rspamd_http_message_add_header_len(msg, QUEUE_ID_HEADER,
-											   found->begin, found->len);
-			rspamd_http_message_add_header_len(msg, LOG_TAG_HEADER,
 											   found->begin, found->len);
 		}
 	}


### PR DESCRIPTION
- detailed in https://github.com/rspamd/rspamd/issues/5194

Consistent logging is voided when using milter, as the original _log tag_ is replaced with the (partial) message id. This prevents tracing emails' processing from connect to disconnect as the _log tag_ changes inbetween.

Removing _LOG_TAG_HEADER_ addition in milter.c restores the old behaviour.