### PR TITLE
[WebUI] Sort symbol groups in filter dropdown

### DIFF
--- a/interface/js/app/symbols.js
+++ b/interface/js/app/symbols.js
@@ -135,6 +135,7 @@ define(["jquery", "app/common", "footable"],
                         construct: function (instance) {
                             this._super(instance);
                             [,this.groups] = items;
+                            this.groups.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
                             this.def = "Any group";
                             this.$group = null;
                         },


### PR DESCRIPTION
Sort symbol groups in the Symbols table dropdown filter in a case-insensitive manner, ensuring alphabetical A–Z ordering regardless of capitalization.