### PR TITLE
Use GCC on EL10 again

### DIFF
--- a/rpm/rspamd.spec
+++ b/rpm/rspamd.spec
@@ -28,9 +28,6 @@ BuildRequires:    gcc-toolset-10-gcc-c++
 BuildRequires:    gcc-toolset-12-gcc-c++
 %endif
 %endif
-%if 0%{?el10}
-BuildRequires:    clang
-%endif
 BuildRequires:    file-devel
 BuildRequires:    glib2-devel
 BuildRequires:    lapack-devel
@@ -127,11 +124,6 @@ rm -f %{_builddir}/luajit-build/lib/*.so || true
 %endif
 %if 0%{?el8}
         -DLINKER_NAME=ld.bfd \
-%endif
-%if 0%{?el10}
-        -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DLINKER_NAME=lld \
 %endif
         -DCMAKE_INSTALL_PREFIX=%{_prefix} \
         -DCONFDIR=%{_sysconfdir}/rspamd \


### PR DESCRIPTION
There is trouble about format macros with clang on [AlmaLinux-flavoured build images](https://github.com/rspamd/rspamd-build-docker/pull/34) - versions of clang and gcc are relatively newer than we'd otherwise have:
https://github.com/fatalbanana/rspamd-build-docker/actions/runs/19734478391/job/56544979751