### PR TITLE
[Fix] Add batching and forced GC for Redis connections in dmarc_report

### DIFF
--- a/lualib/rspamadm/dmarc_report.lua
+++ b/lualib/rspamadm/dmarc_report.lua
@@ -624,10 +624,8 @@ local function process_report_date(opts, start_time, end_time, date)
       end
     end
 
-    -- Force garbage collection between batches to release Redis connections
-    if batch_end < #results then
-      collectgarbage("collect")
-    end
+    -- Force garbage collection after each batch to release Redis connections
+    collectgarbage("collect")
   end
 
   -- Shuffle reports to make sending more fair


### PR DESCRIPTION
Fixes Redis connection exhaustion in `rspamadm dmarc_report` when processing large numbers of domains.

## Root Cause
The coroutine version of `lua_redis.request()` creates connections that are only released when Lua garbage collector runs. In tight loops processing hundreds of domains, GC doesn't run frequently enough, causing connection pool exhaustion.

Technical details:
- `lua_redis.connect_sync()` + `conn:exec()` returns connection objects to Lua
- Connections rely on `__gc` metamethod to call `rspamd_redis_pool_release_connection()`
- Without explicit GC, connections pile up in memory until GC triggers naturally

## Solution
- Process reports in batches (reuses existing `--batch-size` option, default 10)
- Force `collectgarbage("collect")` between batches to trigger `__gc`
- Ensures connections are properly released back to the pool

## Impact
Each `prepare_report()` makes 3-4 Redis requests (EXISTS, RENAME, ZRANGE, DEL). With hundreds of domains, this previously created hundreds of parallel connections that never got returned. Now connections are released after each batch, keeping pool size under control.