### PR TITLE
[Fix] Prevent config failure with defined action as a number

### DIFF
--- a/lualib/lua_cfg_transform.lua
+++ b/lualib/lua_cfg_transform.lua
@@ -367,8 +367,18 @@ return function(cfg)
     for i = 1, (#actions_order - 1) do
       local act = actions_order[i]
 
-      if actions:at(act) and actions:at(act):type() ~= 'object' then
-        local score = actions:at(act):unwrap()
+      local act_value = actions:at(act)
+
+      if act_value then
+        local val_type = act_value:type()
+        local score = 0
+        if val_type == 'string' then
+          if act_value:unwrap() ~= 'null' then
+            score = tonumber(act_value:unwrap())
+          end
+        elseif val_type == 'number' then
+          score = act_value:unwrap()
+        end
 
         for j = i + 1, #actions_order do
           local next_act = actions_order[j]


### PR DESCRIPTION
[Fix #5384] Prevent config failure with defined action as a number  

### Problem  
The configuration fails when a **defined action** is set as a **numeric value**  
instead of a **string**, causing execution errors.  

#### Root Cause  
- If a defined action is assigned a **string** (`"6.0"`), it works correctly.  
- However, if it is assigned a **numeric value** (`6.0`), the code attempts to  
  `unwrap()` it, leading to failure.  

#### Solution  
- Check the type of the defined action before processing.  
- Handle both **string** and **numeric** values correctly without using `unwrap()`.  

### Testing  

#### Config File  
The following configuration was used to verify the fix:  

  ```lua
  rewrite_subject = "6.0";
  subject = "*****SPAM***** %s"
  add_header = false;
  reject = 7.0;
  greylist = null;
```

#### Command

```
rspamadm configtest
```
