### PR TITLE
[Conf] Disable Validity SenderScore RBLs by default

### DIFF
--- a/conf/modules.d/rbl.conf
+++ b/conf/modules.d/rbl.conf
@@ -80,10 +80,9 @@ rbl {
     }
 
     senderscore {
-      # Disabled by default to prioritize the use of score.senderscore.com.
-      # Note: The free query limit applies to both bl.score.senderscore.com and score.senderscore.com RBLs
-      # (see https://knowledge.validity.com/hc/en-us/articles/20961730681243).
-      # Enabling this RBL is recommended for low-traffic systems or MyValidity account users who benefit from using both RBLs.
+      # Disabled by default. Requires a registered MyValidity account to function:
+      # unregistered IPs receive 127.255.255.255 (blocked) regardless of query volume.
+      # See https://knowledge.validity.com/hc/en-us/articles/20961730681243.
       enabled = false;
       symbol = "RBL_SENDERSCORE_UNKNOWN";
       checks = ["from"];
@@ -111,6 +110,10 @@ rbl {
     }
 
     senderscore_reputation {
+      # Disabled by default. Requires a registered MyValidity account to function:
+      # unregistered IPs receive 127.255.255.255 (blocked) regardless of query volume.
+      # See https://knowledge.validity.com/hc/en-us/articles/20961730681243.
+      enabled = false;
       symbol = "RBL_SENDERSCORE_REPUT_UNKNOWN";
       checks = ["from"];
       rbl = "score.senderscore.com";


### PR DESCRIPTION
Both bl.score.senderscore.com and score.senderscore.com require a registered MyValidity account to function. Unregistered IPs receive 127.255.255.255 (blocked) for all queries, making the RBLs non-functional without prior account setup regardless of query volume.

Disable senderscore_reputation (score.senderscore.com) by default and update the senderscore (bl.score.senderscore.com) comment to reflect the actual registration requirement. Users must register their querying IPs at https://my.validity.com before enabling either RBL.