### PR TITLE
[Fix] fix error check in lua_dkim_tools.lua

### DIFF
--- a/lualib/lua_dkim_tools.lua
+++ b/lualib/lua_dkim_tools.lua
@@ -678,7 +678,7 @@ exports.sign_using_vault = function(N, task, settings, selector, sign_func, err_
             nvalid = nvalid + 1
             sign_func(task, dkim_sign_data)
           end, fun.filter(is_selector_valid, elts))
-          for _, e in errs do
+          for _, e in ipairs(errs) do
             lua_util.debugm(N, task, 'error found during processing Vault selectors: %s:%s',
               e[1], e[2])
           end


### PR DESCRIPTION
### Problem

When using rspamd to DKIM sign messages using vault, I get the following error/warning in the logs:

```
2025-08-20 07:08:18 #367466(normal) lua_http_finish_handler: callback call failed: /usr/share/rspamd/lualib/lua_dkim_tools.lua:682: attempt to call a table value
```

The message is signed correctly, it's just the warning that's a bit confusing.

### Probable Root Cause

In [lua_dkim_tools.lua](https://github.com/rspamd/rspamd/blob/72b92615375316044898a075ed36ef05a58071bf/lualib/lua_dkim_tools.lua) on [around line 682](https://github.com/rspamd/rspamd/blob/72b92615375316044898a075ed36ef05a58071bf/lualib/lua_dkim_tools.lua#L681) we check `errs` using

```lua
          for _, e in errs do
            lua_util.debugm(N, task, 'error found during processing Vault selectors: %s:%s',
              e[1], e[2])
          end
```

`errs` is populated like this:

```lua
table.insert(errs, { "missing key/selector", p })
```

I assume we are missing a `ipairs` in the `for` loop

### Setup

```
root@server:/etc/rspamd$ grep PRETTY_NAME= /etc/os-release 
PRETTY_NAME="Rocky Linux 9.6 (Blue Onyx)"
```

```
root@server:/etc/rspamd$ rpm -qa|grep rspamd
rspamd-3.12.1-1.el9.x86_64
```

```
root@server:/etc/rspamd$ cat /etc/rspamd/local.d/dkim_signing.conf
# Warning: File is managed by Ansible
use_vault = true;
allow_username_mismatch = true;
use_esld = false;
vault_domains = false; # check vault for dkim enabled domains
vault_url = "http://127.0.10.10:8100";
vault_token = "PLACEHOLDER" # will be injected by vault proxy
vault_path = "kv_rspamd/data/rspamd"
```

