### PR TITLE
[Fix] Fix TCP DNS uninitialized memory leak

### DIFF
--- a/contrib/librdns/resolver.c
+++ b/contrib/librdns/resolver.c
@@ -473,7 +473,7 @@ rdns_reschedule_req_over_tcp(struct rdns_request *req, struct rdns_server *serv)
 
 		struct rdns_tcp_output_chain *oc;
 
-		oc = calloc(1, sizeof(*oc) + req->packet_len);
+		oc = calloc(1, sizeof(*oc) + req->pos);
 
 		if (oc == NULL) {
 			rdns_err("failed to allocate output buffer for TCP ioc: %s",
@@ -482,8 +482,8 @@ rdns_reschedule_req_over_tcp(struct rdns_request *req, struct rdns_server *serv)
 		}
 
 		oc->write_buf = ((unsigned char *) oc) + sizeof(*oc);
-		memcpy(oc->write_buf, req->packet, req->packet_len);
-		oc->next_write_size = htons(req->packet_len);
+		memcpy(oc->write_buf, req->packet, req->pos);
+		oc->next_write_size = htons(req->pos);
 
 		DL_APPEND(ioc->tcp->output_chain, oc);
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in librdns where uninitialized memory was being sent in TCP DNS requests.

## Problem

When a DNS request is rescheduled from UDP to TCP (e.g., when the response is truncated), the `rdns_reschedule_req_over_tcp` function was using `req->packet_len` instead of `req->pos` to determine how much data to copy and send.

- `req->packet_len` is the **allocated buffer size** (includes extra space for EDNS0, etc.)
- `req->pos` is the **actual packet size** (only the data that was written)

This caused random garbage from uninitialized heap memory to be appended to TCP DNS queries.

## Impact

The bug was particularly noticeable with short queries like TXT records, where:
- Allocated buffer: `namelen + 96 + 2 + 4 + 11` bytes
- Actual packet: typically 2-3x smaller
- Difference: filled with random heap garbage

## Changes

Fixed three instances in `contrib/librdns/resolver.c` where `req->packet_len` was incorrectly used:
1. Line 476: Buffer allocation size
2. Line 485: `memcpy` length  
3. Line 486: TCP packet size header

All three now correctly use `req->pos` to only copy and send the actual packet data.

## Testing

This fix ensures TCP DNS requests contain only valid DNS packet data without trailing garbage bytes.