### PR TITLE
Trying to add command for polling /ready

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-rspamd (3.7.3) unstable; urgency=low
+rspamd (2.5) unstable; urgency=low
 
   * New release.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-rspamd (2.5) unstable; urgency=low
+rspamd (3.7.3) unstable; urgency=low
 
   * New release.
 

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/lualib/rspamadm/ready.lua
+++ b/lualib/rspamadm/ready.lua
@@ -36,7 +36,7 @@ parser:flag '-v --verbose'
 
 local function log_and_print(level, verbose,fmt,...)
     rspamd_logger[level](fmt, ...)
-    if verbose and level ~="errx" then
+    if verbose and (level ~="errx" or level~="warnx")  then
         print(string.format(fmt, ...))
     end
 end
@@ -75,6 +75,8 @@ local function try_again(url, ssl_verify, verbose)
 end
 
 local function check_ready_interval(interval, timeout, url, ssl_verify,verbose)
+
+    try_again(url, ssl_verify,verbose)
     local start_time = os.time()
 
     rspamd_config:add_periodic(rspamadm_ev_base, interval, function(cfg, ev_base)

--- a/lualib/rspamadm/ready.lua
+++ b/lualib/rspamadm/ready.lua
@@ -1,0 +1,111 @@
+local argparse = require "argparse"
+local rspamd_http = require "rspamd_http"
+local rspamd_logger = require "rspamd_logger"
+
+local parser = argparse()
+    :name 'rspamadm ready'
+    :description 'Check whether Rspamd is ready'
+    :help_description_margin(30)
+    :command_target('command')
+    :require_command(true)
+
+parser:option '-t --timeout'
+      :description 'Maximum wait time before reporting an error'
+      :argname('timeout')
+      :default(5)
+
+parser:option '-i --interval'
+      :description 'Interval between two checks'
+      :argname('interval')
+      :default(1)
+
+parser:option '-u --url'
+      :description 'URL to check'
+      :argname('url')
+      :default("http://localhost:11334/ready")
+
+parser:flag '--ssl-verify'
+      :description 'Disable SSL verification'
+      :argname('ssl_verify')
+      :default(false)
+
+parser:flag '-v --verbose'
+      :description 'Give verbose output'
+      :argname('verbose')
+      :default(false)
+
+local function log_and_print(level, verbose,fmt,...)
+    rspamd_logger[level](fmt, ...)
+    if verbose and level ~="errx" then
+        print(string.format(fmt, ...))
+    end
+end
+
+local stop_polling = false
+
+local function try_again(url, ssl_verify, verbose)
+    rspamd_http.request({
+        method = 'GET',
+        ev_base = rspamadm_ev_base,
+        resolver = rspamadm_dns_resolver,
+        session = rspamadm_session,
+        config = rspamd_config,
+        url = url,
+        no_ssl_verify = not ssl_verify,
+        callback = function(err, code, body, headers)
+            if err then
+                log_and_print("warnx", verbose,"HTTP request failed: %s", err)
+                stop_polling = false
+            else
+                if(code == 200) then
+                    if body then
+                        log_and_print("infox",verbose,"Rspamd is ready!")
+                        stop_polling = true
+                    else
+                        log_and_print("warnx",verbose,"No response recieved!")
+                        stop_polling = false
+                    end
+                else
+                    log_and_print("warnx",verbose, "Response from controller: %s",body)
+                    stop_polling = false
+                end
+            end
+        end
+    })
+end
+
+local function check_ready_interval(interval, timeout, url, ssl_verify,verbose)
+    local start_time = os.time()
+
+    rspamd_config:add_periodic(rspamadm_ev_base, interval, function(cfg, ev_base)
+        local elapsed = os.time() - start_time
+        if elapsed >= timeout then
+            log_and_print("infox",verbose,"Rspamd did not respond within %s seconds!", timeout)
+            os.exit(1)
+        elseif stop_polling then
+            os.exit(0)
+        end
+
+        try_again(url, ssl_verify,verbose)
+
+        return true
+    end)
+end
+
+local function handler(args)
+    local cmd_opts = parser:parse(args)
+    local timeout = tonumber(cmd_opts.timeout)
+    local interval = tonumber(cmd_opts.interval)
+    local url = cmd_opts.url
+    local ssl_verify = cmd_opts.ssl_verify
+    local verbose = cmd_opts.verbose
+
+    check_ready_interval(interval, timeout, url, ssl_verify,verbose)
+    rspamadm_ev_base:loop()
+end
+
+return {
+    handler = handler,
+    description = parser._description,
+    name = 'ready'
+}


### PR DESCRIPTION
I have added `ready.lua` in `lualib/rspamadm` folder. The endpoint has the following features:

1. It accepts an `interval` argument from the command line to specify the intervals in which the `/ready` should be polled 
2. It accepts a `timeout` argument from the command line to specify the time interval in which the polling should stop
3. It accepts a `-v` flag to print output to terminal
4. It accepts a `url` argument to specify a custom url to be polled
5. It accepts a `--ssl-verify` flag to enable ssl in the request made

I have made use of `rspamd_http` to make the http request and I have used the `rspamd_config:add_periodic()` function to add register the timer for the asynchronous request. `rspamadm_ev_base:loop()` has been used to keep the script running

Any suggestions or changes would be greatly appreciated 