### PR TITLE
fix: use sub_utf8 to strip headers value to not break utf8 strings

### DIFF
--- a/src/plugins/lua/elastic.lua
+++ b/src/plugins/lua/elastic.lua
@@ -449,6 +449,7 @@ local function get_general_metadata(task)
   local empty = settings['index_template']['empty_value']
   local user = task:get_user()
   r.rspamd_server = rspamd_hostname or empty
+  r.digest = task:get_digest() or empty
 
   r.action = task:get_metric_action() or empty
   r.score = task:get_metric_score()[1] or 0
@@ -1278,6 +1279,7 @@ local function configure_index_template(cfg, ev_base)
             type = 'object',
             properties = {
               rspamd_server = t_keyword,
+              digest = t_keyword,
               action = t_keyword,
               score = t_double,
               symbols = symbols_obj,


### PR DESCRIPTION
`h.decoded:sub(1, headers_text_ignore_above)` was leading to potential broken utf8 string as it had chance to strip line in the middle of utf8 character leading to errors like:
```
error while pushing logs to elastic, status: 400, type: mapper_parsing_exception, reason: failed to parse field [rspamd_meta.header_to] of type [text] in document with id 'X'. Preview of field's value: ''
```

also I added task digest