### PR TITLE
[Feature] Add --recheck-rua option to dmarc_report

### DIFF
--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -143,10 +143,14 @@ local function handle_cdb_map(map_config, key, callback, task)
   return result
 end
 
-local function query_external_map(map_config, upstreams, key, callback, task)
+-- Query external map using HTTP or CDB
+-- task_or_ctx can be either a task object or a context table with:
+--   { config, ev_base, session, resolver } for rspamadm usage
+-- If callback is nil and task_or_ctx is a context table (rspamadm), performs synchronous request
+local function query_external_map(map_config, upstreams, key, callback, task_or_ctx)
   -- Check if this is a CDB map
   if map_config.cdb then
-    return handle_cdb_map(map_config, key, callback, task)
+    return handle_cdb_map(map_config, key, callback, task_or_ctx)
   end
   -- Fallback to HTTP
   local http_method = (map_config.method == 'body' or map_config.method == 'form') and 'POST' or 'GET'
@@ -156,6 +160,12 @@ local function query_external_map(map_config, upstreams, key, callback, task)
   }
   local http_body = nil
   local url = map_config.backend
+
+  -- Determine logging target (task or config)
+  local log_obj = task_or_ctx
+  if type(task_or_ctx) == 'table' and task_or_ctx.config then
+    log_obj = task_or_ctx.config
+  end
 
   if type(key) == 'string' or type(key) == 'userdata' then
     if map_config.method == 'body' then
@@ -178,10 +188,13 @@ local function query_external_map(map_config, upstreams, key, callback, task)
         http_headers['Content-Type'] = 'application/msgpack'
       else
         local caller = debug.getinfo(2) or {}
-        rspamd_logger.errx(task,
+        rspamd_logger.errx(log_obj,
             "requested external map key with a wrong combination body method and missing encode; caller: %s:%s",
             caller.short_src, caller.currentline)
-        callback(false, 'invalid map usage', 500, task)
+        if callback then
+          callback(false, 'invalid map usage', 500, task_or_ctx)
+        end
+        return nil
       end
     else
       -- query/header and no encode
@@ -198,29 +211,20 @@ local function query_external_map(map_config, upstreams, key, callback, task)
         http_headers = key
       else
         local caller = debug.getinfo(2) or {}
-        rspamd_logger.errx(task,
+        rspamd_logger.errx(log_obj,
             "requested external map key with a wrong combination of encode and input; caller: %s:%s",
             caller.short_src, caller.currentline)
-        callback(false, 'invalid map usage', 500, task)
-        return
+        if callback then
+          callback(false, 'invalid map usage', 500, task_or_ctx)
+        end
+        return nil
       end
     end
   end
 
-  local function map_callback(err, code, body, _)
-    if err then
-      callback(false, err, code, task)
-    elseif code == 200 then
-      callback(true, body, 200, task)
-    else
-      callback(false, err, code, task)
-    end
-  end
-
-  local ret = rspamd_http.request {
-    task = task,
+  -- Build HTTP request options - support both task and rspamadm context
+  local http_opts = {
     url = url,
-    callback = map_callback,
     timeout = map_config.timeout or 1.0,
     keepalive = true,
     upstream = upstream,
@@ -229,8 +233,49 @@ local function query_external_map(map_config, upstreams, key, callback, task)
     body = http_body,
   }
 
+  -- Check if task_or_ctx is a context table (rspamadm) or a task (userdata)
+  -- rspamadm context is a Lua table with ev_base, config, session, resolver fields
+  -- task is userdata (C object), so type(task) ~= 'table'
+  local is_rspamadm_ctx = type(task_or_ctx) == 'table' and task_or_ctx.ev_base and task_or_ctx.config
+  if is_rspamadm_ctx then
+    -- rspamadm context
+    http_opts.config = task_or_ctx.config
+    http_opts.ev_base = task_or_ctx.ev_base
+    http_opts.session = task_or_ctx.session
+    http_opts.resolver = task_or_ctx.resolver
+  elseif task_or_ctx then
+    -- Regular task (userdata)
+    http_opts.task = task_or_ctx
+  end
+
+  -- If no callback and rspamadm context, use coroutine-based synchronous mode
+  if not callback and is_rspamadm_ctx then
+    local err, response = rspamd_http.request(http_opts)
+    if err then
+      return nil
+    elseif response and response.code == 200 then
+      return response.content
+    else
+      return nil
+    end
+  end
+
+  -- Async mode with callback
+  local function map_callback(err, code, body, _)
+    if err then
+      callback(false, err, code, task_or_ctx)
+    elseif code == 200 then
+      callback(true, body, 200, task_or_ctx)
+    else
+      callback(false, err, code, task_or_ctx)
+    end
+  end
+
+  http_opts.callback = map_callback
+  local ret = rspamd_http.request(http_opts)
+
   if not ret then
-    callback(false, 'http request error', 500, task)
+    callback(false, 'http request error', 500, task_or_ctx)
   end
 end
 
@@ -246,24 +291,33 @@ end
 --]]
 local function rspamd_map_add_from_ucl(opt, mtype, description, callback)
   local ret = {
-    get_key = function(t, k, key_callback, task)
+    -- get_key supports both task (userdata) and rspamadm context (table with ev_base, config, session, resolver)
+    -- For external maps with rspamadm context (no callback), uses coroutine-based synchronous request
+    get_key = function(t, k, key_callback, task_or_ctx)
       if t.__data then
         local cb = key_callback or callback
         if t.__external then
-          if not cb or not task then
+          -- Check if this is rspamadm context with no callback - use sync mode
+          -- rspamadm context is a Lua table; task is userdata (C object)
+          local is_rspamadm_ctx = type(task_or_ctx) == 'table' and task_or_ctx.ev_base and task_or_ctx.config
+          if not cb and is_rspamadm_ctx then
+            -- Coroutine-based synchronous external map query for rspamadm
+            return query_external_map(t.__data, t.__upstreams, k, nil, task_or_ctx)
+          elseif not cb or not task_or_ctx then
             local caller = debug.getinfo(2) or {}
-            rspamd_logger.errx(rspamd_config, "requested external map key without callback or task; caller: %s:%s",
+            rspamd_logger.errx(rspamd_config, "requested external map key without callback or task/context; caller: %s:%s",
                 caller.short_src, caller.currentline)
             return nil
+          else
+            query_external_map(t.__data, t.__upstreams, k, cb, task_or_ctx)
           end
-          query_external_map(t.__data, t.__upstreams, k, cb, task)
         else
           local result = t.__data:get_key(k)
           if cb then
             if result then
-              cb(true, result, 200, task)
+              cb(true, result, 200, task_or_ctx)
             else
-              cb(false, 'not found', 404, task)
+              cb(false, 'not found', 404, task_or_ctx)
             end
           else
             return result
@@ -281,9 +335,9 @@ local function rspamd_map_add_from_ucl(opt, mtype, description, callback)
     end
   }
   local ret_mt = {
-    __index = function(t, k, key_callback, task)
+    __index = function(t, k, key_callback, task_or_ctx)
       if t.__data then
-        return t.get_key(k, key_callback, task)
+        return t.get_key(k, key_callback, task_or_ctx)
       end
 
       return nil


### PR DESCRIPTION
## Summary

- Add `-r`/`--recheck-rua` flag to `rspamadm dmarc_report` to re-check RUA addresses against `exclude_rua_addresses` map before sending reports
- Extend `lua_maps` to support rspamadm context for external map queries, enabling coroutine-based synchronous HTTP requests
- Works with both local maps and external (HTTP) maps
- Checks both full email address and domain-only against the map

## Motivation

Addresses #5750 - allows RUA validation at report sending time rather than only at report generation time. This is useful when using external RBL services to validate RUA addresses, as domains may not have been tested at initial report generation time.

Related to #5735 which handles multiple RUA addresses at report generation time.

## Usage

```bash
rspamadm dmarc_report --recheck-rua
rspamadm dmarc_report -r 20241201
```

## Changes

### `lualib/lua_maps.lua`
- Extended `query_external_map()` to support rspamadm context (table with `ev_base`, `config`, `session`, `resolver`) in addition to task objects
- Added coroutine-based synchronous mode for external maps when called from rspamadm context without a callback
- Updated `get_key()` method to detect rspamadm context and use sync mode for external maps

### `lualib/rspamadm/dmarc_report.lua`
- Added `--recheck-rua` / `-r` flag
- Added `map_context` table for external map HTTP requests
- Added RUA filtering logic in `prepare_report()` that filters excluded addresses and skips reports if all RUAs are excluded

## Test plan

- [x] Luacheck passes
- [x] Build succeeds
- [x] C++ unit tests pass (100/100)
- [x] Lua unit tests pass (782/785, 3 unassertive)
- [ ] Manual testing with exclude_rua_addresses map configured