### PR TITLE
[Minor] history_redis: remove extra placeholder from format string

### DIFF
--- a/src/plugins/lua/history_redis.lua
+++ b/src/plugins/lua/history_redis.lua
@@ -138,8 +138,7 @@ end
 local function history_save(task)
   local function redis_llen_cb(err, _)
     if err then
-      rspamd_logger.errx(task, 'got error %s when writing history row: %s',
-          err)
+      rspamd_logger.errx(task, 'got error %s when writing history row', err)
     end
   end
 


### PR DESCRIPTION
Probably logger should be fixed to restore the old behaviour or such that the sources of the errors are clear