### PR TITLE
Fix duplicate symbol in once_received plugin

### DIFF
--- a/src/plugins/lua/once_received.lua
+++ b/src/plugins/lua/once_received.lua
@@ -88,7 +88,7 @@ local function check_quantity_received (task)
       for _, h in ipairs(bad_hosts) do
         if string.find(hn, h) then
           task:insert_result(symbol_strict, 1, h)
-          break
+          return
         end
       end
     end


### PR DESCRIPTION
Fix `once_received` plugin to add `ONCE_RECEIVED_STRICT` only once by changing `break` to `return` in `check_quantity_received`.

---
Linear Issue: [RSP-268](https://linear.app/rspamd/issue/RSP-268/bug-once-received-plugin-adds-once-received-strict-several-times)

<a href="https://cursor.com/background-agent?bcId=bc-0c8fea1f-f16f-48f6-bf73-1ea8c5a0cee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c8fea1f-f16f-48f6-bf73-1ea8c5a0cee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

