### PR TITLE
[Rework] Return back N-ary optimizations for arithmetic-alike expressions

### DIFF
--- a/rules/bitcoin.lua
+++ b/rules/bitcoin.lua
@@ -183,8 +183,9 @@ local btc_bleach_re = [[/\b(?:(?:[a-zA-Z]\w+:)|(?:bc1))?[qpzry9x8gf2tvdw0s3jn54k
 
 config.regexp['BITCOIN_ADDR'] = {
   description = 'Message has a valid bitcoin wallet address',
-  -- Use + operator to ensure that each expression is always evaluated
   re = string.format('(%s) + (%s) > 0', normal_wallet_re, btc_bleach_re),
+  -- Disable optimizations for this expression to get all addresses
+  expression_flags = { 'noopt' },
   re_conditions = {
     [normal_wallet_re] = function(task, txt, s, e)
       local len = e - s

--- a/src/plugins/regexp.c
+++ b/src/plugins/regexp.c
@@ -32,6 +32,7 @@ struct regexp_module_item {
 	struct rspamd_expression *expr;
 	const char *symbol;
 	struct ucl_lua_funcdata *lua_function;
+	int expression_flags;
 };
 
 struct regexp_ctx {
@@ -68,12 +69,53 @@ regexp_get_context(struct rspamd_config *cfg)
 }
 
 /* Process regexp expression */
+static int
+parse_expression_flags(const ucl_object_t *flags_obj)
+{
+	int flags = 0;
+	const ucl_object_t *cur;
+	ucl_object_iter_t it = NULL;
+	const char *flag_name;
+
+	if (!flags_obj) {
+		return 0;
+	}
+
+	if (ucl_object_type(flags_obj) == UCL_ARRAY) {
+		/* Array of flag names */
+		while ((cur = ucl_object_iterate(flags_obj, &it, true)) != NULL) {
+			if (ucl_object_type(cur) == UCL_STRING) {
+				flag_name = ucl_object_tostring(cur);
+				if (strcmp(flag_name, "noopt") == 0) {
+					flags |= RSPAMD_EXPRESSION_FLAG_NOOPT;
+				}
+				else {
+					msg_warn("unknown expression flag: %s", flag_name);
+				}
+			}
+		}
+	}
+	else if (ucl_object_type(flags_obj) == UCL_STRING) {
+		/* Single flag name */
+		flag_name = ucl_object_tostring(flags_obj);
+		if (strcmp(flag_name, "noopt") == 0) {
+			flags |= RSPAMD_EXPRESSION_FLAG_NOOPT;
+		}
+		else {
+			msg_warn("unknown expression flag: %s", flag_name);
+		}
+	}
+
+	return flags;
+}
+
 static gboolean
 read_regexp_expression(rspamd_mempool_t *pool,
 					   struct regexp_module_item *chain,
 					   const char *symbol,
 					   const char *line,
-					   struct rspamd_mime_expr_ud *ud)
+					   struct rspamd_mime_expr_ud *ud,
+					   int expression_flags)
 {
 	struct rspamd_expression *e = NULL;
 	GError *err = NULL;
@@ -90,6 +132,7 @@ read_regexp_expression(rspamd_mempool_t *pool,
 
 	g_assert(e != NULL);
 	chain->expr = e;
+	chain->expression_flags = expression_flags;
 
 	return TRUE;
 }
@@ -165,13 +208,14 @@ int regexp_module_config(struct rspamd_config *cfg, bool validate)
 											 sizeof(struct regexp_module_item));
 			cur_item->symbol = ucl_object_key(value);
 			cur_item->magic = rspamd_regexp_cb_magic;
+			cur_item->expression_flags = 0;
 
 			ud.conf_obj = NULL;
 			ud.cfg = cfg;
 
 			if (!read_regexp_expression(cfg->cfg_pool,
 										cur_item, ucl_object_key(value),
-										ucl_obj_tostring(value), &ud)) {
+										ucl_obj_tostring(value), &ud, 0)) {
 				if (validate) {
 					return FALSE;
 				}
@@ -193,6 +237,7 @@ int regexp_module_config(struct rspamd_config *cfg, bool validate)
 			cur_item->magic = rspamd_regexp_cb_magic;
 			cur_item->symbol = ucl_object_key(value);
 			cur_item->lua_function = ucl_object_toclosure(value);
+			cur_item->expression_flags = 0;
 
 			rspamd_symcache_add_symbol(cfg->cache,
 									   cur_item->symbol,
@@ -225,9 +270,13 @@ int regexp_module_config(struct rspamd_config *cfg, bool validate)
 					ud.cfg = cfg;
 					ud.conf_obj = value;
 
+					/* Look for expression_flags */
+					const ucl_object_t *flags_obj = ucl_object_lookup(value, "expression_flags");
+					int expr_flags = parse_expression_flags(flags_obj);
+
 					if (!read_regexp_expression(cfg->cfg_pool,
 												cur_item, ucl_object_key(value),
-												ucl_obj_tostring(elt), &ud)) {
+												ucl_obj_tostring(elt), &ud, expr_flags)) {
 						if (validate) {
 							return FALSE;
 						}
@@ -253,6 +302,7 @@ int regexp_module_config(struct rspamd_config *cfg, bool validate)
 				cur_item->magic = rspamd_regexp_cb_magic;
 				cur_item->symbol = ucl_object_key(value);
 				cur_item->lua_function = ucl_object_toclosure(value);
+				cur_item->expression_flags = 0;
 			}
 
 			if (cur_item && (is_lua || valid_expression)) {
@@ -548,7 +598,7 @@ process_regexp_item(struct rspamd_task *task,
 	else {
 		/* Process expression */
 		if (item->expr) {
-			res = rspamd_process_expression(item->expr, 0, task);
+			res = rspamd_process_expression(item->expr, item->expression_flags, task);
 		}
 		else {
 			msg_warn_task("FIXME: %s symbol is broken with new expressions",

--- a/src/plugins/regexp.c
+++ b/src/plugins/regexp.c
@@ -15,6 +15,10 @@
  */
 /***MODULE:regexp
  * rspamd module that implements different regexp rules
+ *
+ * For object-based configuration, you can specify:
+ * - `expression_flags`: array of strings or single string with expression flags
+ *   - `"noopt"`: disable expression optimizations (useful for some SpamAssassin rules)
  */
 
 
@@ -267,6 +271,7 @@ int regexp_module_config(struct rspamd_config *cfg, bool validate)
 													 sizeof(struct regexp_module_item));
 					cur_item->symbol = ucl_object_key(value);
 					cur_item->magic = rspamd_regexp_cb_magic;
+					cur_item->expression_flags = 0; /* Will be overwritten with parsed flags */
 					ud.cfg = cfg;
 					ud.conf_obj = value;
 


### PR DESCRIPTION
## Breaking Change: Restoration of N-ary Expression Optimizations

### Summary

This change restores arithmetic expression optimizations for N-ary operations (like `+`, `*`, `&`, `|`) that were previously removed. The optimization allows expressions to short-circuit evaluation when the result can be determined early, significantly improving performance for rules with multiple operands.

### What Changed

**Before:** Expressions like `A + B + C + D > 2` would evaluate all operands (A, B, C, D) regardless of intermediate results.

**After:** The same expression will stop evaluating once the sum exceeds the threshold. For example, if `A=1`, `B=1`, `C=1`, the expression stops at C since `1+1+1 > 2` is already true, and D is never evaluated.

### Impact on Existing Rules

Some existing rules were written with the assumption that **all** operands would be evaluated, even when the result could be determined earlier. These rules may now behave differently and could potentially:

1. **Miss expected matches** if they relied on side effects from evaluating all operands
2. **Change scoring behavior** if they expected certain atoms to always be processed
3. **Break test cases** that were written expecting the non-optimized behavior

### Migration Path

For rules that require the old behavior (evaluating all operands), you can now disable optimizations using the new `expression_flags` parameter:

```lua
regexp = {
  -- Rule that needs all operands evaluated
  MY_RULE = {
    regexp = "A + B + C + D > 2",
    expression_flags = {"noopt"}, -- Disable optimizations
    description = "Rule requiring evaluation of all operands",
  },
  
  -- Normal rule with optimizations (default)
  NORMAL_RULE = {
    regexp = "X + Y + Z > 1",
    description = "Optimized rule (default behavior)",
  },
}
```

### Performance Benefits

Rules that can use the optimizations will see significant performance improvements:
- **Faster evaluation** for expressions with many operands
- **Reduced CPU usage** when early termination is possible
- **Better scalability** for complex rule sets

### Identifying Affected Rules

Rules most likely to be affected are those that:
- Use arithmetic operations (`+`, `*`) with comparison operators (`>`, `>=`, `<`, `<=`, `==`, `!=`)
- Have multiple operands that perform expensive operations
- Were written or tested expecting all operands to be evaluated

### Testing Recommendations

1. **Review rule behavior** after upgrading, especially for rules with arithmetic expressions
2. **Check test cases** that may have been written expecting non-optimized behavior
3. **Monitor rule effectiveness** to ensure expected matches are still occurring
4. **Add `expression_flags = {"noopt"}` to rules** that require the old behavior

This change represents a significant performance improvement while maintaining backward compatibility through the `expression_flags` mechanism.