### PR TITLE
Fix librdns maxname limit

### DIFF
--- a/contrib/librdns/dns_private.h
+++ b/contrib/librdns/dns_private.h
@@ -41,7 +41,7 @@ static const int default_tcp_io_cnt = 1;
 #define DNS_COMPRESSION_BITS 0xC0
 
 #define DNS_D_MAXLABEL  63      /* + 1 '\0' */
-#define DNS_D_MAXNAME   255     /* + 1 '\0' */
+#define DNS_D_MAXNAME   253     /* + 1 '\0' */
 
 #define RESOLV_CONF "/etc/resolv.conf"
 


### PR DESCRIPTION
This change required to fix cases when Rspamd tries to query domain that exceed IDNA2008 limits of 255 chars, but practical limit is 253 due to last 2 chars is `.` and `null separator`.

Whenever Rspamd tries to query such DNS record it will always face `query timeout`, so there no reason to create such requests at all.

Mostly such cases could be seen in RBL where no hashing is applied on query selector like `{from}.{primary_rcpt}.{rbl}` or so on.

P.s. changes to the limit double checked with RFCs and `dig` 