### PR TITLE
[Minor] Treat *.svg attachments as slightly bad

### DIFF
--- a/src/plugins/lua/mime_types.lua
+++ b/src/plugins/lua/mime_types.lua
@@ -56,6 +56,7 @@ local settings = {
     exe = 1,
     iso = 4,
     jar = 2,
+    svg = 0.5,
     txz = 2,
     zpaq = 2,
     -- In contrast to HTML MIME parts, dedicated HTML attachments are considered harmful
@@ -210,6 +211,7 @@ local settings = {
     lnk = 4,
     pdf = 0.1,
     pptx = 0.1,
+    svg = 0.1,
     vbs = 4,
     wsf = 4,
     xlsx = 0.1,


### PR DESCRIPTION
Prompted by a recent malspam campaign flagged by CERT.at, which highlights the abuse of Scalable Vector Graphics attachments: https://www.cert.at/de/warnungen/2025/6/phishing-angriffe-mit-manipulierten-svg-dateien-vorsicht-geboten

Since these might appear in legitimate e-mail traffic as well, only treat their occurrence as slightly bad for the time being.