### PR TITLE
Bump UID limit for X_PHPOS_FAKE rule in headers.lua

### DIFF
--- a/rules/regexp/headers.lua
+++ b/rules/regexp/headers.lua
@@ -933,7 +933,7 @@ reconf['CD_MM_BODY'] = {
 }
 
 reconf['X_PHPOS_FAKE'] = {
-  re = 'X-PHP-Originating-Script=/^\\d{7}:/Hi',
+  re = 'X-PHP-Originating-Script=/^\\d{11}:/Hi',
   description = 'Fake X-PHP-Originating-Script header',
   score = 3.0,
   group = 'headers'


### PR DESCRIPTION
Due to the prevalence of 32-bit UIDs (user IDs) a limit of UID length ≤ 6 digits is no longer enough, as 32-bit UIDs may be up 10 digits in length.

Background:
https://github.com/rspamd/rspamd/pull/1205#issuecomment-3446918527 (PR that originally introduced this rule with explanation)
https://github.com/rspamd/rspamd/discussions/4091 (first known complaint about the current rule from 12022)