### PR TITLE
Fix duplicate symbol in once_received plugin

### DIFF
--- a/src/plugins/lua/once_received.lua
+++ b/src/plugins/lua/once_received.lua
@@ -92,6 +92,7 @@ local function check_quantity_received (task)
         end
       end
     end
+    return
   end
 
   if nreceived <= 1 then
@@ -120,16 +121,6 @@ local function check_quantity_received (task)
       if symbol_strict then
         -- Unresolved host
         task:insert_result(symbol, 1)
-
-        if not hn then
-          return
-        end
-        for _, h in ipairs(bad_hosts) do
-          if string.find(hn, h) then
-            task:insert_result(symbol_strict, 1, h)
-            return
-          end
-        end
       else
         task:insert_result(symbol, 1)
       end


### PR DESCRIPTION
Prevent duplicate `ONCE_RECEIVED_STRICT` symbol insertion by refactoring logic in `check_quantity_received`.

The `check_quantity_received` function contained duplicate logic for handling `nreceived <= 1` when a hostname was present. This led to `ONCE_RECEIVED` and `ONCE_RECEIVED_STRICT` symbols being inserted twice. The fix adds a `return` statement after the initial hostname check and removes the redundant symbol insertion logic from a subsequent block, ensuring symbols are added only once.

---
Linear Issue: [RSP-268](https://linear.app/rspamd/issue/RSP-268/bug-once-received-plugin-adds-once-received-strict-several-times)

<a href="https://cursor.com/background-agent?bcId=bc-94ba3f42-d6c2-47bb-8acb-5c0c8d039fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94ba3f42-d6c2-47bb-8acb-5c0c8d039fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

