### PR TITLE
[Feature] Fix SIGSEGV when sign_headers is configured as UCL array

### DIFF
--- a/lualib/lua_ffi/dkim.lua
+++ b/lualib/lua_ffi/dkim.lua
@@ -90,6 +90,11 @@ local function create_sign_context(task, privkey, dkim_headers, sign_type)
 
   if not dkim_headers then
     dkim_headers = default_dkim_headers
+  elseif type(dkim_headers) == 'table' then
+    -- UCL arrays arrive as Lua tables; join into colon-delimited string
+    dkim_headers = table.concat(dkim_headers, ':')
+  elseif type(dkim_headers) ~= 'string' then
+    return nil, 'sign_headers must be a colon-delimited string or array, got ' .. type(dkim_headers)
   end
 
   if not sign_type then

--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -3627,6 +3627,16 @@ rspamd_create_dkim_sign_context(struct rspamd_task *task,
 	nctx->common.is_sign = true;
 
 	if (type != RSPAMD_DKIM_ARC_SEAL) {
+		if (headers == NULL) {
+			g_set_error(err,
+						DKIM_ERROR,
+						DKIM_SIGERROR_EMPTY_H,
+						"sign_headers is NULL (check config: "
+						"use a colon-delimited string, not an array)");
+
+			return NULL;
+		}
+
 		if (!rspamd_dkim_parse_hdrlist_common(&nctx->common, headers,
 											  strlen(headers), true,
 											  err)) {


### PR DESCRIPTION
Howdy!

I initially worked around this by using colon-delimited string instead of array: sign_headers = "from:to:subject:date:message-id";

The issue, AFAICT:

ucl_object_tostring() returns NULL for UCL_ARRAY type objects, but the DKIM signing code passes this NULL to strlen() without checking, causing a segfault on the first signing attempt.

Note, the UCL parser silently accepts array syntax for sign_headers, and some example configs use this format, making the crash difficult to diagnose without core dumps or ASAN builds.   I am in a bit over my head with ASAN.  


Fixes: SIGSEGV in dkim.c:strlen(headers) when headers is NULL

Following @vstakhov's stuff from November:

- **Config loader** (`dkim_check.c`): New `rspamd_dkim_ucl_sign_headers()` helper detects `UCL_ARRAY` and joins elements with `:` delimiter. Logs deprecation warning.

- **C crash site** (`dkim.c`): NULL guard before `strlen(headers)` — returns descriptive `GError` with `DKIM_SIGERROR_EMPTY_H` instead of crashing.

- **Lua FFI bridge** (`lua_ffi/dkim.lua`): Handles `table` type (UCL arrays arrive as Lua tables) via `table.concat(dkim_headers, ':')`.