### PR TITLE
[Feature] Display matched fuzzy hashes in WebUI history

### DIFF
--- a/src/plugins/lua/history_redis.lua
+++ b/src/plugins/lua/history_redis.lua
@@ -139,6 +139,12 @@ local function normalise_results(tbl, task)
   end
 
   tbl.user = task:get_user() or 'unknown'
+
+  -- Retrieve fuzzy hashes that matched during scanning
+  local fuzzy_hashes = task:get_mempool():get_variable('fuzzy_hashes', 'fstrings')
+  if fuzzy_hashes and #fuzzy_hashes > 0 then
+    tbl.fuzzy_hashes = fuzzy_hashes
+  end
 end
 
 local function history_save(task)


### PR DESCRIPTION
## Summary
- Store fuzzy hashes that matched during scanning in Redis history
- Display fuzzy hashes in WebUI History tab (expanded detail row)
- Truncated hash display (16 chars) with full hash in tooltip
- Copy to clipboard button with visual feedback
- Link to bl.rspamd.com removal suggestion form with pre-filled hash

## Changes
- `src/plugins/lua/history_redis.lua`: Retrieve fuzzy hashes from task mempool and include in history data
- `interface/js/app/libft.js`: Add fuzzy_hashes column, rendering logic, and copy button handler

## Test plan
- [ ] Send email through Rspamd that triggers fuzzy match
- [ ] Verify Redis history entry contains `fuzzy_hashes` array
- [ ] Open WebUI History tab and expand a row with fuzzy match
- [ ] Verify "Fuzzy hashes" section displays correctly
- [ ] Click copy button - hash should copy to clipboard
- [ ] Click removal button - should open bl.rspamd.com with hash pre-filled
- [ ] Verify messages without fuzzy matches don't show the field