### PR TITLE
icap.lua: ipv6 format in GET request format

### DIFF
--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -242,10 +242,14 @@ local function icap_check(task, content, digest, rule, maybe_part)
       local function get_req_headers()
 
         local in_client_ip = task:get_from_ip()
+        local in_client_ip_str = in_client_ip:to_string()
         local req_hlen = 2
+        if in_client_ip:get_version() == 6 then
+          in_client_ip_str = "[" .. in_client_ip_str .. "]"
+        end
         if maybe_part then
           table.insert(req_headers,
-              string.format('GET http://%s/%s HTTP/1.0\r\n', in_client_ip, lua_util.url_encode_string(maybe_part:get_filename())))
+              string.format('GET http://%s/%s HTTP/1.0\r\n', in_client_ip_str, lua_util.url_encode_string(maybe_part:get_filename())))
           if rule.use_specific_content_type then
             table.insert(http_headers, string.format('Content-Type: %s/%s\r\n', maybe_part:get_detected_type()))
             --else


### PR DESCRIPTION
For ipv6 [..| is needed in GET request who is encapsulated in ICAP.

Didn't use Lua often maybe the code can be optimized.