### PR TITLE
Add R_HTTP_URL_IN_FROM

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -69,6 +69,14 @@ if rspamd_config:is_mime_utf8() then
   end
 end
 
+reconf['R_HTTP_URL_IN_FROM'] = {
+  re = [[From=/\shttps?:\/\/\S/iH]],
+  score = 5.0,
+  mime_only = true,
+  description = 'HTTP URL in From header',
+  group = 'headers'
+}
+
 -- Detects that there is no space in From header (e.g. Some Name<some@host>)
 reconf['R_NO_SPACE_IN_FROM'] = {
   re = 'From=/\\S<[-\\w\\.]+\\@[-\\w\\.]+>/X',

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -70,7 +70,7 @@ if rspamd_config:is_mime_utf8() then
 end
 
 reconf['R_HTTP_URL_IN_FROM'] = {
-  re = [[From=/(^|\s)https?:\/\/\S/iH]],
+  re = [[From=/(^|"|\s)https?:\/\/\S/iH]],
   score = 5.0,
   mime_only = true,
   description = 'HTTP URL in From header',

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -73,7 +73,7 @@ reconf['R_HTTP_URL_IN_FROM'] = {
   re = [[From=/(^|"|'|\s)[hH][tT][tT][pP][sS]?(:|=3A)\/\/\S/H]],
   score = 5.0,
   mime_only = true,
-  description = 'HTTP URL in From header',
+  description = 'HTTP URL preceded by the start of a line, quote, or whitespace, with normal or URL-encoded colons in From header',
   group = 'headers'
 }
 

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -70,7 +70,7 @@ if rspamd_config:is_mime_utf8() then
 end
 
 reconf['R_HTTP_URL_IN_FROM'] = {
-  re = [[From=/(^|"|\s)https?:\/\/\S/iH]],
+  re = [[From=/(^|"|'|\s)https?:\/\/\S/iH]],
   score = 5.0,
   mime_only = true,
   description = 'HTTP URL in From header',

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -70,7 +70,7 @@ if rspamd_config:is_mime_utf8() then
 end
 
 reconf['R_HTTP_URL_IN_FROM'] = {
-  re = [[From=/(^|"|'|\s)https?:\/\/\S/iH]],
+  re = [[From=/(^|"|'|\s)[hH][tT][tT][pP][sS]?(:|=3A)\/\/\S/H]],
   score = 5.0,
   mime_only = true,
   description = 'HTTP URL in From header',

--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -70,7 +70,7 @@ if rspamd_config:is_mime_utf8() then
 end
 
 reconf['R_HTTP_URL_IN_FROM'] = {
-  re = [[From=/\shttps?:\/\/\S/iH]],
+  re = [[From=/(^|\s)https?:\/\/\S/iH]],
   score = 5.0,
   mime_only = true,
   description = 'HTTP URL in From header',


### PR DESCRIPTION
This symbol will detect if header from contains any URLs and if yes - will add negative score to email. Usually such cases has place when bots spam "contact us" forms on websites and website use "From" as visible part of from in email. Rspamd do not verify URLs in From header, so we can restrict them via this rule as is.

Instead of https://github.com/rspamd/rspamd/pull/5405