### PR TITLE
Fix dkim relaxed bodyhash calculation for spaces

### DIFF
--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -2178,11 +2178,16 @@ rspamd_dkim_skip_empty_lines(struct rspamd_task *task, struct rspamd_dkim_common
 		case test_spaces:
 			t = p - skip;
 
-			while (t >= start + 2 && (*t == ' ' || *t == '\t')) {
+			while (t >= start && (*t == ' ' || *t == '\t')) {
 				t--;
 			}
 
-			if (*t == '\r') {
+			if (t < start) {
+				/* The entire line (or body) is only spaces - treat as empty */
+				p = start - 1;
+				goto end;
+			}
+			else if (*t == '\r') {
 				p = t;
 				state = got_cr;
 			}


### PR DESCRIPTION
Fix DKIM relaxed body canonicalization to correctly handle lines with only whitespace.

Previously, rspamd would not properly treat lines consisting solely of spaces as empty lines during relaxed body canonicalization, leading to bodyhash mismatches. This update ensures compliance with RFC 6376 Section 3.4.4, which specifies that trailing whitespace and empty lines at the end of the body should be ignored. This aligns rspamd's behavior with other DKIM verifiers like OpenDKIM, Gmail, and Microsoft.

---
Linear Issue: [RSP-259](https://linear.app/rspamd/issue/RSP-259/bug-dkim-bodyhash-bh-calculation-fails-in-relaxed-mode-because-of)

<a href="https://cursor.com/background-agent?bcId=bc-75236946-6432-4471-a23f-58c9a67bfb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75236946-6432-4471-a23f-58c9a67bfb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

