### PR TITLE
[Feature] Updated bayes_classify.lua with additional parameters

### DIFF
--- a/lualib/lua_bayes_learn.lua
+++ b/lualib/lua_bayes_learn.lua
@@ -23,13 +23,40 @@ local N = "lua_bayes"
 
 local exports = {}
 
-exports.can_learn = function(task, is_spam, is_unlearn)
+exports.can_learn = function(task, is_spam, is_unlearn, category)
   local learn_type = task:get_request_header('Learn-Type')
 
   if not (learn_type and tostring(learn_type) == 'bulk') then
     local prob = task:get_mempool():get_variable('bayes_prob', 'double')
 
-    if prob then
+    if category then
+      -- Default thresholds, can be overridden by config
+      local thresholds = {
+        spam = { value = 0.95, direction = 'gte' },
+        ham  = { value = 0.05, direction = 'lte' },
+        -- Add more built-in categories if needed
+      }
+      -- Allow per-task or per-config thresholds
+      local th = thresholds[category]
+      if task.extra_learn_categories and task.extra_learn_categories[category] then
+        th = task.extra_learn_categories[category]
+      end
+
+      if prob and th then
+        local in_class = false
+        if th.direction == 'gte' then
+          in_class = prob >= th.value
+        elseif th.direction == 'lte' then
+          in_class = prob <= th.value
+        end
+
+        if in_class then
+          return false, string.format(
+              'already in class %s; probability %.2f%%',
+              category, math.abs((prob - 0.5) * 200.0))
+        end
+      end
+    elseif prob then
       local in_class = false
       local cl
       if is_spam then
@@ -52,7 +79,7 @@ exports.can_learn = function(task, is_spam, is_unlearn)
 end
 
 exports.autolearn = function(task, conf)
-  local function log_can_autolearn(verdict, score, threshold)
+  local function log_can_autolearn(verdict, score, threshold, category)
     local from = task:get_from('smtp')
     local mime_rcpts = 'undef'
     local mr = task:get_recipients('mime')
@@ -69,7 +96,7 @@ exports.autolearn = function(task, conf)
     logger.info(task, 'id: %s, from: <%s>: can autolearn %s: score %s %s %s, mime_rcpts: <%s>',
         task:get_header('Message-Id') or '<undef>',
         from and from[1].addr or 'undef',
-        verdict,
+        category or verdict,
         string.format("%.2f", score),
         verdict == 'ham' and '<=' or verdict == 'spam' and '>=' or '/',
         threshold,
@@ -77,15 +104,11 @@ exports.autolearn = function(task, conf)
   end
 
   if not task:get_queue_id() then
-    -- We should skip messages that come from `rspamc` or webui as they are usually
-    -- not intended for autolearn at all
     lua_util.debugm(N, task, 'no need to autolearn - queue id is missing')
     return
   end
 
-  -- We have autolearn config so let's figure out what is requested
   local verdict, score = lua_verdict.get_specific_verdict("bayes", task)
-  local learn_spam, learn_ham = false, false
 
   if verdict == 'passthrough' then
     -- No need to autolearn
@@ -93,6 +116,27 @@ exports.autolearn = function(task, conf)
         verdict)
     return
   end
+
+  -- Category-aware logic
+  if conf.categories then
+    for cat, cat_conf in pairs(conf.categories) do
+      if verdict == cat and cat_conf.threshold then
+        local match = false
+        if (cat_conf.direction == 'gte' and score >= cat_conf.threshold) or
+           (cat_conf.direction == 'lte' and score <= cat_conf.threshold) then
+          match = true
+        end
+        if match then
+          log_can_autolearn(verdict, score, cat_conf.threshold, cat)
+          -- Save config for can_learn to read later
+          task.extra_learn_categories = conf.categories
+          return cat
+        end
+      end
+    end
+  end
+
+  local learn_spam, learn_ham = false, false
 
   if conf.spam_threshold and conf.ham_threshold then
     if verdict == 'spam' then
@@ -120,7 +164,6 @@ exports.autolearn = function(task, conf)
   end
 
   if conf.check_balance then
-    -- Check balance of learns
     local spam_learns = task:get_mempool():get_variable('spam_learns', 'int64') or 0
     local ham_learns = task:get_mempool():get_variable('ham_learns', 'int64') or 0
 

--- a/lualib/lua_bayes_redis.lua
+++ b/lualib/lua_bayes_redis.lua
@@ -24,21 +24,9 @@ local ucl = require "ucl"
 
 local N = "bayes"
 
-local function resolve_category(is_spam, category)
-  -- If category is provided, use it; otherwise map is_spam to "spam"/"ham"
-  if category then
-    return category
-  elseif is_spam ~= nil then
-    return is_spam and "spam" or "ham"
-  else
-    return "ham" -- fallback, should not really happen
-  end
-end
-
 local function gen_classify_functor(redis_params, classify_script_id)
-  return function(task, expanded_key, id, is_spam, category, stat_tokens, callback)
+  return function(task, expanded_key, id, is_spam, stat_tokens, callback)
 
-    local resolved_category = resolve_category(is_spam, category)
     local function classify_redis_cb(err, data)
       lua_util.debugm(N, task, 'classify redis cb: %s, %s', err, data)
       if err then
@@ -50,13 +38,12 @@ local function gen_classify_functor(redis_params, classify_script_id)
 
     lua_redis.exec_redis_script(classify_script_id,
         { task = task, is_write = false, key = expanded_key },
-        classify_redis_cb, { expanded_key, resolved_category, stat_tokens })
+        classify_redis_cb, { expanded_key, stat_tokens })
   end
 end
 
 local function gen_learn_functor(redis_params, learn_script_id)
-  return function(task, expanded_key, id, is_spam, category, symbol, is_unlearn, stat_tokens, callback, maybe_text_tokens)
-    local resolved_category = resolve_category(is_spam, category)
+  return function(task, expanded_key, id, is_spam, symbol, is_unlearn, stat_tokens, callback, maybe_text_tokens)
     local function learn_redis_cb(err, data)
       lua_util.debugm(N, task, 'learn redis cb: %s, %s', err, data)
       if err then
@@ -70,12 +57,13 @@ local function gen_learn_functor(redis_params, learn_script_id)
       lua_redis.exec_redis_script(learn_script_id,
           { task = task, is_write = true, key = expanded_key },
           learn_redis_cb,
-          { expanded_key, resolved_category, symbol, tostring(is_unlearn), stat_tokens, maybe_text_tokens })
+          { expanded_key, tostring(is_spam), symbol, tostring(is_unlearn), stat_tokens, maybe_text_tokens })
     else
       lua_redis.exec_redis_script(learn_script_id,
           { task = task, is_write = true, key = expanded_key },
-          learn_redis_cb, { expanded_key, resolved_category, symbol, tostring(is_unlearn), stat_tokens })
+          learn_redis_cb, { expanded_key, tostring(is_spam), symbol, tostring(is_unlearn), stat_tokens })
     end
+
   end
 end
 
@@ -124,7 +112,7 @@ end
 --- @param classifier_ucl ucl of the classifier config
 --- @param statfile_ucl ucl of the statfile config
 --- @return a pair of (classify_functor, learn_functor) or `nil` in case of error
-exports.lua_bayes_init_statfile = function(classifier_ucl, statfile_ucl, symbol, is_spam, category, ev_base, stat_periodic_cb)
+exports.lua_bayes_init_statfile = function(classifier_ucl, statfile_ucl, symbol, is_spam, ev_base, stat_periodic_cb)
 
   local redis_params = load_redis_params(classifier_ucl, statfile_ucl)
 
@@ -149,8 +137,10 @@ exports.lua_bayes_init_statfile = function(classifier_ucl, statfile_ucl, symbol,
 
   if ev_base then
     rspamd_config:add_periodic(ev_base, 0.0, function(cfg, _)
+
       local function stat_redis_cb(err, data)
         lua_util.debugm(N, cfg, 'stat redis cb: %s, %s', err, data)
+
         if err then
           logger.warn(cfg, 'cannot get bayes statistics for %s: %s', symbol, err)
         else
@@ -158,6 +148,7 @@ exports.lua_bayes_init_statfile = function(classifier_ucl, statfile_ucl, symbol,
           current_data.users = current_data.users + data[2]
           current_data.revision = current_data.revision + data[3]
           if new_cursor == 0 then
+            -- Done iteration
             final_data = lua_util.shallowcopy(current_data)
             current_data = {
               users = 0,
@@ -166,23 +157,22 @@ exports.lua_bayes_init_statfile = function(classifier_ucl, statfile_ucl, symbol,
             lua_util.debugm(N, cfg, 'final data: %s', final_data)
             stat_periodic_cb(cfg, final_data)
           end
+
           cursor = new_cursor
         end
       end
 
-      local resolved_category = resolve_category(is_spam, category)
       lua_redis.exec_redis_script(stat_script_id,
           { ev_base = ev_base, cfg = cfg, is_write = false },
           stat_redis_cb, { tostring(cursor),
                            symbol,
-                           resolved_category,
+                           is_spam and "learns_spam" or "learns_ham",
                            tostring(max_users) })
       return statfile_ucl.monitor_timeout or classifier_ucl.monitor_timeout or 30.0
     end)
   end
 
-  return gen_classify_functor(redis_params, classify_script_id),
-         gen_learn_functor(redis_params, learn_script_id)
+  return gen_classify_functor(redis_params, classify_script_id), gen_learn_functor(redis_params, learn_script_id)
 end
 
 local function gen_cache_check_functor(redis_params, check_script_id, conf)

--- a/lualib/redis_scripts/bayes_classify.lua
+++ b/lualib/redis_scripts/bayes_classify.lua
@@ -25,7 +25,6 @@ end
 -- This optimisation will save a lot of space for sparse tokens, and in Bayes that assumption is normally held
 
 if learned_ham > 0 and learned_spam > 0 then
-  local input_tokens = cmsgpack.unpack(KEYS[2])
   for i, token in ipairs(input_tokens) do
     local token_data = redis.call('HMGET', token, 'H', 'S')
 


### PR DESCRIPTION
For extending the classifier, a few redis_scripts needs to be changed. In bayes_classify.lua, I introduced category and learned_cat parameter which would be returned to lualib/lua_bayes_learn.lua when called. I made sure that it does not break the existing functionalities of ham/spam