### PR TITLE
[WebUI] Update classifiers on server or tab switch

### DIFF
--- a/interface/js/app/rspamd.js
+++ b/interface/js/app/rspamd.js
@@ -176,7 +176,10 @@ define(["jquery", "app/common", "stickytabs", "visibility",
                 require(["app/symbols"], (module) => module.getSymbols());
                 break;
             case "#scan_nav":
-                require(["app/upload"], (module) => module.getFuzzyStorages());
+                require(["app/upload"], (module) => {
+                    module.getClassifiers();
+                    module.getFuzzyStorages();
+                });
                 break;
             case "#selectors_nav":
                 require(["app/selectors"], (module) => module.displayUI());


### PR DESCRIPTION
Ensure the Bayes classifiers dropdown is refreshed whenever the user changes the selected server or navigates to the Scan/Learn tab, so it always reflects the selected server’s configuration.