### PR TITLE
[Test] Restrict public suffix sync workflow to upstream repository

### DIFF
--- a/.github/workflows/sync_public_suffix_list.yml
+++ b/.github/workflows/sync_public_suffix_list.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   sync:
+    if: github.repository == 'rspamd/rspamd'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Restrict the scheduled/public-dispatch sync job so it runs only in the upstream repository (rspamd/rspamd) and not in forks. This prevents automated PRs from being opened in forks.