### PR TITLE
[Fix] : CVE-2021-32765 in hiredis

### DIFF
--- a/contrib/hiredis/hiredis.c
+++ b/contrib/hiredis/hiredis.c
@@ -179,6 +179,7 @@ static void *createArrayObject(const redisReadTask *task, size_t elements) {
         return NULL;
 
     if (elements > 0) {
+        if (SIZE_MAX / sizeof(redisReply*) < elements) return NULL;  /* Don't overflow */
         r->element = hi_calloc(elements,sizeof(redisReply*));
         if (r->element == NULL) {
             freeReplyObject(r);

--- a/contrib/hiredis/test.c
+++ b/contrib/hiredis/test.c
@@ -552,6 +552,20 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
+    test("Multi-bulk never overflows regardless of maxelements: ");
+    size_t bad_mbulk_len = (SIZE_MAX / sizeof(void *)) + 3;
+    char bad_mbulk_reply[100];
+    snprintf(bad_mbulk_reply, sizeof(bad_mbulk_reply), "*%llu\r\n+asdf\r\n",
+        (unsigned long long) bad_mbulk_len);
+
+    reader = redisReaderCreate();
+    reader->maxelements = 0;    /* Don't rely on default limit */
+    redisReaderFeed(reader, bad_mbulk_reply, strlen(bad_mbulk_reply));
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_ERR && strcasecmp(reader->errstr, "Out of memory") == 0);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
+    
 #if LLONG_MAX > SIZE_MAX
     test("Set error when array > SIZE_MAX: ");
     reader = redisReaderCreate();


### PR DESCRIPTION
### Summary
Fixes CVE-2021-32765 integer overflow vulnerability in bundled hiredis library's createArrayObject function. Adds overflow check to prevent buffer overflow when parsing maliciously crafted Redis RESP multi-bulk data.
[https://nvd.nist.gov/vuln/detail/CVE-2021-32765](https://nvd.nist.gov/vuln/detail/CVE-2021-32765)
[https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e](https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e)

### Location: hiredis library bundled in KBEngine (hiredis.c createArrayObject)

- Vulnerability: Integer overflow when parsing Redis RESP multi-bulk data
- Impact: Buffer overflow from count * sizeof(redisReply*) calculation exceeding SIZE_MAX → potential memory corruption
- Risk: Server crash or RCE when KBEngine's Redis integration receives malicious data (session management, caching, etc.)

###How it was fixed

- Patch: Added overflow check in createArrayObject function
- Specific fix: `if (SIZE_MAX / sizeof(redisReply*) < elements) return NULL;`
- Source: Applied patch from hiredis upstream commit [76a7b10](https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e)