### PR TITLE
some FHS fixes for Run-time variable data

### DIFF
--- a/cmake/Paths.cmake
+++ b/cmake/Paths.cmake
@@ -19,7 +19,7 @@ IF(NOT MANDIR)
 ENDIF(NOT MANDIR)
 
 IF(NOT RUNDIR)
-    SET(RUNDIR "/var/run/rspamd")
+    SET(RUNDIR "/run/rspamd")
 ENDIF(NOT RUNDIR)
 
 IF(NOT DBDIR)

--- a/conf/options.inc
+++ b/conf/options.inc
@@ -44,7 +44,7 @@ classify_headers = [
 	"X-MimeOLE",
 ];
 
-control_socket = "$DBDIR/rspamd.sock mode=0600";
+control_socket = "$RUNDIR/rspamd.sock mode=0600";
 history_rows = 200;
 explicit_modules = ["settings", "bayes_expiry"];
 

--- a/rspamd.service
+++ b/rspamd.service
@@ -6,7 +6,8 @@ Documentation=https://rspamd.com/doc/
 [Service]
 LimitNOFILE=1048576
 NonBlocking=true
-ExecStart=/usr/bin/rspamd -c /etc/rspamd/rspamd.conf -f
+PIDFile=/run/rspamd/rspamd.pid
+ExecStart=/usr/bin/rspamd -c /etc/rspamd/rspamd.conf
 ExecReload=/bin/kill -HUP $MAINPID
 User=_rspamd
 RuntimeDirectory=rspamd

--- a/src/rspamadm/control.c
+++ b/src/rspamadm/control.c
@@ -25,7 +25,7 @@
 #include "libutil/util.h"
 #include "lua/lua_common.h"
 
-static char *control_path = RSPAMD_DBDIR "/rspamd.sock";
+static char *control_path = RSPAMD_RUNDIR "/rspamd.sock";
 static gboolean json = FALSE;
 static gboolean ucl = TRUE;
 static gboolean compact = FALSE;
@@ -75,7 +75,7 @@ rspamadm_control_help(gboolean full_help, const struct rspamadm_command *cmd)
 				   "-c: output compacted json\n"
 				   "-j: output linted json\n"
 				   "-u: output ucl (default)\n"
-				   "-s: use the following socket instead of " RSPAMD_DBDIR "/rspamd.sock\n"
+				   "-s: use the following socket instead of " RSPAMD_RUNDIR "/rspamd.sock\n"
 				   "-t: set IO timeout (1.0 seconds default)\n"
 				   "--help: shows available options and commands\n\n"
 				   "Supported commands:\n"


### PR DESCRIPTION
- socket should reside in **RUNDIR** not **DBDIR**
- don't start rspamd with **-f** in systemd service