### PR TITLE
Update GPT plugin to support OpenAI GPT-5 and other newer models

### DIFF
--- a/src/plugins/lua/gpt.lua
+++ b/src/plugins/lua/gpt.lua
@@ -716,7 +716,7 @@ local function openai_check(task, content, sel_part)
     return true
   end
     
-  local body = {
+  local body_base = {
     model = settings.model,
     messages = {
       {
@@ -741,21 +741,7 @@ local function openai_check(task, content, sel_part)
       }
     }
   }
-
-  -- Set the correct token limit field
-  local token_field = get_max_tokens_field(settings.model)
-  body[token_field] = settings.max_tokens
-
-  -- Set the temperature field if model supports it
-  if supports_temperature(settings.model) then
-    body.temperature = settings.temperature
-  end
-
-  -- Conditionally add response_format
-  if settings.include_response_format then
-    body.response_format = { type = "json_object" }
-  end
-
+  
   if type(settings.model) == 'string' then
     settings.model = { settings.model }
   end
@@ -766,6 +752,21 @@ local function openai_check(task, content, sel_part)
       success = false,
       checked = false
     }
+    local body = body_base
+    -- Set the correct token limit field
+    local token_field = get_max_tokens_field(model)
+    body[token_field] = settings.max_tokens
+
+    -- Set the temperature field if model supports it
+    if supports_temperature(model) then
+      body.temperature = settings.temperature
+    end 
+
+    -- Conditionally add response_format
+    if settings.include_response_format then
+      body.response_format = { type = "json_object" }
+    end
+
     body.model = model
     local http_params = {
       url = settings.url,

--- a/src/plugins/lua/gpt.lua
+++ b/src/plugins/lua/gpt.lua
@@ -717,7 +717,6 @@ local function openai_check(task, content, sel_part)
   end
     
   local body_base = {
-    model = settings.model,
     messages = {
       {
         role = 'system',


### PR DESCRIPTION
OpenAI GPT-5 family and some other models has changed attribute max_tokens into max_completion_tokens. Also attribute temperature isn't supported anymore. For each parallel model request, if configured multiple models, the attributes are now set correctly.