### PR TITLE
"ftp://ftp.arin.net" is not reachable anymore, replaced by HTTP URL

### DIFF
--- a/utils/asn.pl
+++ b/utils/asn.pl
@@ -17,7 +17,7 @@ use URI;
 
 my %config = (
   asn_sources => [
-    'ftp://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest',
+    'https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest',
     'ftp://ftp.ripe.net/ripe/stats/delegated-ripencc-latest',
     'http://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-latest',
     'ftp://ftp.apnic.net/pub/stats/apnic/delegated-apnic-latest',


### PR DESCRIPTION
```
$ ftp ftp.arin.net
Trying 199.5.26.151:21 ...
ftp: Can't connect to `199.5.26.151:21': Connection refused 
Trying 199.71.0.151:21 ...
ftp: Can't connect to `199.71.0.151:21': Connection refused 
Trying 199.212.0.151:21 ...
ftp: Can't connect to `199.212.0.151:21': Connection refused
```