### PR TITLE
Update protocol for ftp.arin.net in asn.pl

### DIFF
--- a/utils/asn.pl
+++ b/utils/asn.pl
@@ -17,7 +17,7 @@ use URI;
 
 my %config = (
   asn_sources => [
-    'ftp://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest',
+    'http://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest',
     'ftp://ftp.ripe.net/ripe/stats/delegated-ripencc-latest',
     'http://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-latest',
     'ftp://ftp.apnic.net/pub/stats/apnic/delegated-apnic-latest',


### PR DESCRIPTION
According to https://www.arin.net/blog/2025/02/10/ftp-retirement/ ftp.arin.net is no longer accessible via the FTP protocol since 31 March 2025. This changes the default protocol from ftp://ftp.arin.net to http://ftp.arin.net (which works)