### PR TITLE
Set headers in DMARC reports to prevent out-of-office replies

### DIFF
--- a/lualib/rspamadm/dmarc_report.lua
+++ b/lualib/rspamadm/dmarc_report.lua
@@ -66,6 +66,9 @@ MIME-Version: 1.0
 Message-ID: <{= message_id =}>
 Content-Type: multipart/mixed;
 	boundary="----=_NextPart_{= uuid =}"
+Auto-Submitted: auto-generated
+Precedence: bulk
+X-Auto-Response-Suppress: All
 
 This is a multipart message in MIME format.
 


### PR DESCRIPTION
To prevent out-of-office-replies, vacation-replies or similar, we should set a few headers in DMARC report mails, which seems to be best-practice for these types of system-generated mails.