### PR TITLE
[Feature] Add /bayes/classifiers HTTP endpoint

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -68,6 +68,7 @@
 #define PATH_NEIGHBOURS "/neighbours"
 #define PATH_PLUGINS "/plugins"
 #define PATH_PING "/ping"
+#define PATH_BAYES_CLASSIFIERS "/bayes/classifiers"
 
 #define msg_err_session(...) rspamd_default_log_function(G_LOG_LEVEL_CRITICAL,                               \
 														 session->pool->tag.tagname, session->pool->tag.uid, \
@@ -3446,6 +3447,40 @@ rspamd_controller_handle_lua_plugin(struct rspamd_http_connection_entry *conn_en
 	return 0;
 }
 
+/*
+ * Bayes classifier list command handler:
+ * request: /bayes/classifiers
+ * headers: Password
+ * reply: JSON array of Bayes classifier names
+ *   Note: list is in reverse of declaration order (GList prepend).
+ */
+static int
+rspamd_controller_handle_bayes_classifiers(struct rspamd_http_connection_entry *conn_ent,
+											struct rspamd_http_message *msg)
+{
+	struct rspamd_controller_session *session = conn_ent->ud;
+	struct rspamd_controller_worker_ctx *ctx = session->ctx;
+	ucl_object_t *arr;
+	struct rspamd_classifier_config *clc;
+	GList *cur;
+
+	if (!rspamd_controller_check_password(conn_ent, session, msg, FALSE)) {
+		return 0;
+	}
+
+	arr = ucl_object_typed_new(UCL_ARRAY);
+	cur = g_list_last(ctx->cfg->classifiers);
+	while (cur) {
+		clc = cur->data;
+		ucl_array_append(arr, ucl_object_fromstring(clc->name));
+		cur = g_list_previous(cur);
+	}
+
+	rspamd_controller_send_ucl(conn_ent, arr);
+	ucl_object_unref(arr);
+	return 0;
+}
+
 
 static void
 rspamd_controller_error_handler(struct rspamd_http_connection_entry *conn_ent,
@@ -4055,6 +4090,9 @@ start_controller_worker(struct rspamd_worker *worker)
 	rspamd_http_router_add_path(ctx->http,
 								PATH_PING,
 								rspamd_controller_handle_ping);
+	rspamd_http_router_add_path(ctx->http,
+								PATH_BAYES_CLASSIFIERS,
+								rspamd_controller_handle_bayes_classifiers);
 	rspamd_controller_register_plugins_paths(ctx);
 
 #if 0


### PR DESCRIPTION
This endpoint returns a JSON array of names of all configured Bayes classifiers in the same order as they are declared in the configuration.