### PR TITLE
Add missing parameters to documentation of rspamd_config:register_symbol function

### DIFF
--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -227,6 +227,9 @@ LUA_FUNCTION_DEF(config, get_classifier);
  *   + `explicit_disable` requires explicit disabling (e.g. via settings)
  *   + `ignore_passthrough` executed even if passthrough result has been set
  * - `parent`: id of parent symbol (useful for virtual symbols)
+ * - `score`: default score of the symbol
+ * - `description`: description of the symbol
+ * - `group`: group of the symbol (ungrouped if missing)
  *
  * @return {number} id of symbol registered
  */


### PR DESCRIPTION
There are some parameters missing in the [Documentation](https://docs.rspamd.com/lua/rspamd_config#m41f8b) of the `rspamd_config:register_symbol` function.

I tried to use the added parameters and they were working.