### PR TITLE
[Minor] Minor RBL pipeline fixes

### DIFF
--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -936,8 +936,8 @@ local function gen_rbl_callback(rule)
     for i, f in ipairs(pipeline) do
       if not f(task, dns_req, whitelist) then
         lua_util.debugm(N, task,
-            "skip rbl check: %s; pipeline condition %s returned false",
-            rule.symbol, i)
+            "skip rbl check: %s; pipeline condition %s (%s) returned false",
+            rule.symbol, i, description[i])
         return
       end
     end

--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -857,7 +857,9 @@ local function gen_rbl_callback(rule)
     check_required_symbols -- if we have require_symbols then check those symbols
   }
   local description = {
+    'allowed',
     'alive',
+    'required_symbols',
   }
 
   if rule.exclude_users then


### PR DESCRIPTION
The `descriptions` array was missing some entries compared to the current `pipeline` .

Also included the `description` on the `pipeline returned false` message, to aid debugging.