### PR TITLE
[Fix] null-terminate the log tag when copying the header

### DIFF
--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -713,7 +713,7 @@ rspamd_protocol_handle_headers(struct rspamd_task *task,
 				msg_debug_protocol("read log-tag header, value: %T", hv_tok);
 				/* Ensure that a tag is valid */
 				if (rspamd_fast_utf8_validate(hv_tok->begin, hv_tok->len) == 0) {
-					int len = MIN(hv_tok->len, sizeof(task->task_pool->tag.uid));
+					int len = MIN(hv_tok->len, sizeof(task->task_pool->tag.uid) - 1);
 					memcpy(task->task_pool->tag.uid, hv_tok->begin, len);
 					task->task_pool->tag.uid[len] = '\0';
 				}


### PR DESCRIPTION
This avoids leaking uninitialized heap memory.