### PR TITLE
Cover more possible use cases of task:set_milter_reply

### DIFF
--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -1009,6 +1009,11 @@ task:set_milter_reply({
 	add_headers = {['X-Lua'] = 'test'},
 	-- 1 is the position of header to remove
 	remove_headers = {['DKIM-Signature'] = 1},
+	-- change smtp from
+	change_from = 'sender@example.com',
+	-- add and/or remove smtp rcpts
+	add_rcpt = {'new-rcpt1@example.com', 'new-rcpt2@example.com'},
+	del_rcpt = {'old-rcpt1@example.com', 'old-rcpt2@example.com'},
 })
  */
 LUA_FUNCTION_DEF(task, set_milter_reply);


### PR DESCRIPTION
This PR covers gap in function documentation. As based on:
https://github.com/rspamd/rspamd/blob/4e2572467284d4df84421c9a92b388355088aef7/src/libserver/milter.c#L2177-L2213
Rspamd can handle more then just adding and removing of mime headers from email 😊