### PR TITLE
Add FREEMAIL_REPLYTO_NEQ_FROM rule

### DIFF
--- a/conf/composites.conf
+++ b/conf/composites.conf
@@ -171,6 +171,12 @@ composites {
     description = "Message exhibits strong characteristics of advance fee fraud (AFF a/k/a '419' spam) involving freemail addresses";
     group = "scams";
   }
+  FREEMAIL_REPLYTO_NEQ_FROM {
+    expression = "FREEMAIL_REPLYTO & !REPLYTO_EQ_FROM & !REPLYTO_ADDR_EQ_FROM & !FREEMAIL_REPLYTO_NEQ_FROM_DOM";
+    score = 2.0;
+    policy = "leave";
+    description = "Reply-To is a Freemail address and it not match From header or SMTP From, also From is not another Freemail";
+  }
   SUSPICIOUS_MDN {
     expression = "(FREEMAIL_MDN | DISPOSABLE_MDN) & !(FREEMAIL_FROM | FREEMAIL_ENVFROM)";
     score = 2.0;


### PR DESCRIPTION
Common spam pattern, less evil then `FREEMAIL_REPLYTO_NEQ_FROM_DOM`, but seen much more.
Can be seen in legit emails - for example PayPal put Reply-To in their notifications and other senders can do it too, so not give it big score.