### PR TITLE
Fix return value for length greater than 65535 in Redis backend

### DIFF
--- a/src/libstat/backends/redis_backend.cxx
+++ b/src/libstat/backends/redis_backend.cxx
@@ -797,7 +797,7 @@ msgpack_str_len(std::size_t len) -> std::size_t
 		return 3 + len;
 	}
 	else {
-		return 4 + len;
+		return 5 + len;
 	}
 }
 


### PR DESCRIPTION
Found in #5904 