### PR TITLE
[Fix] Correct logic error in milter_headers.lua: skip_wanted()

### DIFF
--- a/src/plugins/lua/milter_headers.lua
+++ b/src/plugins/lua/milter_headers.lua
@@ -138,7 +138,7 @@ local function milter_headers(task)
 
   local function skip_wanted(hdr)
     if settings_override then
-      return true
+      return false
     end
     -- Normal checks
     local function match_extended_headers_rcpt()

--- a/test/functional/cases/550_milter_headers.robot
+++ b/test/functional/cases/550_milter_headers.robot
@@ -37,3 +37,14 @@ CHECK HEADERS WITHOUT TEST SYMBOL
   # Check X-Spam-Level header
   Do Not Expect Added Header  X-Spam-Level
   Expect Removed Header  X-Spam-Level
+
+CHECK HEADERS WITH OVERRIDE SETTINGS
+  # id_milter_headers_override setting enables only authentication-results and x-spam-level routines
+  Scan File  ${MESSAGE}  Settings-Id=id_milter_headers_override
+  # Test the milter_headers override behavior
+  # Check that Authentication-Results and X-Spam-Level headers are present (exact values are not important)
+  Expect Header Is Present  Authentication-Results
+  Expect Header Is Present  X-Spam-Level
+  # Verify other headers are not added since only authentication-results and x-spam-level routines run
+  Do Not Expect Added Header  X-Virus
+  Do Not Expect Added Header  My-Spamd-Bar

--- a/test/functional/configs/milter_headers.conf
+++ b/test/functional/configs/milter_headers.conf
@@ -22,3 +22,15 @@ milter_headers {
   }
 
 }
+
+settings {
+  id_milter_headers_override {
+    apply {
+      plugins {
+        milter_headers {
+          routines = [ authentication-results, x-spam-level ];
+        }
+      }
+    }
+  }
+}

--- a/test/functional/lib/rspamd.robot
+++ b/test/functional/lib/rspamd.robot
@@ -120,6 +120,15 @@ Expect Added Header
   Should Be Equal  ${SCAN_RESULT}[milter][add_headers][${header_name}][value]  ${header_value}
   Should Be Equal as Numbers  ${SCAN_RESULT}[milter][add_headers][${header_name}][order]  ${pos}
 
+Expect Header Is Present
+  [Arguments]  ${header_name}
+  Dictionary Should Contain Key  ${SCAN_RESULT}  milter
+  ...  msg=milter block was not present in protocol response
+  Dictionary Should Contain Key  ${SCAN_RESULT}[milter]  add_headers
+  ...  msg=add_headers block was not present in protocol response
+  Dictionary Should Contain Key  ${SCAN_RESULT}[milter][add_headers]  ${header_name}
+  ...  msg=${header_name} was not added
+
 Expect Email
   [Arguments]  ${email}
   List Should Contain Value  ${SCAN_RESULT}[emails]  ${email}


### PR DESCRIPTION
A mechanism that allows overriding the active [`milter_headers`](https://docs.rspamd.com/modules/milter_headers) routines via [`user settings`](https://docs.rspamd.com/configuration/settings) has been added in commit https://github.com/rspamd/rspamd/commit/c116e4e35c7caf9b9cd454d85ea088a2c960f62f.
However, due to a bug in the implementation no routines are running when this mechanism is used.

This PR fixes the logic error and adds a functional test that covers this scenario.

**Changes:**
- fix logic error in `skip_wanted()`
- add new functional test for this scenario
- add override settings in `milter_headers.conf` to support the testing
- add supporting functionality in `rspamd.robot`