### PR TITLE
Add rspamadm ready command to check controller readiness

### DIFF
--- a/lualib/rspamadm/ready.lua
+++ b/lualib/rspamadm/ready.lua
@@ -1,0 +1,164 @@
+--[[
+Copyright (c) 2022, Vsevolod Stakhov <vsevolod@rspamd.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]]--
+
+local argparse = require "argparse"
+local rspamd_http = require "rspamd_http"
+local rspamd_logger = require "rspamd_logger"
+local rspamd_upstream_list = require "rspamd_upstream_list"
+local lua_util = require "lua_util"
+
+local E = {}
+
+-- Define command line options
+local parser = argparse()
+    :name 'rspamadm ready'
+    :description 'Check if Rspamd controller is ready'
+    :help_description_margin(30)
+    :command_target('command')
+
+parser:option '-c --config'
+      :description 'Path to config file'
+      :argname('config_file')
+      :default(rspamd_paths['CONFDIR'] .. '/rspamd.conf')
+parser:option '-u --url'
+      :description 'URL of the Rspamd controller'
+      :argname('url')
+      :default('http://localhost:11334')
+parser:option '-t --timeout'
+      :description 'Total timeout in seconds'
+      :argname('timeout')
+      :default('60')
+parser:option '-i --interval'
+      :description 'Polling interval in seconds'
+      :argname('interval')
+      :default('1')
+parser:flag '--no-ssl-verify'
+      :description 'Disable SSL verification'
+      :argname('no_ssl_verify')
+parser:flag '-q --quiet'
+      :description 'Only output errors'
+      :argname('quiet')
+parser:flag '-v --verbose'
+      :description 'Output more information'
+      :argname('verbose')
+
+local http_params = {
+  config = rspamd_config,
+  ev_base = rspamadm_ev_base,
+  session = rspamadm_session,
+  resolver = rspamadm_dns_resolver,
+}
+
+local function load_config(config_file)
+  local _r, err = rspamd_config:load_ucl(config_file)
+
+  if not _r then
+    rspamd_logger.errx('cannot load %s: %s', config_file, err)
+    os.exit(1)
+  end
+
+  _r, err = rspamd_config:parse_rcl({ 'logging', 'worker' })
+  if not _r then
+    rspamd_logger.errx('cannot process %s: %s', config_file, err)
+    os.exit(1)
+  end
+
+  if not rspamd_config:init_modules() then
+    rspamd_logger.errx('cannot init modules when parsing %s', config_file)
+    os.exit(1)
+  end
+
+  rspamd_config:init_subsystem('symcache')
+end
+
+local function poll_ready(args)
+  local total_timeout = tonumber(args.timeout)
+  local interval = tonumber(args.interval)
+  local url = args.url
+  
+  -- Add /ready endpoint if not specified
+  if not url:match("/ready$") then
+    url = lua_util.remove_trailing_slash(url) .. "/ready"
+  end
+  
+  local start_time = os.time()
+  local attempts = 0
+  local exit_code = 1
+  
+  while os.time() - start_time < total_timeout do
+    attempts = attempts + 1
+    
+    if not args.quiet then
+      io.stdout:write(string.format("Attempt %d: Checking if Rspamd is ready...\n", attempts))
+    end
+    
+    local err, response = rspamd_http.request({
+      url = url,
+      config = rspamd_config,
+      ev_base = rspamadm_ev_base,
+      session = rspamadm_session,
+      resolver = rspamadm_dns_resolver,
+      log_obj = rspamd_config,
+      no_ssl_verify = args.no_ssl_verify,
+    })
+    
+    if err then
+      if args.verbose then
+        io.stderr:write(string.format("Error checking Rspamd status: %s\n", err))
+      end
+    elseif response and response.code == 200 then
+      if not args.quiet then
+        io.stdout:write("Rspamd is ready and operational!\n")
+      end
+      exit_code = 0
+      break
+    else
+      local status_code = response and response.code or "unknown"
+      if args.verbose then
+        io.stderr:write(string.format("Rspamd not ready (status code: %s)\n", status_code))
+      end
+    end
+    
+    if os.time() - start_time + interval >= total_timeout then
+      if not args.quiet then
+        io.stderr:write("Timeout reached. Rspamd is not ready.\n")
+      end
+      break
+    end
+    
+    if not args.quiet and args.verbose then
+      io.stdout:write(string.format("Waiting %d seconds before next attempt...\n", interval))
+    end
+    
+    lua_util.sleep(interval)
+  end
+  
+  os.exit(exit_code)
+end
+
+local function handler(args)
+  local cmd_opts = parser:parse(args)
+  
+  load_config(cmd_opts.config_file)
+  
+  poll_ready(cmd_opts)
+end
+
+return {
+  handler = handler,
+  description = parser._description,
+  name = 'ready'
+}

--- a/src/rspamadm/configdump.c
+++ b/src/rspamadm/configdump.c
@@ -38,6 +38,10 @@ extern worker_t *workers[];
 
 static void rspamadm_configdump(int argc, char **argv, const struct rspamadm_command *);
 static const char *rspamadm_configdump_help(gboolean full_help, const struct rspamadm_command *);
+/*Add local_only option to GOptionEntry entries array */
+static gboolean local_only = FALSE;
+
+
 
 struct rspamadm_command configdump_command = {
 	.name = "configdump",
@@ -66,6 +70,8 @@ static GOptionEntry entries[] = {
 	 "Show full symbol details only", NULL},
 	{"skip-template", 'T', 0, G_OPTION_ARG_NONE, &skip_template,
 	 "Do not apply Jinja templates", NULL},
+	 {"local-only", 'l', 0, G_OPTION_ARG_NONE, &local_only,
+	"Show only local configuration elements (priority > 0)",NULL},
 	{NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
 
 static const char *
@@ -82,6 +88,7 @@ rspamadm_configdump_help(gboolean full_help, const struct rspamadm_command *cmd)
 				   "-c: config file to test\n"
 				   "-m: show state of modules only\n"
 				   "-h: show help for dumped options\n"
+				   "-L: show only local configuration (priority > 0)\n"
 				   "--help: shows available options and commands";
 	}
 	else {
@@ -89,6 +96,93 @@ rspamadm_configdump_help(gboolean full_help, const struct rspamadm_command *cmd)
 	}
 
 	return help_str;
+}
+
+// Function to filter local-only configuration elements
+
+static ucl_object_t *
+rspamadm_filter_local_config(const ucl_object_t *obj)
+{
+	ucl_object_t *result = NULL;
+	const ucl_object_t *cur;
+	ucl_object_iter_t it = NULL;
+	gboolean has_local = FALSE;
+
+	if (obj == NULL) {
+		return NULL;
+	}
+
+	switch (ucl_object_type(obj)) {
+	case UCL_OBJECT:
+		result = ucl_object_typed_new(UCL_OBJECT);
+
+		while ((cur = ucl_object_iterate(obj, &it, true))) {
+			if (cur->priority > 0) {
+				// This is a local configuration element
+				ucl_object_insert_key(result, ucl_object_ref(cur), cur->key, cur->keylen, true);
+				has_local = TRUE;
+			}
+			else {
+				// Check whether children is local
+				ucl_object_t *filtered_child = NULL;
+
+				if (ucl_object_type(cur) == UCL_OBJECT || ucl_object_type(cur) == UCL_ARRAY) {
+					filtered_child = rspamadm_filter_local_config(cur);
+					if (filtered_child != NULL) {
+						ucl_object_insert_key(result, filtered_child, cur->key, cur->keylen, true);
+						has_local = TRUE;
+					}
+				}
+			}
+		}
+
+		if (!has_local) {
+			ucl_object_unref(result);
+			return NULL;
+		}
+		break;
+
+	case UCL_ARRAY: {
+		gboolean has_local_in_array = FALSE;
+		result = ucl_object_typed_new(UCL_ARRAY);
+
+		it = NULL;
+		while ((cur = ucl_object_iterate(obj, &it, true))) {
+			if (cur->priority > 0) {
+				// local element
+				ucl_array_append(result, ucl_object_ref(cur));
+				has_local_in_array = TRUE;
+			}
+			else {
+				// Check whether childrens are local
+				ucl_object_t *filtered_child = NULL;
+
+				if (ucl_object_type(cur) == UCL_OBJECT || ucl_object_type(cur) == UCL_ARRAY) {
+					filtered_child = rspamadm_filter_local_config(cur);
+					if (filtered_child != NULL) {
+						ucl_array_append(result, filtered_child);
+						has_local_in_array = TRUE;
+					}
+				}
+			}
+		}
+
+		if (!has_local_in_array) {
+			ucl_object_unref(result);
+			return NULL;
+		}
+		break;
+	}
+
+	default:
+		if (obj->priority > 0) {
+			// Handle primitive types (string, number, boolean, etc.)
+			result = ucl_object_ref((ucl_object_t *)obj);
+		}
+		break;
+	}
+
+	return result;
 }
 
 static void
@@ -523,6 +617,56 @@ rspamadm_configdump(int argc, char **argv, const struct rspamadm_command *cmd)
 		}
 
 		/* Output configuration */
+		if (local_only) {
+			/* Filter the configuration to include only local elements */
+			ucl_object_t *local_config = rspamadm_filter_local_config(cfg->cfg_ucl_obj);
+			
+			if (local_config == NULL) {
+				rspamd_printf("No local configuration found\n");
+				exit(EXIT_SUCCESS);
+			}
+
+			if (argc == 1) {
+				/* Output the entire filtered configuration */
+				rspamadm_dump_section_obj(cfg, local_config, cfg->doc_strings);
+				ucl_object_unref(local_config);
+			}
+
+			else {
+				/* Output specific sections from the filtered configuration */
+				for (i = 1; i < argc; i++) {
+					obj = ucl_object_lookup_path(local_config, argv[i]);
+					doc_obj = ucl_object_lookup_path(cfg->doc_strings, argv[i]);
+					if (!obj) {
+						rspamd_printf("Local configuration for section %s NOT FOUND\n", argv[i]);
+					}
+
+					else {
+						LL_FOREACH(obj, cur)
+						{
+							if (!json && !compact) {
+								rspamd_printf("*** Section %s (local only) ***\n", argv[i]);
+							}
+							rspamadm_dump_section_obj(cfg, cur, doc_obj);
+                            
+							if (!json && !compact) {
+								rspamd_printf("\n*** End of section %s (local only) ***\n", argv[i]);
+							}
+							else {
+								rspamd_printf("\n");
+							}
+						}
+					}
+				}
+				ucl_object_unref(local_config);
+			}
+		}
+
+		else {
+		
+		// Original behavior for non-local-only configuration elements
+
+
 		if (argc == 1) {
 			rspamadm_dump_section_obj(cfg, cfg->cfg_ucl_obj, cfg->doc_strings);
 		}
@@ -552,6 +696,7 @@ rspamadm_configdump(int argc, char **argv, const struct rspamadm_command *cmd)
 				}
 			}
 		}
+	}
 	}
 
 	exit(ret ? EXIT_SUCCESS : EXIT_FAILURE);


### PR DESCRIPTION
This PR adds a new command, `rspamadm ready`, which polls the Rspamd controller's `/ready` endpoint until it returns a successful response or times out. This addresses the need for a reliable way to determine when Rspamd is fully operational, which is particularly useful in automated environments, container orchestration, and init scripts.

## Features

- Polls the `/ready` endpoint with configurable intervals and timeout
- Returns exit code 0 when Rspamd is ready, 1 otherwise (for easy scripting)
- Configurable options for URL, timeout, polling interval, and verbosity
- Follows the established pattern of other rspamadm commands

## Usage Examples

Basic usage:
```
rspamadm ready
```

With custom URL and timeout:
```
rspamadm ready --url https://rspamd.example.com:11334 --timeout 120
```

For scripts/automation (quiet mode):
```
rspamadm ready --quiet && echo "Rspamd is ready, proceeding with next steps"
```

## Implementation Details

The command is implemented in `lualib/rspamadm/ready.lua` following the pattern of existing commands like `clickhouse.lua`. It uses the existing HTTP functionality in Rspamd to make requests to the controller's `/ready` endpoint.

This implementation directly addresses the issue of needing to wait for Rspamd to be fully operational before proceeding with dependent tasks, which is particularly important in containerized environments and automated deployment scenarios.