### PR TITLE
[Fix] Correct symbols column index in history and scan tables

### DIFF
--- a/interface/js/app/history.js
+++ b/interface/js/app/history.js
@@ -333,7 +333,7 @@ define(["jquery", "app/common", "app/libft", "footable"],
         });
 
         libft.set_page_size("history", $("#history_page_size").val());
-        libft.bindHistoryTableEventHandlers("history", 8);
+        libft.bindHistoryTableEventHandlers("history", 9);
 
         $("#updateHistory").off("click");
         $("#updateHistory").on("click", (e) => {

--- a/interface/js/app/upload.js
+++ b/interface/js/app/upload.js
@@ -175,7 +175,7 @@ define(["jquery", "app/common", "app/libft"],
 
 
         libft.set_page_size("scan", $("#scan_page_size").val());
-        libft.bindHistoryTableEventHandlers("scan", 3);
+        libft.bindHistoryTableEventHandlers("scan", 5);
 
         $("#cleanScanHistory").off("click");
         $("#cleanScanHistory").on("click", (e) => {


### PR DESCRIPTION
Fixes regression introduced in 62b136a where sorting fails with "can't access property 'sortValue', val.options is undefined" on the History tab, and symbol reordering doesn't work on the Scan tab.

The "file" column addition shifted the symbols column index, but history.js and upload.js were not updated, causing symbol reordering to target wrong columns.

Issue: #5789