### PR TITLE
[Fix] Update default URL for openphish

### DIFF
--- a/conf/modules.d/phishing.conf
+++ b/conf/modules.d/phishing.conf
@@ -17,7 +17,7 @@ phishing {
   # Disabled by default
   openphish_enabled = false;
   openphish_premium = false;
-  openphish_map = "https://www.openphish.com/feed.txt";
+  openphish_map = "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt";
   # Phishtank is disabled by default in the module, so let's enable it here explicitly
   phishtank_enabled = true;
 

--- a/src/plugins/lua/phishing.lua
+++ b/src/plugins/lua/phishing.lua
@@ -39,7 +39,7 @@ local anchor_exceptions_maps = {}
 local strict_domains_maps = {}
 local phishing_feed_exclusion_map = nil
 local generic_service_map = nil
-local openphish_map = 'https://www.openphish.com/feed.txt'
+local openphish_map = 'https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt'
 local phishtank_suffix = 'phishtank.rspamd.com'
 -- Not enabled by default as their feed is quite large
 local openphish_premium = false


### PR DESCRIPTION
Update default URL - since we won't follow the redirect.

It looks more like an advertisement than a useful service to me.

Fixes issue #5261 