### PR TITLE
Modify documentation for rspamc "-P" parameter

### DIFF
--- a/doc/rspamc.1
+++ b/doc/rspamc.1
@@ -68,7 +68,8 @@ fuzzy* commands requires input.
 Specify host and port
 .TP
 \-P \f[I]password\f[R], \-\-password=\f[I]password\f[R]
-Specify control password
+Specify control password. Can be an absolute or relative path, in which
+case the password will be read from that file.
 .TP
 \-c \f[I]name\f[R], \-\-classifier=\f[I]name\f[R]
 Classifier to learn spam or ham (bayes is used by default)

--- a/doc/rspamc.1.md
+++ b/doc/rspamc.1.md
@@ -42,7 +42,7 @@ requires input.
 :	Specify host and port
 	
 -P *password*, \--password=*password*
-:	Specify control password
+:	Specify control password. Can be an absolute or relative path, in which case the password will be read from that file.
 	
 -c *name*, \--classifier=*name*
 :	Classifier to learn spam or ham (bayes is used by default)


### PR DESCRIPTION
In https://github.com/rspamd/rspamd/commit/8b18feb6bc086a9ae7f2eef31f78325221707476, the behaviour of the `-P` parameter has been modified to also pass the control password via file input.

This PR aims to adjust the documentation to reflect this behaviour.

Cheers
Thomas