### PR TITLE
[Fix] initialize ollama result table

### DIFF
--- a/src/plugins/lua/gpt.lua
+++ b/src/plugins/lua/gpt.lua
@@ -807,6 +807,10 @@ local function ollama_check(task, content, sel_part)
       body.response_format = { type = "json_object" }
     end
 
+    results[i] = {
+      success = false,
+      checked = false
+    }
     body.model = model
 
     upstream = settings.upstreams:get_upstream_round_robin()


### PR DESCRIPTION
similar to gpt.lua:704 for the chatgpt code path, the ollama code path needs to initialize the result table. Without, rspamd fails gpt requests with

> lua_http_finish_handler: callback call failed: /usr/share/rspamd/plugins/gpt.lua:740: attempt to index a nil value