### PR TITLE
Prevent option duplicates in rspamd_stats.pl

### DIFF
--- a/utils/rspamd_stats.pl
+++ b/utils/rspamd_stats.pl
@@ -39,6 +39,8 @@ my %decompressor = (
     'zst' => 'zstd -cd',
 );
 
+Getopt::Long::Configure( "no_auto_abbrev", "no_ignore_case" );
+
 GetOptions(
     "reject-score|r=f"      => \$reject_score,
     "junk-score|j=f"        => \$junk_score,
@@ -57,7 +59,7 @@ GetOptions(
     "end=s"                 => \$endTime,
     "num-logs|n=i"          => \$num_logs,
     "exclude-logs|x=i"      => \$exclude_logs,
-    "json|j"                => \$json,
+    "json"                  => \$json,
     "help|?"                => \$help,
     "man"                   => \$man
 ) or pod2usage(2);


### PR DESCRIPTION
The `rspamd_stats.pl` script complains about duplicate specification for some options:

```
Duplicate specification "symbol-bidir|S=s@" for option "s"
Duplicate specification "exclude-logs|x=i" for option "x"
Duplicate specification "json|j" for option "j"
```

This fixes those errors by:
* configuring Getopt with `no_ignore_case` to distinguish `symbol|s` from `symbol-bidir|S` and `exclude|X` from `exclude-logs|x`
* removing the short form `j` of `json` and configuring Getopt with `no_auto_abbrev` to prevent abbreviation

It is no longer possible to use `-j` for `--json` but I don't think this is a big change since `junk-score|j` was probably taking precedence before.