### PR TITLE
[Rework] Move obfuscation flags to url->ext

### DIFF
--- a/rules/misc.lua
+++ b/rules/misc.lua
@@ -23,9 +23,6 @@ local rspamd_parsers = require "rspamd_parsers"
 local rspamd_regexp = require "rspamd_regexp"
 local rspamd_logger = require "rspamd_logger"
 local lua_util = require "lua_util"
-local bit = require "bit"
-local rspamd_url = require "rspamd_url"
-local url_flags_tab = rspamd_url.flags
 
 -- Different text parts
 rspamd_config.R_PARTS_DIFFER = {
@@ -136,15 +133,12 @@ else
       local susp_urls = task:get_urls_filtered({ 'obscured', 'zw_spaces' })
 
       if susp_urls and susp_urls[1] then
-        local obs_flag = url_flags_tab.obscured
-        local zw_flag = url_flags_tab.zw_spaces
-
         for _, u in ipairs(susp_urls) do
-          local fl = u:get_flags_num()
-          if bit.band(fl, obs_flag) ~= 0 then
+          local fl = u:get_flags()
+          if fl.obscured then
             task:insert_result('R_SUSPICIOUS_URL', 1.0, u:get_host())
           end
-          if bit.band(fl, zw_flag) ~= 0 then
+          if fl.zw_spaces then
             task:insert_result('ZERO_WIDTH_SPACE_URL', 1.0, u:get_host())
           end
         end

--- a/src/libmime/message.c
+++ b/src/libmime/message.c
@@ -850,7 +850,7 @@ rspamd_message_process_html_text_part(struct rspamd_task *task,
 					if (!u) continue;
 					/* filter: only http/https, visible */
 					if (!(u->protocol == PROTOCOL_HTTP || u->protocol == PROTOCOL_HTTPS)) continue;
-					if (u->flags & RSPAMD_URL_FLAG_INVISIBLE) continue;
+					if (u->ext && (u->ext->obfuscation_flags & RSPAMD_URL_OBF_INVISIBLE)) continue;
 					/* Build small table */
 					lua_createtable(L, 0, 8);
 					/* host */
@@ -867,13 +867,13 @@ rspamd_message_process_html_text_part(struct rspamd_task *task,
 					lua_pushboolean(L, !!(u->flags & RSPAMD_URL_FLAG_NUMERIC));
 					lua_settable(L, -3);
 					lua_pushstring(L, "has_port");
-					lua_pushboolean(L, !!(u->flags & RSPAMD_URL_FLAG_HAS_PORT));
+					lua_pushboolean(L, u->ext && !!(u->ext->obfuscation_flags & RSPAMD_URL_OBF_HAS_PORT));
 					lua_settable(L, -3);
 					lua_pushstring(L, "has_query");
 					lua_pushboolean(L, !!(u->flags & RSPAMD_URL_FLAG_QUERY));
 					lua_settable(L, -3);
 					lua_pushstring(L, "display_mismatch");
-					lua_pushboolean(L, (u->ext && u->ext->linked_url && u->ext->linked_url != u));
+					lua_pushboolean(L, (u->ext && rspamd_url_get_linked(u) && rspamd_url_get_linked(u) != u));
 					lua_settable(L, -3);
 					/* order */
 					lua_pushstring(L, "order");
@@ -922,7 +922,7 @@ rspamd_message_process_html_text_part(struct rspamd_task *task,
 						struct rspamd_url *u = g_ptr_array_index(text_part->mime_part->urls, ui);
 						if (!u) continue;
 						if (!(u->protocol == PROTOCOL_HTTP || u->protocol == PROTOCOL_HTTPS)) continue;
-						if (u->flags & RSPAMD_URL_FLAG_INVISIBLE) continue;
+						if (u->ext && (u->ext->obfuscation_flags & RSPAMD_URL_OBF_INVISIBLE)) continue;
 						float cw = rspamd_html_url_button_weight(text_part->html, u);
 						if (cw > best_w) best_w = cw;
 					}

--- a/src/libserver/html/html.cxx
+++ b/src/libserver/html/html.cxx
@@ -2052,8 +2052,8 @@ html_append_tag_content(rspamd_mempool_t *pool,
 			if (std::holds_alternative<rspamd_url *>(tag->extra)) {
 				auto *u = std::get<rspamd_url *>(tag->extra);
 				if (u && (u->flags & RSPAMD_URL_FLAG_DISPLAY_URL) && (u->flags & RSPAMD_URL_FLAG_HTML_DISPLAYED)) {
-					/* html_process_displayed_href_tag sets linked_url when display URL differs */
-					if (u->ext && u->ext->linked_url && u->ext->linked_url != u) {
+					/* html_process_displayed_href_tag sets displayed_url when display URL differs */
+					if (u->ext && u->ext->displayed_url && u->ext->displayed_url != u) {
 						hc->features.links.display_mismatch_links++;
 					}
 				}
@@ -2088,7 +2088,7 @@ html_append_tag_content(rspamd_mempool_t *pool,
 			 * url to the hash set
 			 */
 			if (url_enclosed) {
-				url_enclosed->flags |= RSPAMD_URL_FLAG_INVISIBLE;
+				rspamd_url_ensure_ext(url_enclosed, pool)->obfuscation_flags |= RSPAMD_URL_OBF_INVISIBLE;
 			}
 		}
 	}
@@ -2385,7 +2385,7 @@ auto html_process_input(struct rspamd_task *task,
 				if (url->flags & RSPAMD_URL_FLAG_NUMERIC) {
 					hc->features.links.ip_links++;
 				}
-				if (url->flags & RSPAMD_URL_FLAG_HAS_PORT) {
+				if (url->ext && (url->ext->obfuscation_flags & RSPAMD_URL_OBF_HAS_PORT)) {
 					hc->features.links.port_links++;
 				}
 				if (url->flags & RSPAMD_URL_FLAG_QUERY) {

--- a/src/libserver/html/html_cta.cxx
+++ b/src/libserver/html/html_cta.cxx
@@ -411,7 +411,7 @@ static auto compute_penalty(const html_tag &tag,
 		penalty += 0.2f;
 	}
 
-	if (url.flags & RSPAMD_URL_FLAG_INVISIBLE) {
+	if (url.ext && (url.ext->obfuscation_flags & RSPAMD_URL_OBF_INVISIBLE)) {
 		penalty += 0.3f;
 	}
 
@@ -452,7 +452,8 @@ static auto compute_cta_weight(const html_tag &tag,
 	else {
 		order_bonus = std::max(0.0f, 0.06f / (1.0f + static_cast<float>(url.order)));
 	}
-	if (url.ext && url.ext->linked_url && url.ext->linked_url != &url) {
+	if (url.ext && ((url.ext->displayed_url && url.ext->displayed_url != &url) ||
+					(url.ext->redirected_url && url.ext->redirected_url != &url))) {
 		order_bonus += 0.12f;
 	}
 	float penalty = compute_penalty(tag, url, lowered, label_view);
@@ -527,7 +528,7 @@ void rspamd_html_process_cta_urls(struct rspamd_mime_text_part *text_part,
 	{
 		if (!u) continue;
 		if (!(u->protocol == PROTOCOL_HTTP || u->protocol == PROTOCOL_HTTPS)) continue;
-		if (u->flags & RSPAMD_URL_FLAG_INVISIBLE) continue;
+		if (u->ext && (u->ext->obfuscation_flags & RSPAMD_URL_OBF_INVISIBLE)) continue;
 		if (u->flags & RSPAMD_URL_FLAG_IMAGE) continue;
 		if (u->flags & RSPAMD_URL_FLAG_HTML_DISPLAYED) continue; /* Skip display-only URLs (phishing bait text) */
 

--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -981,11 +981,14 @@ rspamd_protocol_extended_url(struct rspamd_task *task,
 
 	ucl_object_insert_key(obj, flags, "flags", 0, false);
 
-	if (url->ext && url->ext->linked_url) {
-		encoded = rspamd_url_encode(url->ext->linked_url, &enclen, task->task_pool);
-		elt = rspamd_protocol_extended_url(task, url->ext->linked_url, encoded,
-										   enclen);
-		ucl_object_insert_key(obj, elt, "linked_url", 0, false);
+	if (url->ext) {
+		struct rspamd_url *linked = rspamd_url_get_linked(url);
+		if (linked) {
+			encoded = rspamd_url_encode(linked, &enclen, task->task_pool);
+			elt = rspamd_protocol_extended_url(task, linked, encoded,
+											   enclen);
+			ucl_object_insert_key(obj, elt, "linked_url", 0, false);
+		}
 	}
 
 	return obj;

--- a/src/libserver/url.c
+++ b/src/libserver/url.c
@@ -192,26 +192,44 @@ struct rspamd_url_flag_name {
 	{"html_displayed", RSPAMD_URL_FLAG_HTML_DISPLAYED, -1},
 	{"text", RSPAMD_URL_FLAG_FROM_TEXT, -1},
 	{"subject", RSPAMD_URL_FLAG_SUBJECT, -1},
-	{"host_encoded", RSPAMD_URL_FLAG_HOSTENCODED, -1},
-	{"schema_encoded", RSPAMD_URL_FLAG_SCHEMAENCODED, -1},
-	{"path_encoded", RSPAMD_URL_FLAG_PATHENCODED, -1},
-	{"query_encoded", RSPAMD_URL_FLAG_QUERYENCODED, -1},
-	{"missing_slashes", RSPAMD_URL_FLAG_MISSINGSLASHES, -1},
 	{"idn", RSPAMD_URL_FLAG_IDN, -1},
-	{"has_port", RSPAMD_URL_FLAG_HAS_PORT, -1},
-	{"has_user", RSPAMD_URL_FLAG_HAS_USER, -1},
-	{"schemaless", RSPAMD_URL_FLAG_SCHEMALESS, -1},
-	{"unnormalised", RSPAMD_URL_FLAG_UNNORMALISED, -1},
-	{"zw_spaces", RSPAMD_URL_FLAG_ZW_SPACES, -1},
 	{"url_displayed", RSPAMD_URL_FLAG_DISPLAY_URL, -1},
 	{"image", RSPAMD_URL_FLAG_IMAGE, -1},
 	{"query", RSPAMD_URL_FLAG_QUERY, -1},
 	{"content", RSPAMD_URL_FLAG_CONTENT, -1},
-	{"no_tld", RSPAMD_URL_FLAG_NO_TLD, -1},
-	{"truncated", RSPAMD_URL_FLAG_TRUNCATED, -1},
 	{"redirect_target", RSPAMD_URL_FLAG_REDIRECT_TARGET, -1},
-	{"invisible", RSPAMD_URL_FLAG_INVISIBLE, -1},
 	{"special", RSPAMD_URL_FLAG_SPECIAL, -1},
+};
+
+struct rspamd_url_obfuscation_flag_name {
+	const char *name;
+	int flag;
+	int hash;
+} url_obfuscation_flag_names[] = {
+	{"multiple_at", RSPAMD_URL_OBF_MULTIPLE_AT, -1},
+	{"backslashes", RSPAMD_URL_OBF_BACKSLASHES, -1},
+	{"ip_numeric", RSPAMD_URL_OBF_IP_NUMERIC, -1},
+	{"dot_tricks", RSPAMD_URL_OBF_DOT_TRICKS, -1},
+	{"missing_slashes", RSPAMD_URL_OBF_MISSING_SLASHES, -1},
+	{"has_password", RSPAMD_URL_OBF_HAS_PASSWORD, -1},
+	{"user_badchars", RSPAMD_URL_OBF_USER_BADCHARS, -1},
+	{"domain_in_user", RSPAMD_URL_OBF_DOMAIN_IN_USER, -1},
+	{"zw_spaces", RSPAMD_URL_OBF_ZW_SPACES, -1},
+	{"html_badchars", RSPAMD_URL_OBF_HTML_BADCHARS, -1},
+	{"host_encoded", RSPAMD_URL_OBF_HOST_ENCODED, -1},
+	{"phish_mismatch", RSPAMD_URL_OBF_PHISH_MISMATCH, -1},
+	{"lua_suspicious", RSPAMD_URL_OBF_LUA_SUSPICIOUS, -1},
+	{"double_slash_path", RSPAMD_URL_OBF_DOUBLE_SLASH_PATH, -1},
+	{"schema_encoded", RSPAMD_URL_OBF_SCHEMA_ENCODED, -1},
+	{"path_encoded", RSPAMD_URL_OBF_PATH_ENCODED, -1},
+	{"query_encoded", RSPAMD_URL_OBF_QUERY_ENCODED, -1},
+	{"has_port", RSPAMD_URL_OBF_HAS_PORT, -1},
+	{"has_user", RSPAMD_URL_OBF_HAS_USER, -1},
+	{"schemaless", RSPAMD_URL_OBF_SCHEMALESS, -1},
+	{"unnormalised", RSPAMD_URL_OBF_UNNORMALISED, -1},
+	{"no_tld", RSPAMD_URL_OBF_NO_TLD, -1},
+	{"truncated", RSPAMD_URL_OBF_TRUNCATED, -1},
+	{"invisible", RSPAMD_URL_OBF_INVISIBLE, -1},
 };
 
 
@@ -640,6 +658,24 @@ void rspamd_url_init(const char *tld_file)
 			}
 		}
 	}
+
+	/* Generate hashes for obfuscation flags */
+	for (int i = 0; i < G_N_ELEMENTS(url_obfuscation_flag_names); i++) {
+		url_obfuscation_flag_names[i].hash =
+			rspamd_cryptobox_fast_hash_specific(RSPAMD_CRYPTOBOX_HASHFAST_INDEPENDENT,
+												url_obfuscation_flag_names[i].name,
+												strlen(url_obfuscation_flag_names[i].name), 0);
+	}
+	for (int i = 0; i < G_N_ELEMENTS(url_obfuscation_flag_names) - 1; i++) {
+		for (int j = i + 1; j < G_N_ELEMENTS(url_obfuscation_flag_names); j++) {
+			if (url_obfuscation_flag_names[i].hash == url_obfuscation_flag_names[j].hash) {
+				msg_err("obfuscation flag collision: both %s and %s map to %d",
+						url_obfuscation_flag_names[i].name, url_obfuscation_flag_names[j].name,
+						url_obfuscation_flag_names[i].hash);
+				abort();
+			}
+		}
+	}
 }
 
 #define SET_U(u, field)                             \
@@ -701,7 +737,9 @@ static int
 rspamd_mailto_parse(struct http_parser_url *u,
 					const char *str, gsize len,
 					char const **end,
-					enum rspamd_url_parse_flags parse_flags, unsigned int *flags)
+					enum rspamd_url_parse_flags parse_flags,
+					unsigned int *flags,
+					unsigned int *obf_flags)
 {
 	const char *p = str, *c = str, *last = str + len;
 	char t;
@@ -746,7 +784,7 @@ rspamd_mailto_parse(struct http_parser_url *u,
 				p++;
 			}
 			else {
-				*flags |= RSPAMD_URL_FLAG_MISSINGSLASHES;
+				*obf_flags |= RSPAMD_URL_OBF_MISSING_SLASHES;
 				st = parse_slash_slash;
 			}
 			break;
@@ -1038,6 +1076,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 				 char const **end,
 				 enum rspamd_url_parse_flags parse_flags,
 				 unsigned int *flags,
+				 unsigned int *obf_flags,
 				 void *lua_state)
 {
 	const char *p = str, *c = str, *last = str + len, *slash = NULL,
@@ -1102,7 +1141,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 			}
 			else {
 				st = parse_slash_slash;
-				*(flags) |= RSPAMD_URL_FLAG_MISSINGSLASHES;
+				*(obf_flags) |= RSPAMD_URL_OBF_MISSING_SLASHES;
 			}
 			break;
 		case parse_slash:
@@ -1206,12 +1245,13 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 					st = parse_multiple_at;
 					user_seen = TRUE;
 					*flags |= RSPAMD_URL_FLAG_OBSCURED;
+					*obf_flags |= RSPAMD_URL_OBF_MULTIPLE_AT;
 
 					continue;
 				}
 
 				SET_U(u, UF_USERINFO);
-				*flags |= RSPAMD_URL_FLAG_HAS_USER;
+				*obf_flags |= RSPAMD_URL_OBF_HAS_USER;
 				st = parse_at;
 			}
 			else if (!g_ascii_isgraph(t)) {
@@ -1229,9 +1269,10 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 				else if (lua_decision == RSPAMD_URL_LUA_FILTER_SUSPICIOUS) {
 					/* SUSPICIOUS: Mark as obscured for plugin analysis */
 					*flags |= RSPAMD_URL_FLAG_OBSCURED;
+					*obf_flags |= RSPAMD_URL_OBF_LUA_SUSPICIOUS;
 				}
 				/* ACCEPT or SUSPICIOUS: continue parsing */
-				*flags |= RSPAMD_URL_FLAG_HAS_USER;
+				*obf_flags |= RSPAMD_URL_OBF_HAS_USER;
 			}
 
 			p++;
@@ -1255,7 +1296,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 				p--;
 				SET_U(u, UF_USERINFO);
 				p++;
-				*flags |= RSPAMD_URL_FLAG_HAS_USER;
+				*obf_flags |= RSPAMD_URL_OBF_HAS_USER;
 				st = parse_at;
 			}
 			else {
@@ -1270,7 +1311,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 					/* Eat semicolon */
 					u->field_data[UF_USERINFO].len--;
 				}
-				*flags |= RSPAMD_URL_FLAG_HAS_USER;
+				*obf_flags |= RSPAMD_URL_OBF_HAS_USER;
 				st = parse_at;
 			}
 			else {
@@ -1283,9 +1324,10 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 		case parse_password:
 			if (t == '@') {
 				/* XXX: password is not stored */
+				*obf_flags |= RSPAMD_URL_OBF_HAS_PASSWORD;
 				if (u != NULL) {
 					if (u->field_data[UF_USERINFO].len == 0 && password_start && user_start && password_start > user_start + 1) {
-						*flags |= RSPAMD_URL_FLAG_HAS_USER;
+						*obf_flags |= RSPAMD_URL_OBF_HAS_USER;
 						u->field_set |= 1u << (UF_USERINFO);
 						u->field_data[UF_USERINFO].len =
 							password_start - user_start - 1;
@@ -1308,6 +1350,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 
 			if (t == '@') {
 				*flags |= RSPAMD_URL_FLAG_OBSCURED;
+				*obf_flags |= RSPAMD_URL_OBF_MULTIPLE_AT;
 				p++;
 			}
 			else if (t == '[') {
@@ -1391,7 +1434,8 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 						if (!u_isalnum(uc)) {
 							/* Bad symbol */
 							if (IS_ZERO_WIDTH_SPACE(uc)) {
-								(*flags) |= RSPAMD_URL_FLAG_ZW_SPACES;
+								(*obf_flags) |= RSPAMD_URL_OBF_ZW_SPACES;
+								(*flags) |= RSPAMD_URL_FLAG_OBSCURED;
 							}
 							else {
 								if (!u_isgraph(uc)) {
@@ -1418,6 +1462,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 							/* We have to use all shit we are given here */
 							p++;
 							(*flags) |= RSPAMD_URL_FLAG_OBSCURED;
+							*obf_flags |= RSPAMD_URL_OBF_DOUBLE_SLASH_PATH;
 						}
 						else {
 							if (!(parse_flags & RSPAMD_URL_PARSE_CHECK)) {
@@ -1493,7 +1538,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 				}
 				if (u != NULL) {
 					u->port = pt;
-					*flags |= RSPAMD_URL_FLAG_HAS_PORT;
+					*obf_flags |= RSPAMD_URL_OBF_HAS_PORT;
 				}
 				st = parse_suffix_slash;
 			}
@@ -1504,7 +1549,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 				}
 				if (u != NULL) {
 					u->port = pt;
-					*flags |= RSPAMD_URL_FLAG_HAS_PORT;
+					*obf_flags |= RSPAMD_URL_OBF_HAS_PORT;
 				}
 
 				c = p + 1;
@@ -1517,7 +1562,7 @@ rspamd_web_parse(struct http_parser_url *u, const char *str, gsize len,
 				}
 				if (u != NULL) {
 					u->port = pt;
-					*flags |= RSPAMD_URL_FLAG_HAS_PORT;
+					*obf_flags |= RSPAMD_URL_OBF_HAS_PORT;
 				}
 
 				c = p + 1;
@@ -1774,7 +1819,7 @@ rspamd_url_regen_from_inet_addr(struct rspamd_url *uri, const void *addr, int af
 		slen += INET6_ADDRSTRLEN;
 	}
 
-	if (uri->flags & RSPAMD_URL_FLAG_HAS_PORT) {
+	if (uri->ext && (uri->ext->obfuscation_flags & RSPAMD_URL_OBF_HAS_PORT)) {
 		slen += sizeof("65535") - 1;
 	}
 
@@ -1794,7 +1839,7 @@ rspamd_url_regen_from_inet_addr(struct rspamd_url *uri, const void *addr, int af
 	uri->flags |= RSPAMD_URL_FLAG_NUMERIC;
 
 	/* Reconstruct URL */
-	if (uri->flags & RSPAMD_URL_FLAG_HAS_PORT && uri->ext) {
+	if (uri->ext && (uri->ext->obfuscation_flags & RSPAMD_URL_OBF_HAS_PORT)) {
 		p = strbuf + r;
 		start_offset = p + 1;
 		r += rspamd_snprintf(strbuf + r, slen - r, ":%ud",
@@ -1974,6 +2019,7 @@ rspamd_url_maybe_regenerate_from_ip(struct rspamd_url *uri, rspamd_mempool_t *po
 				memcpy(&in4, &n, sizeof(in4));
 				rspamd_url_regen_from_inet_addr(uri, &in4, AF_INET, pool);
 				uri->flags |= RSPAMD_URL_FLAG_OBSCURED;
+				rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_IP_NUMERIC;
 				ret = TRUE;
 			}
 			else if (end - c > (int) sizeof(buf) - 1) {
@@ -1982,6 +2028,7 @@ rspamd_url_maybe_regenerate_from_ip(struct rspamd_url *uri, rspamd_mempool_t *po
 				if (inet_pton(AF_INET6, buf, &in6) == 1) {
 					rspamd_url_regen_from_inet_addr(uri, &in6, AF_INET6, pool);
 					uri->flags |= RSPAMD_URL_FLAG_OBSCURED;
+					rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_IP_NUMERIC;
 					ret = TRUE;
 				}
 			}
@@ -1993,7 +2040,8 @@ rspamd_url_maybe_regenerate_from_ip(struct rspamd_url *uri, rspamd_mempool_t *po
 
 static void
 rspamd_url_shift(struct rspamd_url *uri, gsize nlen,
-				 enum http_parser_url_fields field)
+				 enum http_parser_url_fields field,
+				 rspamd_mempool_t *pool)
 {
 	unsigned int old_shift, shift = 0;
 	int remain;
@@ -2015,7 +2063,7 @@ rspamd_url_shift(struct rspamd_url *uri, gsize nlen,
 		memmove(uri->string + uri->protocollen, uri->string + old_shift,
 				remain);
 		uri->urllen -= shift;
-		uri->flags |= RSPAMD_URL_FLAG_SCHEMAENCODED;
+		rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_SCHEMA_ENCODED;
 		break;
 	case UF_HOST:
 		if (nlen >= uri->hostlen) {
@@ -2033,7 +2081,7 @@ rspamd_url_shift(struct rspamd_url *uri, gsize nlen,
 				rspamd_url_host_unsafe(uri) + old_shift,
 				remain);
 		uri->urllen -= shift;
-		uri->flags |= RSPAMD_URL_FLAG_HOSTENCODED;
+		rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_HOST_ENCODED;
 		break;
 	case UF_PATH:
 		if (nlen >= uri->datalen) {
@@ -2051,7 +2099,7 @@ rspamd_url_shift(struct rspamd_url *uri, gsize nlen,
 				rspamd_url_data_unsafe(uri) + old_shift,
 				remain);
 		uri->urllen -= shift;
-		uri->flags |= RSPAMD_URL_FLAG_PATHENCODED;
+		rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_PATH_ENCODED;
 		break;
 	case UF_QUERY:
 		if (nlen >= uri->querylen) {
@@ -2069,7 +2117,7 @@ rspamd_url_shift(struct rspamd_url *uri, gsize nlen,
 				rspamd_url_query_unsafe(uri) + old_shift,
 				remain);
 		uri->urllen -= shift;
-		uri->flags |= RSPAMD_URL_FLAG_QUERYENCODED;
+		rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_QUERY_ENCODED;
 		break;
 	case UF_FRAGMENT:
 		if (nlen >= uri->fragmentlen) {
@@ -2182,7 +2230,7 @@ is_idna_label_dot(UChar ch)
  * In this case, it should be treated as obfuscation attempt.
  */
 static bool
-rspamd_url_remove_dots(struct rspamd_url *uri)
+rspamd_url_remove_dots(struct rspamd_url *uri, rspamd_mempool_t *pool)
 {
 	const char *hstart = rspamd_url_host_unsafe(uri);
 	char *t;
@@ -2220,7 +2268,7 @@ rspamd_url_remove_dots(struct rspamd_url *uri)
 	}
 
 	if (ret) {
-		rspamd_url_shift(uri, t - hstart, UF_HOST);
+		rspamd_url_shift(uri, t - hstart, UF_HOST, pool);
 	}
 
 	return ret;
@@ -2302,6 +2350,7 @@ rspamd_url_parse(struct rspamd_url *uri,
 	char *p;
 	const char *end;
 	unsigned int complen, ret, flags = 0;
+	unsigned int obf_flags = 0;
 	gsize unquoted_len = 0;
 
 	memset(uri, 0, sizeof(*uri));
@@ -2316,7 +2365,7 @@ rspamd_url_parse(struct rspamd_url *uri,
 	}
 
 	if (len >= G_MAXUINT16 / 2) {
-		flags |= RSPAMD_URL_FLAG_TRUNCATED;
+		obf_flags |= RSPAMD_URL_OBF_TRUNCATED;
 		len = G_MAXUINT16 / 2;
 	}
 
@@ -2327,7 +2376,7 @@ rspamd_url_parse(struct rspamd_url *uri,
 		/* For mailto: urls we also need to add slashes to make it a valid URL */
 		if (g_ascii_strncasecmp(p, "mailto:", sizeof("mailto:") - 1) == 0) {
 			ret = rspamd_mailto_parse(&u, uristring, len, &end, parse_flags,
-									  &flags);
+									  &flags, &obf_flags);
 		}
 		else if (g_ascii_strncasecmp(p, "tel:", sizeof("tel:") - 1) == 0 ||
 				 g_ascii_strncasecmp(p, "callto:", sizeof("callto:") - 1) == 0) {
@@ -2337,11 +2386,11 @@ rspamd_url_parse(struct rspamd_url *uri,
 		}
 		else {
 			ret = rspamd_web_parse(&u, uristring, len, &end, parse_flags,
-								   &flags, lua_state);
+								   &flags, &obf_flags, lua_state);
 		}
 	}
 	else {
-		ret = rspamd_web_parse(&u, uristring, len, &end, parse_flags, &flags, lua_state);
+		ret = rspamd_web_parse(&u, uristring, len, &end, parse_flags, &flags, &obf_flags, lua_state);
 	}
 
 	if (ret != 0) {
@@ -2355,7 +2404,7 @@ rspamd_url_parse(struct rspamd_url *uri,
 	uri->raw = p;
 	uri->rawlen = len;
 
-	if (flags & RSPAMD_URL_FLAG_MISSINGSLASHES) {
+	if (obf_flags & RSPAMD_URL_OBF_MISSING_SLASHES) {
 		len += 2;
 		uri->string = rspamd_mempool_alloc(pool, len + 1);
 		memcpy(uri->string, p, u.field_data[UF_SCHEMA].len);
@@ -2420,11 +2469,9 @@ rspamd_url_parse(struct rspamd_url *uri,
 
 	/* Port is 'special' in case of url_parser as it is not a part of UF_* macro logic */
 	if (u.port != 0) {
-		if (!uri->ext) {
-			uri->ext = rspamd_mempool_alloc0_type(pool, struct rspamd_url_ext);
-		}
-		uri->flags |= RSPAMD_URL_FLAG_HAS_PORT;
-		uri->ext->port = u.port;
+		struct rspamd_url_ext *ext = rspamd_url_ensure_ext(uri, pool);
+		ext->obfuscation_flags |= RSPAMD_URL_OBF_HAS_PORT;
+		ext->port = u.port;
 	}
 
 	if (!uri->hostlen) {
@@ -2435,14 +2482,14 @@ rspamd_url_parse(struct rspamd_url *uri,
 	unquoted_len = rspamd_url_decode(uri->string,
 									 uri->string,
 									 uri->protocollen);
-	rspamd_url_shift(uri, unquoted_len, UF_SCHEMA);
+	rspamd_url_shift(uri, unquoted_len, UF_SCHEMA, pool);
 	unquoted_len = rspamd_url_decode(rspamd_url_host_unsafe(uri),
 									 rspamd_url_host_unsafe(uri), uri->hostlen);
 
 	rspamd_url_normalise_propagate_flags(pool, rspamd_url_host_unsafe(uri),
-										 &unquoted_len, uri->flags);
+										 &unquoted_len, uri, uri->flags);
 
-	rspamd_url_shift(uri, unquoted_len, UF_HOST);
+	rspamd_url_shift(uri, unquoted_len, UF_HOST, pool);
 
 	/*
 	 * Remove extra slashes between host and path.
@@ -2502,8 +2549,9 @@ rspamd_url_parse(struct rspamd_url *uri,
 		}
 	}
 
-	if (rspamd_url_remove_dots(uri)) {
+	if (rspamd_url_remove_dots(uri, pool)) {
 		uri->flags |= RSPAMD_URL_FLAG_OBSCURED;
+		rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_DOT_TRICKS;
 	}
 
 	if (uri->protocol & (PROTOCOL_HTTP | PROTOCOL_HTTPS | PROTOCOL_MAILTO | PROTOCOL_FTP | PROTOCOL_FILE)) {
@@ -2561,7 +2609,7 @@ rspamd_url_parse(struct rspamd_url *uri,
 	}
 
 	/* Final shift of lengths */
-	rspamd_url_shift(uri, norm_utf8_len, UF_HOST);
+	rspamd_url_shift(uri, norm_utf8_len, UF_HOST, pool);
 
 	/* Process data part */
 	if (uri->datalen) {
@@ -2569,13 +2617,13 @@ rspamd_url_parse(struct rspamd_url *uri,
 										 rspamd_url_data_unsafe(uri), uri->datalen);
 
 		rspamd_url_normalise_propagate_flags(pool, rspamd_url_data_unsafe(uri),
-											 &unquoted_len, uri->flags);
+											 &unquoted_len, uri, uri->flags);
 
-		rspamd_url_shift(uri, unquoted_len, UF_PATH);
+		rspamd_url_shift(uri, unquoted_len, UF_PATH, pool);
 		/* We now normalize path */
 		rspamd_normalize_path_inplace(rspamd_url_data_unsafe(uri),
 									  uri->datalen, &unquoted_len);
-		rspamd_url_shift(uri, unquoted_len, UF_PATH);
+		rspamd_url_shift(uri, unquoted_len, UF_PATH, pool);
 	}
 
 	if (uri->querylen) {
@@ -2584,8 +2632,8 @@ rspamd_url_parse(struct rspamd_url *uri,
 										 uri->querylen);
 
 		rspamd_url_normalise_propagate_flags(pool, rspamd_url_query_unsafe(uri),
-											 &unquoted_len, uri->flags);
-		rspamd_url_shift(uri, unquoted_len, UF_QUERY);
+											 &unquoted_len, uri, uri->flags);
+		rspamd_url_shift(uri, unquoted_len, UF_QUERY, pool);
 	}
 
 	if (uri->fragmentlen) {
@@ -2594,13 +2642,13 @@ rspamd_url_parse(struct rspamd_url *uri,
 										 uri->fragmentlen);
 
 		rspamd_url_normalise_propagate_flags(pool, rspamd_url_fragment_unsafe(uri),
-											 &unquoted_len, uri->flags);
-		rspamd_url_shift(uri, unquoted_len, UF_FRAGMENT);
+											 &unquoted_len, uri, uri->flags);
+		rspamd_url_shift(uri, unquoted_len, UF_FRAGMENT, pool);
 	}
 
 	rspamd_str_lc(uri->string, uri->protocollen);
 	unquoted_len = rspamd_str_lc_utf8(rspamd_url_host_unsafe(uri), uri->hostlen);
-	rspamd_url_shift(uri, unquoted_len, UF_HOST);
+	rspamd_url_shift(uri, unquoted_len, UF_HOST, pool);
 
 	if (uri->protocol == PROTOCOL_UNKNOWN) {
 		for (int i = 0; i < G_N_ELEMENTS(rspamd_url_protocols); i++) {
@@ -2686,12 +2734,12 @@ rspamd_url_parse(struct rspamd_url *uri,
 							uri->tldshift = uri->hostshift;
 							uri->tldlen = uri->hostlen;
 						}
-						else if (uri->flags & RSPAMD_URL_FLAG_SCHEMALESS) {
+						else if (uri->ext && (uri->ext->obfuscation_flags & RSPAMD_URL_OBF_SCHEMALESS)) {
 							/* Ignore urls with both no schema and no tld */
 							return URI_ERRNO_TLD_MISSING;
 						}
 
-						uri->flags |= RSPAMD_URL_FLAG_NO_TLD;
+						rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_NO_TLD;
 					}
 				}
 				else {
@@ -2700,7 +2748,7 @@ rspamd_url_parse(struct rspamd_url *uri,
 						return URI_ERRNO_TLD_MISSING;
 					}
 					else {
-						uri->flags |= RSPAMD_URL_FLAG_NO_TLD;
+						rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_NO_TLD;
 					}
 				}
 			}
@@ -2717,6 +2765,7 @@ rspamd_url_parse(struct rspamd_url *uri,
 				if (*pos == '\\') {
 					*pos = '/';
 					uri->flags |= RSPAMD_URL_FLAG_OBSCURED;
+					rspamd_url_ensure_ext(uri, pool)->obfuscation_flags |= RSPAMD_URL_OBF_BACKSLASHES;
 				}
 				pos++;
 			}
@@ -2744,6 +2793,16 @@ rspamd_url_parse(struct rspamd_url *uri,
 			/* Hack, hack, hack */
 			uri->protocol = PROTOCOL_UNKNOWN;
 		}
+	}
+
+	/* Merge early-parser obfuscation flags into ext */
+	if (obf_flags != 0) {
+		struct rspamd_url_ext *ext = rspamd_url_ensure_ext(uri, pool);
+		ext->obfuscation_flags |= obf_flags;
+	}
+	/* Compute obfuscation count */
+	if (uri->ext && uri->ext->obfuscation_flags != 0) {
+		uri->ext->obfuscation_count = __builtin_popcount(uri->ext->obfuscation_flags);
 	}
 
 	return URI_ERRNO_OK;
@@ -3073,8 +3132,9 @@ url_web_end(struct url_callback_data *cb,
 		len = MIN(len, match->newline_pos - pos);
 	}
 
+	unsigned int obf_flags_check = 0;
 	if (rspamd_web_parse(NULL, pos, len, &last,
-						 RSPAMD_URL_PARSE_CHECK, &flags, NULL) != 0) {
+						 RSPAMD_URL_PARSE_CHECK, &flags, &obf_flags_check, NULL) != 0) {
 		return FALSE;
 	}
 
@@ -3149,10 +3209,11 @@ url_email_end(struct url_callback_data *cb,
 		len = MIN(len, match->newline_pos - pos);
 	}
 
+	unsigned int obf_flags_check = 0;
 	if (!match->prefix || match->prefix[0] == '\0') {
 		/* We have mailto:// at the beginning */
 		if (rspamd_mailto_parse(&u, pos, len, &last,
-								RSPAMD_URL_PARSE_CHECK, &flags) != 0) {
+								RSPAMD_URL_PARSE_CHECK, &flags, &obf_flags_check) != 0) {
 			return FALSE;
 		}
 
@@ -3561,7 +3622,7 @@ rspamd_url_trie_generic_callback_common(struct rspamd_multipattern *mp,
 
 		if (rc == URI_ERRNO_OK && url->hostlen > 0) {
 			if (cb->prefix_added) {
-				url->flags |= RSPAMD_URL_FLAG_SCHEMALESS;
+				rspamd_url_ensure_ext(url, pool)->obfuscation_flags |= RSPAMD_URL_OBF_SCHEMALESS;
 				cb->prefix_added = FALSE;
 			}
 
@@ -3927,7 +3988,7 @@ rspamd_url_task_subject_callback(struct rspamd_url *url, gsize start_offset,
 							   url_str, url->querylen, rspamd_url_query_unsafe(url));
 
 				if (prefix_added) {
-					query_url->flags |= RSPAMD_URL_FLAG_SCHEMALESS;
+					rspamd_url_ensure_ext(query_url, task->task_pool)->obfuscation_flags |= RSPAMD_URL_OBF_SCHEMALESS;
 				}
 
 				if (query_url->protocol == PROTOCOL_MAILTO) {
@@ -4369,7 +4430,7 @@ bool rspamd_url_set_add_or_increase(khash_t(rspamd_url_hash) * set,
 	if (k != kh_end(set)) {
 		/* Existing url */
 		struct rspamd_url *ex = kh_key(set, k);
-#define SUSPICIOUS_URL_FLAGS (RSPAMD_URL_FLAG_PHISHED | RSPAMD_URL_FLAG_OBSCURED | RSPAMD_URL_FLAG_ZW_SPACES)
+#define SUSPICIOUS_URL_FLAGS (RSPAMD_URL_FLAG_PHISHED | RSPAMD_URL_FLAG_OBSCURED)
 		if (enforce_replace) {
 			kh_key(set, k) = u;
 			u->count++;
@@ -4558,4 +4619,31 @@ int rspamd_url_cmp_qsort(const void *_u1, const void *_u2)
 							*u2 = *(struct rspamd_url **) _u2;
 
 	return rspamd_url_cmp(u1, u2);
+}
+
+const char *
+rspamd_url_obfuscation_flag_to_string(int flag)
+{
+	for (int i = 0; i < G_N_ELEMENTS(url_obfuscation_flag_names); i++) {
+		if (url_obfuscation_flag_names[i].flag & flag) {
+			return url_obfuscation_flag_names[i].name;
+		}
+	}
+
+	return NULL;
+}
+
+bool rspamd_url_obfuscation_flag_from_string(const char *str, int *flag)
+{
+	int h = rspamd_cryptobox_fast_hash_specific(RSPAMD_CRYPTOBOX_HASHFAST_INDEPENDENT,
+												str, strlen(str), 0);
+
+	for (int i = 0; i < G_N_ELEMENTS(url_obfuscation_flag_names); i++) {
+		if (url_obfuscation_flag_names[i].hash == h) {
+			*flag |= url_obfuscation_flag_names[i].flag;
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/src/lua/lua_mimepart.c
+++ b/src/lua/lua_mimepart.c
@@ -1566,9 +1566,9 @@ lua_textpart_get_cta_urls(lua_State *L)
 		if (entry && entry->url) {
 			struct rspamd_url *chosen = entry->url;
 
-			if (!return_original && chosen->ext && chosen->ext->linked_url &&
-				chosen->ext->linked_url != chosen) {
-				chosen = chosen->ext->linked_url;
+			if (!return_original && chosen->ext && rspamd_url_get_linked(chosen) &&
+				rspamd_url_get_linked(chosen) != chosen) {
+				chosen = rspamd_url_get_linked(chosen);
 			}
 
 			khiter_t k = kh_get(lua_cta_url_set, seen, (khint64_t) (uintptr_t) chosen);

--- a/src/lua/lua_url.h
+++ b/src/lua/lua_url.h
@@ -28,6 +28,8 @@ struct lua_tree_cb_data {
 	int metatable_pos;
 	unsigned int flags_mask;
 	unsigned int flags_exclude_mask;
+	unsigned int obf_flags_mask;
+	unsigned int obf_flags_exclude_mask;
 	unsigned int protocols_mask;
 	enum {
 		url_flags_mode_include_any,

--- a/src/plugins/lua/url_suspect.lua
+++ b/src/plugins/lua/url_suspect.lua
@@ -256,11 +256,10 @@ local checks = {}
 -- Check: User/password in URL
 function checks.user_password_analysis(task, url, cfg)
   local findings = {}
-  local url_flags_tab = rspamd_url.flags
-  local flags = url:get_flags_num()
+  local flags = url:get_flags()
 
   -- Check if user field present
-  if bit.band(flags, url_flags_tab.has_user) == 0 then
+  if not flags.has_user then
     return findings
   end
 
@@ -324,10 +323,9 @@ end
 -- Check: Numeric IP as hostname
 function checks.numeric_ip_analysis(task, url, cfg)
   local findings = {}
-  local url_flags_tab = rspamd_url.flags
-  local flags = url:get_flags_num()
+  local flags = url:get_flags()
 
-  if bit.band(flags, url_flags_tab.numeric) == 0 then
+  if not flags.numeric then
     return findings
   end
 
@@ -354,7 +352,7 @@ function checks.numeric_ip_analysis(task, url, cfg)
     })
   else
     -- Check if user present (more suspicious)
-    if bit.band(flags, url_flags_tab.has_user) ~= 0 then
+    if flags.has_user then
       table.insert(findings, {
         symbol = symbols.numeric_ip_user,
         options = { host }
@@ -381,8 +379,7 @@ end
 -- Check: TLD validation
 function checks.tld_analysis(task, url, cfg)
   local findings = {}
-  local url_flags_tab = rspamd_url.flags
-  local flags = url:get_flags_num()
+  local flags = url:get_flags()
   local host = url:get_host()
 
   if not host then
@@ -390,9 +387,9 @@ function checks.tld_analysis(task, url, cfg)
   end
 
   -- Check for missing TLD
-  if bit.band(flags, url_flags_tab.no_tld) ~= 0 then
+  if flags.no_tld then
     -- Skip if it's a numeric IP (handled separately)
-    if bit.band(flags, url_flags_tab.numeric) == 0 then
+    if not flags.numeric then
       lua_util.debugm(N, task, "URL has no TLD: %s", host)
       table.insert(findings, {
         symbol = symbols.no_tld,
@@ -431,11 +428,10 @@ end
 -- Check: Unicode anomalies
 function checks.unicode_analysis(task, url, cfg)
   local findings = {}
-  local url_flags_tab = rspamd_url.flags
-  local flags = url:get_flags_num()
+  local flags = url:get_flags()
 
   -- Check zero-width spaces (flag check only, no string needed)
-  if cfg.check_zero_width and bit.band(flags, url_flags_tab.zw_spaces) ~= 0 then
+  if cfg.check_zero_width and flags.zw_spaces then
     lua_util.debugm(N, task, "URL contains zero-width spaces")
     table.insert(findings, {
       symbol = symbols.zero_width,

--- a/test/lua/unit/url.lua
+++ b/test/lua/unit/url.lua
@@ -179,7 +179,7 @@ context("URL check functions", function()
               v, k, uf[k], c[1], uf))
         end
         for k, v in pairs(uf) do
-          if k ~= 'url' and k ~= 'protocol' and k ~= 'tld' then
+          if k ~= 'url' and k ~= 'protocol' and k ~= 'tld' and k ~= 'obfuscation' then
             assert_not_nil(c[3][k], k .. ' should be absent but it is ' .. v .. ' in: ' .. c[1])
           end
         end

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -31,6 +31,7 @@
 #include "rspamd_cxx_unit_upstream_token_bucket.hxx"
 #include "rspamd_cxx_unit_upstream_ring_hash.hxx"
 #include "rspamd_cxx_unit_multipart.hxx"
+#include "rspamd_cxx_unit_url_obfuscation.hxx"
 
 static gboolean verbose = false;
 static const GOptionEntry entries[] =

--- a/test/rspamd_cxx_unit_url_obfuscation.hxx
+++ b/test/rspamd_cxx_unit_url_obfuscation.hxx
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Unit tests for URL obfuscation detail flags */
+
+#ifndef RSPAMD_CXX_UNIT_URL_OBFUSCATION_HXX
+#define RSPAMD_CXX_UNIT_URL_OBFUSCATION_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+#include "libserver/url.h"
+#include "libutil/mem_pool.h"
+
+#include <string>
+
+struct url_obf_test_ctx {
+	rspamd_mempool_t *pool;
+
+	url_obf_test_ctx()
+	{
+		static bool url_initialized = false;
+		if (!url_initialized) {
+			rspamd_url_init(NULL);
+			url_initialized = true;
+		}
+		pool = rspamd_mempool_new(rspamd_mempool_suggest_size(), "url_obf_test", 0);
+	}
+
+	~url_obf_test_ctx()
+	{
+		rspamd_mempool_delete(pool);
+	}
+
+	struct rspamd_url *parse_url(const std::string &url_str,
+								 enum rspamd_url_parse_flags flags = RSPAMD_URL_PARSE_TEXT)
+	{
+		auto *url = rspamd_mempool_alloc0_type(pool, struct rspamd_url);
+		char *copy = rspamd_mempool_strdup(pool, url_str.c_str());
+		auto rc = rspamd_url_parse(url, copy, strlen(copy), pool, flags, nullptr);
+		if (rc == URI_ERRNO_OK) {
+			return url;
+		}
+		return nullptr;
+	}
+};
+
+TEST_SUITE("url_obfuscation")
+{
+	TEST_CASE("numeric IP sets OBF_IP_NUMERIC")
+	{
+		url_obf_test_ctx ctx;
+		/* Numeric IP in decimal: 0x7f000001 = 2130706433 = 127.0.0.1 */
+		auto *url = ctx.parse_url("http://2130706433/test");
+		REQUIRE(url != nullptr);
+		CHECK((url->flags & RSPAMD_URL_FLAG_OBSCURED) != 0);
+		REQUIRE(url->ext != nullptr);
+		CHECK((url->ext->obfuscation_flags & RSPAMD_URL_OBF_IP_NUMERIC) != 0);
+		CHECK(url->ext->obfuscation_count > 0);
+	}
+
+	TEST_CASE("backslashes set OBF_BACKSLASHES")
+	{
+		url_obf_test_ctx ctx;
+		auto *url = ctx.parse_url("http:\\\\example.com/test", RSPAMD_URL_PARSE_HREF);
+		if (url != nullptr) {
+			if (url->flags & RSPAMD_URL_FLAG_OBSCURED) {
+				REQUIRE(url->ext != nullptr);
+				CHECK((url->ext->obfuscation_flags & RSPAMD_URL_OBF_BACKSLASHES) != 0);
+			}
+		}
+	}
+
+	TEST_CASE("missing slashes sets OBF_MISSING_SLASHES")
+	{
+		url_obf_test_ctx ctx;
+		/* URL without // after schema */
+		auto *url = ctx.parse_url("http:example.com/test");
+		if (url != nullptr) {
+			REQUIRE(url->ext != nullptr);
+			CHECK((url->ext->obfuscation_flags & RSPAMD_URL_OBF_MISSING_SLASHES) != 0);
+		}
+	}
+
+	TEST_CASE("host encoding sets OBF_HOST_ENCODED")
+	{
+		url_obf_test_ctx ctx;
+		auto *url = ctx.parse_url("http://%65%78%61%6d%70%6c%65.com/test");
+		if (url != nullptr) {
+			REQUIRE(url->ext != nullptr);
+			CHECK((url->ext->obfuscation_flags & RSPAMD_URL_OBF_HOST_ENCODED) != 0);
+		}
+	}
+
+	TEST_CASE("multiple @ signs set OBF_MULTIPLE_AT")
+	{
+		url_obf_test_ctx ctx;
+		auto *url = ctx.parse_url("http://user@@example.com/test");
+		if (url != nullptr) {
+			CHECK((url->flags & RSPAMD_URL_FLAG_OBSCURED) != 0);
+			REQUIRE(url->ext != nullptr);
+			CHECK((url->ext->obfuscation_flags & RSPAMD_URL_OBF_MULTIPLE_AT) != 0);
+		}
+	}
+
+	TEST_CASE("password in URL sets OBF_HAS_PASSWORD")
+	{
+		url_obf_test_ctx ctx;
+		auto *url = ctx.parse_url("http://user:pass@example.com/test");
+		if (url != nullptr) {
+			REQUIRE(url->ext != nullptr);
+			CHECK((url->ext->obfuscation_flags & RSPAMD_URL_OBF_HAS_PASSWORD) != 0);
+		}
+	}
+
+	TEST_CASE("obfuscation_flag_to_string returns correct names")
+	{
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_MULTIPLE_AT)) == "multiple_at");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_BACKSLASHES)) == "backslashes");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_IP_NUMERIC)) == "ip_numeric");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_DOT_TRICKS)) == "dot_tricks");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_HTML_BADCHARS)) == "html_badchars");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_PHISH_MISMATCH)) == "phish_mismatch");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_HOST_ENCODED)) == "host_encoded");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_HAS_PORT)) == "has_port");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_HAS_USER)) == "has_user");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_SCHEMALESS)) == "schemaless");
+		CHECK(std::string(rspamd_url_obfuscation_flag_to_string(RSPAMD_URL_OBF_NO_TLD)) == "no_tld");
+	}
+
+	TEST_CASE("obfuscation_flag_from_string works")
+	{
+		int flag = 0;
+		CHECK(rspamd_url_obfuscation_flag_from_string("multiple_at", &flag) == true);
+		CHECK((flag & RSPAMD_URL_OBF_MULTIPLE_AT) != 0);
+
+		flag = 0;
+		CHECK(rspamd_url_obfuscation_flag_from_string("ip_numeric", &flag) == true);
+		CHECK((flag & RSPAMD_URL_OBF_IP_NUMERIC) != 0);
+
+		flag = 0;
+		CHECK(rspamd_url_obfuscation_flag_from_string("nonexistent_flag", &flag) == false);
+	}
+
+	TEST_CASE("obfuscation_count matches popcount")
+	{
+		url_obf_test_ctx ctx;
+		/* Numeric IP should trigger OBSCURED + IP_NUMERIC */
+		auto *url = ctx.parse_url("http://2130706433/test");
+		REQUIRE(url != nullptr);
+		REQUIRE(url->ext != nullptr);
+
+		unsigned int expected_count = __builtin_popcount(url->ext->obfuscation_flags);
+		CHECK(url->ext->obfuscation_count == expected_count);
+	}
+
+	TEST_CASE("displayed_url and redirected_url are independent")
+	{
+		url_obf_test_ctx ctx;
+		auto *url1 = ctx.parse_url("http://example.com/path1");
+		auto *url2 = ctx.parse_url("http://phishing.com/path2");
+		auto *url3 = ctx.parse_url("http://redirect-target.com/path3");
+
+		REQUIRE(url1 != nullptr);
+		REQUIRE(url2 != nullptr);
+		REQUIRE(url3 != nullptr);
+
+		auto *ext = rspamd_url_ensure_ext(url1, ctx.pool);
+		ext->displayed_url = url2;
+		ext->redirected_url = url3;
+
+		CHECK(url1->ext->displayed_url == url2);
+		CHECK(url1->ext->redirected_url == url3);
+		CHECK(url1->ext->displayed_url != url1->ext->redirected_url);
+
+		/* rspamd_url_get_linked prefers displayed_url */
+		CHECK(rspamd_url_get_linked(url1) == url2);
+	}
+}
+
+#endif


### PR DESCRIPTION
## Summary

- Move 13 obfuscation-related flags from `url->flags` (main 32-bit field) to `url->ext->obfuscation_flags`, consolidating all obfuscation/suspicious URL state in one place
- Compact main `enum rspamd_url_flags` from 27 bits to 14 bits, freeing space for future non-obfuscation flags
- Add 10 new OBF flag constants (SCHEMA_ENCODED, PATH_ENCODED, QUERY_ENCODED, HAS_PORT, HAS_USER, SCHEMALESS, UNNORMALISED, NO_TLD, TRUNCATED, INVISIBLE) and rename EXCESSIVE_ENCODING to HOST_ENCODED

## Changes

**C/C++ core:**
- Unify normalisation macros into single `rspamd_url_normalise_propagate_flags(pool, input, len_out, url, flags_out)` that sets OBF_UNNORMALISED/OBF_ZW_SPACES via ext
- Add `pool` parameter to `rspamd_url_shift()` and `rspamd_url_remove_dots()` so they can allocate ext
- Add `obf_flags` parameter to `rspamd_mailto_parse()` for MISSING_SLASHES detection
- Update all SET/CHECK sites across url.c, html.cxx, html_cta.cxx, html_url.cxx, message.c
- Simplify `SUSPICIOUS_URL_FLAGS` to `PHISHED | OBSCURED` (ZW_SPACES now sets OBSCURED directly)

**Lua bindings:**
- `get_flags()` includes OBF flag names in the returned table for full backward compatibility
- `get_urls_filtered()` resolves flag names from both main and OBF namespaces
- Add `obf_flags_mask`/`obf_flags_exclude_mask` to callback filtering
- Add `rspamd_url.obf_flags` table for numeric OBF flag access

**Lua plugins:**
- Migrate `url_suspect.lua` from `bit.band(flags, tab.X)` to table-form `flags.X` checks
- Clean up unused `bit`/`url_flags_tab` imports in `rules/misc.lua`

## Test plan

- [x] `ninja -j8 install` - builds clean
- [x] `rspamd-test-cxx` - 168/168 C++ tests pass (including new obfuscation flag tests)
- [x] `rspamd-test -p /rspamd/lua` - 775/775 Lua tests pass
- [x] `luacheck` - 0 warnings, 0 errors on modified files
- [ ] Verify URL flag behavior in integration tests