### PR TITLE
[Enhancement] Expand Detection of Fake Reply Subjects Across Multiple Languages

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -644,7 +644,7 @@ reconf['REPTO_QUOTE_YAHOO'] = {
 }
 
 reconf['FAKE_REPLY'] = {
-  re = [[Subject=/^(atb|aw|bls|odp|res?|rif|sv|ynt)[. ]*:/i{header} & !(header_exists(In-Reply-To) | header_exists(References))]],
+  re = [[Subject=/^(antw|atb|aw|bls|odp|res?|rif|sv|ynt)[. ]*:/i{header} & !(header_exists(In-Reply-To) | header_exists(References))]],
   description = 'Fake reply',
   score = 1.0,
   group = 'headers'

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -644,7 +644,7 @@ reconf['REPTO_QUOTE_YAHOO'] = {
 }
 
 reconf['FAKE_REPLY'] = {
-  re = [[Subject=/^re:/i{header} & !(header_exists(In-Reply-To) | header_exists(References))]],
+  re = [[Subject=/^(atb|aw|bls|odp|res?|rif|sv|ynt)[. ]*:/i{header} & !(header_exists(In-Reply-To) | header_exists(References))]],
   description = 'Fake reply',
   score = 1.0,
   group = 'headers'


### PR DESCRIPTION
Expand subject detection for fake replies by adding abbreviations from multiple languages: Dutch/German (Antw), Latvian/Welsh (ATB), German (AW), Indonesian (BLS), Polish (ODP), Portuguese (RES), Italian (RIF), Danish/Icelandic/Norwegian/Swedish (SV), and Turkish (YNT).