### PR TITLE
Add HEADER_FROM_CONTAINS_URL

### DIFF
--- a/rules/headers_checks.lua
+++ b/rules/headers_checks.lua
@@ -552,6 +552,23 @@ rspamd_config.HEADER_FORGED_MDN = {
   description = 'Read confirmation address is different to return path'
 }
 
+rspamd_config.HEADER_FROM_CONTAINS_URL = {
+  callback = function(task)
+    local from = task:get_from('mime')
+    if from and from[1] and from[1].name then
+      local display_name = from[1].name
+      if display_name:match(' https?://') then
+        return true
+      end
+    end
+    return false
+  end,
+
+  score = 5.0,
+  group = 'headers',
+  description = 'Name in From header contains URL'
+}
+
 local headers_unique = {
   ['Content-Type'] = 1.0,
   ['Content-Transfer-Encoding'] = 1.0,


### PR DESCRIPTION
This symbol will detect if header from contains any URLs and if yes - will add negative score to email. Usually such cases has place when bots spam "contact us" forms on websites and website use "From" as visible part of from in email. Rspamd do not verify URLs in From header, so we can restrict them via this rule as is.