### PR TITLE
Fix score calculation for dcc  - Fixes #5451

### DIFF
--- a/lualib/lua_scanners/dcc.lua
+++ b/lualib/lua_scanners/dcc.lua
@@ -223,7 +223,7 @@ local function dcc_check(task, content, digest, rule)
 
               if rnum and rnum >= lim then
                 opts[#opts + 1] = string.format('%s=%s', what, num)
-                score = score * rep
+                score = score + (rep / 3.0)
               end
             end
 


### PR DESCRIPTION
As reported in #5451 , score calculation for DCC is wrong since #5161 .

This PR reverts a line of the previous patch. In fact, the local variable `score` is an accumulator of 3 components, hence it starts at 0 and is added by thirds.