### PR TITLE
[Feature] Add obfuscated URL detection to url_suspect plugin

### DIFF
--- a/test/functional/cases/001_merged/400_url_suspect.robot
+++ b/test/functional/cases/001_merged/400_url_suspect.robot
@@ -50,3 +50,27 @@ URL Suspect - Normal URL
   Do Not Expect Symbol  URL_USER_PASSWORD
   Do Not Expect Symbol  URL_NUMERIC_IP
   Do Not Expect Symbol  URL_SUSPICIOUS_TLD
+
+URL Suspect - Obfuscated hxxp
+  # Test hxxp:// obfuscation detection
+  Scan File  ${RSPAMD_TESTDIR}/messages/url_obfuscated_hxxp.eml
+  ...  Settings={symbols_enabled = [URL_OBFUSCATED_TEXT]}
+  Expect Symbol  URL_OBFUSCATED_TEXT
+
+URL Suspect - Obfuscated Bracket Dots
+  # Test bracket dots obfuscation detection: example[.]com
+  Scan File  ${RSPAMD_TESTDIR}/messages/url_obfuscated_bracket_dots.eml
+  ...  Settings={symbols_enabled = [URL_OBFUSCATED_TEXT]}
+  Expect Symbol  URL_OBFUSCATED_TEXT
+
+URL Suspect - Obfuscated Word Dot
+  # Test word dot obfuscation detection: example dot com
+  Scan File  ${RSPAMD_TESTDIR}/messages/url_obfuscated_word_dot.eml
+  ...  Settings={symbols_enabled = [URL_OBFUSCATED_TEXT]}
+  Expect Symbol  URL_OBFUSCATED_TEXT
+
+URL Suspect - Obfuscated Spaced Protocol
+  # Test spaced protocol obfuscation: h t t p s : / /
+  Scan File  ${RSPAMD_TESTDIR}/messages/url_obfuscated_spaced.eml
+  ...  Settings={symbols_enabled = [URL_OBFUSCATED_TEXT]}
+  Expect Symbol  URL_OBFUSCATED_TEXT

--- a/test/functional/messages/url_obfuscated_bracket_dots.eml
+++ b/test/functional/messages/url_obfuscated_bracket_dots.eml
@@ -1,0 +1,6 @@
+From: sender@example.com
+To: victim@example.com
+Subject: Test bracket dots obfuscation
+Content-Type: text/plain; charset=utf-8
+
+Visit our site at example[.]com/login

--- a/test/functional/messages/url_obfuscated_hxxp.eml
+++ b/test/functional/messages/url_obfuscated_hxxp.eml
@@ -1,0 +1,6 @@
+From: sender@example.com
+To: victim@example.com
+Subject: Test hxxp obfuscation
+Content-Type: text/plain; charset=utf-8
+
+Check this link: hxxp://malicious-site.com/phish

--- a/test/functional/messages/url_obfuscated_spaced.eml
+++ b/test/functional/messages/url_obfuscated_spaced.eml
@@ -1,0 +1,6 @@
+From: sender@example.com
+To: victim@example.com
+Subject: Test spaced protocol obfuscation
+Content-Type: text/plain; charset=utf-8
+
+Visit h t t p s : / / evil-site.com/page for details

--- a/test/functional/messages/url_obfuscated_word_dot.eml
+++ b/test/functional/messages/url_obfuscated_word_dot.eml
@@ -1,0 +1,6 @@
+From: sender@example.com
+To: victim@example.com
+Subject: Test word dot obfuscation
+Content-Type: text/plain; charset=utf-8
+
+Contact us at secure-login dot net for support


### PR DESCRIPTION
## Summary

Detect URLs hidden in message text using various obfuscation techniques commonly used by spammers to evade detection:

- **Spaced protocols**: `h t t p s : / / example.com`
- **hxxp variants**: `hxxp://malicious.com`
- **Bracket dots**: `example[.]com`, `phishing(.)site`
- **Word dots**: `secure-login dot net`
- **HTML entities**: `https://bad&#46;co&#46;za`

## Implementation

- Hyperscan-based prefiltering for fast pattern matching
- Text normalization to remove obfuscation
- URL extraction and injection with `obscured` flag
- Configurable via built-in settings or external maps
- DoS protection with strict limits (max matches, max URLs, max text length)

## New symbol

`URL_OBFUSCATED_TEXT` (score: 5.0) - indicates obfuscated URL found in message text

## Configuration

```hcl
url_suspect {
  checks {
    obfuscated_text {
      enabled = true;
      patterns_enabled {
        spaced_protocol = true;
        hxxp = true;
        bracket_dots = true;
        word_dots = true;
        html_entities = true;
      }
      # Optional: use map for pattern control
      # pattern_map = "/etc/rspamd/maps.d/url_obfuscated_patterns.map";
    }
  }
}
```

## Test plan

- [x] Test with sample emails containing obfuscated URLs
- [x] Verify URL injection works correctly
- [x] Check performance on large messages
- [ ] Validate DoS protection limits