### PR TITLE
[Fix] Add expiration for neural ham and spam sets

### DIFF
--- a/lualib/plugins/neural.lua
+++ b/lualib/plugins/neural.lua
@@ -757,7 +757,7 @@ local function process_rules_settings()
           type = 'set',
         })
     lua_redis.register_prefix(selt.prefix .. '_\\d+_ham_set', N,
-        string.format('NN learning set (spam) for rule "%s"; settings id "%s"',
+        string.format('NN learning set (ham) for rule "%s"; settings id "%s"',
             rule.prefix, selt.name), {
           persistent = true,
           type = 'set',

--- a/lualib/redis_scripts/neural_save_unlock.lua
+++ b/lualib/redis_scripts/neural_save_unlock.lua
@@ -17,6 +17,8 @@ redis.call('DEL', KEYS[1] .. '_ham_set')
 redis.call('HDEL', KEYS[1], 'lock')
 redis.call('HDEL', KEYS[7], 'lock')
 redis.call('EXPIRE', KEYS[1], tonumber(KEYS[5]))
+redis.call('EXPIRE', KEYS[1] .. '_spam_set', tonumber(KEYS[5]))
+redis.call('EXPIRE', KEYS[1] .. '_ham_set', tonumber(KEYS[5]))
 redis.call('HSET', KEYS[1], 'roc_thresholds', KEYS[8])
 if KEYS[9] then
   redis.call('HSET', KEYS[1], 'pca', KEYS[9])


### PR DESCRIPTION
This PR should solve issue that ham and spam sets are persist in redis indefinitely as well as fix small typo