### PR TITLE
[Fix]Solve #5370

### DIFF
--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -279,11 +279,10 @@ auto symcache_runtime::is_symbol_enabled(struct rspamd_task *task, const symcach
 
 auto symcache_runtime::get_dynamic_item(int id) const -> cache_dynamic_item *
 {
-
 	/* Not found in the cache, do a hash lookup */
 	auto our_id_maybe = rspamd::find_map(order->by_cache_id, id);
 
-	if (our_id_maybe) {
+	if (our_id_maybe && our_id_maybe.value() < dynamic_items.size()) {
 		return &dynamic_items[our_id_maybe.value()];
 	}
 
@@ -342,7 +341,7 @@ auto symcache_runtime::process_pre_postfilters(struct rspamd_task *task,
 
 		auto dyn_item = get_dynamic_item(item->id);
 
-		if (dyn_item->status == cache_item_status::not_started) {
+		if (dyn_item && dyn_item->status == cache_item_status::not_started) {
 			if (slow_status == slow_status::enabled) {
 				return false;
 			}


### PR DESCRIPTION
# Bug Report

## Description
Segmentation faults occur when processing large messages (>50-60MB) due to null pointer dereferences and out-of-bounds array access in the dynamic items cache handling.

## Steps to Reproduce
1. Configure Rspamd 3.11 with default settings
2. Process a large email message (>50MB)
3. Observe segmentation fault in worker process

Alternatively:
1. Stress test Rspamd with many concurrent large messages
2. Segmentation faults will occur intermittently

## Expected Behavior
Rspamd should process large messages without crashing, gracefully handling memory constraints.

## Actual Behavior
Rspamd worker processes crash with segmentation faults when processing large messages.

## Environment
- Rspamd version: 3.11
- OS: [e.g. Linux distribution and version]
- Hardware: [if relevant]

## Additional Information
The issue occurs in the dynamic items cache handling:
1. `process_pre_postfilters` attempts to access `dyn_item->status` without null check
2. `get_dynamic_item` accesses `dynamic_items` array without bounds checking

## Proposed Fix
The issue is fixed by:
1. Adding null pointer checks before accessing dynamic items
2. Adding bounds checking for array accesses

```cpp
// In process_pre_postfilters:
if (dyn_item && dyn_item->status == cache_item_status::not_started) {

// In get_dynamic_item:
if (our_id_maybe && our_id_maybe.value() < dynamic_items.size()) {
    return &dynamic_items[our_id_maybe.value()];
}