### PR TITLE
[Enhancement] hfilter: Add OVH VPS generic hostname

### DIFF
--- a/src/plugins/lua/hfilter.lua
+++ b/src/plugins/lua/hfilter.lua
@@ -131,6 +131,7 @@ local checks_hellohost = [[
 /modem[.-][0-9]/i 5
 /[0-9][.-]?dhcp/i 5
 /wifi[.-][0-9]/i 5
+/\.vps\.ovh\.(us|net)$/i 5
 ]]
 local checks_hellohost_map
 


### PR DESCRIPTION
This pull requests adds `*.vps.ovh.us` and `*.vps.ovh.net` hostnames that are set by default for OVH VPS. Frequently seen from spam sources.