### PR TITLE
Allow to use different servers for fuzzy operations

### DIFF
--- a/test/functional/cases/120_fuzzy/lib.robot
+++ b/test/functional/cases/120_fuzzy/lib.robot
@@ -16,6 +16,7 @@ ${RSPAMD_FUZZY_ENCRYPTED_ONLY}  false
 ${RSPAMD_FUZZY_ENCRYPTION_KEY}  null
 ${RSPAMD_FUZZY_INCLUDE}         ${RSPAMD_TESTDIR}/configs/empty.conf
 ${RSPAMD_FUZZY_KEY}             null
+${RSPAMD_FUZZY_SERVER_MODE}     servers
 ${RSPAMD_FUZZY_SHINGLES_KEY}    null
 ${RSPAMD_SCOPE}                 Suite
 ${SETTINGS_FUZZY_CHECK}         ${EMPTY}
@@ -109,6 +110,7 @@ Fuzzy Setup Encrypted
   Set Suite Variable  ${RSPAMD_FUZZY_ENCRYPTION_KEY}  ${RSPAMD_KEY_PUB1}
   Set Suite Variable  ${RSPAMD_FUZZY_CLIENT_ENCRYPTION_KEY}  ${RSPAMD_KEY_PUB1}
   Set Suite Variable  ${RSPAMD_FUZZY_INCLUDE}  ${RSPAMD_TESTDIR}/configs/fuzzy-encryption-key.conf
+  Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  servers
   Rspamd Redis Setup
 
 Fuzzy Setup Encrypted Dyn1
@@ -142,6 +144,7 @@ Fuzzy Setup Encrypted Keyed
 Fuzzy Setup Plain
   [Arguments]  ${algorithm}
   Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  ${algorithm}
+  Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  servers
   Rspamd Redis Setup
 
 Fuzzy Setup Keyed
@@ -149,6 +152,7 @@ Fuzzy Setup Keyed
   Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  ${algorithm}
   Set Suite Variable  ${RSPAMD_FUZZY_KEY}  mYN888sydwLTfE32g2hN
   Set Suite Variable  ${RSPAMD_FUZZY_SHINGLES_KEY}  hXUCgul9yYY3Zlk1QIT2
+  Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  servers
   Rspamd Redis Setup
 
 Fuzzy Setup Plain Fasthash
@@ -218,3 +222,18 @@ Fuzzy Multimessage Overwrite Test
   FOR  ${i}  IN  @{MESSAGES}
     Fuzzy Overwrite Test  ${i}
   END
+
+Fuzzy Setup Split Servers
+  Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  siphash
+  Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  split
+  Rspamd Redis Setup
+
+Fuzzy Setup Read Only
+  Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  siphash
+  Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  read_only
+  Rspamd Redis Setup
+
+Fuzzy Setup Write Only
+  Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  siphash
+  Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  write_only
+  Rspamd Redis Setup

--- a/test/functional/cases/120_fuzzy/lib.robot
+++ b/test/functional/cases/120_fuzzy/lib.robot
@@ -145,6 +145,7 @@ Fuzzy Setup Plain
   [Arguments]  ${algorithm}
   Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  ${algorithm}
   Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  servers
+  Set Suite Variable  ${SETTINGS_FUZZY_CHECK}  servers = "${RSPAMD_LOCAL_ADDR}:${RSPAMD_PORT_FUZZY}";
   Rspamd Redis Setup
 
 Fuzzy Setup Keyed
@@ -226,14 +227,17 @@ Fuzzy Multimessage Overwrite Test
 Fuzzy Setup Split Servers
   Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  siphash
   Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  split
+  Set Suite Variable  ${SETTINGS_FUZZY_CHECK}  read_servers = "${RSPAMD_LOCAL_ADDR}:${RSPAMD_PORT_FUZZY}"; write_servers = "${RSPAMD_LOCAL_ADDR}:${RSPAMD_PORT_FUZZY}";
   Rspamd Redis Setup
 
 Fuzzy Setup Read Only
   Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  siphash
   Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  read_only
+  Set Suite Variable  ${SETTINGS_FUZZY_CHECK}  read_only = true;
   Rspamd Redis Setup
 
 Fuzzy Setup Write Only
   Set Suite Variable  ${RSPAMD_FUZZY_ALGORITHM}  siphash
   Set Suite Variable  ${RSPAMD_FUZZY_SERVER_MODE}  write_only
+  Set Suite Variable  ${SETTINGS_FUZZY_CHECK}  mode = "write_only";
   Rspamd Redis Setup

--- a/test/functional/cases/120_fuzzy/read-only.robot
+++ b/test/functional/cases/120_fuzzy/read-only.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Suite Setup     Fuzzy Setup Read Only
+Suite Teardown  Rspamd Redis Teardown
+Resource        lib.robot
+
+*** Test Cases ***
+Fuzzy Add
+  Fuzzy Multimessage Add Test
+
+Fuzzy Fuzzy
+  Fuzzy Multimessage Fuzzy Test
+
+Fuzzy Miss
+  Fuzzy Multimessage Miss Test

--- a/test/functional/cases/120_fuzzy/split-servers.robot
+++ b/test/functional/cases/120_fuzzy/split-servers.robot
@@ -2,6 +2,10 @@
 Suite Setup     Fuzzy Setup Split Servers
 Suite Teardown  Rspamd Redis Teardown
 Resource        lib.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}       ${RSPAMD_TESTDIR}/configs/fuzzy-split-servers.conf
 
 *** Test Cases ***
 Fuzzy Add

--- a/test/functional/cases/120_fuzzy/split-servers.robot
+++ b/test/functional/cases/120_fuzzy/split-servers.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Suite Setup     Fuzzy Setup Split Servers
+Suite Teardown  Rspamd Redis Teardown
+Resource        lib.robot
+
+*** Test Cases ***
+Fuzzy Add
+  Fuzzy Multimessage Add Test
+
+Fuzzy Fuzzy
+  Fuzzy Multimessage Fuzzy Test
+
+Fuzzy Miss
+  Fuzzy Multimessage Miss Test

--- a/test/functional/cases/120_fuzzy/write-only.robot
+++ b/test/functional/cases/120_fuzzy/write-only.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Suite Setup     Fuzzy Setup Write Only
+Suite Teardown  Rspamd Redis Teardown
+Resource        lib.robot
+
+*** Test Cases ***
+Fuzzy Add
+  Fuzzy Multimessage Add Test
+
+Fuzzy Fuzzy
+  Fuzzy Multimessage Fuzzy Test
+
+Fuzzy Miss
+  Fuzzy Multimessage Miss Test

--- a/test/functional/configs/fuzzy-split-servers.conf
+++ b/test/functional/configs/fuzzy-split-servers.conf
@@ -1,0 +1,97 @@
+redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+}
+lua = "{= env.TESTDIR =}/lua/test_coverage.lua";
+options = {
+	filters = "fuzzy_check";
+	pidfile = "{= env.TMPDIR =}/rspamd.pid";
+	control_socket = "{= env.TMPDIR =}/rspamd.sock mode=0600";
+	url_tld = "{= env.TESTDIR =}/../lua/unit/test_tld.dat";
+	dns {
+		retransmits = 10;
+		timeout = 2s;
+	}
+}
+logging = {
+	type = "file",
+	level = "debug"
+	filename = "{= env.TMPDIR =}/rspamd.log"
+}
+metric = {
+	name = "default",
+	actions = {
+		reject = 100500,
+	}
+	unknown_weight = 1
+        symbol {
+            weight = 10.0;
+            name = "{= env.FLAG1_SYMBOL =}";
+        }
+        symbol {
+            weight = -1.0;
+            name = "{= env.FLAG2_SYMBOL =}";
+        }
+}
+
+worker {
+	type = normal
+	bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_NORMAL =}";
+	count = 1
+	task_timeout = 60s;
+}
+
+worker {
+        type = controller
+        bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_CONTROLLER =}";
+        count = 1
+        secure_ip = ["{= env.LOCAL_ADDR =}"];
+        stats_path = "{= env.TMPDIR =}/stats.ucl";
+}
+
+worker {
+	count = 1;
+        backend = "{= env.FUZZY_BACKEND =}";
+	bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_FUZZY =}";
+	type = "fuzzy";
+	hashfile = "{= env.TMPDIR =}/fuzzy.db";
+	allow_update = ["{= env.LOCAL_ADDR =}"];
+	encrypted_only = {= env.FUZZY_ENCRYPTED_ONLY =};
+	keypair {
+		privkey = "{= env.KEY_PVT1 =}";
+		pubkey = "{= env.KEY_PUB1 =}";
+	}
+	dynamic_keys_map = "{= env.TESTDIR =}/configs/maps/fuzzy_keymap.map";
+}
+
+fuzzy_check {
+	min_bytes = 100;
+	timeout = 1s;
+	retransmits = 10;
+
+	rule {
+	  min_bytes = 0;
+	  min_length = 0;
+		algorithm = "{= env.FUZZY_ALGORITHM =}";
+		read_servers = "{= env.LOCAL_ADDR =}:{= env.PORT_FUZZY =}";
+		write_servers = "{= env.LOCAL_ADDR =}:{= env.PORT_FUZZY =}";
+		symbol = "R_TEST_FUZZY";
+		max_score = 10.0;
+		mime_types = ["application/*"];
+		read_only = false;
+		skip_unknown = true;
+		skip_hashes = "{= env.TMPDIR =}/skip_hash.map";
+		fuzzy_key = {= env.FUZZY_KEY =};
+		fuzzy_shingles_key = {= env.FUZZY_SHINGLES_KEY =};
+.include "{= env.FUZZY_INCLUDE =}";
+		fuzzy_map = {
+			R_TEST_FUZZY_DENIED {
+				max_score = 10.0;
+				flag = {= env.FLAG1_NUMBER =};
+			}
+			R_TEST_FUZZY_WHITE {
+				max_score = 1.0;
+				flag = {= env.FLAG2_NUMBER =};
+			}
+		}
+	}
+}


### PR DESCRIPTION
- **[Feature] Add support for separate read and write servers in fuzzy check**
- **[Minor] Remove servers completely and use `read_servers` for all compat stuff**
- **test: add fuzzy tests for split, read-only, and write-only server modes**
- **[Test] Improve fuzzy split server test configuration and setup**
- **[Minor] Some fixes**
