### PR TITLE
[Feature] Add separate encryption keys for read/write operations in fuzzy_check

### DIFF
--- a/lualib/rspamadm/fuzzy_ping.lua
+++ b/lualib/rspamadm/fuzzy_ping.lua
@@ -87,7 +87,17 @@ local function print_storages(rules)
   for n, rule in pairs(rules) do
     print(highlight('Rule: %s', n))
     print(string.format("\tRead only: %s", rule.read_only))
-    print(string.format("\tServers: %s", table.concat(lua_util.values(rule.servers), ',')))
+    -- Handle both unified servers and separate read/write servers
+    if rule.servers then
+      print(string.format("\tServers: %s", table.concat(lua_util.values(rule.servers), ',')))
+    else
+      if rule.read_servers then
+        print(string.format("\tRead servers: %s", table.concat(lua_util.values(rule.read_servers), ',')))
+      end
+      if rule.write_servers then
+        print(string.format("\tWrite servers: %s", table.concat(lua_util.values(rule.write_servers), ',')))
+      end
+    end
     print("\tFlags:")
 
     for fl, id in pairs(rule.flags or E) do

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -2537,6 +2537,7 @@ fuzzy_process_reply(unsigned char **pos, int *r, GPtrArray *req,
 				/* Successfully decrypted */
 				memcpy(&encrep, &encrep_copy, sizeof(encrep));
 				decrypted = TRUE;
+				break;
 			}
 		}
 

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -2476,20 +2476,35 @@ fuzzy_process_reply(unsigned char **pos, int *r, GPtrArray *req,
 			peer_keys[nkeys] = rule->read_peer_key;
 			nkeys++;
 		}
-		/* Then try write keys */
-		if (rule->write_peer_key && rule->write_local_key &&
-			(rule->write_peer_key != rule->read_peer_key)) {
-			local_keys[nkeys] = rule->write_local_key;
-			peer_keys[nkeys] = rule->write_peer_key;
-			nkeys++;
+		/* Then try write keys if not already added */
+		if (rule->write_peer_key && rule->write_local_key) {
+			gboolean already_added = FALSE;
+			for (int j = 0; j < nkeys; j++) {
+				if (peer_keys[j] == rule->write_peer_key) {
+					already_added = TRUE;
+					break;
+				}
+			}
+			if (!already_added) {
+				local_keys[nkeys] = rule->write_local_key;
+				peer_keys[nkeys] = rule->write_peer_key;
+				nkeys++;
+			}
 		}
-		/* Finally try common keys if they differ from specific ones */
-		if (rule->peer_key && rule->local_key &&
-			(rule->peer_key != rule->read_peer_key) &&
-			(rule->peer_key != rule->write_peer_key)) {
-			local_keys[nkeys] = rule->local_key;
-			peer_keys[nkeys] = rule->peer_key;
-			nkeys++;
+		/* Finally try common keys if not already added */
+		if (rule->peer_key && rule->local_key) {
+			gboolean already_added = FALSE;
+			for (int j = 0; j < nkeys; j++) {
+				if (peer_keys[j] == rule->peer_key) {
+					already_added = TRUE;
+					break;
+				}
+			}
+			if (!already_added) {
+				local_keys[nkeys] = rule->local_key;
+				peer_keys[nkeys] = rule->peer_key;
+				nkeys++;
+			}
 		}
 
 		/* Try decryption with each key pair */


### PR DESCRIPTION
## Description

This PR adds support for using separate encryption keys for read and write operations in the fuzzy_check plugin.

## Changes

- Added new fields to `fuzzy_rule` structure for separate read/write encryption keys
- Added configuration parameters: `read_encryption_key` and `write_encryption_key`
- Modified `fuzzy_encrypt_cmd()` to accept keys as parameters
- Updated all command generation functions to select appropriate keys based on operation type:
  - **Read operations**: FUZZY_CHECK, FUZZY_STAT, FUZZY_PING
  - **Write operations**: FUZZY_WRITE, FUZZY_DEL
- Updated `fuzzy_free_rule()` to properly free new key structures
- Added configuration documentation for new parameters

## Backward Compatibility

Fully backward compatible. If `read_encryption_key` or `write_encryption_key` are not specified, the common `encryption_key` parameter is used for both operations.

## Use Case

This feature is useful when you have different encryption keys for read-only fuzzy servers and write servers, allowing better security separation between read and write operations.

## Example Configuration

```conf
fuzzy_check {
    rule {
        my_storage {
            read_servers = "fuzzy-read.example.com:11335";
            write_servers = "fuzzy-write.example.com:11335";
            
            # Use different keys for different operations
            read_encryption_key = "read_key_base32_encoded";
            write_encryption_key = "write_key_base32_encoded";
            
            # ... other parameters ...
        }
    }
}
```
