### PR TITLE
[Fix] Use 0 instead of LUA_OK for lua_pcall result comparison

### DIFF
--- a/src/rspamadm/confighelp.c
+++ b/src/rspamadm/confighelp.c
@@ -207,7 +207,7 @@ rspamadm_confighelp_load_plugins_doc(struct rspamd_config *cfg)
 	lua_getglobal(L, "require");
 	lua_pushstring(L, "rspamadm.confighelp_plugins");
 
-	if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+	if (lua_pcall(L, 1, 1, 0) != 0) {
 		rspamd_fprintf(stderr, "cannot load confighelp_plugins module: %s\n",
 					   lua_tostring(L, -1));
 		lua_pop(L, 1);
@@ -221,7 +221,7 @@ rspamadm_confighelp_load_plugins_doc(struct rspamd_config *cfg)
 		return NULL;
 	}
 
-	if (lua_pcall(L, 0, 1, 0) != LUA_OK) {
+	if (lua_pcall(L, 0, 1, 0) != 0) {
 		rspamd_fprintf(stderr, "cannot execute confighelp_plugins function: %s\n",
 					   lua_tostring(L, -1));
 		lua_pop(L, 1);


### PR DESCRIPTION
Lua 5.1 does not define LUA_OK, so the result of lua_pcall is compared to 0 instead, which is consistent with the rest of the codebase.

This solves the Gentoo Bug: https://bugs.gentoo.org/967009