### PR TITLE
[Fix] Allow custom actions with flags in config validation

### DIFF
--- a/lualib/lua_cfg_transform.lua
+++ b/lualib/lua_cfg_transform.lua
@@ -350,9 +350,16 @@ return function(cfg)
     actions_set['grow_factor'] = true
     actions_set['subject'] = true
 
-    for k, _ in cfg:at('actions'):pairs() do
+    for k, v in cfg:at('actions'):pairs() do
       if not actions_set[k] then
-        logger.warnx(rspamd_config, 'unknown element in actions section: %s', k)
+        -- Check if this is a custom action with flags (e.g., no_threshold)
+        local is_custom_action = false
+        if v and v:type() == 'object' and v:at('flags') then
+          is_custom_action = true
+        end
+        if not is_custom_action then
+          logger.warnx(rspamd_config, 'unknown element in actions section: %s', k)
+        end
       end
     end
 


### PR DESCRIPTION
## Problem

The config validation in `lua_cfg_transform.lua` was emitting warnings for custom actions like `malware`, `virus`, `hard-reject`, `discard`, `phishing`, and `soft-reject` even when they were properly defined with flags like `no_threshold`.

Example config that triggered spurious warnings:
```
actions {
    malware = {
        flags = ["no_threshold"];
    }
    virus = {
        flags = ["no_threshold"];
    }
}
```

## Root Cause

The validation code only recognized a hardcoded list of built-in actions and warned about any others, not accounting for the fact that custom actions are fully supported by the C code when defined as objects with flags.

## Solution

Check if an unknown action is defined as an object with flags before emitting the warning. This allows properly configured custom actions to pass validation while still catching actual typos or garbage in the config.