### PR TITLE
Updated gpt.lua to fix issue with the reason_header is not ASCII

### DIFF
--- a/src/plugins/lua/gpt.lua
+++ b/src/plugins/lua/gpt.lua
@@ -1007,14 +1007,14 @@ if opts then
     if settings.extra_symbols then
       settings.prompt = "Analyze this email strictly as a spam detector given the email message, subject, " ..
           "FROM and url domains. Evaluate spam probability (0-1). " ..
-          "Output ONLY 3 lines:\n" ..
+          "Output ONLY 3 lines containing only ASCII characters:\n" ..
           "1. Numeric score (0.00-1.00)\n" ..
           "2. One-sentence reason citing whether it is spam, the strongest red flag, or why it is ham\n" ..
           "3. Primary concern category if found from the list: " .. table.concat(lua_util.keys(categories_map), ', ')
     else
       settings.prompt = "Analyze this email strictly as a spam detector given the email message, subject, " ..
           "FROM and url domains. Evaluate spam probability (0-1). " ..
-          "Output ONLY 2 lines:\n" ..
+          "Output ONLY 2 lines containing only ASCII characters:\n" ..
           "1. Numeric score (0.00-1.00)\n" ..
           "2. One-sentence reason citing whether it is spam, the strongest red flag, or why it is ham\n"
     end


### PR DESCRIPTION
When GPT responding reason, it contains often UTF8 characters. This results into issues when sending these messages to mail servers not supporting SMTPUTF8. reason_header should be in ASCII only to support any mailserver.

Fixed by requesting GPT to answer back only in ASCII.