### PR TITLE
[Fix] Use C++20 standard consistently to resolve ODR violations

### DIFF
--- a/contrib/backward-cpp/CMakeLists.txt
+++ b/contrib/backward-cpp/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 # set CXX standard
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 if (${COMPILER_IS_NVCC})
   # GNU CXX extensions are not supported by nvcc
   set(CMAKE_CXX_EXTENSIONS OFF)

--- a/contrib/simdutf/cmake/simdutf-flags.cmake
+++ b/contrib/simdutf/cmake/simdutf-flags.cmake
@@ -18,7 +18,7 @@ endif()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
 # We compile tools, tests, etc. with C++ 11. Override yourself if you need on a target.
-set(SIMDUTF_CXX_STANDARD 11 CACHE STRING "the C++ standard to use for simdutf")
+set(SIMDUTF_CXX_STANDARD 20 CACHE STRING "the C++ standard to use for simdutf")
 
 set(CMAKE_CXX_STANDARD ${SIMDUTF_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
This commit resolves an ODR violations when compiling with -flto and -Werror=odr [1]. The main project used a newer C++20 standard, while the backward-cpp and simdutf libraries used an older C++11 standard. This difference caused the linker to fail.

Setting C++20 standard in both libraries resolves the ODR issue.

Link: https://bugs.gentoo.org/962041 [1]