### PR TITLE
Fix rspamd nameserver round robin

### DIFF
--- a/src/libserver/dns.c
+++ b/src/libserver/dns.c
@@ -910,7 +910,7 @@ rspamd_dns_resolver_init(rspamd_logger_t *logger,
 			rspamd_upstreams_set_flags(dns_resolver->ups,
 									   RSPAMD_UPSTREAM_FLAG_DNS);
 			rspamd_upstreams_set_rotation(dns_resolver->ups,
-										  RSPAMD_UPSTREAM_MASTER_SLAVE);
+										  RSPAMD_UPSTREAM_ROUND_ROBIN);
 
 			if (!rdns_resolver_parse_resolv_conf_cb(dns_resolver->r,
 													"/etc/resolv.conf",


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-47193b34-5af0-4fa4-9113-c2eaa35f249a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-47193b34-5af0-4fa4-9113-c2eaa35f249a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

