### PR TITLE
[Fix] FreeBSD 15 inotify build compatibility

### DIFF
--- a/contrib/libev/ev.c
+++ b/contrib/libev/ev.c
@@ -527,7 +527,11 @@
 #endif
 
 #if EV_USE_INOTIFY
+# ifdef __FreeBSD__
+# include <sys/mount.h>
+# else
 # include <sys/statfs.h>
+# endif
 # include <sys/inotify.h>
 /* some very old inotify.h headers don't have IN_DONT_FOLLOW */
 # ifndef IN_DONT_FOLLOW


### PR DESCRIPTION
FreeBSD 15.0 introduced native inotify support, which causes libev to enable EV_USE_INOTIFY. On FreeBSD, struct statfs is defined in <sys/mount.h> rather than <sys/statfs.h>.

Note: This fix obsoletes the corresponding patch file in the FreeBSD `mail/rspamd` and `mail/rspamd-devel` ports.