### PR TITLE
Adjust to build against lua 5.5

### DIFF
--- a/src/lua/lua_common.c
+++ b/src/lua/lua_common.c
@@ -932,7 +932,11 @@ rspamd_lua_init(bool wipe_mem)
 		/* TODO: broken on luajit without GC64 */
 		L = luaL_newstate();
 #else
+#ifdef LUA_VERSION_NUM < 505
 		L = lua_newstate(rspamd_lua_wipe_realloc, NULL);
+#else
+                L = lua_newstate(rspamd_lua_wipe_realloc, NULL, 0);
+#endif
 #endif
 	}
 	else {
@@ -1089,8 +1093,13 @@ void rspamd_lua_start_gc(struct rspamd_config *cfg)
 	lua_settop(L, 0);
 	/* Set up GC */
 	lua_gc(L, LUA_GCCOLLECT, 0);
+#ifdef LUA_VERSION_NUM < 505
 	lua_gc(L, LUA_GCSETSTEPMUL, cfg->lua_gc_step);
 	lua_gc(L, LUA_GCSETPAUSE, cfg->lua_gc_pause);
+#else
+        lua_gc(L, LUA_GCPARAM, LUA_GCPSTEPMUL, cfg->lua_gc_step);
+        lua_gc(L, LUA_GCPARAM, LUA_GCPPAUSE, cfg->lua_gc_pause);
+#endif
 	lua_gc(L, LUA_GCRESTART, 0);
 }
 


### PR DESCRIPTION
In Lua 5.5, the signature for lua_newstate changes (there is now an additional "seed" argument),
and the mechanism for adjusting garbage collection also changes.

I don't know whether the seed of 0 is ideal when using lua_newstate; probably, using a random seed would be better. My goal was just to get to a working build.