### PR TITLE
[Minor] Print error on multimap invalid type

### DIFF
--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -1333,6 +1333,9 @@ local function add_multimap_rule(key, newrule)
       end
     elseif newrule['type'] == 'dnsbl' then
       ret = true
+    else
+      rspamd_logger.errx(rspamd_config, 'cannot add rule %s: invalid type %s',
+          key, newrule['type'])
     end
   end
 


### PR DESCRIPTION
When a multimap rule is configured with an invalid type it fails but no explicit reason is given. Added a log line.