### PR TITLE
[Feature] Add SMTP proxy worker with protocol enforcement

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,7 +95,8 @@ set(RSPAMD_SOURCES
         fuzzy_storage.c
         rspamd.c
         worker.c
-        rspamd_proxy.c)
+        rspamd_proxy.c
+        smtp_proxy.cxx)
 
 set(PLUGIN_SOURCES
         plugins/regexp.c
@@ -106,7 +107,7 @@ set(PLUGIN_SOURCES
 
 # Define module and worker lists
 set(MODULES_LIST regexp chartable fuzzy_check dkim)
-set(WORKERS_LIST normal controller fuzzy rspamd_proxy)
+set(WORKERS_LIST normal controller fuzzy rspamd_proxy smtp_proxy)
 
 # Add hyperscan worker if enabled
 if (ENABLE_HYPERSCAN)

--- a/src/libserver/CMakeLists.txt
+++ b/src/libserver/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Librspamdserver
 ADD_SUBDIRECTORY(css)
 SET(LIBRSPAMDSERVERSRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/smtp_proxy/smtp_proxy_session.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/cfg_utils.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/cfg_rcl.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/composites/composites.cxx

--- a/src/libserver/smtp_proxy/command_parser.hxx
+++ b/src/libserver/smtp_proxy/command_parser.hxx
@@ -1,0 +1,494 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_COMMAND_PARSER_HXX
+#define RSPAMD_COMMAND_PARSER_HXX
+
+#pragma once
+
+#include "config.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <optional>
+#include <vector>
+#include <algorithm>
+#include <cctype>
+
+#include "contrib/ankerl/unordered_dense.h"
+
+namespace rspamd::smtp {
+
+/**
+ * SMTP command types
+ */
+enum class command_type {
+	unknown,
+	ehlo,
+	helo,
+	mail_from,
+	rcpt_to,
+	data,
+	rset,
+	noop,
+	quit,
+	starttls,
+	vrfy,
+	expn,
+	help,
+	bdat,// CHUNKING extension - not supported in v1
+	auth // AUTH extension - not supported in v1
+};
+
+/**
+ * ESMTP parameter parsed from MAIL FROM or RCPT TO
+ */
+struct esmtp_param {
+	std::string name;
+	std::optional<std::string> value;
+};
+
+/**
+ * Parsed SMTP command
+ */
+struct parsed_command {
+	command_type type = command_type::unknown;
+	std::string verb;               // Original command verb (e.g., "EHLO", "MAIL")
+	std::string argument;           // Primary argument (domain for EHLO, path for MAIL/RCPT)
+	std::vector<esmtp_param> params;// ESMTP parameters
+	std::string raw_line;           // Original line for transparent forwarding
+
+	/**
+	 * Check if command has a specific ESMTP parameter
+	 */
+	[[nodiscard]] auto has_param(std::string_view name) const noexcept -> bool
+	{
+		return std::any_of(params.begin(), params.end(),
+						   [name](const esmtp_param &p) {
+							   return case_insensitive_equal(p.name, name);
+						   });
+	}
+
+	/**
+	 * Get value of an ESMTP parameter
+	 */
+	[[nodiscard]] auto get_param(std::string_view name) const noexcept -> std::optional<std::string_view>
+	{
+		auto it = std::find_if(params.begin(), params.end(),
+							   [name](const esmtp_param &p) {
+								   return case_insensitive_equal(p.name, name);
+							   });
+		if (it != params.end() && it->value) {
+			return *it->value;
+		}
+		return std::nullopt;
+	}
+
+private:
+	[[nodiscard]] static auto case_insensitive_equal(std::string_view a, std::string_view b) noexcept -> bool
+	{
+		if (a.size() != b.size()) {
+			return false;
+		}
+		return std::equal(a.begin(), a.end(), b.begin(),
+						  [](char c1, char c2) {
+							  return std::toupper(static_cast<unsigned char>(c1)) ==
+									 std::toupper(static_cast<unsigned char>(c2));
+						  });
+	}
+};
+
+/**
+ * SMTP command parser
+ *
+ * Parses SMTP commands including:
+ * - EHLO/HELO with domain argument
+ * - MAIL FROM with path and ESMTP parameters
+ * - RCPT TO with path and ESMTP parameters
+ * - DATA, RSET, NOOP, QUIT, STARTTLS
+ *
+ * Retains raw line for transparent forwarding to backend.
+ */
+class command_parser {
+public:
+	command_parser() = default;
+
+	/**
+	 * Parse a command line (without CRLF terminator)
+	 *
+	 * @param line Command line to parse
+	 * @param raw_line Original line including CRLF (for forwarding)
+	 * @return parsed_command structure
+	 */
+	[[nodiscard]] auto parse(std::string_view line, std::string_view raw_line = {}) const -> parsed_command
+	{
+		parsed_command cmd;
+		cmd.raw_line = raw_line.empty() ? std::string(line) + "\r\n" : std::string(raw_line);
+
+		if (line.empty()) {
+			return cmd;
+		}
+
+		// Extract verb (first word)
+		auto space_pos = line.find(' ');
+		std::string_view verb_sv;
+		std::string_view rest;
+
+		if (space_pos == std::string_view::npos) {
+			verb_sv = line;
+		}
+		else {
+			verb_sv = line.substr(0, space_pos);
+			rest = line.substr(space_pos + 1);
+			// Trim leading whitespace from rest
+			while (!rest.empty() && std::isspace(static_cast<unsigned char>(rest.front()))) {
+				rest.remove_prefix(1);
+			}
+		}
+
+		// Store original verb
+		cmd.verb.assign(verb_sv.begin(), verb_sv.end());
+
+		// Identify command type
+		cmd.type = identify_command(verb_sv);
+
+		// Parse arguments based on command type
+		switch (cmd.type) {
+		case command_type::ehlo:
+		case command_type::helo:
+			cmd.argument = std::string(rest);
+			break;
+
+		case command_type::mail_from:
+			parse_mail_from(rest, cmd);
+			break;
+
+		case command_type::rcpt_to:
+			parse_rcpt_to(rest, cmd);
+			break;
+
+		case command_type::bdat:
+			parse_bdat(rest, cmd);
+			break;
+
+		case command_type::auth:
+			cmd.argument = std::string(rest);
+			break;
+
+		case command_type::vrfy:
+		case command_type::expn:
+		case command_type::help:
+			cmd.argument = std::string(rest);
+			break;
+
+		case command_type::data:
+		case command_type::rset:
+		case command_type::noop:
+		case command_type::quit:
+		case command_type::starttls:
+		case command_type::unknown:
+			// These commands have no arguments or we don't parse them
+			if (!rest.empty()) {
+				cmd.argument = std::string(rest);
+			}
+			break;
+		}
+
+		return cmd;
+	}
+
+	/**
+	 * Check if a command type is valid for pipelining
+	 * (can be sent before receiving response to previous command)
+	 */
+	[[nodiscard]] static auto is_pipelineable(command_type type) noexcept -> bool
+	{
+		switch (type) {
+		case command_type::mail_from:
+		case command_type::rcpt_to:
+		case command_type::rset:
+		case command_type::noop:
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	/**
+	 * Check if a command requires waiting for all pending responses
+	 * before being sent (synchronization point)
+	 */
+	[[nodiscard]] static auto is_sync_command(command_type type) noexcept -> bool
+	{
+		switch (type) {
+		case command_type::ehlo:
+		case command_type::helo:
+		case command_type::data:
+		case command_type::starttls:
+		case command_type::quit:
+		case command_type::bdat:
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	/**
+	 * Get string representation of command type
+	 */
+	[[nodiscard]] static auto command_type_to_string(command_type type) noexcept -> const char *
+	{
+		switch (type) {
+		case command_type::unknown:
+			return "UNKNOWN";
+		case command_type::ehlo:
+			return "EHLO";
+		case command_type::helo:
+			return "HELO";
+		case command_type::mail_from:
+			return "MAIL";
+		case command_type::rcpt_to:
+			return "RCPT";
+		case command_type::data:
+			return "DATA";
+		case command_type::rset:
+			return "RSET";
+		case command_type::noop:
+			return "NOOP";
+		case command_type::quit:
+			return "QUIT";
+		case command_type::starttls:
+			return "STARTTLS";
+		case command_type::vrfy:
+			return "VRFY";
+		case command_type::expn:
+			return "EXPN";
+		case command_type::help:
+			return "HELP";
+		case command_type::bdat:
+			return "BDAT";
+		case command_type::auth:
+			return "AUTH";
+		}
+		return "UNKNOWN";
+	}
+
+private:
+	/**
+	 * Identify command type from verb
+	 */
+	[[nodiscard]] auto identify_command(std::string_view verb) const noexcept -> command_type
+	{
+		// Convert to uppercase for comparison
+		std::string upper;
+		upper.reserve(verb.size());
+		for (char c: verb) {
+			upper.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+		}
+
+		if (upper == "EHLO") return command_type::ehlo;
+		if (upper == "HELO") return command_type::helo;
+		if (upper == "MAIL") return command_type::mail_from;
+		if (upper == "RCPT") return command_type::rcpt_to;
+		if (upper == "DATA") return command_type::data;
+		if (upper == "RSET") return command_type::rset;
+		if (upper == "NOOP") return command_type::noop;
+		if (upper == "QUIT") return command_type::quit;
+		if (upper == "STARTTLS") return command_type::starttls;
+		if (upper == "VRFY") return command_type::vrfy;
+		if (upper == "EXPN") return command_type::expn;
+		if (upper == "HELP") return command_type::help;
+		if (upper == "BDAT") return command_type::bdat;
+		if (upper == "AUTH") return command_type::auth;
+
+		return command_type::unknown;
+	}
+
+	/**
+	 * Parse MAIL FROM:<path> [params]
+	 */
+	auto parse_mail_from(std::string_view rest, parsed_command &cmd) const -> void
+	{
+		// Expect "FROM:" prefix (case-insensitive)
+		if (rest.size() < 5) {
+			return;
+		}
+
+		std::string prefix;
+		prefix.reserve(5);
+		for (size_t i = 0; i < 5 && i < rest.size(); ++i) {
+			prefix.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(rest[i]))));
+		}
+
+		if (prefix != "FROM:") {
+			return;
+		}
+
+		rest.remove_prefix(5);
+
+		// Skip optional whitespace after colon
+		while (!rest.empty() && std::isspace(static_cast<unsigned char>(rest.front()))) {
+			rest.remove_prefix(1);
+		}
+
+		// Parse path and parameters
+		parse_path_and_params(rest, cmd);
+	}
+
+	/**
+	 * Parse RCPT TO:<path> [params]
+	 */
+	auto parse_rcpt_to(std::string_view rest, parsed_command &cmd) const -> void
+	{
+		// Expect "TO:" prefix (case-insensitive)
+		if (rest.size() < 3) {
+			return;
+		}
+
+		std::string prefix;
+		prefix.reserve(3);
+		for (size_t i = 0; i < 3 && i < rest.size(); ++i) {
+			prefix.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(rest[i]))));
+		}
+
+		if (prefix != "TO:") {
+			return;
+		}
+
+		rest.remove_prefix(3);
+
+		// Skip optional whitespace after colon
+		while (!rest.empty() && std::isspace(static_cast<unsigned char>(rest.front()))) {
+			rest.remove_prefix(1);
+		}
+
+		// Parse path and parameters
+		parse_path_and_params(rest, cmd);
+	}
+
+	/**
+	 * Parse <path> and ESMTP parameters
+	 */
+	auto parse_path_and_params(std::string_view rest, parsed_command &cmd) const -> void
+	{
+		if (rest.empty()) {
+			return;
+		}
+
+		// Handle angle-bracketed path
+		if (rest.front() == '<') {
+			auto close = rest.find('>');
+			if (close != std::string_view::npos) {
+				cmd.argument = std::string(rest.substr(0, close + 1));
+				rest.remove_prefix(close + 1);
+			}
+			else {
+				// Malformed - take everything
+				cmd.argument = std::string(rest);
+				return;
+			}
+		}
+		else {
+			// Path without angle brackets - take until whitespace
+			auto space = rest.find(' ');
+			if (space != std::string_view::npos) {
+				cmd.argument = std::string(rest.substr(0, space));
+				rest.remove_prefix(space);
+			}
+			else {
+				cmd.argument = std::string(rest);
+				return;
+			}
+		}
+
+		// Parse ESMTP parameters (space-separated KEY=VALUE or KEY)
+		while (!rest.empty()) {
+			// Skip whitespace
+			while (!rest.empty() && std::isspace(static_cast<unsigned char>(rest.front()))) {
+				rest.remove_prefix(1);
+			}
+
+			if (rest.empty()) {
+				break;
+			}
+
+			// Find end of parameter
+			auto space = rest.find(' ');
+			std::string_view param_str;
+			if (space != std::string_view::npos) {
+				param_str = rest.substr(0, space);
+				rest.remove_prefix(space);
+			}
+			else {
+				param_str = rest;
+				rest = {};
+			}
+
+			// Parse KEY=VALUE or KEY
+			esmtp_param param;
+			auto eq = param_str.find('=');
+			if (eq != std::string_view::npos) {
+				param.name = std::string(param_str.substr(0, eq));
+				param.value = std::string(param_str.substr(eq + 1));
+			}
+			else {
+				param.name = std::string(param_str);
+			}
+
+			if (!param.name.empty()) {
+				cmd.params.push_back(std::move(param));
+			}
+		}
+	}
+
+	/**
+	 * Parse BDAT <size> [LAST]
+	 */
+	auto parse_bdat(std::string_view rest, parsed_command &cmd) const -> void
+	{
+		// Extract size
+		auto space = rest.find(' ');
+		if (space != std::string_view::npos) {
+			cmd.argument = std::string(rest.substr(0, space));
+			rest.remove_prefix(space);
+
+			// Skip whitespace and check for LAST
+			while (!rest.empty() && std::isspace(static_cast<unsigned char>(rest.front()))) {
+				rest.remove_prefix(1);
+			}
+
+			if (!rest.empty()) {
+				std::string upper;
+				upper.reserve(rest.size());
+				for (char c: rest) {
+					upper.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+				}
+				if (upper == "LAST") {
+					cmd.params.push_back({"LAST", std::nullopt});
+				}
+			}
+		}
+		else {
+			cmd.argument = std::string(rest);
+		}
+	}
+};
+
+}// namespace rspamd::smtp
+
+#endif// RSPAMD_COMMAND_PARSER_HXX

--- a/src/libserver/smtp_proxy/eod_scanner.hxx
+++ b/src/libserver/smtp_proxy/eod_scanner.hxx
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_EOD_SCANNER_HXX
+#define RSPAMD_EOD_SCANNER_HXX
+
+#pragma once
+
+#include "config.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace rspamd::smtp {
+
+/**
+ * SMTP End-of-Data scanner using a state machine.
+ * Scans for <CRLF>.<CRLF>, handles bare LF violations.
+ * Maintains state across buffer boundaries.
+ */
+class eod_scanner {
+public:
+	/**
+	 * Result of scanning
+	 */
+	struct result {
+		bool found = false;
+		std::size_t eod_start = 0; // Position where EOD sequence starts (the leading CR or LF)
+		std::size_t eod_length = 0;// Length of the EOD sequence
+		std::size_t body_end = 0;  // Position of last body byte (before terminator)
+		bool had_violation = false;// True if bare LF or other violation detected
+	};
+
+	/**
+	 * Reset scanner to initial state
+	 */
+	auto reset() noexcept -> void
+	{
+		state_ = state::body;
+		bytes_scanned_ = 0;
+		eod_start_offset_ = 0;
+		had_violation_ = false;
+	}
+
+	/**
+	 * Feed data to the scanner incrementally
+	 *
+	 * @param data Pointer to data chunk
+	 * @param len Length of data chunk
+	 * @param base_offset Offset in the overall stream where this chunk starts
+	 * @return result if EOD found, nullopt if more data needed
+	 */
+	[[nodiscard]] auto feed(const std::uint8_t *data, std::size_t len,
+							std::size_t base_offset = 0) noexcept -> std::optional<result>
+	{
+		for (std::size_t i = 0; i < len; ++i) {
+			std::uint8_t ch = data[i];
+			std::size_t pos = base_offset + i;
+
+			switch (state_) {
+			case state::body:
+				// Looking for start of line terminator
+				if (ch == '\r') {
+					state_ = state::got_cr;
+					eod_start_offset_ = pos;
+				}
+				else if (ch == '\n') {
+					// Bare LF - violation but continue
+					state_ = state::got_lf;
+					eod_start_offset_ = pos;
+					had_violation_ = true;
+				}
+				break;
+
+			case state::got_cr:
+				if (ch == '\n') {
+					state_ = state::got_crlf;
+				}
+				else if (ch == '\r') {
+					// \r\r - stay in got_cr, update start
+					eod_start_offset_ = pos;
+				}
+				else if (ch == '.') {
+					// \r. without LF - unusual but handle it
+					// This is actually a violation
+					had_violation_ = true;
+					state_ = state::got_crlf_dot;
+				}
+				else {
+					state_ = state::body;
+				}
+				break;
+
+			case state::got_lf:
+				// After bare LF (violation case)
+				if (ch == '.') {
+					state_ = state::got_crlf_dot;
+				}
+				else if (ch == '\r') {
+					state_ = state::got_cr;
+					eod_start_offset_ = pos;
+				}
+				else if (ch == '\n') {
+					// \n\n - double bare LF
+					eod_start_offset_ = pos;
+				}
+				else {
+					state_ = state::body;
+				}
+				break;
+
+			case state::got_crlf:
+				// After CRLF (or bare LF), looking for dot
+				if (ch == '.') {
+					state_ = state::got_crlf_dot;
+				}
+				else if (ch == '\r') {
+					state_ = state::got_cr;
+					eod_start_offset_ = pos;
+				}
+				else if (ch == '\n') {
+					// Bare LF after CRLF
+					state_ = state::got_lf;
+					eod_start_offset_ = pos;
+					had_violation_ = true;
+				}
+				else {
+					state_ = state::body;
+				}
+				break;
+
+			case state::got_crlf_dot:
+				// After CRLF. (or LF.), looking for final line terminator
+				if (ch == '\r') {
+					state_ = state::got_crlf_dot_cr;
+				}
+				else if (ch == '\n') {
+					// CRLF.LF or LF.LF - bare LF termination (violation)
+					had_violation_ = true;
+					return make_result(pos + 1);
+				}
+				else {
+					// Not EOD, just a dot-stuffed line
+					state_ = state::body;
+				}
+				break;
+
+			case state::got_crlf_dot_cr:
+				// After CRLF.\r, looking for final LF
+				if (ch == '\n') {
+					// Found complete EOD: CRLF.CRLF
+					return make_result(pos + 1);
+				}
+				else if (ch == '\r') {
+					// CRLF.\r\r - weird but handle it
+					// Stay in this state
+				}
+				else {
+					// CRLF.\r<other> - not EOD
+					state_ = state::body;
+				}
+				break;
+			}
+
+			bytes_scanned_++;
+		}
+
+		return std::nullopt;
+	}
+
+	/**
+	 * Convenience overload for char data
+	 */
+	[[nodiscard]] auto feed(const char *data, std::size_t len,
+							std::size_t base_offset = 0) noexcept -> std::optional<result>
+	{
+		return feed(reinterpret_cast<const std::uint8_t *>(data), len, base_offset);
+	}
+
+	/**
+	 * Get number of bytes scanned so far
+	 */
+	[[nodiscard]] auto bytes_scanned() const noexcept -> std::size_t
+	{
+		return bytes_scanned_;
+	}
+
+	/**
+	 * Check if any protocol violations were detected
+	 */
+	[[nodiscard]] auto had_violation() const noexcept -> bool
+	{
+		return had_violation_;
+	}
+
+	/**
+	 * Get minimum bytes that must be preserved in buffer for state continuity
+	 * This is useful for determining how much data can be safely forwarded
+	 * while keeping enough context for the state machine.
+	 */
+	[[nodiscard]] auto pending_bytes() const noexcept -> std::size_t
+	{
+		switch (state_) {
+		case state::body:
+			return 0;
+		case state::got_cr:
+		case state::got_lf:
+			return 1;
+		case state::got_crlf:
+			return 2;
+		case state::got_crlf_dot:
+			return 3;
+		case state::got_crlf_dot_cr:
+			return 4;
+		}
+		return 0;
+	}
+
+	/**
+	 * Check if scanner is in the middle of a potential EOD sequence
+	 */
+	[[nodiscard]] auto in_potential_eod() const noexcept -> bool
+	{
+		return state_ != state::body;
+	}
+
+private:
+	enum class state {
+		body,          // Normal body content
+		got_cr,        // Saw \r
+		got_lf,        // Saw \n (bare LF - violation)
+		got_crlf,      // Saw \r\n or \n
+		got_crlf_dot,  // Saw \r\n. or \n.
+		got_crlf_dot_cr// Saw \r\n.\r
+	};
+
+	[[nodiscard]] auto make_result(std::size_t end_pos) const noexcept -> result
+	{
+		result r;
+		r.found = true;
+		r.eod_start = eod_start_offset_;
+		r.eod_length = end_pos - eod_start_offset_;
+		r.body_end = eod_start_offset_;
+		r.had_violation = had_violation_;
+		return r;
+	}
+
+	state state_ = state::body;
+	std::size_t bytes_scanned_ = 0;
+	std::size_t eod_start_offset_ = 0;
+	bool had_violation_ = false;
+};
+
+/**
+ * Simple CRLF scanner for line-by-line reading
+ * Tracks state across buffer boundaries
+ */
+class crlf_scanner {
+public:
+	struct result {
+		bool found = false;
+		std::size_t line_end = 0; // Position of \r (or \n for bare LF)
+		std::size_t next_line = 0;// Position after \n
+		bool bare_lf = false;     // True if bare LF detected
+	};
+
+	auto reset() noexcept -> void
+	{
+		saw_cr_ = false;
+		cr_position_ = 0;
+	}
+
+	/**
+	 * Scan for next CRLF in data
+	 * @param data Data to scan
+	 * @param len Length of data
+	 * @param base_offset Offset in stream
+	 * @return result if CRLF found
+	 */
+	[[nodiscard]] auto scan(const std::uint8_t *data, std::size_t len,
+							std::size_t base_offset = 0) noexcept -> std::optional<result>
+	{
+		for (std::size_t i = 0; i < len; ++i) {
+			std::uint8_t ch = data[i];
+			std::size_t pos = base_offset + i;
+
+			if (saw_cr_) {
+				if (ch == '\n') {
+					result r;
+					r.found = true;
+					r.line_end = cr_position_;
+					r.next_line = pos + 1;
+					r.bare_lf = false;
+					saw_cr_ = false;
+					return r;
+				}
+				else if (ch == '\r') {
+					// \r\r - update position
+					cr_position_ = pos;
+				}
+				else {
+					// \r without \n - could be old Mac style, treat as line end
+					result r;
+					r.found = true;
+					r.line_end = cr_position_;
+					r.next_line = pos;
+					r.bare_lf = false;
+					saw_cr_ = false;
+					return r;
+				}
+			}
+			else {
+				if (ch == '\r') {
+					saw_cr_ = true;
+					cr_position_ = pos;
+				}
+				else if (ch == '\n') {
+					// Bare LF
+					result r;
+					r.found = true;
+					r.line_end = pos;
+					r.next_line = pos + 1;
+					r.bare_lf = true;
+					return r;
+				}
+			}
+		}
+
+		return std::nullopt;
+	}
+
+	[[nodiscard]] auto scan(const char *data, std::size_t len,
+							std::size_t base_offset = 0) noexcept -> std::optional<result>
+	{
+		return scan(reinterpret_cast<const std::uint8_t *>(data), len, base_offset);
+	}
+
+	/**
+	 * Check if we have a pending CR that needs context from next buffer
+	 */
+	[[nodiscard]] auto has_pending_cr() const noexcept -> bool
+	{
+		return saw_cr_;
+	}
+
+private:
+	bool saw_cr_ = false;
+	std::size_t cr_position_ = 0;
+};
+
+/**
+ * NUL byte scanner - detects NUL characters which are protocol violations
+ */
+class nul_scanner {
+public:
+	struct result {
+		bool found = false;
+		std::size_t position = 0;
+	};
+
+	[[nodiscard]] static auto scan(const std::uint8_t *data, std::size_t len,
+								   std::size_t base_offset = 0) noexcept -> std::optional<result>
+	{
+		for (std::size_t i = 0; i < len; ++i) {
+			if (data[i] == '\0') {
+				return result{true, base_offset + i};
+			}
+		}
+		return std::nullopt;
+	}
+
+	[[nodiscard]] static auto scan(const char *data, std::size_t len,
+								   std::size_t base_offset = 0) noexcept -> std::optional<result>
+	{
+		return scan(reinterpret_cast<const std::uint8_t *>(data), len, base_offset);
+	}
+};
+
+}// namespace rspamd::smtp
+
+#endif// RSPAMD_EOD_SCANNER_HXX

--- a/src/libserver/smtp_proxy/line_reader.hxx
+++ b/src/libserver/smtp_proxy/line_reader.hxx
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_LINE_READER_HXX
+#define RSPAMD_LINE_READER_HXX
+
+#pragma once
+
+#include "config.h"
+#include "ring_buffer.hxx"
+#include "eod_scanner.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <optional>
+#include <variant>
+
+namespace rspamd::smtp {
+
+/**
+ * SMTP protocol violations that can be detected during line reading
+ */
+enum class line_violation {
+	none,
+	bare_lf,      // LF without preceding CR
+	line_too_long,// Line exceeds max_line_length
+	nul_in_line,  // NUL character in command line
+	missing_crlf  // Line doesn't end with CRLF (truncated)
+};
+
+/**
+ * Result of trying to read a line from the buffer
+ */
+struct line_result {
+	enum class status {
+		ok,        // Complete line available
+		incomplete,// Need more data
+		violation  // Protocol violation detected
+	};
+
+	status state = status::incomplete;
+	line_violation violation_type = line_violation::none;
+	std::string line;              // Line content without CRLF
+	std::string raw_line;          // Original line including terminator (for forwarding)
+	std::size_t bytes_consumed = 0;// Bytes consumed from buffer
+};
+
+/**
+ * Extracts CRLF-terminated lines from a ring buffer.
+ */
+class line_reader {
+public:
+	static constexpr std::size_t default_max_line_length = 4096;
+
+	explicit line_reader(std::size_t max_line_length = default_max_line_length)
+		: max_line_length_(max_line_length)
+	{
+	}
+
+	/**
+	 * Set maximum line length
+	 */
+	auto set_max_line_length(std::size_t len) noexcept -> void
+	{
+		max_line_length_ = len;
+	}
+
+	/**
+	 * Get maximum line length
+	 */
+	[[nodiscard]] auto max_line_length() const noexcept -> std::size_t
+	{
+		return max_line_length_;
+	}
+
+	/**
+	 * Try to extract a complete line from the ring buffer
+	 *
+	 * @tparam Capacity Ring buffer capacity
+	 * @param buffer Reference to ring buffer
+	 * @return line_result with status and data
+	 */
+	template<std::size_t Capacity>
+	[[nodiscard]] auto try_read_line(io::ring_buffer<Capacity> &buffer) -> line_result
+	{
+		line_result result;
+
+		if (buffer.empty()) {
+			result.state = line_result::status::incomplete;
+			return result;
+		}
+
+		// Get buffer data for scanning - we need to handle wrap-around
+		auto [ptr1, len1, ptr2, len2] = buffer.get_read_regions();
+
+		// Scan both regions of the ring buffer
+		std::optional<crlf_scanner::result> crlf_result;
+		std::optional<std::size_t> nul_pos;
+		std::optional<std::size_t> bare_lf_pos;
+
+		// Reset scanner for fresh scan
+		crlf_scanner_.reset();
+
+		// Scan first region
+		if (len1 > 0) {
+			// Check for NUL
+			auto nul_scan = nul_scanner::scan(ptr1, len1, 0);
+			if (nul_scan) {
+				nul_pos = nul_scan->position;
+			}
+
+			// Scan for CRLF
+			crlf_result = crlf_scanner_.scan(ptr1, len1, 0);
+			if (crlf_result && crlf_result->bare_lf) {
+				bare_lf_pos = crlf_result->line_end;
+			}
+		}
+
+		// Continue scanning second region if needed and no CRLF found yet
+		if (!crlf_result && len2 > 0) {
+			// Check for NUL in second region
+			if (!nul_pos) {
+				auto nul_scan = nul_scanner::scan(ptr2, len2, len1);
+				if (nul_scan) {
+					nul_pos = nul_scan->position;
+				}
+			}
+
+			// Continue CRLF scan
+			crlf_result = crlf_scanner_.scan(ptr2, len2, len1);
+			if (crlf_result && crlf_result->bare_lf && !bare_lf_pos) {
+				bare_lf_pos = crlf_result->line_end;
+			}
+		}
+
+		// Check for NUL violation before CRLF
+		if (nul_pos) {
+			if (!crlf_result || *nul_pos < crlf_result->line_end) {
+				result.state = line_result::status::violation;
+				result.violation_type = line_violation::nul_in_line;
+				return result;
+			}
+		}
+
+		// Check for bare LF violation
+		if (bare_lf_pos) {
+			result.state = line_result::status::violation;
+			result.violation_type = line_violation::bare_lf;
+			return result;
+		}
+
+		if (!crlf_result) {
+			// No complete line yet - check length
+			if (buffer.size() > max_line_length_) {
+				result.state = line_result::status::violation;
+				result.violation_type = line_violation::line_too_long;
+				return result;
+			}
+			result.state = line_result::status::incomplete;
+			return result;
+		}
+
+		// Check if line is too long
+		if (crlf_result->line_end > max_line_length_) {
+			result.state = line_result::status::violation;
+			result.violation_type = line_violation::line_too_long;
+			return result;
+		}
+
+		// Extract the line
+		std::size_t line_len = crlf_result->line_end;
+		std::size_t total_len = crlf_result->next_line;
+
+		// Read line content (without CRLF)
+		result.line.resize(line_len);
+		(void) buffer.peek(result.line.data(), line_len);
+
+		// Read raw line (with CRLF) for forwarding
+		result.raw_line.resize(total_len);
+		(void) buffer.peek(result.raw_line.data(), total_len);
+
+		// Consume the line from buffer
+		buffer.consume(total_len);
+
+		result.state = line_result::status::ok;
+		result.bytes_consumed = total_len;
+		return result;
+	}
+
+	/**
+	 * Read line with timeout tracking (for use with async I/O)
+	 * This version accumulates partial data across calls
+	 */
+	template<std::size_t Capacity>
+	[[nodiscard]] auto read_line_incremental(io::ring_buffer<Capacity> &buffer) -> line_result
+	{
+		// For incremental reading, we just delegate to try_read_line
+		// State management is handled by the caller
+		return try_read_line(buffer);
+	}
+
+	/**
+	 * Check if a partial line in the buffer would exceed max length
+	 */
+	template<std::size_t Capacity>
+	[[nodiscard]] auto check_line_length(const io::ring_buffer<Capacity> &buffer) const noexcept -> bool
+	{
+		return buffer.size() <= max_line_length_;
+	}
+
+	/**
+	 * Get a descriptive string for a violation type
+	 */
+	[[nodiscard]] static auto violation_to_string(line_violation v) noexcept -> const char *
+	{
+		switch (v) {
+		case line_violation::none:
+			return "none";
+		case line_violation::bare_lf:
+			return "bare LF without CR";
+		case line_violation::line_too_long:
+			return "line too long";
+		case line_violation::nul_in_line:
+			return "NUL character in line";
+		case line_violation::missing_crlf:
+			return "missing CRLF terminator";
+		}
+		return "unknown violation";
+	}
+
+private:
+	std::size_t max_line_length_;
+	crlf_scanner crlf_scanner_;
+};
+
+}// namespace rspamd::smtp
+
+#endif// RSPAMD_LINE_READER_HXX

--- a/src/libserver/smtp_proxy/pipelining_tracker.hxx
+++ b/src/libserver/smtp_proxy/pipelining_tracker.hxx
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_PIPELINING_TRACKER_HXX
+#define RSPAMD_PIPELINING_TRACKER_HXX
+
+#pragma once
+
+#include "config.h"
+#include "command_parser.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <string>
+
+namespace rspamd::smtp {
+
+/**
+ * Pipelining violations that can be detected
+ */
+enum class pipelining_violation {
+	none,
+	too_many_outstanding, // Exceeded max_outstanding limit
+	data_before_354,      // Client sent data before receiving 354
+	command_during_tls,   // Commands sent during TLS handshake
+	command_during_data,  // Commands sent during DATA transfer
+	sync_command_pipelined// Sync command was pipelined (EHLO, DATA, STARTTLS, QUIT)
+};
+
+/**
+ * State of the DATA phase
+ */
+enum class data_state {
+	none,     // Not in DATA phase
+	wait_354, // Sent DATA, waiting for 354
+	receiving,// Receiving message body
+	completed // Received end-of-data, waiting for final response
+};
+
+/**
+ * Queued command awaiting response
+ */
+struct pending_command {
+	command_type type;
+	std::string raw_line;  // For forwarding to backend
+	bool expects_multiline;// EHLO expects multiline response
+};
+
+/**
+ * SMTP pipelining tracker
+ *
+ * Tracks outstanding pipelined commands and detects violations:
+ * - Too many outstanding commands (configurable limit)
+ * - DATA bytes sent before 354 response
+ * - Commands during TLS handshake
+ * - Invalid state transitions
+ *
+ * Also handles multiline EHLO responses properly.
+ */
+class pipelining_tracker {
+public:
+	static constexpr std::size_t default_max_outstanding = 10;
+
+	explicit pipelining_tracker(std::size_t max_outstanding = default_max_outstanding)
+		: max_outstanding_(max_outstanding)
+	{
+	}
+
+	/**
+	 * Set maximum outstanding pipelined commands
+	 */
+	auto set_max_outstanding(std::size_t max) noexcept -> void
+	{
+		max_outstanding_ = max;
+	}
+
+	/**
+	 * Get maximum outstanding pipelined commands
+	 */
+	[[nodiscard]] auto max_outstanding() const noexcept -> std::size_t
+	{
+		return max_outstanding_;
+	}
+
+	/**
+	 * Reset tracker to initial state
+	 */
+	auto reset() noexcept -> void
+	{
+		pending_.clear();
+		data_state_ = data_state::none;
+		in_tls_handshake_ = false;
+		ehlo_received_ = false;
+		pipelining_enabled_ = false;
+	}
+
+	/**
+	 * Check if a command can be accepted given current state
+	 * @param cmd The command to check
+	 * @return pipelining_violation if violation detected, none otherwise
+	 */
+	[[nodiscard]] auto check_command(const parsed_command &cmd) const noexcept -> pipelining_violation
+	{
+		// Check TLS handshake state
+		if (in_tls_handshake_) {
+			return pipelining_violation::command_during_tls;
+		}
+
+		// Check DATA state
+		if (data_state_ == data_state::receiving) {
+			return pipelining_violation::command_during_data;
+		}
+
+		// Check outstanding limit (only if pipelining is enabled)
+		if (pipelining_enabled_ && pending_.size() >= max_outstanding_) {
+			return pipelining_violation::too_many_outstanding;
+		}
+
+		// Check if sync command is being pipelined
+		if (pipelining_enabled_ && !pending_.empty() && command_parser::is_sync_command(cmd.type)) {
+			return pipelining_violation::sync_command_pipelined;
+		}
+
+		return pipelining_violation::none;
+	}
+
+	/**
+	 * Record that a command has been sent/forwarded
+	 * @param cmd The command that was sent
+	 */
+	auto command_sent(const parsed_command &cmd) -> void
+	{
+		pending_command pending;
+		pending.type = cmd.type;
+		pending.raw_line = cmd.raw_line;
+		pending.expects_multiline = (cmd.type == command_type::ehlo);
+
+		pending_.push_back(std::move(pending));
+
+		// Update state for DATA command
+		if (cmd.type == command_type::data) {
+			data_state_ = data_state::wait_354;
+		}
+
+		// Update state for STARTTLS
+		if (cmd.type == command_type::starttls) {
+			// We'll enter TLS handshake when we receive 220 response
+		}
+
+		// Track EHLO/HELO
+		if (cmd.type == command_type::ehlo || cmd.type == command_type::helo) {
+			ehlo_received_ = true;
+		}
+	}
+
+	/**
+	 * Check if we're waiting for DATA 354 response and client is trying to send body
+	 */
+	[[nodiscard]] auto check_data_before_354() const noexcept -> bool
+	{
+		return data_state_ == data_state::wait_354;
+	}
+
+	/**
+	 * Record that a response has been received
+	 * @param code SMTP response code (e.g., 250, 354, 220)
+	 * @param is_final True if this is the final line of a multiline response
+	 * @return The command type this response was for, or nullopt if unexpected
+	 */
+	auto response_received(int code, bool is_final) -> std::optional<command_type>
+	{
+		if (pending_.empty()) {
+			return std::nullopt;
+		}
+
+		auto &front = pending_.front();
+
+		// For EHLO, wait for final line of multiline response
+		if (front.expects_multiline && !is_final) {
+			return front.type;
+		}
+
+		auto type = front.type;
+		pending_.pop_front();
+
+		// Handle state transitions based on response
+		switch (type) {
+		case command_type::ehlo:
+			// EHLO 250 response enables pipelining (usually)
+			// Note: We should check for PIPELINING in capability list
+			if (code >= 200 && code < 300) {
+				pipelining_enabled_ = true;
+			}
+			break;
+
+		case command_type::data:
+			if (code == 354) {
+				data_state_ = data_state::receiving;
+			}
+			else {
+				data_state_ = data_state::none;
+			}
+			break;
+
+		case command_type::starttls:
+			if (code == 220) {
+				in_tls_handshake_ = true;
+			}
+			break;
+
+		case command_type::rset:
+			// RSET resets transaction state but not session state
+			data_state_ = data_state::none;
+			break;
+
+		default:
+			break;
+		}
+
+		return type;
+	}
+
+	/**
+	 * Record that DATA transfer has completed (end-of-data received)
+	 */
+	auto data_transfer_complete() -> void
+	{
+		if (data_state_ == data_state::receiving) {
+			data_state_ = data_state::completed;
+		}
+	}
+
+	/**
+	 * Record that final DATA response has been received
+	 */
+	auto data_response_received() -> void
+	{
+		data_state_ = data_state::none;
+	}
+
+	/**
+	 * Record that TLS handshake has completed
+	 * @param success True if handshake succeeded
+	 */
+	auto tls_handshake_complete(bool success) -> void
+	{
+		in_tls_handshake_ = false;
+		if (success) {
+			// After STARTTLS, client must send EHLO again
+			ehlo_received_ = false;
+			pipelining_enabled_ = false;
+			// Clear any pending commands (shouldn't be any)
+			pending_.clear();
+		}
+	}
+
+	/**
+	 * Check if we need to enable pipelining based on EHLO capabilities
+	 */
+	auto enable_pipelining(bool enable) noexcept -> void
+	{
+		pipelining_enabled_ = enable;
+	}
+
+	/**
+	 * Current number of outstanding commands
+	 */
+	[[nodiscard]] auto outstanding_count() const noexcept -> std::size_t
+	{
+		return pending_.size();
+	}
+
+	/**
+	 * Check if any commands are pending
+	 */
+	[[nodiscard]] auto has_pending() const noexcept -> bool
+	{
+		return !pending_.empty();
+	}
+
+	/**
+	 * Get the next expected response command type
+	 */
+	[[nodiscard]] auto next_expected_response() const noexcept -> std::optional<command_type>
+	{
+		if (pending_.empty()) {
+			return std::nullopt;
+		}
+		return pending_.front().type;
+	}
+
+	/**
+	 * Current DATA phase state
+	 */
+	[[nodiscard]] auto get_data_state() const noexcept -> data_state
+	{
+		return data_state_;
+	}
+
+	/**
+	 * Check if in DATA receiving phase
+	 */
+	[[nodiscard]] auto is_in_data() const noexcept -> bool
+	{
+		return data_state_ == data_state::receiving;
+	}
+
+	/**
+	 * Check if in TLS handshake
+	 */
+	[[nodiscard]] auto is_in_tls_handshake() const noexcept -> bool
+	{
+		return in_tls_handshake_;
+	}
+
+	/**
+	 * Check if EHLO has been received
+	 */
+	[[nodiscard]] auto has_ehlo() const noexcept -> bool
+	{
+		return ehlo_received_;
+	}
+
+	/**
+	 * Check if pipelining is enabled
+	 */
+	[[nodiscard]] auto is_pipelining_enabled() const noexcept -> bool
+	{
+		return pipelining_enabled_;
+	}
+
+	/**
+	 * Get string representation of a pipelining violation
+	 */
+	[[nodiscard]] static auto violation_to_string(pipelining_violation v) noexcept -> const char *
+	{
+		switch (v) {
+		case pipelining_violation::none:
+			return "none";
+		case pipelining_violation::too_many_outstanding:
+			return "too many outstanding pipelined commands";
+		case pipelining_violation::data_before_354:
+			return "data sent before 354 response";
+		case pipelining_violation::command_during_tls:
+			return "command sent during TLS handshake";
+		case pipelining_violation::command_during_data:
+			return "command sent during DATA transfer";
+		case pipelining_violation::sync_command_pipelined:
+			return "synchronization command was pipelined";
+		}
+		return "unknown violation";
+	}
+
+private:
+	std::deque<pending_command> pending_;
+	std::size_t max_outstanding_;
+	data_state data_state_ = data_state::none;
+	bool in_tls_handshake_ = false;
+	bool ehlo_received_ = false;
+	bool pipelining_enabled_ = false;
+};
+
+}// namespace rspamd::smtp
+
+#endif// RSPAMD_PIPELINING_TRACKER_HXX

--- a/src/libserver/smtp_proxy/reply_parser.hxx
+++ b/src/libserver/smtp_proxy/reply_parser.hxx
@@ -1,0 +1,542 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_REPLY_PARSER_HXX
+#define RSPAMD_REPLY_PARSER_HXX
+
+#pragma once
+
+#include "config.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <optional>
+#include <algorithm>
+#include <cctype>
+
+namespace rspamd::smtp {
+
+/**
+ * Parsed SMTP reply line
+ */
+struct reply_line {
+	int code = 0;         // 3-digit reply code
+	bool is_final = false;// True if this is the last line (code followed by space)
+	std::string text;     // Text after code (without leading space/dash)
+	std::string raw_line; // Original line including CRLF (for forwarding)
+
+	/**
+	 * Check if this is a successful response (2xx)
+	 */
+	[[nodiscard]] auto is_success() const noexcept -> bool
+	{
+		return code >= 200 && code < 300;
+	}
+
+	/**
+	 * Check if this is a temporary failure (4xx)
+	 */
+	[[nodiscard]] auto is_temp_failure() const noexcept -> bool
+	{
+		return code >= 400 && code < 500;
+	}
+
+	/**
+	 * Check if this is a permanent failure (5xx)
+	 */
+	[[nodiscard]] auto is_perm_failure() const noexcept -> bool
+	{
+		return code >= 500 && code < 600;
+	}
+
+	/**
+	 * Check if this is a positive preliminary (1xx)
+	 */
+	[[nodiscard]] auto is_preliminary() const noexcept -> bool
+	{
+		return code >= 100 && code < 200;
+	}
+
+	/**
+	 * Check if this is a positive intermediate (3xx)
+	 */
+	[[nodiscard]] auto is_intermediate() const noexcept -> bool
+	{
+		return code >= 300 && code < 400;
+	}
+};
+
+/**
+ * Complete multiline SMTP reply
+ */
+struct smtp_reply {
+	int code = 0;                 // Reply code (from first/final line)
+	std::vector<reply_line> lines;// All lines of the reply
+	std::string enhanced_status;  // Enhanced status code if present (e.g., "2.1.0")
+
+	/**
+	 * Get all raw lines concatenated (for forwarding)
+	 */
+	[[nodiscard]] auto get_raw() const -> std::string
+	{
+		std::string raw;
+		for (const auto &line: lines) {
+			raw += line.raw_line;
+		}
+		return raw;
+	}
+
+	/**
+	 * Check if reply is complete (has final line)
+	 */
+	[[nodiscard]] auto is_complete() const noexcept -> bool
+	{
+		return !lines.empty() && lines.back().is_final;
+	}
+
+	/**
+	 * Get all text lines combined
+	 */
+	[[nodiscard]] auto get_text() const -> std::string
+	{
+		std::string text;
+		for (const auto &line: lines) {
+			if (!text.empty()) {
+				text += "\n";
+			}
+			text += line.text;
+		}
+		return text;
+	}
+
+	// Delegate to reply_line methods using the final code
+	[[nodiscard]] auto is_success() const noexcept -> bool
+	{
+		return code >= 200 && code < 300;
+	}
+
+	[[nodiscard]] auto is_temp_failure() const noexcept -> bool
+	{
+		return code >= 400 && code < 500;
+	}
+
+	[[nodiscard]] auto is_perm_failure() const noexcept -> bool
+	{
+		return code >= 500 && code < 600;
+	}
+};
+
+/**
+ * SMTP EHLO capability
+ */
+struct ehlo_capability {
+	std::string name;               // Capability name (uppercase)
+	std::vector<std::string> params;// Parameters (e.g., SIZE limit, AUTH mechanisms)
+};
+
+/**
+ * Parsed EHLO response
+ */
+struct ehlo_response {
+	std::string greeting;// First line greeting
+	std::vector<ehlo_capability> capabilities;
+	smtp_reply raw_reply;// Original reply for forwarding
+
+	/**
+	 * Check if a capability is present
+	 */
+	[[nodiscard]] auto has_capability(std::string_view name) const noexcept -> bool
+	{
+		std::string upper;
+		upper.reserve(name.size());
+		for (char c: name) {
+			upper.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+		}
+
+		return std::any_of(capabilities.begin(), capabilities.end(),
+						   [&upper](const ehlo_capability &cap) {
+							   return cap.name == upper;
+						   });
+	}
+
+	/**
+	 * Get capability parameters
+	 */
+	[[nodiscard]] auto get_capability(std::string_view name) const noexcept
+		-> std::optional<std::reference_wrapper<const ehlo_capability>>
+	{
+		std::string upper;
+		upper.reserve(name.size());
+		for (char c: name) {
+			upper.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+		}
+
+		auto it = std::find_if(capabilities.begin(), capabilities.end(),
+							   [&upper](const ehlo_capability &cap) {
+								   return cap.name == upper;
+							   });
+		if (it != capabilities.end()) {
+			return std::cref(*it);
+		}
+		return std::nullopt;
+	}
+
+	/**
+	 * Get SIZE limit if advertised
+	 */
+	[[nodiscard]] auto get_size_limit() const noexcept -> std::optional<std::size_t>
+	{
+		auto cap = get_capability("SIZE");
+		if (cap && !cap->get().params.empty()) {
+			try {
+				return std::stoull(cap->get().params[0]);
+			} catch (...) {
+				return std::nullopt;
+			}
+		}
+		return std::nullopt;
+	}
+};
+
+/**
+ * SMTP reply parser
+ *
+ * Parses SMTP responses including:
+ * - Single line responses (code SP text CRLF)
+ * - Multiline responses (code - text CRLF ... code SP text CRLF)
+ * - EHLO capability parsing
+ */
+class reply_parser {
+public:
+	reply_parser() = default;
+
+	/**
+	 * Parse a single reply line (without CRLF terminator)
+	 *
+	 * @param line Reply line to parse
+	 * @param raw_line Original line including CRLF (for forwarding)
+	 * @return Parsed reply_line or nullopt if invalid
+	 */
+	[[nodiscard]] auto parse_line(std::string_view line, std::string_view raw_line = {}) const
+		-> std::optional<reply_line>
+	{
+		if (line.size() < 3) {
+			return std::nullopt;
+		}
+
+		reply_line result;
+		result.raw_line = raw_line.empty() ? std::string(line) + "\r\n" : std::string(raw_line);
+
+		// Parse 3-digit code
+		if (!std::isdigit(static_cast<unsigned char>(line[0])) ||
+			!std::isdigit(static_cast<unsigned char>(line[1])) ||
+			!std::isdigit(static_cast<unsigned char>(line[2]))) {
+			return std::nullopt;
+		}
+
+		result.code = (line[0] - '0') * 100 + (line[1] - '0') * 10 + (line[2] - '0');
+
+		// Check for continuation or final line
+		if (line.size() == 3) {
+			// Just the code
+			result.is_final = true;
+			return result;
+		}
+
+		char sep = line[3];
+		if (sep == ' ') {
+			result.is_final = true;
+		}
+		else if (sep == '-') {
+			result.is_final = false;
+		}
+		else {
+			return std::nullopt;
+		}
+
+		// Extract text
+		if (line.size() > 4) {
+			result.text = std::string(line.substr(4));
+		}
+
+		return result;
+	}
+
+	/**
+	 * Accumulate lines into a complete reply
+	 *
+	 * @param reply Reply being accumulated
+	 * @param line Line to add
+	 * @return true if reply is now complete
+	 */
+	auto accumulate(smtp_reply &reply, const reply_line &line) const -> bool
+	{
+		reply.lines.push_back(line);
+
+		if (line.is_final) {
+			reply.code = line.code;
+
+			// Try to extract enhanced status code from first line text
+			if (!reply.lines.empty()) {
+				const auto &first_text = reply.lines[0].text;
+				if (first_text.size() >= 5 && std::isdigit(static_cast<unsigned char>(first_text[0]))) {
+					// Look for enhanced status code pattern: x.y.z
+					auto dot1 = first_text.find('.');
+					if (dot1 != std::string::npos && dot1 < 2) {
+						auto dot2 = first_text.find('.', dot1 + 1);
+						if (dot2 != std::string::npos) {
+							auto end = first_text.find(' ', dot2);
+							if (end == std::string::npos) {
+								end = first_text.size();
+							}
+							reply.enhanced_status = first_text.substr(0, end);
+						}
+					}
+				}
+			}
+
+			return true;
+		}
+
+		// Validate that multiline responses have consistent code
+		if (reply.lines.size() > 1) {
+			if (reply.lines.front().code != line.code) {
+				// Inconsistent code - this is a protocol error
+				// We'll accept it but note that it's weird
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Parse a complete EHLO response
+	 *
+	 * @param reply Complete SMTP reply from EHLO command
+	 * @return Parsed EHLO response with capabilities
+	 */
+	[[nodiscard]] auto parse_ehlo_response(const smtp_reply &reply) const -> ehlo_response
+	{
+		ehlo_response result;
+		result.raw_reply = reply;
+
+		if (reply.lines.empty()) {
+			return result;
+		}
+
+		// First line is the greeting
+		result.greeting = reply.lines[0].text;
+
+		// Subsequent lines are capabilities
+		for (size_t i = 1; i < reply.lines.size(); ++i) {
+			const auto &text = reply.lines[i].text;
+			if (text.empty()) {
+				continue;
+			}
+
+			ehlo_capability cap;
+
+			// Split on first space
+			auto space = text.find(' ');
+			std::string_view name_sv;
+			std::string_view params_sv;
+
+			if (space != std::string::npos) {
+				name_sv = std::string_view(text).substr(0, space);
+				params_sv = std::string_view(text).substr(space + 1);
+			}
+			else {
+				name_sv = text;
+			}
+
+			// Convert name to uppercase
+			cap.name.reserve(name_sv.size());
+			for (char c: name_sv) {
+				cap.name.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+			}
+
+			// Parse parameters (space-separated)
+			if (!params_sv.empty()) {
+				std::string current_param;
+				for (char c: params_sv) {
+					if (c == ' ') {
+						if (!current_param.empty()) {
+							cap.params.push_back(std::move(current_param));
+							current_param.clear();
+						}
+					}
+					else {
+						current_param.push_back(c);
+					}
+				}
+				if (!current_param.empty()) {
+					cap.params.push_back(std::move(current_param));
+				}
+			}
+
+			result.capabilities.push_back(std::move(cap));
+		}
+
+		return result;
+	}
+
+	/**
+	 * Build a rewritten EHLO response with filtered capabilities
+	 *
+	 * @param original Original EHLO response
+	 * @param caps_to_keep Set of capability names to keep (uppercase)
+	 * @param caps_to_remove Set of capability names to remove (uppercase)
+	 * @param caps_to_add Additional capabilities to add
+	 * @return Rewritten response as raw SMTP reply
+	 */
+	[[nodiscard]] auto rewrite_ehlo_response(
+		const ehlo_response &original,
+		const std::vector<std::string> &caps_to_keep,
+		const std::vector<std::string> &caps_to_remove,
+		const std::vector<ehlo_capability> &caps_to_add,
+		std::optional<std::size_t> size_limit = std::nullopt) const -> std::string
+	{
+		std::string result;
+		const int code = original.raw_reply.code;
+
+		// Helper to check if cap should be included
+		auto should_include = [&](const std::string &name) -> bool {
+			// Check removal list first
+			for (const auto &r: caps_to_remove) {
+				if (r == name) {
+					return false;
+				}
+			}
+			// If keep list is empty, keep all (except removed)
+			if (caps_to_keep.empty()) {
+				return true;
+			}
+			// Check keep list
+			for (const auto &k: caps_to_keep) {
+				if (k == name) {
+					return true;
+				}
+			}
+			return false;
+		};
+
+		// Build filtered capability list
+		std::vector<std::string> output_lines;
+
+		// First line is always the greeting
+		output_lines.push_back(original.greeting);
+
+		// Add filtered capabilities
+		for (const auto &cap: original.capabilities) {
+			if (!should_include(cap.name)) {
+				continue;
+			}
+
+			std::string line = cap.name;
+
+			// Special handling for SIZE
+			if (cap.name == "SIZE" && size_limit) {
+				line += " " + std::to_string(*size_limit);
+			}
+			else if (!cap.params.empty()) {
+				for (const auto &p: cap.params) {
+					line += " " + p;
+				}
+			}
+
+			output_lines.push_back(std::move(line));
+		}
+
+		// Add new capabilities
+		for (const auto &cap: caps_to_add) {
+			std::string line = cap.name;
+			for (const auto &p: cap.params) {
+				line += " " + p;
+			}
+			output_lines.push_back(std::move(line));
+		}
+
+		// Build output
+		for (size_t i = 0; i < output_lines.size(); ++i) {
+			char sep = (i == output_lines.size() - 1) ? ' ' : '-';
+			result += std::to_string(code) + sep + output_lines[i] + "\r\n";
+		}
+
+		return result;
+	}
+
+	/**
+	 * Create a simple single-line reply
+	 */
+	[[nodiscard]] static auto make_reply(int code, std::string_view text) -> std::string
+	{
+		return std::to_string(code) + " " + std::string(text) + "\r\n";
+	}
+
+	/**
+	 * Create a reply with enhanced status code
+	 */
+	[[nodiscard]] static auto make_reply(int code, std::string_view enhanced,
+										 std::string_view text) -> std::string
+	{
+		return std::to_string(code) + " " + std::string(enhanced) + " " +
+			   std::string(text) + "\r\n";
+	}
+
+	/**
+	 * Get standard reply for common scenarios
+	 */
+	[[nodiscard]] static auto get_standard_reply(int code) -> const char *
+	{
+		switch (code) {
+		case 220:
+			return "220 Service ready\r\n";
+		case 221:
+			return "221 2.0.0 Bye\r\n";
+		case 250:
+			return "250 2.0.0 OK\r\n";
+		case 354:
+			return "354 Start mail input; end with <CRLF>.<CRLF>\r\n";
+		case 421:
+			return "421 4.7.0 Service not available, closing transmission channel\r\n";
+		case 450:
+			return "450 4.7.1 Requested mail action not taken: mailbox unavailable\r\n";
+		case 451:
+			return "451 4.3.0 Requested action aborted: local error in processing\r\n";
+		case 500:
+			return "500 5.5.1 Syntax error, command unrecognized\r\n";
+		case 501:
+			return "501 5.5.4 Syntax error in parameters or arguments\r\n";
+		case 502:
+			return "502 5.5.1 Command not implemented\r\n";
+		case 503:
+			return "503 5.5.1 Bad sequence of commands\r\n";
+		case 550:
+			return "550 5.7.1 Requested action not taken: mailbox unavailable\r\n";
+		case 554:
+			return "554 5.7.1 Transaction failed\r\n";
+		default:
+			return nullptr;
+		}
+	}
+};
+
+}// namespace rspamd::smtp
+
+#endif// RSPAMD_REPLY_PARSER_HXX

--- a/src/libserver/smtp_proxy/ring_buffer.hxx
+++ b/src/libserver/smtp_proxy/ring_buffer.hxx
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_RING_BUFFER_HXX
+#define RSPAMD_RING_BUFFER_HXX
+
+#pragma once
+
+#include "config.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+#include <array>
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <span>
+
+#include <sys/uio.h>// for readv/writev
+
+namespace rspamd::io {
+
+/**
+ * Fixed-capacity ring buffer for I/O operations with watermarks.
+ */
+template<std::size_t Capacity = 16384>
+class ring_buffer {
+public:
+	static constexpr std::size_t capacity = Capacity;
+
+	/**
+	 * I/O operation result
+	 */
+	enum class io_result {
+		ok,         // Operation completed successfully
+		would_block,// EAGAIN/EWOULDBLOCK - try again later
+		error,      // I/O error occurred
+		eof,        // End of file/connection closed
+		buffer_full,// No space left in buffer
+		buffer_empty// No data available in buffer
+	};
+
+	ring_buffer() = default;
+	~ring_buffer() = default;
+
+	ring_buffer(const ring_buffer &) = delete;
+	ring_buffer &operator=(const ring_buffer &) = delete;
+	ring_buffer(ring_buffer &&) noexcept = default;
+	ring_buffer &operator=(ring_buffer &&) noexcept = default;
+
+	/**
+	 * Set watermark thresholds for backpressure
+	 * @param low Resume reading when bytes drop below this
+	 * @param high Stop reading when bytes exceed this
+	 */
+	auto set_watermarks(std::size_t low, std::size_t high) noexcept -> void
+	{
+		low_watermark_ = low;
+		high_watermark_ = high;
+	}
+
+	/**
+	 * Check if buffer has reached high watermark
+	 */
+	[[nodiscard]] auto is_above_high_watermark() const noexcept -> bool
+	{
+		return size() >= high_watermark_;
+	}
+
+	/**
+	 * Check if buffer has dropped below low watermark
+	 */
+	[[nodiscard]] auto is_below_low_watermark() const noexcept -> bool
+	{
+		return size() <= low_watermark_;
+	}
+
+	/**
+	 * Current number of bytes in buffer
+	 */
+	[[nodiscard]] auto size() const noexcept -> std::size_t
+	{
+		return size_;
+	}
+
+	/**
+	 * Available space for writing
+	 */
+	[[nodiscard]] auto available_space() const noexcept -> std::size_t
+	{
+		return capacity - size_;
+	}
+
+	/**
+	 * Check if buffer is empty
+	 */
+	[[nodiscard]] auto empty() const noexcept -> bool
+	{
+		return size_ == 0;
+	}
+
+	/**
+	 * Check if buffer is full
+	 */
+	[[nodiscard]] auto full() const noexcept -> bool
+	{
+		return size_ >= capacity;
+	}
+
+	/**
+	 * Reset buffer to empty state
+	 */
+	auto reset() noexcept -> void
+	{
+		read_head_ = 0;
+		write_head_ = 0;
+		size_ = 0;
+	}
+
+	/**
+	 * Read from file descriptor into buffer
+	 * @param fd File descriptor to read from
+	 * @return io_result indicating outcome
+	 */
+	auto read_from_fd(int fd) noexcept -> std::pair<io_result, std::size_t>
+	{
+		if (full()) {
+			return {io_result::buffer_full, 0};
+		}
+
+		// Calculate contiguous write region
+		auto [ptr1, len1, ptr2, len2] = get_write_regions();
+
+		struct iovec iov[2];
+		int iovcnt = 0;
+
+		if (len1 > 0) {
+			iov[iovcnt].iov_base = ptr1;
+			iov[iovcnt].iov_len = len1;
+			iovcnt++;
+		}
+		if (len2 > 0) {
+			iov[iovcnt].iov_base = ptr2;
+			iov[iovcnt].iov_len = len2;
+			iovcnt++;
+		}
+
+		if (iovcnt == 0) {
+			return {io_result::buffer_full, 0};
+		}
+
+		ssize_t n = ::readv(fd, iov, iovcnt);
+
+		if (n < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				return {io_result::would_block, 0};
+			}
+			return {io_result::error, 0};
+		}
+
+		if (n == 0) {
+			return {io_result::eof, 0};
+		}
+
+		advance_write(static_cast<std::size_t>(n));
+		return {io_result::ok, static_cast<std::size_t>(n)};
+	}
+
+	/**
+	 * Write from buffer to file descriptor
+	 * @param fd File descriptor to write to
+	 * @return io_result indicating outcome
+	 */
+	auto write_to_fd(int fd) noexcept -> std::pair<io_result, std::size_t>
+	{
+		if (empty()) {
+			return {io_result::buffer_empty, 0};
+		}
+
+		// Calculate contiguous read region
+		auto [ptr1, len1, ptr2, len2] = get_read_regions();
+
+		struct iovec iov[2];
+		int iovcnt = 0;
+
+		if (len1 > 0) {
+			iov[iovcnt].iov_base = const_cast<std::uint8_t *>(ptr1);
+			iov[iovcnt].iov_len = len1;
+			iovcnt++;
+		}
+		if (len2 > 0) {
+			iov[iovcnt].iov_base = const_cast<std::uint8_t *>(ptr2);
+			iov[iovcnt].iov_len = len2;
+			iovcnt++;
+		}
+
+		if (iovcnt == 0) {
+			return {io_result::buffer_empty, 0};
+		}
+
+		ssize_t n = ::writev(fd, iov, iovcnt);
+
+		if (n < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				return {io_result::would_block, 0};
+			}
+			return {io_result::error, 0};
+		}
+
+		consume(static_cast<std::size_t>(n));
+		return {io_result::ok, static_cast<std::size_t>(n)};
+	}
+
+	/**
+	 * Copy data into the buffer
+	 * @param data Pointer to data to copy
+	 * @param len Length of data
+	 * @return Number of bytes actually copied
+	 */
+	auto write(const void *data, std::size_t len) noexcept -> std::size_t
+	{
+		const auto *src = static_cast<const std::uint8_t *>(data);
+		std::size_t to_write = std::min(len, available_space());
+		std::size_t written = 0;
+
+		while (written < to_write) {
+			std::size_t chunk = std::min(to_write - written, capacity - write_head_);
+			std::memcpy(&buffer_[write_head_], src + written, chunk);
+			advance_write(chunk);
+			written += chunk;
+		}
+
+		return written;
+	}
+
+	/**
+	 * Copy data into the buffer from string_view
+	 */
+	auto write(std::string_view sv) noexcept -> std::size_t
+	{
+		return write(sv.data(), sv.size());
+	}
+
+	/**
+	 * Get read regions as two spans (handles wrap-around)
+	 * @return Tuple of (ptr1, len1, ptr2, len2)
+	 */
+	[[nodiscard]] auto get_read_regions() const noexcept
+		-> std::tuple<const std::uint8_t *, std::size_t, const std::uint8_t *, std::size_t>
+	{
+		if (size_ == 0) {
+			return {nullptr, 0, nullptr, 0};
+		}
+
+		std::size_t first_len = std::min(size_, capacity - read_head_);
+		const std::uint8_t *first_ptr = &buffer_[read_head_];
+
+		if (first_len < size_) {
+			// Data wraps around
+			return {first_ptr, first_len, &buffer_[0], size_ - first_len};
+		}
+
+		return {first_ptr, first_len, nullptr, 0};
+	}
+
+	/**
+	 * Get write regions as two spans (handles wrap-around)
+	 */
+	[[nodiscard]] auto get_write_regions() noexcept
+		-> std::tuple<std::uint8_t *, std::size_t, std::uint8_t *, std::size_t>
+	{
+		std::size_t avail = available_space();
+		if (avail == 0) {
+			return {nullptr, 0, nullptr, 0};
+		}
+
+		std::size_t first_len = std::min(avail, capacity - write_head_);
+		std::uint8_t *first_ptr = &buffer_[write_head_];
+
+		if (first_len < avail) {
+			return {first_ptr, first_len, &buffer_[0], avail - first_len};
+		}
+
+		return {first_ptr, first_len, nullptr, 0};
+	}
+
+	/**
+	 * Peek at buffer contents without consuming
+	 * Copies data to linear output buffer
+	 * @param out Output buffer
+	 * @param max_len Maximum bytes to peek
+	 * @return Number of bytes copied
+	 */
+	[[nodiscard]] auto peek(void *out, std::size_t max_len) const noexcept -> std::size_t
+	{
+		auto *dst = static_cast<std::uint8_t *>(out);
+		std::size_t to_peek = std::min(max_len, size_);
+		auto [ptr1, len1, ptr2, len2] = get_read_regions();
+
+		std::size_t copied = 0;
+		if (len1 > 0 && copied < to_peek) {
+			std::size_t chunk = std::min(len1, to_peek - copied);
+			std::memcpy(dst + copied, ptr1, chunk);
+			copied += chunk;
+		}
+		if (len2 > 0 && copied < to_peek) {
+			std::size_t chunk = std::min(len2, to_peek - copied);
+			std::memcpy(dst + copied, ptr2, chunk);
+			copied += chunk;
+		}
+
+		return copied;
+	}
+
+	/**
+	 * Peek at a specific position without consuming
+	 * @param offset Offset from read head
+	 * @return Byte value or nullopt if out of range
+	 */
+	[[nodiscard]] auto peek_at(std::size_t offset) const noexcept -> std::optional<std::uint8_t>
+	{
+		if (offset >= size_) {
+			return std::nullopt;
+		}
+		std::size_t pos = (read_head_ + offset) % capacity;
+		return buffer_[pos];
+	}
+
+	/**
+	 * Consume bytes from the buffer
+	 * @param len Number of bytes to consume
+	 */
+	auto consume(std::size_t len) noexcept -> void
+	{
+		len = std::min(len, size_);
+		read_head_ = (read_head_ + len) % capacity;
+		size_ -= len;
+	}
+
+	/**
+	 * Get pointer and length for contiguous data from read head
+	 * Returns (ptr, len) for the first contiguous segment only.
+	 * Use get_read_regions() if you need both segments of wrapped data.
+	 */
+	[[nodiscard]] auto get_contiguous_data() const noexcept -> std::pair<const std::uint8_t *, std::size_t>
+	{
+		if (size_ == 0) {
+			return {nullptr, 0};
+		}
+		std::size_t first_len = std::min(size_, capacity - read_head_);
+		return {&buffer_[read_head_], first_len};
+	}
+
+	/**
+	 * Copy data from buffer to string_view (uses temporary storage)
+	 * Note: The returned view is only valid until the next buffer modification
+	 * @param len Maximum length to copy
+	 * @return string_view of the data
+	 */
+	[[nodiscard]] auto peek_string(std::size_t len) const noexcept -> std::string_view
+	{
+		auto [ptr1, len1, ptr2, len2] = get_read_regions();
+
+		// If data is contiguous, return direct view
+		if (len <= len1) {
+			return {reinterpret_cast<const char *>(ptr1), std::min(len, len1)};
+		}
+
+		// Data wraps - can't return contiguous view without copy
+		// Return only the first segment for now
+		return {reinterpret_cast<const char *>(ptr1), len1};
+	}
+
+private:
+	auto advance_write(std::size_t len) noexcept -> void
+	{
+		write_head_ = (write_head_ + len) % capacity;
+		size_ += len;
+	}
+
+	alignas(64) std::array<std::uint8_t, Capacity> buffer_{};
+	std::size_t read_head_ = 0;
+	std::size_t write_head_ = 0;
+	std::size_t size_ = 0;
+	std::size_t low_watermark_ = Capacity / 4;
+	std::size_t high_watermark_ = Capacity * 3 / 4;
+};
+
+}// namespace rspamd::io
+
+#endif// RSPAMD_RING_BUFFER_HXX

--- a/src/libserver/smtp_proxy/ring_buffer.hxx
+++ b/src/libserver/smtp_proxy/ring_buffer.hxx
@@ -386,13 +386,17 @@ public:
 		return {reinterpret_cast<const char *>(ptr1), len1};
 	}
 
-private:
+	/**
+	 * Advance write head after external write to write regions
+	 * @param len Number of bytes written
+	 */
 	auto advance_write(std::size_t len) noexcept -> void
 	{
 		write_head_ = (write_head_ + len) % capacity;
 		size_ += len;
 	}
 
+private:
 	alignas(64) std::array<std::uint8_t, Capacity> buffer_{};
 	std::size_t read_head_ = 0;
 	std::size_t write_head_ = 0;

--- a/src/libserver/smtp_proxy/ring_buffer.hxx
+++ b/src/libserver/smtp_proxy/ring_buffer.hxx
@@ -28,6 +28,7 @@
 #include <array>
 #include <optional>
 #include <string_view>
+#include <tuple>
 #include <utility>
 #include <span>
 

--- a/src/libserver/smtp_proxy/ring_buffer.hxx
+++ b/src/libserver/smtp_proxy/ring_buffer.hxx
@@ -30,7 +30,6 @@
 #include <string_view>
 #include <tuple>
 #include <utility>
-#include <span>
 
 #include <sys/uio.h>// for readv/writev
 

--- a/src/libserver/smtp_proxy/smtp_proxy.hxx
+++ b/src/libserver/smtp_proxy/smtp_proxy.hxx
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_SMTP_PROXY_HXX
+#define RSPAMD_SMTP_PROXY_HXX
+
+#pragma once
+
+/**
+ * SMTP Proxy Library
+ *
+ * This library provides the underlying components for implementing an SMTP proxy:
+ *
+ * - ring_buffer: Fixed-capacity I/O buffer with watermarks and CRLF scanning
+ * - line_reader: CRLF-terminated line extraction with violation detection
+ * - command_parser: SMTP command parsing (EHLO, MAIL, RCPT, etc.)
+ * - reply_parser: SMTP response parsing and EHLO capability handling
+ * - pipelining_tracker: Pipelining state tracking and violation detection
+ *
+ * These components are designed to be used together in an async I/O context
+ * with libev and the Rspamd worker infrastructure.
+ */
+
+#include "ring_buffer.hxx"
+#include "line_reader.hxx"
+#include "command_parser.hxx"
+#include "reply_parser.hxx"
+#include "pipelining_tracker.hxx"
+
+namespace rspamd::smtp {
+
+/**
+ * Unified violation type that combines all protocol violations
+ */
+enum class violation_type {
+	// Line violations
+	bare_lf,
+	line_too_long,
+	nul_in_line,
+	missing_crlf,
+
+	// Pipelining violations
+	too_many_outstanding,
+	data_before_354,
+	command_during_tls,
+	command_during_data,
+	sync_command_pipelined,
+
+	// Command violations
+	unknown_command,
+	invalid_syntax,
+	unsupported_command
+};
+
+/**
+ * Convert violation type to human-readable string
+ */
+[[nodiscard]] inline auto violation_to_string(violation_type v) noexcept -> const char *
+{
+	switch (v) {
+	case violation_type::bare_lf:
+		return "bare LF without CR";
+	case violation_type::line_too_long:
+		return "line too long";
+	case violation_type::nul_in_line:
+		return "NUL character in line";
+	case violation_type::missing_crlf:
+		return "missing CRLF terminator";
+	case violation_type::too_many_outstanding:
+		return "too many outstanding pipelined commands";
+	case violation_type::data_before_354:
+		return "data sent before 354 response";
+	case violation_type::command_during_tls:
+		return "command sent during TLS handshake";
+	case violation_type::command_during_data:
+		return "command sent during DATA transfer";
+	case violation_type::sync_command_pipelined:
+		return "synchronization command was pipelined";
+	case violation_type::unknown_command:
+		return "unknown command";
+	case violation_type::invalid_syntax:
+		return "invalid command syntax";
+	case violation_type::unsupported_command:
+		return "unsupported command";
+	}
+	return "unknown violation";
+}
+
+/**
+ * Convert line_violation to unified violation_type
+ */
+[[nodiscard]] inline auto to_violation_type(line_violation v) noexcept -> violation_type
+{
+	switch (v) {
+	case line_violation::bare_lf:
+		return violation_type::bare_lf;
+	case line_violation::line_too_long:
+		return violation_type::line_too_long;
+	case line_violation::nul_in_line:
+		return violation_type::nul_in_line;
+	case line_violation::missing_crlf:
+		return violation_type::missing_crlf;
+	case line_violation::none:
+		break;
+	}
+	return violation_type::invalid_syntax;// Fallback
+}
+
+/**
+ * Convert pipelining_violation to unified violation_type
+ */
+[[nodiscard]] inline auto to_violation_type(pipelining_violation v) noexcept -> violation_type
+{
+	switch (v) {
+	case pipelining_violation::too_many_outstanding:
+		return violation_type::too_many_outstanding;
+	case pipelining_violation::data_before_354:
+		return violation_type::data_before_354;
+	case pipelining_violation::command_during_tls:
+		return violation_type::command_during_tls;
+	case pipelining_violation::command_during_data:
+		return violation_type::command_during_data;
+	case pipelining_violation::sync_command_pipelined:
+		return violation_type::sync_command_pipelined;
+	case pipelining_violation::none:
+		break;
+	}
+	return violation_type::invalid_syntax;// Fallback
+}
+
+/**
+ * SMTP session state
+ */
+enum class session_state {
+	initial,      // Before client sends EHLO/HELO
+	greeted,      // After successful EHLO/HELO
+	mail_from,    // After successful MAIL FROM
+	rcpt_to,      // After at least one successful RCPT TO
+	data,         // In DATA transfer
+	tls_handshake,// During STARTTLS handshake
+	closing       // Connection is closing
+};
+
+/**
+ * Transaction state (within a session)
+ */
+struct transaction_state {
+	std::string mail_from;
+	std::vector<std::string> rcpt_to;
+	std::size_t message_size = 0;
+	bool has_8bitmime = false;
+	bool has_smtputf8 = false;
+
+	auto reset() -> void
+	{
+		mail_from.clear();
+		rcpt_to.clear();
+		message_size = 0;
+		has_8bitmime = false;
+		has_smtputf8 = false;
+	}
+
+	[[nodiscard]] auto has_envelope() const noexcept -> bool
+	{
+		return !mail_from.empty() && !rcpt_to.empty();
+	}
+};
+
+/**
+ * Default buffer size for SMTP proxy
+ */
+constexpr std::size_t default_buffer_size = 16384;
+
+/**
+ * Type alias for the default ring buffer
+ */
+using smtp_buffer = io::ring_buffer<default_buffer_size>;
+
+}// namespace rspamd::smtp
+
+#endif// RSPAMD_SMTP_PROXY_HXX

--- a/src/libserver/smtp_proxy/smtp_proxy_session.cxx
+++ b/src/libserver/smtp_proxy/smtp_proxy_session.cxx
@@ -19,6 +19,11 @@
 #include "libutil/addr.h"
 #include "libserver/dns.h"
 #include "libserver/ssl_util.h"
+#include "libserver/task.h"
+#include "libserver/cfg_file.h"
+#include "libserver/cfg_file_private.h"
+#include "libmime/scan_result.h"
+#include "libmime/email_addr.h"
 #include "unix-std.h"
 
 #include <sys/socket.h>
@@ -30,7 +35,6 @@ namespace rspamd::smtp {
 
 namespace {
 
-// Set socket to non-blocking mode
 auto set_nonblocking(int fd) -> bool
 {
 	int flags = fcntl(fd, F_GETFL, 0);
@@ -40,31 +44,27 @@ auto set_nonblocking(int fd) -> bool
 	return fcntl(fd, F_SETFL, flags | O_NONBLOCK) >= 0;
 }
 
-// Enable TCP_NODELAY
 auto set_nodelay(int fd) -> bool
 {
 	int flag = 1;
 	return setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) >= 0;
 }
 
-// Generate random log tag
 auto generate_log_tag(char *buf, size_t len) -> void
 {
-	static const char alphanum[] = "0123456789abcdef";
+	static constexpr char alphanum[] = "0123456789abcdef";
 	for (size_t i = 0; i < len - 1; ++i) {
 		buf[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
 	}
 	buf[len - 1] = '\0';
 }
 
-}// anonymous namespace
+}// namespace
 
 auto smtp_proxy_session::create(smtp_proxy_ctx *ctx, int client_fd,
 								const rspamd_inet_addr_t *client_addr) -> ptr
 {
-	// Use shared_ptr with custom destructor pattern
-	auto session = ptr(new smtp_proxy_session(ctx, client_fd, client_addr));
-	return session;
+	return ptr(new smtp_proxy_session(ctx, client_fd, client_addr));
 }
 
 smtp_proxy_session::smtp_proxy_session(smtp_proxy_ctx *ctx, int client_fd,
@@ -73,24 +73,19 @@ smtp_proxy_session::smtp_proxy_session(smtp_proxy_ctx *ctx, int client_fd,
 	  client_addr_(client_addr),
 	  pipeline_(ctx->max_outstanding)
 {
-	// Create memory pool for session
 	pool_ = rspamd_mempool_new(rspamd_mempool_suggest_size(), "smtp_proxy", 0);
 
-	// Generate log tag
 	generate_log_tag(log_tag_, sizeof(log_tag_));
 	rspamd_strlcpy(pool_->tag.tagname, "smtp_proxy", sizeof(pool_->tag.tagname));
 	rspamd_strlcpy(pool_->tag.uid, log_tag_, sizeof(pool_->tag.uid));
 
-	// Initialize client connection
 	client_.fd = client_fd;
 	client_.session = this;
 	client_.reader.set_max_line_length(ctx->max_line_length);
 
-	// Set socket options
 	set_nonblocking(client_fd);
 	set_nodelay(client_fd);
 
-	// Initialize libev watchers
 	ev_io_init(&client_.read_ev, client_read_cb, client_fd, EV_READ);
 	ev_io_init(&client_.write_ev, client_write_cb, client_fd, EV_WRITE);
 	ev_timer_init(&client_.timeout_ev, client_timeout_cb, ctx->client_timeout, 0.0);
@@ -99,7 +94,6 @@ smtp_proxy_session::smtp_proxy_session(smtp_proxy_ctx *ctx, int client_fd,
 	client_.write_ev.data = this;
 	client_.timeout_ev.data = this;
 
-	// Initialize backend connection (not connected yet)
 	backend_.fd = -1;
 	backend_.session = this;
 
@@ -126,18 +120,13 @@ smtp_proxy_session::~smtp_proxy_session()
 
 auto smtp_proxy_session::start() -> void
 {
-	// Connect to backend first
 	if (!connect_backend()) {
-		// Send temporary failure and close
 		forward_to_client(reply_parser::get_standard_reply(421));
 		close("backend connection failed");
 		return;
 	}
 
-	// Start timeout timer
 	reset_client_timeout();
-
-	// We'll wait for backend greeting before enabling client reads
 }
 
 auto smtp_proxy_session::close(const char *reason) -> void
@@ -151,7 +140,6 @@ auto smtp_proxy_session::close(const char *reason) -> void
 		close_reason_ = reason;
 	}
 
-	// Stop all watchers
 	if (ctx_ && ctx_->event_loop) {
 		ev_io_stop(ctx_->event_loop, &client_.read_ev);
 		ev_io_stop(ctx_->event_loop, &client_.write_ev);
@@ -163,7 +151,6 @@ auto smtp_proxy_session::close(const char *reason) -> void
 		ev_timer_stop(ctx_->event_loop, &backend_.connect_timeout_ev);
 	}
 
-	// Close SSL connections if active
 	if (client_.ssl) {
 		rspamd_ssl_connection_free(client_.ssl);
 		client_.ssl = nullptr;
@@ -173,7 +160,6 @@ auto smtp_proxy_session::close(const char *reason) -> void
 		backend_.ssl = nullptr;
 	}
 
-	// Close file descriptors
 	if (client_.fd >= 0) {
 		::close(client_.fd);
 		client_.fd = -1;
@@ -188,7 +174,6 @@ auto smtp_proxy_session::close(const char *reason) -> void
 
 auto smtp_proxy_session::connect_backend() -> bool
 {
-	// Create socket
 	int fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (fd < 0) {
 		return false;
@@ -197,17 +182,14 @@ auto smtp_proxy_session::connect_backend() -> bool
 	set_nonblocking(fd);
 	set_nodelay(fd);
 
-	// Connect to backend (simplified - real implementation would use DNS resolution)
 	struct sockaddr_in addr{};
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(ctx_->backend_port);
 
-	// For now, assume backend_host is an IP address or use localhost
 	if (ctx_->backend_host.empty()) {
 		addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	}
 	else {
-		// This is simplified - real implementation would use proper address resolution
 		if (inet_pton(AF_INET, ctx_->backend_host.c_str(), &addr.sin_addr) != 1) {
 			::close(fd);
 			return false;
@@ -223,13 +205,11 @@ auto smtp_proxy_session::connect_backend() -> bool
 	backend_.fd = fd;
 	backend_.state = backend_state::connecting;
 
-	// Initialize watchers with actual fd
 	ev_io_init(&backend_.read_ev, backend_read_cb, fd, EV_READ);
 	ev_io_init(&backend_.write_ev, backend_write_cb, fd, EV_WRITE);
 	backend_.read_ev.data = this;
 	backend_.write_ev.data = this;
 
-	// Wait for connection to complete (write becomes ready)
 	ev_io_init(&backend_.read_ev, backend_connect_cb, fd, EV_WRITE);
 	ev_io_start(ctx_->event_loop, &backend_.read_ev);
 	ev_timer_start(ctx_->event_loop, &backend_.connect_timeout_ev);
@@ -237,7 +217,6 @@ auto smtp_proxy_session::connect_backend() -> bool
 	return true;
 }
 
-// Static callback wrappers
 void smtp_proxy_session::client_read_cb(struct ev_loop *loop, ev_io *w, int revents)
 {
 	auto *session = static_cast<smtp_proxy_session *>(w->data);
@@ -284,7 +263,6 @@ void smtp_proxy_session::backend_connect_cb(struct ev_loop *loop, ev_io *w, int 
 	ev_io_stop(loop, w);
 	ev_timer_stop(loop, &session->backend_.connect_timeout_ev);
 
-	// Check if connection succeeded
 	int err = 0;
 	socklen_t len = sizeof(err);
 	if (getsockopt(session->backend_.fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0 || err != 0) {
@@ -295,7 +273,6 @@ void smtp_proxy_session::backend_connect_cb(struct ev_loop *loop, ev_io *w, int 
 
 	session->backend_.state = backend_state::connected;
 
-	// Re-initialize watchers for normal operation
 	ev_io_init(&session->backend_.read_ev, backend_read_cb,
 			   session->backend_.fd, EV_READ);
 	ev_io_init(&session->backend_.write_ev, backend_write_cb,
@@ -303,7 +280,6 @@ void smtp_proxy_session::backend_connect_cb(struct ev_loop *loop, ev_io *w, int 
 	session->backend_.read_ev.data = session;
 	session->backend_.write_ev.data = session;
 
-	// Start reading backend greeting
 	session->enable_backend_read();
 	session->reset_backend_timeout();
 }
@@ -319,8 +295,7 @@ auto smtp_proxy_session::handle_client_read() -> void
 {
 	reset_client_timeout();
 
-	// Read data into buffer
-	auto [result, bytes] = client_.read_buffer.read_from_fd(client_.fd);
+	auto [result, bytes] = read_client_data();
 
 	switch (result) {
 	case io::ring_buffer<>::io_result::ok:
@@ -334,19 +309,17 @@ auto smtp_proxy_session::handle_client_read() -> void
 		close("client read error");
 		return;
 	case io::ring_buffer<>::io_result::buffer_full:
-		// Backpressure - disable reads
+
 		disable_client_read();
 		return;
 	default:
 		return;
 	}
 
-	// Process data based on state
 	if (in_data_stream_) {
-		// Stream DATA directly to backend
+
 		auto [ptr1, len1, ptr2, len2] = client_.read_buffer.get_read_regions();
 
-		// Feed data to the eod_scanner to find end-of-data sequence
 		std::optional<eod_scanner::result> eod_result;
 
 		if (len1 > 0) {
@@ -357,11 +330,9 @@ auto smtp_proxy_session::handle_client_read() -> void
 		}
 
 		if (eod_result && eod_result->found) {
-			// Calculate how much of the current buffer contains the EOD
 			std::size_t eod_relative_start = eod_result->eod_start - data_bytes_transferred_;
 			std::size_t total = eod_relative_start + eod_result->eod_length;
 
-			// Forward up to and including end-of-data
 			if (len1 >= total) {
 				forward_to_backend({reinterpret_cast<const char *>(ptr1), total});
 			}
@@ -379,9 +350,6 @@ auto smtp_proxy_session::handle_client_read() -> void
 			pipeline_.data_transfer_complete();
 		}
 		else {
-			// Forward all available data (keeping potential partial terminator)
-			// The eod_scanner tells us how many bytes are "pending" as part of
-			// a potential EOD sequence that we shouldn't forward yet
 			std::size_t pending = eod_scanner_.pending_bytes();
 			std::size_t buffer_size = client_.read_buffer.size();
 			std::size_t safe_len = buffer_size > pending ? buffer_size - pending : 0;
@@ -402,7 +370,6 @@ auto smtp_proxy_session::handle_client_read() -> void
 		}
 	}
 	else {
-		// Process command lines
 		while (!closed_) {
 			auto line = client_.reader.try_read_line(client_.read_buffer);
 
@@ -422,7 +389,7 @@ auto smtp_proxy_session::handle_client_read() -> void
 
 auto smtp_proxy_session::handle_client_write() -> void
 {
-	auto [result, bytes] = client_.write_buffer.write_to_fd(client_.fd);
+	auto [result, bytes] = write_client_data();
 
 	switch (result) {
 	case io::ring_buffer<>::io_result::ok:
@@ -439,7 +406,6 @@ auto smtp_proxy_session::handle_client_write() -> void
 		break;
 	}
 
-	// Re-enable backend reads if we have space
 	if (client_.write_buffer.is_below_low_watermark()) {
 		enable_backend_read();
 	}
@@ -449,7 +415,7 @@ auto smtp_proxy_session::handle_backend_read() -> void
 {
 	reset_backend_timeout();
 
-	auto [result, bytes] = backend_.read_buffer.read_from_fd(backend_.fd);
+	auto [result, bytes] = read_backend_data();
 
 	switch (result) {
 	case io::ring_buffer<>::io_result::ok:
@@ -469,7 +435,6 @@ auto smtp_proxy_session::handle_backend_read() -> void
 		return;
 	}
 
-	// Parse reply lines
 	line_reader reader;
 	while (!closed_) {
 		auto line = reader.try_read_line(backend_.read_buffer);
@@ -480,7 +445,6 @@ auto smtp_proxy_session::handle_backend_read() -> void
 
 		auto parsed = backend_.parser.parse_line(line.line, line.raw_line);
 		if (!parsed) {
-			// Invalid reply - forward as-is for robustness
 			forward_to_client(line.raw_line);
 			continue;
 		}
@@ -496,7 +460,7 @@ auto smtp_proxy_session::handle_backend_read() -> void
 
 auto smtp_proxy_session::handle_backend_write() -> void
 {
-	auto [result, bytes] = backend_.write_buffer.write_to_fd(backend_.fd);
+	auto [result, bytes] = write_backend_data();
 
 	switch (result) {
 	case io::ring_buffer<>::io_result::ok:
@@ -513,7 +477,6 @@ auto smtp_proxy_session::handle_backend_write() -> void
 		break;
 	}
 
-	// Re-enable client reads if we have space
 	if (backend_.write_buffer.is_below_low_watermark() && !client_.read_paused) {
 		enable_client_read();
 	}
@@ -521,17 +484,14 @@ auto smtp_proxy_session::handle_backend_write() -> void
 
 auto smtp_proxy_session::process_client_line(const line_result &line) -> void
 {
-	// Parse the command
 	auto cmd = cmd_parser_.parse(line.line, line.raw_line);
 
-	// Check pipelining rules
 	auto violation = pipeline_.check_command(cmd);
 	if (violation != pipelining_violation::none) {
 		report_violation(to_violation_type(violation));
 		return;
 	}
 
-	// Handle unsupported commands
 	if (cmd.type == command_type::bdat) {
 		forward_to_client("502 5.5.1 BDAT not implemented\r\n");
 		return;
@@ -542,7 +502,6 @@ auto smtp_proxy_session::process_client_line(const line_result &line) -> void
 		return;
 	}
 
-	// Track command state
 	switch (cmd.type) {
 	case command_type::ehlo:
 	case command_type::helo:
@@ -579,7 +538,6 @@ auto smtp_proxy_session::process_client_line(const line_result &line) -> void
 		break;
 
 	case command_type::quit:
-		// Forward QUIT and prepare to close
 		state_ = session_state::closing;
 		break;
 
@@ -587,37 +545,61 @@ auto smtp_proxy_session::process_client_line(const line_result &line) -> void
 		break;
 	}
 
-	// Record command sent
 	pipeline_.command_sent(cmd);
 
-	// Forward to backend
 	forward_to_backend(cmd.raw_line);
+}
+
+auto smtp_proxy_session::should_run_precheck(command_type cmd) const -> bool
+{
+	switch (ctx_->precheck_hook) {
+	case precheck_point::disabled:
+		return false;
+
+	case precheck_point::on_connect:
+		return false;
+
+	case precheck_point::after_mail:
+		return cmd == command_type::mail_from && !precheck_done_;
+
+	case precheck_point::after_first_rcpt:
+		return cmd == command_type::rcpt_to &&
+			   transaction_.rcpt_to.size() == 1 &&
+			   !precheck_done_;
+	}
+
+	return false;
 }
 
 auto smtp_proxy_session::process_backend_reply(const smtp_reply &reply) -> void
 {
-	// Get expected command type
 	auto expected = pipeline_.next_expected_response();
 
-	// For greeting (no command expected), relay directly
 	if (!expected && backend_.state == backend_state::connected) {
 		backend_.state = backend_state::ready;
+
+		if (ctx_->precheck_hook == precheck_point::on_connect && !precheck_done_) {
+			precheck_done_ = true;
+			if (!run_precheck()) {
+				forward_to_client(precheck_reject_reply_);
+				close("precheck rejected");
+				return;
+			}
+		}
+
 		forward_to_client(reply.get_raw());
 		enable_client_read();
 		return;
 	}
 
-	// Record response received
 	bool is_final = reply.is_complete();
 	auto responded_to = pipeline_.response_received(reply.code, is_final);
 
 	if (!responded_to) {
-		// Unexpected response - forward anyway
 		forward_to_client(reply.get_raw());
 		return;
 	}
 
-	// Handle specific responses
 	switch (*responded_to) {
 	case command_type::ehlo:
 		handle_ehlo_response(reply);
@@ -632,12 +614,18 @@ auto smtp_proxy_session::process_backend_reply(const smtp_reply &reply) -> void
 		break;
 
 	default:
-		// Forward reply as-is
+		if (reply.is_success() && should_run_precheck(*responded_to)) {
+			precheck_done_ = true;
+			if (!run_precheck()) {
+				forward_to_client(precheck_reject_reply_);
+				close("precheck rejected");
+				return;
+			}
+		}
 		forward_to_client(reply.get_raw());
 		break;
 	}
 
-	// Update session state
 	if (responded_to && reply.is_success()) {
 		switch (*responded_to) {
 		case command_type::ehlo:
@@ -726,26 +714,131 @@ auto smtp_proxy_session::handle_starttls_response(const smtp_reply &reply) -> vo
 		return;
 	}
 
-	// Don't forward 220 yet - initiate TLS on both sides
 	state_ = session_state::tls_handshake;
 
-	// Start backend TLS first, then client TLS
 	start_backend_tls();
+}
+
+void smtp_proxy_session::client_ssl_handler(int fd, short what, gpointer d)
+{
+	auto *session = static_cast<smtp_proxy_session *>(d);
+	session->handle_client_ssl_ready();
+}
+
+void smtp_proxy_session::client_ssl_error_handler(gpointer d, GError *err)
+{
+	auto *session = static_cast<smtp_proxy_session *>(d);
+	session->close("client TLS handshake failed");
+}
+
+void smtp_proxy_session::backend_ssl_handler(int fd, short what, gpointer d)
+{
+	auto *session = static_cast<smtp_proxy_session *>(d);
+	session->handle_backend_ssl_ready();
+}
+
+void smtp_proxy_session::backend_ssl_error_handler(gpointer d, GError *err)
+{
+	auto *session = static_cast<smtp_proxy_session *>(d);
+	session->forward_to_client("454 4.7.0 TLS handshake failed\r\n");
+	session->close("backend TLS handshake failed");
+}
+
+auto smtp_proxy_session::handle_client_ssl_ready() -> void
+{
+	client_.ssl_active = true;
+
+	disable_client_read();
+	disable_client_write();
+
+	pipeline_.tls_handshake_complete(true);
+
+	enable_client_read();
+	state_ = session_state::initial;// Client must re-EHLO
+}
+
+auto smtp_proxy_session::handle_backend_ssl_ready() -> void
+{
+	backend_.ssl_active = true;
+	backend_.state = backend_state::ready;
+
+	start_client_tls();
 }
 
 auto smtp_proxy_session::start_client_tls() -> void
 {
-	// Forward the 220 to client to trigger their TLS handshake
+	if (!ctx_->ssl_ctx) {
+		forward_to_client("454 4.7.0 TLS not available\r\n");
+		pipeline_.tls_handshake_complete(false);
+		state_ = session_state::greeted;
+		return;
+	}
+
+	disable_client_read();
+	disable_client_write();
+
+	client_.ssl = rspamd_ssl_connection_new(ctx_->ssl_ctx,
+											ctx_->event_loop,
+											FALSE,// Don't verify client cert
+											log_tag_);
+
+	if (!client_.ssl) {
+		forward_to_client("454 4.7.0 TLS initialization failed\r\n");
+		pipeline_.tls_handshake_complete(false);
+		state_ = session_state::greeted;
+		return;
+	}
+
 	forward_to_client("220 2.0.0 Ready to start TLS\r\n");
 
-	// TODO: Implement SSL accept using rspamd_ssl_accept_fd (to be added)
-	// For now, this is a placeholder
+	rspamd_ev_watcher_init(&client_.ssl_ev, client_.fd, EV_READ | EV_WRITE,
+						   nullptr, this);
+
+	if (!rspamd_ssl_accept_fd(client_.ssl, client_.fd,
+							  &client_.ssl_ev, ctx_->client_timeout,
+							  client_ssl_handler, client_ssl_error_handler,
+							  this)) {
+		rspamd_ssl_connection_free(client_.ssl);
+		client_.ssl = nullptr;
+		pipeline_.tls_handshake_complete(false);
+		close("client TLS handshake initiation failed");
+	}
 }
 
 auto smtp_proxy_session::start_backend_tls() -> void
 {
-	// TODO: Implement backend TLS upgrade
-	// This would use rspamd_ssl_connect_fd
+	disable_backend_read();
+	disable_backend_write();
+
+	backend_.ssl = rspamd_ssl_connection_new(rspamd_init_ssl_ctx_noverify(),
+											 ctx_->event_loop,
+											 FALSE,// Don't verify for now (configurable)
+											 log_tag_);
+
+	if (!backend_.ssl) {
+		forward_to_client("454 4.7.0 Backend TLS initialization failed\r\n");
+		pipeline_.tls_handshake_complete(false);
+		state_ = session_state::greeted;
+		return;
+	}
+
+	backend_.state = backend_state::tls_handshaking;
+
+	rspamd_ev_watcher_init(&backend_.ssl_ev, backend_.fd, EV_READ | EV_WRITE,
+						   nullptr, this);
+
+	const char *hostname = ctx_->backend_host.empty() ? nullptr : ctx_->backend_host.c_str();
+
+	if (!rspamd_ssl_connect_fd(backend_.ssl, backend_.fd, hostname,
+							   &backend_.ssl_ev, ctx_->backend_timeout,
+							   backend_ssl_handler, backend_ssl_error_handler,
+							   this)) {
+		rspamd_ssl_connection_free(backend_.ssl);
+		backend_.ssl = nullptr;
+		forward_to_client("454 4.7.0 Backend TLS handshake initiation failed\r\n");
+		pipeline_.tls_handshake_complete(false);
+		state_ = session_state::greeted;
+	}
 }
 
 auto smtp_proxy_session::forward_to_backend(std::string_view data) -> void
@@ -755,7 +848,6 @@ auto smtp_proxy_session::forward_to_backend(std::string_view data) -> void
 		enable_backend_write();
 	}
 
-	// Apply backpressure if needed
 	if (backend_.write_buffer.is_above_high_watermark()) {
 		disable_client_read();
 	}
@@ -768,7 +860,6 @@ auto smtp_proxy_session::forward_to_client(std::string_view data) -> void
 		enable_client_write();
 	}
 
-	// Apply backpressure if needed
 	if (client_.write_buffer.is_above_high_watermark()) {
 		disable_backend_read();
 	}
@@ -776,24 +867,158 @@ auto smtp_proxy_session::forward_to_client(std::string_view data) -> void
 
 auto smtp_proxy_session::report_violation(violation_type v) -> void
 {
-	// TODO: Call Lua on_violation hook
-
-	// Default action: send error and close
 	std::string msg = "500 5.5.1 Protocol violation: ";
 	msg += violation_to_string(v);
 	msg += "\r\n";
-
 	forward_to_client(msg);
 	close(violation_to_string(v));
 }
 
-auto smtp_proxy_session::run_precheck() -> bool
+/**
+ * Result of a precheck scan
+ */
+struct precheck_result {
+	bool should_reject = false;
+	bool is_tempfail = false;
+	std::string reply_code;
+	std::string reply_message;
+};
+
+/**
+ * Check the action from a task result to determine if we should reject
+ */
+static auto check_task_action(struct rspamd_task *task) -> precheck_result
 {
-	// TODO: Implement precheck using rspamd_task
-	return true;
+	precheck_result result;
+
+	if (!task || !task->result) {
+		return result;
+	}
+
+	struct rspamd_passthrough_result *ppr = nullptr;
+	auto *action = rspamd_check_action_metric(task, &ppr, task->result);
+
+	if (!action) {
+		return result;
+	}
+
+	// Check the action type
+	switch (action->action_type) {
+	case METRIC_ACTION_REJECT:
+	case METRIC_ACTION_DISCARD:
+		result.should_reject = true;
+		result.is_tempfail = false;
+		result.reply_code = "550";
+		if (ppr && ppr->message) {
+			result.reply_message = ppr->message;
+		}
+		else {
+			result.reply_message = "5.7.1 Message rejected";
+		}
+		break;
+
+	case METRIC_ACTION_SOFT_REJECT:
+		result.should_reject = true;
+		result.is_tempfail = true;
+		result.reply_code = "451";
+		if (ppr && ppr->message) {
+			result.reply_message = ppr->message;
+		}
+		else {
+			result.reply_message = "4.7.1 Try again later";
+		}
+		break;
+
+	case METRIC_ACTION_GREYLIST:
+		// For precheck, greylist means tempfail
+		result.should_reject = true;
+		result.is_tempfail = true;
+		result.reply_code = "451";
+		if (ppr && ppr->message) {
+			result.reply_message = ppr->message;
+		}
+		else {
+			result.reply_message = "4.7.1 Greylisted, please try again later";
+		}
+		break;
+
+	default:
+		// Allow the message through
+		result.should_reject = false;
+		break;
+	}
+
+	return result;
 }
 
-// Helper methods for event management
+auto smtp_proxy_session::run_precheck() -> bool
+{
+	if (ctx_->precheck_hook == precheck_point::disabled) {
+		return true;
+	}
+
+	auto *task = rspamd_task_new(ctx_->worker, ctx_->cfg, nullptr,
+								 nullptr, ctx_->event_loop, FALSE);
+
+	if (!task) {
+		return true;
+	}
+
+	task->flags |= RSPAMD_TASK_FLAG_SKIP_PROCESS;
+
+	if (client_addr_) {
+		task->from_addr = rspamd_inet_address_copy(client_addr_, task->task_pool);
+		task->client_addr = task->from_addr;
+	}
+
+	if (!client_helo_domain_.empty()) {
+		task->helo = rspamd_mempool_strdup(task->task_pool, client_helo_domain_.c_str());
+	}
+
+	if (!transaction_.mail_from.empty()) {
+		task->from_envelope = rspamd_email_address_from_smtp(
+			transaction_.mail_from.c_str(),
+			transaction_.mail_from.length());
+	}
+
+	if (!transaction_.rcpt_to.empty()) {
+		task->rcpt_envelope = g_ptr_array_sized_new(transaction_.rcpt_to.size());
+		rspamd_mempool_add_destructor(task->task_pool,
+									  rspamd_ptr_array_free_hard,
+									  task->rcpt_envelope);
+
+		for (const auto &rcpt: transaction_.rcpt_to) {
+			auto *addr = rspamd_email_address_from_smtp(rcpt.c_str(), rcpt.length());
+			if (addr) {
+				g_ptr_array_add(task->rcpt_envelope, addr);
+			}
+		}
+	}
+
+	rspamd_create_metric_result(task, nullptr, -1);
+
+	unsigned int stages = RSPAMD_TASK_STAGE_CONNECT | RSPAMD_TASK_STAGE_CONNFILTERS;
+
+	rspamd_task_process(task, stages);
+
+	if (!RSPAMD_TASK_IS_PROCESSED(task)) {
+	}
+
+	auto precheck_res = check_task_action(task);
+
+	bool allow = !precheck_res.should_reject;
+
+	if (precheck_res.should_reject) {
+		std::string reply = precheck_res.reply_code + " " +
+							precheck_res.reply_message + "\r\n";
+		precheck_reject_reply_ = std::move(reply);
+	}
+
+	rspamd_task_free(task);
+
+	return allow;
+}
+
 auto smtp_proxy_session::enable_client_read() -> void
 {
 	if (!ev_is_active(&client_.read_ev)) {
@@ -854,6 +1079,144 @@ auto smtp_proxy_session::reset_backend_timeout() -> void
 	ev_timer_stop(ctx_->event_loop, &backend_.timeout_ev);
 	ev_timer_set(&backend_.timeout_ev, ctx_->backend_timeout, 0.0);
 	ev_timer_start(ctx_->event_loop, &backend_.timeout_ev);
+}
+
+auto smtp_proxy_session::read_client_data() -> std::pair<io::ring_buffer<>::io_result, std::size_t>
+{
+	if (client_.ssl_active && client_.ssl) {
+		if (client_.read_buffer.full()) {
+			return {io::ring_buffer<>::io_result::buffer_full, 0};
+		}
+
+		auto [ptr1, len1, ptr2, len2] = client_.read_buffer.get_write_regions();
+		if (len1 == 0 && len2 == 0) {
+			return {io::ring_buffer<>::io_result::buffer_full, 0};
+		}
+
+		gssize n = rspamd_ssl_read(client_.ssl, ptr1, len1);
+
+		if (n < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				return {io::ring_buffer<>::io_result::would_block, 0};
+			}
+			return {io::ring_buffer<>::io_result::error, 0};
+		}
+
+		if (n == 0) {
+			return {io::ring_buffer<>::io_result::eof, 0};
+		}
+
+		client_.read_buffer.advance_write(static_cast<std::size_t>(n));
+		return {io::ring_buffer<>::io_result::ok, static_cast<std::size_t>(n)};
+	}
+
+	return client_.read_buffer.read_from_fd(client_.fd);
+}
+
+auto smtp_proxy_session::write_client_data() -> std::pair<io::ring_buffer<>::io_result, std::size_t>
+{
+	if (client_.ssl_active && client_.ssl) {
+		if (client_.write_buffer.empty()) {
+			return {io::ring_buffer<>::io_result::buffer_empty, 0};
+		}
+
+		auto [ptr1, len1, ptr2, len2] = client_.write_buffer.get_read_regions();
+		if (len1 == 0) {
+			return {io::ring_buffer<>::io_result::buffer_empty, 0};
+		}
+
+		gssize n;
+		if (len2 > 0) {
+			struct iovec iov[2] = {
+				{const_cast<std::uint8_t *>(ptr1), len1},
+				{const_cast<std::uint8_t *>(ptr2), len2}};
+			n = rspamd_ssl_writev(client_.ssl, iov, 2);
+		}
+		else {
+			n = rspamd_ssl_write(client_.ssl, ptr1, len1);
+		}
+
+		if (n < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				return {io::ring_buffer<>::io_result::would_block, 0};
+			}
+			return {io::ring_buffer<>::io_result::error, 0};
+		}
+
+		client_.write_buffer.consume(static_cast<std::size_t>(n));
+		return {io::ring_buffer<>::io_result::ok, static_cast<std::size_t>(n)};
+	}
+
+	return client_.write_buffer.write_to_fd(client_.fd);
+}
+
+auto smtp_proxy_session::read_backend_data() -> std::pair<io::ring_buffer<>::io_result, std::size_t>
+{
+	if (backend_.ssl_active && backend_.ssl) {
+		if (backend_.read_buffer.full()) {
+			return {io::ring_buffer<>::io_result::buffer_full, 0};
+		}
+
+		auto [ptr1, len1, ptr2, len2] = backend_.read_buffer.get_write_regions();
+		if (len1 == 0 && len2 == 0) {
+			return {io::ring_buffer<>::io_result::buffer_full, 0};
+		}
+
+		gssize n = rspamd_ssl_read(backend_.ssl, ptr1, len1);
+
+		if (n < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				return {io::ring_buffer<>::io_result::would_block, 0};
+			}
+			return {io::ring_buffer<>::io_result::error, 0};
+		}
+
+		if (n == 0) {
+			return {io::ring_buffer<>::io_result::eof, 0};
+		}
+
+		backend_.read_buffer.advance_write(static_cast<std::size_t>(n));
+		return {io::ring_buffer<>::io_result::ok, static_cast<std::size_t>(n)};
+	}
+
+	return backend_.read_buffer.read_from_fd(backend_.fd);
+}
+
+auto smtp_proxy_session::write_backend_data() -> std::pair<io::ring_buffer<>::io_result, std::size_t>
+{
+	if (backend_.ssl_active && backend_.ssl) {
+		if (backend_.write_buffer.empty()) {
+			return {io::ring_buffer<>::io_result::buffer_empty, 0};
+		}
+
+		auto [ptr1, len1, ptr2, len2] = backend_.write_buffer.get_read_regions();
+		if (len1 == 0) {
+			return {io::ring_buffer<>::io_result::buffer_empty, 0};
+		}
+
+		gssize n;
+		if (len2 > 0) {
+			struct iovec iov[2] = {
+				{const_cast<std::uint8_t *>(ptr1), len1},
+				{const_cast<std::uint8_t *>(ptr2), len2}};
+			n = rspamd_ssl_writev(backend_.ssl, iov, 2);
+		}
+		else {
+			n = rspamd_ssl_write(backend_.ssl, ptr1, len1);
+		}
+
+		if (n < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				return {io::ring_buffer<>::io_result::would_block, 0};
+			}
+			return {io::ring_buffer<>::io_result::error, 0};
+		}
+
+		backend_.write_buffer.consume(static_cast<std::size_t>(n));
+		return {io::ring_buffer<>::io_result::ok, static_cast<std::size_t>(n)};
+	}
+
+	return backend_.write_buffer.write_to_fd(backend_.fd);
 }
 
 }// namespace rspamd::smtp

--- a/src/libserver/smtp_proxy/smtp_proxy_session.cxx
+++ b/src/libserver/smtp_proxy/smtp_proxy_session.cxx
@@ -1,0 +1,859 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "smtp_proxy_session.hxx"
+#include "libutil/util.h"
+#include "libutil/addr.h"
+#include "libserver/dns.h"
+#include "libserver/ssl_util.h"
+#include "unix-std.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <fcntl.h>
+
+namespace rspamd::smtp {
+
+namespace {
+
+// Set socket to non-blocking mode
+auto set_nonblocking(int fd) -> bool
+{
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (flags < 0) {
+		return false;
+	}
+	return fcntl(fd, F_SETFL, flags | O_NONBLOCK) >= 0;
+}
+
+// Enable TCP_NODELAY
+auto set_nodelay(int fd) -> bool
+{
+	int flag = 1;
+	return setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) >= 0;
+}
+
+// Generate random log tag
+auto generate_log_tag(char *buf, size_t len) -> void
+{
+	static const char alphanum[] = "0123456789abcdef";
+	for (size_t i = 0; i < len - 1; ++i) {
+		buf[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
+	}
+	buf[len - 1] = '\0';
+}
+
+}// anonymous namespace
+
+auto smtp_proxy_session::create(smtp_proxy_ctx *ctx, int client_fd,
+								const rspamd_inet_addr_t *client_addr) -> ptr
+{
+	// Use shared_ptr with custom destructor pattern
+	auto session = ptr(new smtp_proxy_session(ctx, client_fd, client_addr));
+	return session;
+}
+
+smtp_proxy_session::smtp_proxy_session(smtp_proxy_ctx *ctx, int client_fd,
+									   const rspamd_inet_addr_t *client_addr)
+	: ctx_(ctx),
+	  client_addr_(client_addr),
+	  pipeline_(ctx->max_outstanding)
+{
+	// Create memory pool for session
+	pool_ = rspamd_mempool_new(rspamd_mempool_suggest_size(), "smtp_proxy", 0);
+
+	// Generate log tag
+	generate_log_tag(log_tag_, sizeof(log_tag_));
+	rspamd_strlcpy(pool_->tag.tagname, "smtp_proxy", sizeof(pool_->tag.tagname));
+	rspamd_strlcpy(pool_->tag.uid, log_tag_, sizeof(pool_->tag.uid));
+
+	// Initialize client connection
+	client_.fd = client_fd;
+	client_.session = this;
+	client_.reader.set_max_line_length(ctx->max_line_length);
+
+	// Set socket options
+	set_nonblocking(client_fd);
+	set_nodelay(client_fd);
+
+	// Initialize libev watchers
+	ev_io_init(&client_.read_ev, client_read_cb, client_fd, EV_READ);
+	ev_io_init(&client_.write_ev, client_write_cb, client_fd, EV_WRITE);
+	ev_timer_init(&client_.timeout_ev, client_timeout_cb, ctx->client_timeout, 0.0);
+
+	client_.read_ev.data = this;
+	client_.write_ev.data = this;
+	client_.timeout_ev.data = this;
+
+	// Initialize backend connection (not connected yet)
+	backend_.fd = -1;
+	backend_.session = this;
+
+	ev_io_init(&backend_.read_ev, backend_read_cb, -1, EV_READ);
+	ev_io_init(&backend_.write_ev, backend_write_cb, -1, EV_WRITE);
+	ev_timer_init(&backend_.timeout_ev, backend_timeout_cb, ctx->backend_timeout, 0.0);
+	ev_timer_init(&backend_.connect_timeout_ev, backend_timeout_cb, ctx->backend_timeout, 0.0);
+
+	backend_.read_ev.data = this;
+	backend_.write_ev.data = this;
+	backend_.timeout_ev.data = this;
+	backend_.connect_timeout_ev.data = this;
+}
+
+smtp_proxy_session::~smtp_proxy_session()
+{
+	close("session destroyed");
+
+	if (pool_) {
+		rspamd_mempool_delete(pool_);
+		pool_ = nullptr;
+	}
+}
+
+auto smtp_proxy_session::start() -> void
+{
+	// Connect to backend first
+	if (!connect_backend()) {
+		// Send temporary failure and close
+		forward_to_client(reply_parser::get_standard_reply(421));
+		close("backend connection failed");
+		return;
+	}
+
+	// Start timeout timer
+	reset_client_timeout();
+
+	// We'll wait for backend greeting before enabling client reads
+}
+
+auto smtp_proxy_session::close(const char *reason) -> void
+{
+	if (closed_) {
+		return;
+	}
+
+	closed_ = true;
+	if (reason) {
+		close_reason_ = reason;
+	}
+
+	// Stop all watchers
+	if (ctx_ && ctx_->event_loop) {
+		ev_io_stop(ctx_->event_loop, &client_.read_ev);
+		ev_io_stop(ctx_->event_loop, &client_.write_ev);
+		ev_timer_stop(ctx_->event_loop, &client_.timeout_ev);
+
+		ev_io_stop(ctx_->event_loop, &backend_.read_ev);
+		ev_io_stop(ctx_->event_loop, &backend_.write_ev);
+		ev_timer_stop(ctx_->event_loop, &backend_.timeout_ev);
+		ev_timer_stop(ctx_->event_loop, &backend_.connect_timeout_ev);
+	}
+
+	// Close SSL connections if active
+	if (client_.ssl) {
+		rspamd_ssl_connection_free(client_.ssl);
+		client_.ssl = nullptr;
+	}
+	if (backend_.ssl) {
+		rspamd_ssl_connection_free(backend_.ssl);
+		backend_.ssl = nullptr;
+	}
+
+	// Close file descriptors
+	if (client_.fd >= 0) {
+		::close(client_.fd);
+		client_.fd = -1;
+	}
+	if (backend_.fd >= 0) {
+		::close(backend_.fd);
+		backend_.fd = -1;
+	}
+
+	state_ = session_state::closing;
+}
+
+auto smtp_proxy_session::connect_backend() -> bool
+{
+	// Create socket
+	int fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd < 0) {
+		return false;
+	}
+
+	set_nonblocking(fd);
+	set_nodelay(fd);
+
+	// Connect to backend (simplified - real implementation would use DNS resolution)
+	struct sockaddr_in addr{};
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(ctx_->backend_port);
+
+	// For now, assume backend_host is an IP address or use localhost
+	if (ctx_->backend_host.empty()) {
+		addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	}
+	else {
+		// This is simplified - real implementation would use proper address resolution
+		if (inet_pton(AF_INET, ctx_->backend_host.c_str(), &addr.sin_addr) != 1) {
+			::close(fd);
+			return false;
+		}
+	}
+
+	int ret = connect(fd, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr));
+	if (ret < 0 && errno != EINPROGRESS) {
+		::close(fd);
+		return false;
+	}
+
+	backend_.fd = fd;
+	backend_.state = backend_state::connecting;
+
+	// Initialize watchers with actual fd
+	ev_io_init(&backend_.read_ev, backend_read_cb, fd, EV_READ);
+	ev_io_init(&backend_.write_ev, backend_write_cb, fd, EV_WRITE);
+	backend_.read_ev.data = this;
+	backend_.write_ev.data = this;
+
+	// Wait for connection to complete (write becomes ready)
+	ev_io_init(&backend_.read_ev, backend_connect_cb, fd, EV_WRITE);
+	ev_io_start(ctx_->event_loop, &backend_.read_ev);
+	ev_timer_start(ctx_->event_loop, &backend_.connect_timeout_ev);
+
+	return true;
+}
+
+// Static callback wrappers
+void smtp_proxy_session::client_read_cb(struct ev_loop *loop, ev_io *w, int revents)
+{
+	auto *session = static_cast<smtp_proxy_session *>(w->data);
+	if (revents & EV_READ) {
+		session->handle_client_read();
+	}
+}
+
+void smtp_proxy_session::client_write_cb(struct ev_loop *loop, ev_io *w, int revents)
+{
+	auto *session = static_cast<smtp_proxy_session *>(w->data);
+	if (revents & EV_WRITE) {
+		session->handle_client_write();
+	}
+}
+
+void smtp_proxy_session::client_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents)
+{
+	auto *session = static_cast<smtp_proxy_session *>(w->data);
+	session->forward_to_client("421 4.4.2 Timeout\r\n");
+	session->close("client timeout");
+}
+
+void smtp_proxy_session::backend_read_cb(struct ev_loop *loop, ev_io *w, int revents)
+{
+	auto *session = static_cast<smtp_proxy_session *>(w->data);
+	if (revents & EV_READ) {
+		session->handle_backend_read();
+	}
+}
+
+void smtp_proxy_session::backend_write_cb(struct ev_loop *loop, ev_io *w, int revents)
+{
+	auto *session = static_cast<smtp_proxy_session *>(w->data);
+	if (revents & EV_WRITE) {
+		session->handle_backend_write();
+	}
+}
+
+void smtp_proxy_session::backend_connect_cb(struct ev_loop *loop, ev_io *w, int revents)
+{
+	auto *session = static_cast<smtp_proxy_session *>(w->data);
+
+	ev_io_stop(loop, w);
+	ev_timer_stop(loop, &session->backend_.connect_timeout_ev);
+
+	// Check if connection succeeded
+	int err = 0;
+	socklen_t len = sizeof(err);
+	if (getsockopt(session->backend_.fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0 || err != 0) {
+		session->forward_to_client(reply_parser::get_standard_reply(421));
+		session->close("backend connection failed");
+		return;
+	}
+
+	session->backend_.state = backend_state::connected;
+
+	// Re-initialize watchers for normal operation
+	ev_io_init(&session->backend_.read_ev, backend_read_cb,
+			   session->backend_.fd, EV_READ);
+	ev_io_init(&session->backend_.write_ev, backend_write_cb,
+			   session->backend_.fd, EV_WRITE);
+	session->backend_.read_ev.data = session;
+	session->backend_.write_ev.data = session;
+
+	// Start reading backend greeting
+	session->enable_backend_read();
+	session->reset_backend_timeout();
+}
+
+void smtp_proxy_session::backend_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents)
+{
+	auto *session = static_cast<smtp_proxy_session *>(w->data);
+	session->forward_to_client("421 4.4.2 Backend timeout\r\n");
+	session->close("backend timeout");
+}
+
+auto smtp_proxy_session::handle_client_read() -> void
+{
+	reset_client_timeout();
+
+	// Read data into buffer
+	auto [result, bytes] = client_.read_buffer.read_from_fd(client_.fd);
+
+	switch (result) {
+	case io::ring_buffer<>::io_result::ok:
+		break;
+	case io::ring_buffer<>::io_result::would_block:
+		return;
+	case io::ring_buffer<>::io_result::eof:
+		close("client closed connection");
+		return;
+	case io::ring_buffer<>::io_result::error:
+		close("client read error");
+		return;
+	case io::ring_buffer<>::io_result::buffer_full:
+		// Backpressure - disable reads
+		disable_client_read();
+		return;
+	default:
+		return;
+	}
+
+	// Process data based on state
+	if (in_data_stream_) {
+		// Stream DATA directly to backend
+		auto [ptr1, len1, ptr2, len2] = client_.read_buffer.get_read_regions();
+
+		// Feed data to the eod_scanner to find end-of-data sequence
+		std::optional<eod_scanner::result> eod_result;
+
+		if (len1 > 0) {
+			eod_result = eod_scanner_.feed(ptr1, len1, data_bytes_transferred_);
+		}
+		if (!eod_result && len2 > 0) {
+			eod_result = eod_scanner_.feed(ptr2, len2, data_bytes_transferred_ + len1);
+		}
+
+		if (eod_result && eod_result->found) {
+			// Calculate how much of the current buffer contains the EOD
+			std::size_t eod_relative_start = eod_result->eod_start - data_bytes_transferred_;
+			std::size_t total = eod_relative_start + eod_result->eod_length;
+
+			// Forward up to and including end-of-data
+			if (len1 >= total) {
+				forward_to_backend({reinterpret_cast<const char *>(ptr1), total});
+			}
+			else {
+				forward_to_backend({reinterpret_cast<const char *>(ptr1), len1});
+				if (ptr2 && total > len1) {
+					forward_to_backend({reinterpret_cast<const char *>(ptr2), total - len1});
+				}
+			}
+			client_.read_buffer.consume(total);
+			data_bytes_transferred_ += total;
+
+			in_data_stream_ = false;
+			eod_scanner_.reset();
+			pipeline_.data_transfer_complete();
+		}
+		else {
+			// Forward all available data (keeping potential partial terminator)
+			// The eod_scanner tells us how many bytes are "pending" as part of
+			// a potential EOD sequence that we shouldn't forward yet
+			std::size_t pending = eod_scanner_.pending_bytes();
+			std::size_t buffer_size = client_.read_buffer.size();
+			std::size_t safe_len = buffer_size > pending ? buffer_size - pending : 0;
+
+			if (safe_len > 0) {
+				if (len1 >= safe_len) {
+					forward_to_backend({reinterpret_cast<const char *>(ptr1), safe_len});
+				}
+				else {
+					forward_to_backend({reinterpret_cast<const char *>(ptr1), len1});
+					if (ptr2) {
+						forward_to_backend({reinterpret_cast<const char *>(ptr2), safe_len - len1});
+					}
+				}
+				client_.read_buffer.consume(safe_len);
+				data_bytes_transferred_ += safe_len;
+			}
+		}
+	}
+	else {
+		// Process command lines
+		while (!closed_) {
+			auto line = client_.reader.try_read_line(client_.read_buffer);
+
+			switch (line.state) {
+			case line_result::status::ok:
+				process_client_line(line);
+				break;
+			case line_result::status::incomplete:
+				return;
+			case line_result::status::violation:
+				report_violation(to_violation_type(line.violation_type));
+				return;
+			}
+		}
+	}
+}
+
+auto smtp_proxy_session::handle_client_write() -> void
+{
+	auto [result, bytes] = client_.write_buffer.write_to_fd(client_.fd);
+
+	switch (result) {
+	case io::ring_buffer<>::io_result::ok:
+		if (client_.write_buffer.empty()) {
+			disable_client_write();
+		}
+		break;
+	case io::ring_buffer<>::io_result::would_block:
+		break;
+	case io::ring_buffer<>::io_result::error:
+		close("client write error");
+		break;
+	default:
+		break;
+	}
+
+	// Re-enable backend reads if we have space
+	if (client_.write_buffer.is_below_low_watermark()) {
+		enable_backend_read();
+	}
+}
+
+auto smtp_proxy_session::handle_backend_read() -> void
+{
+	reset_backend_timeout();
+
+	auto [result, bytes] = backend_.read_buffer.read_from_fd(backend_.fd);
+
+	switch (result) {
+	case io::ring_buffer<>::io_result::ok:
+		break;
+	case io::ring_buffer<>::io_result::would_block:
+		return;
+	case io::ring_buffer<>::io_result::eof:
+		close("backend closed connection");
+		return;
+	case io::ring_buffer<>::io_result::error:
+		close("backend read error");
+		return;
+	case io::ring_buffer<>::io_result::buffer_full:
+		disable_backend_read();
+		return;
+	default:
+		return;
+	}
+
+	// Parse reply lines
+	line_reader reader;
+	while (!closed_) {
+		auto line = reader.try_read_line(backend_.read_buffer);
+
+		if (line.state != line_result::status::ok) {
+			break;
+		}
+
+		auto parsed = backend_.parser.parse_line(line.line, line.raw_line);
+		if (!parsed) {
+			// Invalid reply - forward as-is for robustness
+			forward_to_client(line.raw_line);
+			continue;
+		}
+
+		bool complete = backend_.parser.accumulate(backend_.current_reply, *parsed);
+
+		if (complete) {
+			process_backend_reply(backend_.current_reply);
+			backend_.current_reply = smtp_reply{};// Reset for next reply
+		}
+	}
+}
+
+auto smtp_proxy_session::handle_backend_write() -> void
+{
+	auto [result, bytes] = backend_.write_buffer.write_to_fd(backend_.fd);
+
+	switch (result) {
+	case io::ring_buffer<>::io_result::ok:
+		if (backend_.write_buffer.empty()) {
+			disable_backend_write();
+		}
+		break;
+	case io::ring_buffer<>::io_result::would_block:
+		break;
+	case io::ring_buffer<>::io_result::error:
+		close("backend write error");
+		break;
+	default:
+		break;
+	}
+
+	// Re-enable client reads if we have space
+	if (backend_.write_buffer.is_below_low_watermark() && !client_.read_paused) {
+		enable_client_read();
+	}
+}
+
+auto smtp_proxy_session::process_client_line(const line_result &line) -> void
+{
+	// Parse the command
+	auto cmd = cmd_parser_.parse(line.line, line.raw_line);
+
+	// Check pipelining rules
+	auto violation = pipeline_.check_command(cmd);
+	if (violation != pipelining_violation::none) {
+		report_violation(to_violation_type(violation));
+		return;
+	}
+
+	// Handle unsupported commands
+	if (cmd.type == command_type::bdat) {
+		forward_to_client("502 5.5.1 BDAT not implemented\r\n");
+		return;
+	}
+
+	if (cmd.type == command_type::auth) {
+		forward_to_client("502 5.5.1 AUTH not implemented\r\n");
+		return;
+	}
+
+	// Track command state
+	switch (cmd.type) {
+	case command_type::ehlo:
+	case command_type::helo:
+		client_helo_domain_ = cmd.argument;
+		break;
+
+	case command_type::mail_from:
+		transaction_.reset();
+		transaction_.mail_from = cmd.argument;
+		if (cmd.has_param("BODY")) {
+			auto body = cmd.get_param("BODY");
+			if (body && (*body == "8BITMIME" || *body == "8bitmime")) {
+				transaction_.has_8bitmime = true;
+			}
+		}
+		if (cmd.has_param("SMTPUTF8")) {
+			transaction_.has_smtputf8 = true;
+		}
+		break;
+
+	case command_type::rcpt_to:
+		transaction_.rcpt_to.push_back(cmd.argument);
+		break;
+
+	case command_type::data:
+		if (pipeline_.check_data_before_354()) {
+			report_violation(violation_type::data_before_354);
+			return;
+		}
+		break;
+
+	case command_type::rset:
+		transaction_.reset();
+		break;
+
+	case command_type::quit:
+		// Forward QUIT and prepare to close
+		state_ = session_state::closing;
+		break;
+
+	default:
+		break;
+	}
+
+	// Record command sent
+	pipeline_.command_sent(cmd);
+
+	// Forward to backend
+	forward_to_backend(cmd.raw_line);
+}
+
+auto smtp_proxy_session::process_backend_reply(const smtp_reply &reply) -> void
+{
+	// Get expected command type
+	auto expected = pipeline_.next_expected_response();
+
+	// For greeting (no command expected), relay directly
+	if (!expected && backend_.state == backend_state::connected) {
+		backend_.state = backend_state::ready;
+		forward_to_client(reply.get_raw());
+		enable_client_read();
+		return;
+	}
+
+	// Record response received
+	bool is_final = reply.is_complete();
+	auto responded_to = pipeline_.response_received(reply.code, is_final);
+
+	if (!responded_to) {
+		// Unexpected response - forward anyway
+		forward_to_client(reply.get_raw());
+		return;
+	}
+
+	// Handle specific responses
+	switch (*responded_to) {
+	case command_type::ehlo:
+		handle_ehlo_response(reply);
+		break;
+
+	case command_type::data:
+		handle_data_response(reply);
+		break;
+
+	case command_type::starttls:
+		handle_starttls_response(reply);
+		break;
+
+	default:
+		// Forward reply as-is
+		forward_to_client(reply.get_raw());
+		break;
+	}
+
+	// Update session state
+	if (responded_to && reply.is_success()) {
+		switch (*responded_to) {
+		case command_type::ehlo:
+		case command_type::helo:
+			state_ = session_state::greeted;
+			break;
+		case command_type::mail_from:
+			state_ = session_state::mail_from;
+			break;
+		case command_type::rcpt_to:
+			state_ = session_state::rcpt_to;
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+auto smtp_proxy_session::handle_ehlo_response(const smtp_reply &reply) -> void
+{
+	if (!reply.is_success()) {
+		forward_to_client(reply.get_raw());
+		return;
+	}
+
+	// Parse EHLO capabilities
+	backend_ehlo_ = backend_.parser.parse_ehlo_response(reply);
+
+	// Check for PIPELINING capability
+	if (backend_ehlo_->has_capability("PIPELINING")) {
+		pipeline_.enable_pipelining(true);
+	}
+
+	// Rewrite capabilities based on configuration
+	std::vector<std::string> caps_to_remove;
+	std::vector<ehlo_capability> caps_to_add;
+
+	// Always remove AUTH (v1)
+	if (ctx_->ehlo_filter.remove_auth) {
+		caps_to_remove.push_back("AUTH");
+	}
+
+	// Remove CHUNKING/BDAT (v1)
+	if (ctx_->ehlo_filter.remove_chunking) {
+		caps_to_remove.push_back("CHUNKING");
+		caps_to_remove.push_back("BINARYMIME");
+	}
+
+	// Handle STARTTLS
+	if (!ctx_->starttls_enabled) {
+		caps_to_remove.push_back("STARTTLS");
+	}
+	else if (!backend_ehlo_->has_capability("STARTTLS")) {
+		// Add STARTTLS if we support it but backend doesn't advertise
+		caps_to_add.push_back({"STARTTLS", {}});
+	}
+
+	// Generate rewritten response
+	std::string rewritten = backend_.parser.rewrite_ehlo_response(
+		*backend_ehlo_,
+		{},// Keep all by default
+		caps_to_remove,
+		caps_to_add,
+		ctx_->ehlo_filter.max_size);
+
+	forward_to_client(rewritten);
+}
+
+auto smtp_proxy_session::handle_data_response(const smtp_reply &reply) -> void
+{
+	forward_to_client(reply.get_raw());
+
+	if (reply.code == 354) {
+		// Backend accepted DATA, enter streaming mode
+		in_data_stream_ = true;
+		state_ = session_state::data;
+		data_bytes_transferred_ = 0;
+	}
+}
+
+auto smtp_proxy_session::handle_starttls_response(const smtp_reply &reply) -> void
+{
+	if (reply.code != 220) {
+		forward_to_client(reply.get_raw());
+		pipeline_.tls_handshake_complete(false);
+		return;
+	}
+
+	// Don't forward 220 yet - initiate TLS on both sides
+	state_ = session_state::tls_handshake;
+
+	// Start backend TLS first, then client TLS
+	start_backend_tls();
+}
+
+auto smtp_proxy_session::start_client_tls() -> void
+{
+	// Forward the 220 to client to trigger their TLS handshake
+	forward_to_client("220 2.0.0 Ready to start TLS\r\n");
+
+	// TODO: Implement SSL accept using rspamd_ssl_accept_fd (to be added)
+	// For now, this is a placeholder
+}
+
+auto smtp_proxy_session::start_backend_tls() -> void
+{
+	// TODO: Implement backend TLS upgrade
+	// This would use rspamd_ssl_connect_fd
+}
+
+auto smtp_proxy_session::forward_to_backend(std::string_view data) -> void
+{
+	std::size_t written = backend_.write_buffer.write(data);
+	if (written > 0) {
+		enable_backend_write();
+	}
+
+	// Apply backpressure if needed
+	if (backend_.write_buffer.is_above_high_watermark()) {
+		disable_client_read();
+	}
+}
+
+auto smtp_proxy_session::forward_to_client(std::string_view data) -> void
+{
+	std::size_t written = client_.write_buffer.write(data);
+	if (written > 0) {
+		enable_client_write();
+	}
+
+	// Apply backpressure if needed
+	if (client_.write_buffer.is_above_high_watermark()) {
+		disable_backend_read();
+	}
+}
+
+auto smtp_proxy_session::report_violation(violation_type v) -> void
+{
+	// TODO: Call Lua on_violation hook
+
+	// Default action: send error and close
+	std::string msg = "500 5.5.1 Protocol violation: ";
+	msg += violation_to_string(v);
+	msg += "\r\n";
+
+	forward_to_client(msg);
+	close(violation_to_string(v));
+}
+
+auto smtp_proxy_session::run_precheck() -> bool
+{
+	// TODO: Implement precheck using rspamd_task
+	return true;
+}
+
+// Helper methods for event management
+auto smtp_proxy_session::enable_client_read() -> void
+{
+	if (!ev_is_active(&client_.read_ev)) {
+		ev_io_start(ctx_->event_loop, &client_.read_ev);
+	}
+}
+
+auto smtp_proxy_session::disable_client_read() -> void
+{
+	ev_io_stop(ctx_->event_loop, &client_.read_ev);
+}
+
+auto smtp_proxy_session::enable_client_write() -> void
+{
+	if (!ev_is_active(&client_.write_ev)) {
+		ev_io_start(ctx_->event_loop, &client_.write_ev);
+	}
+}
+
+auto smtp_proxy_session::disable_client_write() -> void
+{
+	ev_io_stop(ctx_->event_loop, &client_.write_ev);
+}
+
+auto smtp_proxy_session::enable_backend_read() -> void
+{
+	if (!ev_is_active(&backend_.read_ev)) {
+		ev_io_start(ctx_->event_loop, &backend_.read_ev);
+	}
+}
+
+auto smtp_proxy_session::disable_backend_read() -> void
+{
+	ev_io_stop(ctx_->event_loop, &backend_.read_ev);
+}
+
+auto smtp_proxy_session::enable_backend_write() -> void
+{
+	if (!ev_is_active(&backend_.write_ev)) {
+		ev_io_start(ctx_->event_loop, &backend_.write_ev);
+	}
+}
+
+auto smtp_proxy_session::disable_backend_write() -> void
+{
+	ev_io_stop(ctx_->event_loop, &backend_.write_ev);
+}
+
+auto smtp_proxy_session::reset_client_timeout() -> void
+{
+	ev_timer_stop(ctx_->event_loop, &client_.timeout_ev);
+	ev_timer_set(&client_.timeout_ev, ctx_->client_timeout, 0.0);
+	ev_timer_start(ctx_->event_loop, &client_.timeout_ev);
+}
+
+auto smtp_proxy_session::reset_backend_timeout() -> void
+{
+	ev_timer_stop(ctx_->event_loop, &backend_.timeout_ev);
+	ev_timer_set(&backend_.timeout_ev, ctx_->backend_timeout, 0.0);
+	ev_timer_start(ctx_->event_loop, &backend_.timeout_ev);
+}
+
+}// namespace rspamd::smtp

--- a/src/libserver/smtp_proxy/smtp_proxy_session.hxx
+++ b/src/libserver/smtp_proxy/smtp_proxy_session.hxx
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_SMTP_PROXY_SESSION_HXX
+#define RSPAMD_SMTP_PROXY_SESSION_HXX
+
+#pragma once
+
+#include "config.h"
+#include "smtp_proxy.hxx"
+#include "eod_scanner.hxx"
+#include "contrib/libev/ev.h"
+#include "libutil/mem_pool.h"
+#include "libutil/addr.h"
+
+#include <memory>
+#include <string>
+#include <optional>
+#include <functional>
+
+struct rspamd_worker;
+struct rspamd_config;
+struct rspamd_dns_resolver;
+struct rspamd_ssl_connection;
+struct lua_State;
+
+namespace rspamd::smtp {
+
+/**
+ * Forward declarations
+ */
+class smtp_proxy_session;
+struct smtp_proxy_ctx;
+
+/**
+ * Precheck hook point configuration
+ */
+enum class precheck_point {
+	disabled,       // No precheck
+	on_connect,     // After connection established
+	after_mail,     // After MAIL FROM accepted
+	after_first_rcpt// After first RCPT TO accepted
+};
+
+/**
+ * EHLO capability filtering configuration
+ */
+struct ehlo_filter_config {
+	bool keep_dsn = true;
+	bool keep_8bitmime = true;
+	bool keep_pipelining = true;
+	bool keep_smtputf8 = true;
+	bool remove_auth = true;
+	bool remove_chunking = true;
+	bool advertise_starttls = false;
+	std::optional<std::size_t> max_size;// Optional SIZE limit clamp
+};
+
+/**
+ * SMTP proxy worker context
+ *
+ * This is the shared context for all sessions within a worker process.
+ */
+struct smtp_proxy_ctx {
+	static constexpr uint64_t magic = 0x534d545050524f58ULL;// "SMTPPROX"
+
+	uint64_t ctx_magic = magic;
+
+	// Common worker fields (must be at start for rspamd_worker_check_context)
+	struct ev_loop *event_loop = nullptr;
+	struct rspamd_dns_resolver *resolver = nullptr;
+	struct rspamd_config *cfg = nullptr;
+
+	// SMTP proxy specific configuration
+	ev_tstamp client_timeout = 300.0;// Client I/O timeout
+	ev_tstamp backend_timeout = 60.0;// Backend connection timeout
+	ev_tstamp greeting_delay = 0.0;  // Delay before sending greeting
+
+	std::size_t max_line_length = 4096;// Maximum line length
+	std::size_t max_outstanding = 10;  // Maximum pipelined commands
+	std::size_t max_connections = 0;   // Maximum connections (0 = unlimited)
+
+	precheck_point precheck_hook = precheck_point::disabled;
+	ehlo_filter_config ehlo_filter;
+
+	// TLS configuration
+	bool starttls_enabled = false;
+	void *ssl_ctx = nullptr;// SSL_CTX for server-side TLS
+
+	// Backend configuration
+	std::string backend_host;
+	uint16_t backend_port = 25;
+	bool backend_ssl = false;
+
+	// Lua state for policy hooks
+	lua_State *lua_state = nullptr;
+	int on_connect_ref = -1;  // Lua callback ref for on_connect
+	int on_violation_ref = -1;// Lua callback ref for on_violation
+	int on_precheck_ref = -1; // Lua callback ref for precheck
+
+	// Session cache
+	void *sessions_cache = nullptr;
+
+	// Worker reference
+	struct rspamd_worker *worker = nullptr;
+};
+
+/**
+ * Backend connection state
+ */
+enum class backend_state {
+	disconnected,
+	connecting,
+	connected,
+	tls_handshaking,
+	ready
+};
+
+/**
+ * Client connection leg
+ */
+struct client_connection {
+	int fd = -1;
+	smtp_buffer read_buffer;
+	smtp_buffer write_buffer;
+	ev_io read_ev;
+	ev_io write_ev;
+	ev_timer timeout_ev;
+
+	struct rspamd_ssl_connection *ssl = nullptr;
+	bool ssl_active = false;
+
+	// Read state
+	line_reader reader;
+	bool read_paused = false;
+
+	// Session reference
+	smtp_proxy_session *session = nullptr;
+};
+
+/**
+ * Backend connection leg
+ */
+struct backend_connection {
+	int fd = -1;
+	smtp_buffer read_buffer;
+	smtp_buffer write_buffer;
+	ev_io read_ev;
+	ev_io write_ev;
+	ev_timer timeout_ev;
+	ev_timer connect_timeout_ev;
+
+	struct rspamd_ssl_connection *ssl = nullptr;
+	bool ssl_active = false;
+
+	backend_state state = backend_state::disconnected;
+
+	// Response parsing state
+	reply_parser parser;
+	smtp_reply current_reply;
+
+	// Session reference
+	smtp_proxy_session *session = nullptr;
+};
+
+/**
+ * SMTP proxy session
+ *
+ * Manages a single client connection and its backend connection.
+ * Handles command parsing, pipelining tracking, and DATA streaming.
+ */
+class smtp_proxy_session : public std::enable_shared_from_this<smtp_proxy_session> {
+public:
+	using ptr = std::shared_ptr<smtp_proxy_session>;
+
+	/**
+	 * Create a new session
+	 */
+	static auto create(smtp_proxy_ctx *ctx, int client_fd,
+					   const rspamd_inet_addr_t *client_addr) -> ptr;
+
+	~smtp_proxy_session();
+
+	// Prevent copying
+	smtp_proxy_session(const smtp_proxy_session &) = delete;
+	smtp_proxy_session &operator=(const smtp_proxy_session &) = delete;
+
+	/**
+	 * Start the session (connect to backend, etc.)
+	 */
+	auto start() -> void;
+
+	/**
+	 * Close the session
+	 */
+	auto close(const char *reason = nullptr) -> void;
+
+	/**
+	 * Get session state
+	 */
+	[[nodiscard]] auto get_state() const noexcept -> session_state
+	{
+		return state_;
+	}
+
+	/**
+	 * Get client address
+	 */
+	[[nodiscard]] auto get_client_addr() const noexcept -> const rspamd_inet_addr_t *
+	{
+		return client_addr_;
+	}
+
+	/**
+	 * Get current transaction state
+	 */
+	[[nodiscard]] auto get_transaction() const noexcept -> const transaction_state &
+	{
+		return transaction_;
+	}
+
+	/**
+	 * Get memory pool
+	 */
+	[[nodiscard]] auto get_pool() const noexcept -> rspamd_mempool_t *
+	{
+		return pool_;
+	}
+
+private:
+	explicit smtp_proxy_session(smtp_proxy_ctx *ctx, int client_fd,
+								const rspamd_inet_addr_t *client_addr);
+
+	// Event handlers
+	static void client_read_cb(struct ev_loop *loop, ev_io *w, int revents);
+	static void client_write_cb(struct ev_loop *loop, ev_io *w, int revents);
+	static void client_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents);
+
+	static void backend_read_cb(struct ev_loop *loop, ev_io *w, int revents);
+	static void backend_write_cb(struct ev_loop *loop, ev_io *w, int revents);
+	static void backend_connect_cb(struct ev_loop *loop, ev_io *w, int revents);
+	static void backend_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents);
+
+	// Internal handlers
+	auto handle_client_read() -> void;
+	auto handle_client_write() -> void;
+	auto handle_backend_read() -> void;
+	auto handle_backend_write() -> void;
+
+	auto process_client_line(const line_result &line) -> void;
+	auto process_backend_reply(const smtp_reply &reply) -> void;
+
+	auto connect_backend() -> bool;
+	auto forward_to_backend(std::string_view data) -> void;
+	auto forward_to_client(std::string_view data) -> void;
+
+	auto handle_ehlo_response(const smtp_reply &reply) -> void;
+	auto handle_data_response(const smtp_reply &reply) -> void;
+	auto handle_starttls_response(const smtp_reply &reply) -> void;
+
+	auto start_client_tls() -> void;
+	auto start_backend_tls() -> void;
+
+	auto report_violation(violation_type v) -> void;
+	auto run_precheck() -> bool;
+
+	auto enable_client_read() -> void;
+	auto disable_client_read() -> void;
+	auto enable_client_write() -> void;
+	auto disable_client_write() -> void;
+
+	auto enable_backend_read() -> void;
+	auto disable_backend_read() -> void;
+	auto enable_backend_write() -> void;
+	auto disable_backend_write() -> void;
+
+	auto reset_client_timeout() -> void;
+	auto reset_backend_timeout() -> void;
+
+	// Context and configuration
+	smtp_proxy_ctx *ctx_;
+	rspamd_mempool_t *pool_;
+	const rspamd_inet_addr_t *client_addr_;
+
+	// Connection state
+	client_connection client_;
+	backend_connection backend_;
+
+	// SMTP state
+	session_state state_ = session_state::initial;
+	transaction_state transaction_;
+	pipelining_tracker pipeline_;
+	command_parser cmd_parser_;
+
+	// EHLO state
+	std::optional<ehlo_response> client_ehlo_;
+	std::optional<ehlo_response> backend_ehlo_;
+	std::string client_helo_domain_;
+
+	// DATA streaming state
+	bool in_data_stream_ = false;
+	std::size_t data_bytes_transferred_ = 0;
+	eod_scanner eod_scanner_;// Scanner for end-of-data sequence
+
+	// Session bookkeeping
+	bool closed_ = false;
+	std::string close_reason_;
+
+	// Logging tag
+	char log_tag_[9] = {0};
+};
+
+}// namespace rspamd::smtp
+
+#endif// RSPAMD_SMTP_PROXY_SESSION_HXX

--- a/src/libserver/ssl_util.h
+++ b/src/libserver/ssl_util.h
@@ -57,6 +57,22 @@ gboolean rspamd_ssl_connect_fd(struct rspamd_ssl_connection *conn, int fd,
 							   gpointer handler_data);
 
 /**
+ * Accepts SSL session on an already connected (accepted) FD
+ * @param conn connection
+ * @param fd fd to use (already accepted TCP socket)
+ * @param ev event to use
+ * @param tv timeout for handshake
+ * @param handler connected session handler
+ * @param err_handler error handler
+ * @param handler_data opaque data
+ * @return TRUE if handshake has started
+ */
+gboolean rspamd_ssl_accept_fd(struct rspamd_ssl_connection *conn, int fd,
+							  struct rspamd_io_ev *ev, ev_tstamp timeout,
+							  rspamd_ssl_handler_t handler, rspamd_ssl_error_handler_t err_handler,
+							  gpointer handler_data);
+
+/**
  * Restores SSL handlers for the existing ssl connection (e.g. after keepalive)
  * @param conn
  * @param handler

--- a/src/rspamadm/CMakeLists.txt
+++ b/src/rspamadm/CMakeLists.txt
@@ -14,7 +14,8 @@ SET(RSPAMADMSRC rspamadm.c
         ${CMAKE_SOURCE_DIR}/src/controller.c
         ${CMAKE_SOURCE_DIR}/src/fuzzy_storage.c
         ${CMAKE_SOURCE_DIR}/src/worker.c
-        ${CMAKE_SOURCE_DIR}/src/rspamd_proxy.c)
+        ${CMAKE_SOURCE_DIR}/src/rspamd_proxy.c
+        ${CMAKE_SOURCE_DIR}/src/smtp_proxy.cxx)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 IF (ENABLE_HYPERSCAN MATCHES "ON")
     LIST(APPEND RSPAMADMSRC "${CMAKE_SOURCE_DIR}/src/hs_helper.c")

--- a/src/smtp_proxy.cxx
+++ b/src/smtp_proxy.cxx
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include "libutil/util.h"
+#include "libutil/addr.h"
+#include "libserver/cfg_file.h"
+#include "libserver/cfg_rcl.h"
+#include "libserver/dns.h"
+#include "libserver/ssl_util.h"
+#include "libserver/worker_util.h"
+#include "rspamd.h"
+#include "lua/lua_common.h"
+#include "unix-std.h"
+
+#include "libserver/smtp_proxy/smtp_proxy_session.hxx"
+
+#include <unordered_map>
+#include <memory>
+
+/* Log module ID */
+INIT_LOG_MODULE(smtp_proxy)
+
+/* Worker function declarations */
+extern "C" {
+gpointer init_smtp_proxy(struct rspamd_config *cfg);
+void start_smtp_proxy(struct rspamd_worker *worker);
+}
+
+/* Worker definition */
+worker_t smtp_proxy_worker = {
+	"smtp_proxy",     /* Name */
+	init_smtp_proxy,  /* Init function */
+	start_smtp_proxy, /* Start function */
+	RSPAMD_WORKER_HAS_SOCKET | RSPAMD_WORKER_KILLABLE,
+	RSPAMD_WORKER_SOCKET_TCP, /* TCP socket */
+	RSPAMD_WORKER_VER};
+
+/* Session storage */
+static std::unordered_map<void *, rspamd::smtp::smtp_proxy_session::ptr> g_sessions;
+
+/* Logging macros */
+#define msg_err_ctx(...) rspamd_default_log_function(G_LOG_LEVEL_CRITICAL,                                                         \
+													 "smtp_proxy", ctx->worker ? ctx->worker->srv->cfg->cfg_pool->tag.uid : "???", \
+													 RSPAMD_LOG_FUNC, __VA_ARGS__)
+#define msg_warn_ctx(...) rspamd_default_log_function(G_LOG_LEVEL_WARNING,                                                          \
+													  "smtp_proxy", ctx->worker ? ctx->worker->srv->cfg->cfg_pool->tag.uid : "???", \
+													  RSPAMD_LOG_FUNC, __VA_ARGS__)
+#define msg_info_ctx(...) rspamd_default_log_function(G_LOG_LEVEL_INFO,                                                             \
+													  "smtp_proxy", ctx->worker ? ctx->worker->srv->cfg->cfg_pool->tag.uid : "???", \
+													  RSPAMD_LOG_FUNC, __VA_ARGS__)
+
+/**
+ * Accept callback for new connections
+ */
+static void
+smtp_proxy_accept_socket(struct ev_loop *loop, ev_io *w, int revents)
+{
+	auto *worker = static_cast<struct rspamd_worker *>(w->data);
+	auto *ctx = static_cast<rspamd::smtp::smtp_proxy_ctx *>(worker->ctx);
+
+	rspamd_inet_addr_t *addr = nullptr;
+	int nfd = rspamd_accept_from_socket(w->fd, &addr, nullptr, nullptr);
+
+	if (nfd < 0) {
+		if (addr) {
+			rspamd_inet_address_free(addr);
+		}
+		return;
+	}
+
+	/* Check connection limits (use worker-level limit if configured) */
+	if (ctx->max_connections > 0 &&
+		worker->nconns >= ctx->max_connections) {
+		msg_info_ctx("connection limit reached (%u), rejecting connection from %s",
+					 ctx->max_connections,
+					 rspamd_inet_address_to_string(addr));
+		close(nfd);
+		rspamd_inet_address_free(addr);
+		return;
+	}
+
+	msg_info_ctx("accepted connection from %s on fd %d",
+				 rspamd_inet_address_to_string(addr), nfd);
+
+	/* Create session */
+	auto session = rspamd::smtp::smtp_proxy_session::create(ctx, nfd, addr);
+
+	if (!session) {
+		msg_err_ctx("failed to create session for %s",
+					rspamd_inet_address_to_string(addr));
+		close(nfd);
+		rspamd_inet_address_free(addr);
+		return;
+	}
+
+	/* Store session */
+	g_sessions[session.get()] = session;
+	worker->nconns++;
+
+	/* Start the session */
+	session->start();
+}
+
+/**
+ * Parse precheck configuration
+ */
+static gboolean
+rspamd_smtp_proxy_parse_precheck(rspamd_mempool_t *pool,
+								 const ucl_object_t *obj,
+								 gpointer ud,
+								 struct rspamd_rcl_section *section,
+								 GError **err)
+{
+	auto *ctx = static_cast<rspamd::smtp::smtp_proxy_ctx *>(ud);
+	const char *val = ucl_object_tostring(obj);
+
+	if (!val) {
+		ctx->precheck_hook = rspamd::smtp::precheck_point::disabled;
+		return TRUE;
+	}
+
+	if (g_ascii_strcasecmp(val, "connect") == 0) {
+		ctx->precheck_hook = rspamd::smtp::precheck_point::on_connect;
+	}
+	else if (g_ascii_strcasecmp(val, "mail") == 0 ||
+			 g_ascii_strcasecmp(val, "after_mail") == 0) {
+		ctx->precheck_hook = rspamd::smtp::precheck_point::after_mail;
+	}
+	else if (g_ascii_strcasecmp(val, "rcpt") == 0 ||
+			 g_ascii_strcasecmp(val, "after_first_rcpt") == 0) {
+		ctx->precheck_hook = rspamd::smtp::precheck_point::after_first_rcpt;
+	}
+	else if (g_ascii_strcasecmp(val, "disabled") == 0 ||
+			 g_ascii_strcasecmp(val, "none") == 0) {
+		ctx->precheck_hook = rspamd::smtp::precheck_point::disabled;
+	}
+	else {
+		g_set_error(err, g_quark_from_static_string("smtp_proxy"), EINVAL,
+					"invalid precheck value: %s", val);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/**
+ * Parse backend configuration
+ */
+static gboolean
+rspamd_smtp_proxy_parse_backend(rspamd_mempool_t *pool,
+								const ucl_object_t *obj,
+								gpointer ud,
+								struct rspamd_rcl_section *section,
+								GError **err)
+{
+	auto *ctx = static_cast<rspamd::smtp::smtp_proxy_ctx *>(ud);
+
+	if (ucl_object_type(obj) == UCL_STRING) {
+		/* Simple format: "host:port" or just "host" */
+		const char *val = ucl_object_tostring(obj);
+		std::string backend_str(val);
+
+		auto colon_pos = backend_str.find(':');
+		if (colon_pos != std::string::npos) {
+			ctx->backend_host = backend_str.substr(0, colon_pos);
+			ctx->backend_port = static_cast<uint16_t>(
+				std::stoul(backend_str.substr(colon_pos + 1)));
+		}
+		else {
+			ctx->backend_host = backend_str;
+			ctx->backend_port = 25;
+		}
+	}
+	else if (ucl_object_type(obj) == UCL_OBJECT) {
+		/* Complex format with options */
+		const ucl_object_t *host = ucl_object_lookup(obj, "host");
+		const ucl_object_t *port = ucl_object_lookup(obj, "port");
+		const ucl_object_t *ssl = ucl_object_lookup(obj, "ssl");
+
+		if (host) {
+			ctx->backend_host = ucl_object_tostring(host);
+		}
+		if (port) {
+			ctx->backend_port = static_cast<uint16_t>(ucl_object_toint(port));
+		}
+		if (ssl) {
+			ctx->backend_ssl = ucl_object_toboolean(ssl);
+		}
+	}
+	else {
+		g_set_error(err, g_quark_from_static_string("smtp_proxy"), EINVAL,
+					"backend must be a string or object");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/**
+ * Initialize worker context
+ */
+gpointer
+init_smtp_proxy(struct rspamd_config *cfg)
+{
+	auto *ctx = rspamd_mempool_alloc0_type(cfg->cfg_pool,
+										   rspamd::smtp::smtp_proxy_ctx);
+
+	/* Initialize with magic and defaults */
+	new (ctx) rspamd::smtp::smtp_proxy_ctx();
+
+	GQuark type = g_quark_try_string("smtp_proxy");
+
+	/* Register configuration options */
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "timeout",
+									  rspamd_rcl_parse_struct_time,
+									  ctx,
+									  G_STRUCT_OFFSET(rspamd::smtp::smtp_proxy_ctx, client_timeout),
+									  RSPAMD_CL_FLAG_TIME_FLOAT,
+									  "Client connection timeout (default: 300s)");
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "backend_timeout",
+									  rspamd_rcl_parse_struct_time,
+									  ctx,
+									  G_STRUCT_OFFSET(rspamd::smtp::smtp_proxy_ctx, backend_timeout),
+									  RSPAMD_CL_FLAG_TIME_FLOAT,
+									  "Backend connection timeout (default: 60s)");
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "greeting_delay",
+									  rspamd_rcl_parse_struct_time,
+									  ctx,
+									  G_STRUCT_OFFSET(rspamd::smtp::smtp_proxy_ctx, greeting_delay),
+									  RSPAMD_CL_FLAG_TIME_FLOAT,
+									  "Delay before sending greeting (tarpit)");
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "max_line_length",
+									  rspamd_rcl_parse_struct_integer,
+									  ctx,
+									  G_STRUCT_OFFSET(rspamd::smtp::smtp_proxy_ctx, max_line_length),
+									  RSPAMD_CL_FLAG_INT_SIZE,
+									  "Maximum line length (default: 4096)");
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "max_pipelined",
+									  rspamd_rcl_parse_struct_integer,
+									  ctx,
+									  G_STRUCT_OFFSET(rspamd::smtp::smtp_proxy_ctx, max_outstanding),
+									  RSPAMD_CL_FLAG_INT_SIZE,
+									  "Maximum pipelined commands (default: 10)");
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "max_connections",
+									  rspamd_rcl_parse_struct_integer,
+									  ctx,
+									  G_STRUCT_OFFSET(rspamd::smtp::smtp_proxy_ctx, max_connections),
+									  RSPAMD_CL_FLAG_INT_SIZE,
+									  "Maximum concurrent connections (default: 0 = unlimited)");
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "starttls",
+									  rspamd_rcl_parse_struct_boolean,
+									  ctx,
+									  G_STRUCT_OFFSET(rspamd::smtp::smtp_proxy_ctx, starttls_enabled),
+									  0,
+									  "Enable STARTTLS support");
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "backend",
+									  rspamd_smtp_proxy_parse_backend,
+									  ctx,
+									  0,
+									  0,
+									  "Backend MTA configuration (host:port or object)");
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "precheck",
+									  rspamd_smtp_proxy_parse_precheck,
+									  ctx,
+									  0,
+									  0,
+									  "Precheck hook point: disabled, connect, after_mail, after_first_rcpt");
+
+	return ctx;
+}
+
+/**
+ * Start worker
+ */
+__attribute__((noreturn)) void
+start_smtp_proxy(struct rspamd_worker *worker)
+{
+	auto *ctx = static_cast<rspamd::smtp::smtp_proxy_ctx *>(worker->ctx);
+
+	g_assert(rspamd_worker_check_context(worker->ctx, rspamd::smtp::smtp_proxy_ctx::magic));
+
+	ctx->cfg = worker->srv->cfg;
+	ctx->worker = worker;
+	CFG_REF_RETAIN(ctx->cfg);
+
+	/* Prepare worker */
+	ctx->event_loop = rspamd_prepare_worker(worker, "smtp_proxy", smtp_proxy_accept_socket);
+
+	/* Initialize DNS resolver */
+	ctx->resolver = rspamd_dns_resolver_init(worker->srv->logger,
+											 ctx->event_loop,
+											 worker->srv->cfg);
+
+	rspamd_upstreams_library_config(worker->srv->cfg, ctx->cfg->ups_ctx,
+									ctx->event_loop, ctx->resolver->r);
+
+	/* Initialize SSL context if STARTTLS is enabled */
+	if (ctx->starttls_enabled) {
+		ctx->ssl_ctx = rspamd_init_ssl_ctx();
+		if (ctx->ssl_ctx) {
+			rspamd_ssl_ctx_config(ctx->cfg, ctx->ssl_ctx);
+		}
+	}
+
+	/* Store Lua state reference */
+	ctx->lua_state = static_cast<lua_State *>(ctx->cfg->lua_state);
+
+	/* Create sessions cache */
+	ctx->sessions_cache = rspamd_worker_session_cache_new(worker, ctx->event_loop);
+
+	msg_info_ctx("started smtp_proxy worker, backend: %s:%d, starttls: %s",
+				 ctx->backend_host.empty() ? "127.0.0.1" : ctx->backend_host.c_str(),
+				 ctx->backend_port,
+				 ctx->starttls_enabled ? "enabled" : "disabled");
+
+	/* Run Lua postloads */
+	rspamd_lua_run_postloads(ctx->lua_state, ctx->cfg, ctx->event_loop, worker);
+
+	/* Main event loop */
+	ev_loop(ctx->event_loop, 0);
+
+	/* Cleanup */
+	rspamd_worker_block_signals();
+
+	/* Close all sessions */
+	g_sessions.clear();
+
+	if (ctx->ssl_ctx) {
+		rspamd_ssl_ctx_free(ctx->ssl_ctx);
+	}
+
+	CFG_REF_RELEASE(ctx->cfg);
+	rspamd_log_close(worker->srv->logger);
+	rspamd_unset_crash_handler(worker->srv);
+
+	exit(EXIT_SUCCESS);
+}

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -28,6 +28,7 @@
 #include "rspamd_cxx_unit_rfc2047.hxx"
 #include "rspamd_cxx_unit_html_url_rewrite.hxx"
 #include "rspamd_cxx_unit_html_cta.hxx"
+#include "rspamd_cxx_unit_smtp_proxy.hxx"
 #include "rspamd_cxx_unit_upstream_token_bucket.hxx"
 
 static gboolean verbose = false;

--- a/test/rspamd_cxx_unit_smtp_proxy.hxx
+++ b/test/rspamd_cxx_unit_smtp_proxy.hxx
@@ -1,0 +1,513 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_CXX_UNIT_SMTP_PROXY_HXX
+#define RSPAMD_CXX_UNIT_SMTP_PROXY_HXX
+
+#pragma once
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+#include "libserver/smtp_proxy/smtp_proxy.hxx"
+#include "libserver/smtp_proxy/eod_scanner.hxx"
+
+TEST_SUITE("smtp_proxy")
+{
+
+	TEST_CASE("ring_buffer: basic operations")
+	{
+		rspamd::io::ring_buffer<256> buf;
+
+		CHECK(buf.empty());
+		CHECK(buf.size() == 0);
+		CHECK(buf.available_space() == 256);
+
+		// Write some data
+		std::string_view test_data = "Hello, World!";
+		auto written = buf.write(test_data);
+		CHECK(written == test_data.size());
+		CHECK(buf.size() == test_data.size());
+		CHECK(!buf.empty());
+
+		// Peek at data
+		char peek_buf[32];
+		auto peeked = buf.peek(peek_buf, sizeof(peek_buf));
+		CHECK(peeked == test_data.size());
+		CHECK(std::string_view(peek_buf, peeked) == test_data);
+
+		// Consume data
+		buf.consume(5);// "Hello"
+		CHECK(buf.size() == test_data.size() - 5);
+
+		// Reset
+		buf.reset();
+		CHECK(buf.empty());
+	}
+
+	TEST_CASE("ring_buffer: wrap-around")
+	{
+		rspamd::io::ring_buffer<16> buf;
+
+		// Fill near end
+		std::string data1 = "AAAAAAAAAA";// 10 bytes
+		buf.write(data1);
+		buf.consume(8);// Consume 8, leaving 2 at position 8-9
+
+		// Write more data that wraps
+		std::string data2 = "BBBBBBBBBB";// 10 bytes
+		auto written = buf.write(data2);
+		CHECK(written == 10);// Should wrap and fill
+
+		// Total should be 12 bytes (2 A's + 10 B's)
+		CHECK(buf.size() == 12);
+
+		// Peek should give correct data
+		char peek_buf[16];
+		auto peeked = buf.peek(peek_buf, sizeof(peek_buf));
+		CHECK(peeked == 12);
+		CHECK(std::string_view(peek_buf, 2) == "AA");
+		CHECK(std::string_view(peek_buf + 2, 10) == "BBBBBBBBBB");
+	}
+
+	TEST_CASE("eod_scanner: basic EOD detection")
+	{
+		rspamd::smtp::eod_scanner scanner;
+
+		// Standard EOD sequence
+		const char *data = "Message body\r\n.\r\n";
+		auto result = scanner.feed(data, strlen(data), 0);
+		REQUIRE(result.has_value());
+		CHECK(result->found);
+		CHECK(result->eod_start == 12);// Position of first \r
+		CHECK(result->eod_length == 5);// \r\n.\r\n
+		CHECK(!result->had_violation);
+	}
+
+	TEST_CASE("eod_scanner: bare LF violation")
+	{
+		rspamd::smtp::eod_scanner scanner;
+
+		// Bare LF EOD sequence
+		const char *data = "Message body\n.\n";
+		auto result = scanner.feed(data, strlen(data), 0);
+		REQUIRE(result.has_value());
+		CHECK(result->found);
+		CHECK(result->had_violation);
+	}
+
+	TEST_CASE("eod_scanner: incremental feeding")
+	{
+		rspamd::smtp::eod_scanner scanner;
+
+		// Feed data in chunks
+		const char *chunk1 = "Message body\r";
+		const char *chunk2 = "\n.\r";
+		const char *chunk3 = "\n";
+
+		auto result = scanner.feed(chunk1, strlen(chunk1), 0);
+		CHECK(!result.has_value());
+
+		result = scanner.feed(chunk2, strlen(chunk2), strlen(chunk1));
+		CHECK(!result.has_value());
+
+		result = scanner.feed(chunk3, strlen(chunk3), strlen(chunk1) + strlen(chunk2));
+		REQUIRE(result.has_value());
+		CHECK(result->found);
+	}
+
+	TEST_CASE("eod_scanner: no EOD")
+	{
+		rspamd::smtp::eod_scanner scanner;
+
+		const char *data = "No end of data here";
+		auto result = scanner.feed(data, strlen(data), 0);
+		CHECK(!result.has_value());
+	}
+
+	TEST_CASE("crlf_scanner: CRLF detection")
+	{
+		rspamd::smtp::crlf_scanner scanner;
+
+		const char *data = "EHLO example.com\r\n";
+		auto result = scanner.scan(data, strlen(data), 0);
+		REQUIRE(result.has_value());
+		CHECK(result->found);
+		CHECK(result->line_end == 16);
+		CHECK(result->next_line == 18);
+		CHECK(!result->bare_lf);
+	}
+
+	TEST_CASE("crlf_scanner: bare LF detection")
+	{
+		rspamd::smtp::crlf_scanner scanner;
+
+		const char *data = "Line1\nLine2";
+		auto result = scanner.scan(data, strlen(data), 0);
+		REQUIRE(result.has_value());
+		CHECK(result->found);
+		CHECK(result->line_end == 5);
+		CHECK(result->bare_lf);
+	}
+
+	TEST_CASE("crlf_scanner: incremental scan")
+	{
+		rspamd::smtp::crlf_scanner scanner;
+
+		// CR at end of first chunk
+		const char *chunk1 = "Hello\r";
+		auto result = scanner.scan(chunk1, strlen(chunk1), 0);
+		CHECK(!result.has_value());
+		CHECK(scanner.has_pending_cr());
+
+		// LF at start of next chunk
+		const char *chunk2 = "\nWorld";
+		result = scanner.scan(chunk2, strlen(chunk2), strlen(chunk1));
+		REQUIRE(result.has_value());
+		CHECK(result->found);
+		CHECK(result->line_end == 5);
+		CHECK(result->next_line == 7);
+	}
+
+	TEST_CASE("nul_scanner: NUL detection")
+	{
+		const char data[] = "Hello\0World";
+		auto result = rspamd::smtp::nul_scanner::scan(data, sizeof(data) - 1, 0);
+		REQUIRE(result.has_value());
+		CHECK(result->found);
+		CHECK(result->position == 5);
+	}
+
+	TEST_CASE("nul_scanner: no NUL")
+	{
+		const char *data = "Hello World";
+		auto result = rspamd::smtp::nul_scanner::scan(data, strlen(data), 0);
+		CHECK(!result.has_value());
+	}
+
+	TEST_CASE("line_reader: basic line reading")
+	{
+		rspamd::io::ring_buffer<256> buf;
+		rspamd::smtp::line_reader reader;
+
+		buf.write("EHLO example.com\r\n");
+
+		auto result = reader.try_read_line(buf);
+		CHECK(result.state == rspamd::smtp::line_result::status::ok);
+		CHECK(result.line == "EHLO example.com");
+		CHECK(result.raw_line == "EHLO example.com\r\n");
+		CHECK(result.bytes_consumed == 18);
+		CHECK(buf.empty());
+	}
+
+	TEST_CASE("line_reader: incomplete line")
+	{
+		rspamd::io::ring_buffer<256> buf;
+		rspamd::smtp::line_reader reader;
+
+		buf.write("EHLO example.com");// No CRLF
+
+		auto result = reader.try_read_line(buf);
+		CHECK(result.state == rspamd::smtp::line_result::status::incomplete);
+	}
+
+	TEST_CASE("line_reader: line too long")
+	{
+		rspamd::io::ring_buffer<256> buf;
+		rspamd::smtp::line_reader reader(10);// Max 10 chars
+
+		buf.write("This line is way too long\r\n");
+
+		auto result = reader.try_read_line(buf);
+		CHECK(result.state == rspamd::smtp::line_result::status::violation);
+		CHECK(result.violation_type == rspamd::smtp::line_violation::line_too_long);
+	}
+
+	TEST_CASE("line_reader: bare LF violation")
+	{
+		rspamd::io::ring_buffer<256> buf;
+		rspamd::smtp::line_reader reader;
+
+		buf.write("Invalid\nline\r\n");
+
+		auto result = reader.try_read_line(buf);
+		CHECK(result.state == rspamd::smtp::line_result::status::violation);
+		CHECK(result.violation_type == rspamd::smtp::line_violation::bare_lf);
+	}
+
+	TEST_CASE("command_parser: EHLO command")
+	{
+		rspamd::smtp::command_parser parser;
+
+		auto cmd = parser.parse("EHLO mail.example.com");
+		CHECK(cmd.type == rspamd::smtp::command_type::ehlo);
+		CHECK(cmd.verb == "EHLO");
+		CHECK(cmd.argument == "mail.example.com");
+	}
+
+	TEST_CASE("command_parser: MAIL FROM with params")
+	{
+		rspamd::smtp::command_parser parser;
+
+		auto cmd = parser.parse("MAIL FROM:<user@example.com> SIZE=1024 BODY=8BITMIME");
+		CHECK(cmd.type == rspamd::smtp::command_type::mail_from);
+		CHECK(cmd.argument == "<user@example.com>");
+		CHECK(cmd.params.size() == 2);
+		CHECK(cmd.has_param("SIZE"));
+		CHECK(cmd.has_param("BODY"));
+		CHECK(cmd.get_param("SIZE").value() == "1024");
+		CHECK(cmd.get_param("BODY").value() == "8BITMIME");
+	}
+
+	TEST_CASE("command_parser: RCPT TO")
+	{
+		rspamd::smtp::command_parser parser;
+
+		auto cmd = parser.parse("RCPT TO:<recipient@example.com>");
+		CHECK(cmd.type == rspamd::smtp::command_type::rcpt_to);
+		CHECK(cmd.argument == "<recipient@example.com>");
+	}
+
+	TEST_CASE("command_parser: simple commands")
+	{
+		rspamd::smtp::command_parser parser;
+
+		CHECK(parser.parse("DATA").type == rspamd::smtp::command_type::data);
+		CHECK(parser.parse("RSET").type == rspamd::smtp::command_type::rset);
+		CHECK(parser.parse("NOOP").type == rspamd::smtp::command_type::noop);
+		CHECK(parser.parse("QUIT").type == rspamd::smtp::command_type::quit);
+		CHECK(parser.parse("STARTTLS").type == rspamd::smtp::command_type::starttls);
+	}
+
+	TEST_CASE("command_parser: case insensitive")
+	{
+		rspamd::smtp::command_parser parser;
+
+		CHECK(parser.parse("ehlo example.com").type == rspamd::smtp::command_type::ehlo);
+		CHECK(parser.parse("Ehlo example.com").type == rspamd::smtp::command_type::ehlo);
+		CHECK(parser.parse("mail from:<a@b.c>").type == rspamd::smtp::command_type::mail_from);
+	}
+
+	TEST_CASE("command_parser: pipelining classification")
+	{
+		using rspamd::smtp::command_parser;
+		using rspamd::smtp::command_type;
+
+		CHECK(command_parser::is_pipelineable(command_type::mail_from));
+		CHECK(command_parser::is_pipelineable(command_type::rcpt_to));
+		CHECK(command_parser::is_pipelineable(command_type::rset));
+		CHECK(command_parser::is_pipelineable(command_type::noop));
+
+		CHECK(!command_parser::is_pipelineable(command_type::ehlo));
+		CHECK(!command_parser::is_pipelineable(command_type::data));
+		CHECK(!command_parser::is_pipelineable(command_type::quit));
+
+		CHECK(command_parser::is_sync_command(command_type::ehlo));
+		CHECK(command_parser::is_sync_command(command_type::data));
+		CHECK(command_parser::is_sync_command(command_type::starttls));
+		CHECK(command_parser::is_sync_command(command_type::quit));
+	}
+
+	TEST_CASE("reply_parser: single line reply")
+	{
+		rspamd::smtp::reply_parser parser;
+
+		auto line = parser.parse_line("250 OK");
+		REQUIRE(line.has_value());
+		CHECK(line->code == 250);
+		CHECK(line->is_final);
+		CHECK(line->text == "OK");
+		CHECK(line->is_success());
+	}
+
+	TEST_CASE("reply_parser: multiline reply")
+	{
+		rspamd::smtp::reply_parser parser;
+		rspamd::smtp::smtp_reply reply;
+
+		// First line
+		auto line1 = parser.parse_line("250-mail.example.com");
+		REQUIRE(line1.has_value());
+		CHECK(line1->code == 250);
+		CHECK(!line1->is_final);
+		parser.accumulate(reply, *line1);
+
+		// Middle line
+		auto line2 = parser.parse_line("250-PIPELINING");
+		REQUIRE(line2.has_value());
+		parser.accumulate(reply, *line2);
+
+		// Final line
+		auto line3 = parser.parse_line("250 SIZE 10240000");
+		REQUIRE(line3.has_value());
+		CHECK(line3->is_final);
+		bool complete = parser.accumulate(reply, *line3);
+
+		CHECK(complete);
+		CHECK(reply.is_complete());
+		CHECK(reply.code == 250);
+		CHECK(reply.lines.size() == 3);
+	}
+
+	TEST_CASE("reply_parser: EHLO capability parsing")
+	{
+		rspamd::smtp::reply_parser parser;
+		rspamd::smtp::smtp_reply reply;
+
+		parser.accumulate(reply, *parser.parse_line("250-mail.example.com"));
+		parser.accumulate(reply, *parser.parse_line("250-PIPELINING"));
+		parser.accumulate(reply, *parser.parse_line("250-SIZE 10240000"));
+		parser.accumulate(reply, *parser.parse_line("250-AUTH PLAIN LOGIN"));
+		parser.accumulate(reply, *parser.parse_line("250-8BITMIME"));
+		parser.accumulate(reply, *parser.parse_line("250 STARTTLS"));
+
+		auto ehlo = parser.parse_ehlo_response(reply);
+
+		CHECK(ehlo.greeting == "mail.example.com");
+		CHECK(ehlo.has_capability("PIPELINING"));
+		CHECK(ehlo.has_capability("SIZE"));
+		CHECK(ehlo.has_capability("AUTH"));
+		CHECK(ehlo.has_capability("8BITMIME"));
+		CHECK(ehlo.has_capability("STARTTLS"));
+		CHECK(!ehlo.has_capability("CHUNKING"));
+
+		auto size_limit = ehlo.get_size_limit();
+		REQUIRE(size_limit.has_value());
+		CHECK(*size_limit == 10240000);
+	}
+
+	TEST_CASE("reply_parser: error codes")
+	{
+		rspamd::smtp::reply_parser parser;
+
+		auto temp_fail = parser.parse_line("450 4.7.1 Temporary failure");
+		REQUIRE(temp_fail.has_value());
+		CHECK(temp_fail->is_temp_failure());
+		CHECK(!temp_fail->is_perm_failure());
+
+		auto perm_fail = parser.parse_line("550 5.7.1 Access denied");
+		REQUIRE(perm_fail.has_value());
+		CHECK(perm_fail->is_perm_failure());
+		CHECK(!perm_fail->is_temp_failure());
+
+		auto intermediate = parser.parse_line("354 Start mail input");
+		REQUIRE(intermediate.has_value());
+		CHECK(intermediate->is_intermediate());
+	}
+
+	TEST_CASE("pipelining_tracker: basic tracking")
+	{
+		rspamd::smtp::pipelining_tracker tracker(10);
+		rspamd::smtp::command_parser parser;
+
+		CHECK(!tracker.has_pending());
+		CHECK(tracker.outstanding_count() == 0);
+
+		auto cmd = parser.parse("MAIL FROM:<a@b.c>");
+		tracker.command_sent(cmd);
+
+		CHECK(tracker.has_pending());
+		CHECK(tracker.outstanding_count() == 1);
+	}
+
+	TEST_CASE("pipelining_tracker: response handling")
+	{
+		rspamd::smtp::pipelining_tracker tracker;
+		rspamd::smtp::command_parser parser;
+
+		tracker.command_sent(parser.parse("MAIL FROM:<a@b.c>"));
+		tracker.command_sent(parser.parse("RCPT TO:<x@y.z>"));
+
+		CHECK(tracker.outstanding_count() == 2);
+
+		auto resp1 = tracker.response_received(250, true);
+		REQUIRE(resp1.has_value());
+		CHECK(*resp1 == rspamd::smtp::command_type::mail_from);
+		CHECK(tracker.outstanding_count() == 1);
+
+		auto resp2 = tracker.response_received(250, true);
+		REQUIRE(resp2.has_value());
+		CHECK(*resp2 == rspamd::smtp::command_type::rcpt_to);
+		CHECK(tracker.outstanding_count() == 0);
+	}
+
+	TEST_CASE("pipelining_tracker: too many outstanding")
+	{
+		rspamd::smtp::pipelining_tracker tracker(3);
+		rspamd::smtp::command_parser parser;
+
+		// Simulate EHLO with PIPELINING enabled
+		tracker.command_sent(parser.parse("EHLO test.com"));
+		tracker.response_received(250, true);
+		tracker.enable_pipelining(true);
+
+		// Add commands up to limit
+		for (int i = 0; i < 3; ++i) {
+			auto cmd = parser.parse("RCPT TO:<test@test.com>");
+			auto violation = tracker.check_command(cmd);
+			CHECK(violation == rspamd::smtp::pipelining_violation::none);
+			tracker.command_sent(cmd);
+		}
+
+		// Next command should trigger violation
+		auto cmd = parser.parse("RCPT TO:<test@test.com>");
+		auto violation = tracker.check_command(cmd);
+		CHECK(violation == rspamd::smtp::pipelining_violation::too_many_outstanding);
+	}
+
+	TEST_CASE("pipelining_tracker: DATA state transitions")
+	{
+		rspamd::smtp::pipelining_tracker tracker;
+		rspamd::smtp::command_parser parser;
+
+		tracker.command_sent(parser.parse("DATA"));
+		CHECK(tracker.get_data_state() == rspamd::smtp::data_state::wait_354);
+
+		// 354 response starts data transfer
+		tracker.response_received(354, true);
+		CHECK(tracker.get_data_state() == rspamd::smtp::data_state::receiving);
+		CHECK(tracker.is_in_data());
+
+		// End of data
+		tracker.data_transfer_complete();
+		CHECK(tracker.get_data_state() == rspamd::smtp::data_state::completed);
+
+		// Final response
+		tracker.data_response_received();
+		CHECK(tracker.get_data_state() == rspamd::smtp::data_state::none);
+	}
+
+	TEST_CASE("unified violation types")
+	{
+		using namespace rspamd::smtp;
+
+		// Line violations
+		CHECK(to_violation_type(line_violation::bare_lf) == violation_type::bare_lf);
+		CHECK(to_violation_type(line_violation::line_too_long) == violation_type::line_too_long);
+
+		// Pipelining violations
+		CHECK(to_violation_type(pipelining_violation::too_many_outstanding) ==
+			  violation_type::too_many_outstanding);
+		CHECK(to_violation_type(pipelining_violation::data_before_354) ==
+			  violation_type::data_before_354);
+
+		// String representation
+		CHECK(std::string(violation_to_string(violation_type::bare_lf)) == "bare LF without CR");
+	}
+
+}// TEST_SUITE
+
+#endif// RSPAMD_CXX_UNIT_SMTP_PROXY_HXX


### PR DESCRIPTION
## Summary
- Implement new `smtp_proxy` worker in C++20 for proxying SMTP to backend MTA
- State machine-based protocol parsing with EOD scanner following `rspamd_string_find_eoh` pattern
- Pipelining discipline enforcement with violation detection
- STARTTLS support via new `rspamd_ssl_accept_fd()` function
- Ring buffer I/O with watermarks, command/reply parsers

## Test plan
- [x] Unit tests for ring_buffer, eod_scanner, crlf_scanner, nul_scanner
- [x] Unit tests for line_reader, command_parser, reply_parser
- [x] Unit tests for pipelining_tracker state transitions
- [x] Build passes with all existing tests (130 C++ tests, 755 Lua tests)
- [ ] Integration testing with real SMTP traffic