### PR TITLE
Better support for maps and IP-related fixes/improvements in settings

### DIFF
--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -526,15 +526,12 @@ local function rspamd_maybe_check_map(key, what)
       return rspamd_maybe_check_map(key, elt)
     end, what)
   end
-  if type(rspamd_maps) == "table" then
-    local mn
-    if starts(key, "map:") then
-      mn = string.sub(key, 5)
-    elseif starts(key, "map://") then
-      mn = string.sub(key, 7)
+  if type(rspamd_maps) == "table" and starts(key, "map:") then
+    local mn = string.sub(key, 5)
+    if starts(mn, "//") then
+      mn = string.sub(mn, 3)
     end
-
-    if mn and rspamd_maps[mn] then
+    if rspamd_maps[mn] then
       return rspamd_maps[mn]:get_key(what)
     end
   end

--- a/src/plugins/lua/settings.lua
+++ b/src/plugins/lua/settings.lua
@@ -617,6 +617,12 @@ end
 
 -- Used to create a checking closure: if value matches expected somehow, return true
 local function gen_check_closure(expected, check_func)
+  if not check_func then
+    check_func = function(a, b)
+      return a == b
+    end
+  end
+
   return function(value)
     if not value then
       return false
@@ -627,13 +633,6 @@ local function gen_check_closure(expected, check_func)
     end
 
     if value then
-
-      if not check_func then
-        check_func = function(a, b)
-          return a == b
-        end
-      end
-
       local ret
       if type(expected) == 'table' then
         ret = fun.any(function(d)


### PR DESCRIPTION
Fix several small issues plus code improvements:
 * Support `map://` prefix based on original intention (the check never worked because it was shadowed by the preceeding `map:` check)
 * Avoid misleading "cannot parse ip" logging by checking for `map:` prefix early
 * Do not use tables for maps or IPs without mask (store as strings)
 * Normalize IPs by applying mask during processing (for example specifying `ip = "192.168.0.123/24"` would now work when matching against `192.168.0.123`)
 * Add error logging for wrong IP mask
 * Simplify `check_ip_settings()` based on changes in `process_ip_condition()`
 * Skip invalid IPs (with appropriate error logging)
   (previously a bad IP would cause the subsequent IPs in a list to be ignored or make the whole IP condition to be ignored)
 * Add validated IPs/maps into a _flat_ table
