### PR TITLE
Lua: Add index to rspamd_config and symbol proxy to enable piecewise symbol updates

### DIFF
--- a/src/lua/lua_common.c
+++ b/src/lua/lua_common.c
@@ -105,6 +105,7 @@ void rspamd_lua_new_class(lua_State *L,
 	lua_createtable(L, 0, 3 + nmethods);
 
 	if (!seen_index) {
+		/* Default __index = metatable only for plain classes without custom __index */
 		lua_pushstring(L, "__index");
 		lua_pushvalue(L, -2); /* pushes the metatable */
 		lua_settable(L, -3);  /* metatable.__index = metatable */


### PR DESCRIPTION
### Summary
This PR introduces an __index metamethod for `rspamd_config` that returns a symbol proxy userdata, enabling safe, piecewise updates like `rspamd_config.SYM.condition = ...` or `rspamd_config.SYM.score = ...`. Previously, only `__newindex` existed, so `rspamd_config.SYM` could not be read or modified incrementally. As part of this change, I refactored `rules/headers_checks.lua` to avoid direct in-place modification of `rspamd_config` and instead build local tables first.

### Motivation
- Allow users and modules to override specific symbol fields (e.g. `condition`, `score`, `group`) without re-declaring the whole symbol.
- Preserve compatibility with existing table-based registration.
- Align Lua API ergonomics with typical Lua patterns for configuration objects.

### What’s new
- `rspamd_config.__index` now returns a proxy object for any key (symbol name).
- The symbol proxy supports:
  - Reading: `name`, `score`, `description`, `group`, `nshots`.
  - Writing:
    - `condition = function(task) ... end` (added via delayed condition in symcache)
    - `callback = function(task) ... end` (registers or replaces a Lua callback)
    - Metric fields: `score`, `description`, `group`, `nshots`, `one_shot`, `one_param`, `flags`, `priority`, `groups`
    - Extras: `augmentations`, `allowed_ids`, `forbidden_ids`
- New class registered: `rspamd{config_symbol_proxy}`.
- `rules/headers_checks.lua`: symbols are now built as locals, conditionally amended, then assigned to `rspamd_config` at the end (avoids indexing issues).

### Usage examples
```lua
-- Add or replace condition
rspamd_config.MY_RULE.condition = function(task) return task:has_header("X-My-Flag") end

-- Replace callback
rspamd_config.MY_RULE.callback = function(task) return true end

-- Change metric properties
rspamd_config.MY_RULE.score = 1.5
rspamd_config.MY_RULE.description = "My rule"
rspamd_config.MY_RULE.group = "headers"
rspamd_config.MY_RULE.nshots = 1
rspamd_config.MY_RULE.flags = {"one_param"}

-- Still works: full-table registration
rspamd_config.MY_RULE = {
  callback = function(task) return true end,
  score = 1.0,
  group = "headers",
}
```

### Backward compatibility
- Table assignment (`rspamd_config.SYM = {...}`) remains supported and unchanged.
- Potential behavior change: reading `rspamd_config.SYM` now returns a proxy instead of `nil`. If you need to test existence, prefer `rspamd_config:get_symbol("SYM")` or `rspamd_config:get_symbol_callback("SYM")`.

### Implementation details
- Files: `src/lua/lua_config.c`, `src/lua/lua_common.c`, `rules/headers_checks.lua`
- Added:
  - `lua_config_index` (metamethod)
  - `lua_symbol_proxy_index`, `lua_symbol_proxy_newindex`
  - Registration of `rspamd{config_symbol_proxy}` in `luaopen_config`
- The proxy updates config via existing C APIs:
  - Metric updates: `rspamd_config_add_symbol`, `rspamd_config_add_symbol_group`
  - Conditions and IDs: `rspamd_symcache_add_condition_delayed`, `rspamd_symcache_set_allowed_settings_ids`, `rspamd_symcache_set_forbidden_settings_ids`
  - Callback replacement uses `rspamd_symcache_get_cbdata` with Lua ref management

### Testing and validation
- Lua linter: no new linter errors.
- Verified table-based registration continues to work.
- Verified piecewise updates for conditions, callbacks, and metric fields.

### Risks
- Scripts that previously relied on `rspamd_config.SOMETHING == nil` may need to switch to `rspamd_config:get_symbol("SOMETHING")` to check existence explicitly.
