### PR TITLE
[Feature] Add/improve BSD build workflows with Lua version selection

### DIFF
--- a/.github/workflows/freebsd_build.yml
+++ b/.github/workflows/freebsd_build.yml
@@ -98,7 +98,7 @@ jobs:
 
             # Build
             echo "==> Building Rspamd"
-            ninja -j$(sysctl -n hw.ncpu)
+            ninja
 
             # Run tests
             echo "==> Running C++ unit tests"

--- a/.github/workflows/netbsd_build.yml
+++ b/.github/workflows/netbsd_build.yml
@@ -105,7 +105,7 @@ jobs:
 
             # Build
             echo "==> Building Rspamd"
-            ninja -j$(sysctl -n hw.ncpu)
+            ninja
 
             # Run tests
             echo "==> Running C++ unit tests"

--- a/.github/workflows/openbsd_build.yml
+++ b/.github/workflows/openbsd_build.yml
@@ -92,7 +92,7 @@ jobs:
 
             # Build
             echo "==> Building Rspamd"
-            ninja -j$(sysctl -n hw.ncpu)
+            ninja
 
             # Run tests
             echo "==> Running C++ unit tests"


### PR DESCRIPTION
## Summary

This PR adds comprehensive GitHub Actions workflows for BSD systems with the ability to select different Lua versions during testing.

## Changes

### NetBSD Workflow Improvements

**Fixed issues:**
- Added missing dependencies: `libarchive`, `zstd`, `xxhash`, `file`
- Removed `|| true` from `pkg_add` to catch installation failures
- Fixed test executable paths (added `./` prefix)
- Added NetBSD 9.4 to supported versions

**New features:**
- Lua version selection: LuaJIT, Lua 5.1, 5.3, 5.4
- Proper CMake flags:
  - `-DENABLE_HYPERSCAN=OFF` (not available on NetBSD)
  - `-DSYSTEM_ZSTD=ON` and `-DSYSTEM_XXHASH=ON`
  - Conditional `-DENABLE_LUAJIT` based on selected version

### New FreeBSD Workflow

**Supported versions:** FreeBSD 14.2, 13.4, 13.3

**Features:**
- Lua version selection: LuaJIT, Lua 5.1, 5.3, 5.4
- Full dependency list including `hyperscan`
- CMake flags:
  - `-DENABLE_HYPERSCAN=ON` (available on FreeBSD)
  - `-DSYSTEM_ZSTD=ON` and `-DSYSTEM_XXHASH=ON`
- Proper `pkg update` before package installation

### New OpenBSD Workflow

**Supported versions:** OpenBSD 7.6, 7.5, 7.4

**Features:**
- Lua version selection: LuaJIT, Lua 5.1, 5.3
- Full dependency list including `hyperscan`
- OpenBSD-specific package names: `icu4c`, `perl-5`, `lua%5.x`
- CMake flags:
  - `-DENABLE_HYPERSCAN=ON`
  - `-DENABLE_JEMALLOC=OFF` (OpenBSD uses system allocator)
  - `-DSYSTEM_ZSTD=ON` and `-DSYSTEM_XXHASH=ON`

## Testing

All workflows use:
- `workflow_dispatch` trigger for manual execution
- `vmactions` for BSD VM testing
- Ninja build system for faster compilation
- Both C++ and Lua unit tests

## Benefits

1. **Comprehensive BSD coverage**: Tests on NetBSD, FreeBSD, and OpenBSD
2. **Lua version testing**: Ensures compatibility with different Lua versions
3. **Multiple OS versions**: Tests on current and previous releases
4. **Better debugging**: Removed silent failures, added proper error handling
5. **Complete dependencies**: Fixed missing packages that caused build failures

## Manual Testing

These workflows can be triggered manually from GitHub Actions tab:
1. Go to Actions → Select workflow (NetBSD/FreeBSD/OpenBSD Build)
2. Click "Run workflow"
3. Select desired OS version and Lua version
4. Click "Run workflow" button

Would appreciate testing on actual BSD systems to verify package names and availability.