### PR TITLE
[Feature] Auto-mark whitelist symbols with SYMBOL_TYPE_FINE flag

### DIFF
--- a/src/libserver/cfg_utils.cxx
+++ b/src/libserver/cfg_utils.cxx
@@ -1016,6 +1016,8 @@ rspamd_config_post_load(struct rspamd_config *cfg,
 			rspamd_composites_set_inverted_index(cfg->composites_manager,
 												 cfg->composites_inverted_index);
 			rspamd_composites_process_deps(cfg->composites_manager, cfg);
+			/* Mark symbols used by whitelist composites (negative score) as FINE */
+			rspamd_composites_mark_whitelist_deps(cfg->composites_manager, cfg);
 		}
 	}
 

--- a/src/libserver/composites/composites.h
+++ b/src/libserver/composites/composites.h
@@ -101,6 +101,15 @@ struct rspamd_composites_stats_export {
  */
 void rspamd_composites_get_stats(void *cm_ptr, struct rspamd_composites_stats_export *stats);
 
+/**
+ * Mark symbols used in whitelist composites (negative score) with SYMBOL_TYPE_FINE
+ * so they won't be skipped when reject threshold is reached. This ensures
+ * whitelist composites can still evaluate correctly.
+ * @param cm_ptr composites manager pointer
+ * @param cfg config structure
+ */
+void rspamd_composites_mark_whitelist_deps(void *cm_ptr, struct rspamd_config *cfg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libserver/composites/composites_internal.hxx
+++ b/src/libserver/composites/composites_internal.hxx
@@ -144,6 +144,8 @@ public:
 	void process_dependencies();
 	/* Build inverted index for fast composite lookup */
 	void build_inverted_index();
+	/* Mark symbols used in whitelist composites (negative score) as FINE */
+	void mark_whitelist_dependencies();
 };
 
 /**

--- a/src/libserver/rspamd_symcache.h
+++ b/src/libserver/rspamd_symcache.h
@@ -578,6 +578,16 @@ void rspamd_symcache_runtime_destroy(struct rspamd_task *task);
  */
 void rspamd_symcache_promote_resort(struct rspamd_symcache *cache);
 
+/**
+ * Marks a symbol with SYMBOL_TYPE_FINE flag so it won't be skipped on early stop
+ * (when reject threshold is reached). Also propagates flag to parent/children.
+ * @param cache
+ * @param symbol symbol name
+ * @return TRUE if symbol was found and marked
+ */
+gboolean rspamd_symcache_set_symbol_fine(struct rspamd_symcache *cache,
+										 const char *symbol);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

- Automatically marks symbols with negative weight as `SYMBOL_TYPE_FINE` during config validation
- New `rspamd_composites_mark_whitelist_deps()` function marks all symbols used in whitelist composites (composites with negative score) as FINE
- Ensures whitelist symbols always execute regardless of reject threshold (early-stop optimization)

## Problem

When the reject score threshold is reached, rspamd's early-stop optimization skips remaining symbols. This could cause whitelist symbols to not execute, leading to false positives where emails should have been whitelisted but weren't.

## Solution

Symbols marked with `SYMBOL_TYPE_FINE` flag are never skipped, even when the reject threshold is reached. This PR automatically marks:

1. All symbols with negative weight (whitelist symbols)
2. All symbols used in composites that have negative score (whitelist composites)

The transitive expansion ensures that nested composites are properly handled.

## Test plan

- [x] Build passes
- [x] Unit tests pass (100 tests)
- [ ] Manual testing with whitelist symbols under reject threshold