### PR TITLE
[Fix] Use proper rounding for symbol frequency statistics

### DIFF
--- a/interface/js/app/symbols.js
+++ b/interface/js/app/symbols.js
@@ -68,7 +68,8 @@ define(["jquery", "app/common", "footable"],
                         item.frequency = 0;
                     }
                     freqs.push(item.frequency);
-                    item.frequency = Number(item.frequency).toFixed(2);
+                    // Don't round yet, keep precision for scaling
+                    item.frequency = Number(item.frequency);
                     if (!(item.group in lookup)) {
                         lookup[item.group] = 1;
                         distinct_groups.push(item.group);

--- a/src/client/rspamc.cxx
+++ b/src/client/rspamc.cxx
@@ -1564,6 +1564,9 @@ rspamc_counters_output(FILE *out, ucl_object_t *obj)
 	rspamc_print(out, " {} \n", emphasis_argument(dash_buf));
 	rspamc_print(out, "| {:<4} | {:<{}} | {:^7} | {:^13} | {:^7} |\n", "",
 				 "", max_len,
+				 "", "avg (stddev)", "");
+	rspamc_print(out, "| {:<4} | {:<{}} | {:^7} | {:^13} | {:^7} |\n", "",
+				 "", max_len,
 				 "", "hits/min", "");
 
 	for (const auto [i, cur]: rspamd::enumerate(counters_vec)) {

--- a/src/libserver/symcache/symcache_impl.cxx
+++ b/src/libserver/symcache/symcache_impl.cxx
@@ -373,7 +373,7 @@ auto symcache::load_items() -> bool
 template<typename T>
 static constexpr auto round_to_hundreds(T x)
 {
-	return (::floor(x) * 100.0) / 100.0;
+	return ::round(x * 100.0) / 100.0;
 }
 
 bool symcache::save_items() const
@@ -1031,7 +1031,7 @@ auto symcache::counters() const -> ucl_object_t *
 	auto *top = ucl_object_typed_new(UCL_ARRAY);
 	constexpr const auto round_float = [](const auto x, const int digits) -> auto {
 		const auto power10 = ::pow(10, digits);
-		return (::floor(x * power10) / power10);
+		return (::round(x * power10) / power10);
 	};
 
 	for (auto &pair: items_by_symbol) {
@@ -1049,8 +1049,11 @@ auto symcache::counters() const -> ucl_object_t *
 									  ucl_object_fromdouble(round_float(item->st->weight, 3)),
 									  "weight", 0, false);
 				ucl_object_insert_key(obj,
-									  ucl_object_fromdouble(round_float(parent->st->avg_frequency, 3)),
+									  ucl_object_fromdouble(round_float(parent->st->avg_frequency, 6)),
 									  "frequency", 0, false);
+				ucl_object_insert_key(obj,
+									  ucl_object_fromdouble(round_float(::sqrt(parent->st->stddev_frequency), 6)),
+									  "frequency_stddev", 0, false);
 				ucl_object_insert_key(obj,
 									  ucl_object_fromint(parent->st->total_hits),
 									  "hits", 0, false);
@@ -1067,6 +1070,9 @@ auto symcache::counters() const -> ucl_object_t *
 									  "frequency", 0, false);
 				ucl_object_insert_key(obj,
 									  ucl_object_fromdouble(0.0),
+									  "frequency_stddev", 0, false);
+				ucl_object_insert_key(obj,
+									  ucl_object_fromdouble(0.0),
 									  "hits", 0, false);
 				ucl_object_insert_key(obj,
 									  ucl_object_fromdouble(0.0),
@@ -1078,8 +1084,11 @@ auto symcache::counters() const -> ucl_object_t *
 								  ucl_object_fromdouble(round_float(item->st->weight, 3)),
 								  "weight", 0, false);
 			ucl_object_insert_key(obj,
-								  ucl_object_fromdouble(round_float(item->st->avg_frequency, 3)),
+								  ucl_object_fromdouble(round_float(item->st->avg_frequency, 6)),
 								  "frequency", 0, false);
+			ucl_object_insert_key(obj,
+								  ucl_object_fromdouble(round_float(::sqrt(item->st->stddev_frequency), 6)),
+								  "frequency_stddev", 0, false);
 			ucl_object_insert_key(obj,
 								  ucl_object_fromint(item->st->total_hits),
 								  "hits", 0, false);


### PR DESCRIPTION
- Replace incorrect floor() with round() in rounding functions to avoid losing small values
- Increase counters API frequency precision from 3 to 6 decimal places (need 5 to avoid rspamc displaying values as multiples of 0.06, need 6 for /counters endpoint itself - no additional overhead as JSON stores double anyway)
- Add frequency_stddev field to counters API output (fixes zero stdev in `rspamc counters` output)
- Clarify `rspamc counters` table header with "avg (stddev)" subheading
- Fix WebUI to preserve frequency precision before scaling

Example for symbol with frequency 0.004772 hits/sec:
- Before: /symbols returns 0.004772, /counters returns 0.004000, `rspamc counters` shows 0.240
- After:  /symbols returns 0.004772, /counters returns 0.004772, `rspamc counters` shows 0.286