### PR TITLE
Allow for use of Lua 5.5

### DIFF
--- a/src/lua/lua_common.c
+++ b/src/lua/lua_common.c
@@ -933,7 +933,7 @@ rspamd_lua_init(bool wipe_mem)
 		L = luaL_newstate();
 #else
 #if LUA_VERSION_NUM >= 505
-                L = lua_newstate(rspamd_lua_wipe_realloc, NULL, 0);
+		L = lua_newstate(rspamd_lua_wipe_realloc, NULL, 0);
 #else
 		L = lua_newstate(rspamd_lua_wipe_realloc, NULL);
 #endif
@@ -1094,8 +1094,8 @@ void rspamd_lua_start_gc(struct rspamd_config *cfg)
 	/* Set up GC */
 	lua_gc(L, LUA_GCCOLLECT, 0);
 #if LUA_VERSION_NUM >= 505
-        lua_gc(L, LUA_GCPARAM, LUA_GCPSTEPMUL, cfg->lua_gc_step);
-        lua_gc(L, LUA_GCPARAM, LUA_GCPPAUSE, cfg->lua_gc_pause);
+	lua_gc(L, LUA_GCPARAM, LUA_GCPSTEPMUL, cfg->lua_gc_step);
+	lua_gc(L, LUA_GCPARAM, LUA_GCPPAUSE, cfg->lua_gc_pause);
 #else
 	lua_gc(L, LUA_GCSETSTEPMUL, cfg->lua_gc_step);
 	lua_gc(L, LUA_GCSETPAUSE, cfg->lua_gc_pause);


### PR DESCRIPTION
In Lua 5.5, the signature for lua_newstate changes (there is now an additional "seed" argument),
and the mechanism for adjusting garbage collection also changes.

I don't know whether the seed of 0 is ideal when using lua_newstate; probably, using a random seed would be better. This is a minimal patch that gets back to a working build.