### PR TITLE
Add module to save rejected mails for debugging

### DIFF
--- a/conf/modules.d/save_rejected.conf
+++ b/conf/modules.d/save_rejected.conf
@@ -1,0 +1,22 @@
+# Please don't modify this file as your changes might be overwritten with
+# the next update.
+#
+# You can modify 'local.d/save_rejected.conf' to add and merge
+# parameters defined inside this section
+#
+# You can modify 'override.d/save_rejected.conf' to strictly override all
+# parameters defined inside this section
+#
+# See https://rspamd.com/doc/faq.html#what-are-the-locald-and-overrided-directories
+# for details
+#
+# Module documentation can be found at  https://rspamd.com/doc/modules/save_rejected.html
+
+save_rejected {
+  enabled = false;
+  base_path = "/var/lib/rspamd/rejected";
+
+  .include(try=true,priority=5) "${DBDIR}/dynamic/save_rejected.conf"
+  .include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/save_rejected.conf"
+  .include(try=true,priority=10) "$LOCAL_CONFDIR/override.d/save_rejected.conf"
+}

--- a/src/plugins/lua/save_rejected.lua
+++ b/src/plugins/lua/save_rejected.lua
@@ -1,0 +1,38 @@
+local logger = require "rspamd_logger"
+local util = require "rspamd_util"
+
+local function save_message(task)
+  base = rspamd_config:get_module_opt('save_rejected', 'base_path')
+  filename = string.format("%d.R%s.%s", os.time(), util.random_hex(16), util.get_hostname())
+  path = base .. '/' .. filename
+
+  logger.infox(task, "Saving rejected message %s to %s", task:get_message_id(), path)
+
+  file = io.open(path, 'w')
+
+  if not file then
+    logger.errx("Cannot open file %s for writing!", file)
+    return
+  end
+
+  file:write(tostring(task:get_raw_headers()))
+  file:write(tostring(task:get_rawbody()))
+  file:close()
+end
+
+local function check_action(task)
+  if rspamd_config:get_module_opt('save_rejected', 'enabled') then
+    if task:get_metric_result()['action'] == 'reject' then
+      return true
+    end
+  end
+  return false
+end
+
+rspamd_config:register_symbol({
+  name = 'SAVE_REJECTED_MESSAGE',
+  type = 'idempotent',
+  flags = 'ignore_passthrough',
+  condition = check_action,
+  callback = save_message
+})


### PR DESCRIPTION
When installing and configuring a new server some ham mails might be rejected too. And as the mails are rejected there is no possibility to learn them as ham. By enabling the new `save_rejected` module all rejected mails are saved in a directory so `rspamc learn_ham` can be used to learn false positives as ham. In the corresponding merge request in the docs repository is an example for a systemd timer to remove older mails in the directory.