### PR TITLE
[Feature] Shard migration and multi-class Bayes in statistics_dump

### DIFF
--- a/lualib/rspamadm/statistics_dump.lua
+++ b/lualib/rspamadm/statistics_dump.lua
@@ -780,6 +780,14 @@ local function restore_handler(opts)
 
   local batch = {}
   local pending_cmds = 0
+  local total_lines = 0
+  local total_cmds = 0
+  local total_batches = 0
+  local start_time = os.time()
+  local last_report_time = start_time
+
+  rspamd_logger.messagex("starting restore (batch_size=%s, pipeline_max=%s, mode=%s)",
+      opts.batch_size, pipeline_max, opts.mode or 'add')
 
   for _, f in ipairs(files) do
     local fd
@@ -788,6 +796,7 @@ local function restore_handler(opts)
       io.input(fd)
     end
 
+    rspamd_logger.messagex("processing file: %s", f)
     local cur_line = 1
     for line in io.lines() do
       local ucl_parser = ucl.parser()
@@ -807,29 +816,57 @@ local function restore_handler(opts)
         local ok
         ok, conns = flush_restore_batch(batch, conns, selected, opts)
         if not ok then
+          rspamd_logger.errx("restore failed at line %s (total restored: %s lines, %s commands in %s batches)",
+              total_lines + cur_line, total_lines, total_cmds, total_batches)
           os.exit(1)
         end
+        total_cmds = total_cmds + pending_cmds
+        total_batches = total_batches + 1
         pending_cmds = 0
 
-        if cur_line % (opts.batch_size * 10) == 0 then
-          collectgarbage('collect')
-          rspamd_logger.messagex("restored %s lines", cur_line)
+        -- Incremental GC after each batch to spread collection cost
+        collectgarbage('step', 100)
+
+        local now = os.time()
+        if now - last_report_time >= 10 then
+          local elapsed = now - start_time
+          local rate = total_lines > 0 and math.floor(total_lines / elapsed) or 0
+          rspamd_logger.messagex("restored %s lines, %s commands in %s batches (%s lines/sec, %s KB lua mem)",
+              total_lines + cur_line - 1, total_cmds, total_batches, rate,
+              math.floor(collectgarbage('count')))
+          last_report_time = now
         end
       end
     end
 
+    total_lines = total_lines + cur_line - 1
+
     if fd then
       fd:close()
     end
+
+    -- Full GC between files
+    collectgarbage('collect')
   end
 
   if #batch > 0 then
     local ok
     ok, conns = flush_restore_batch(batch, conns, selected, opts)
     if not ok then
+      rspamd_logger.errx("restore failed on final batch (total restored: %s lines, %s commands)",
+          total_lines, total_cmds)
       os.exit(1)
     end
+    total_cmds = total_cmds + pending_cmds
+    total_batches = total_batches + 1
   end
+
+  local elapsed = os.time() - start_time
+  if elapsed == 0 then
+    elapsed = 1
+  end
+  rspamd_logger.messagex("restore complete: %s lines, %s commands in %s batches (%s sec, %s lines/sec)",
+      total_lines, total_cmds, total_batches, elapsed, math.floor(total_lines / elapsed))
 end
 
 -- Migrate a single prefix's token keys from source to target using pipelined commands.


### PR DESCRIPTION
## Summary

- Add `rspamadm statistics_dump migrate` subcommand for migrating per-user Bayes data between Redis shards after the Jump Hash → Ketama hash transition (commit `4ea750466`)
- Fix multi-class Bayes support in dump/restore: now handles arbitrary statfile classes (not just binary spam/ham) with proper class label mapping (`class_labels` config, `tbl.class` field)
- Fix dump to iterate all shards via `all_upstreams()` instead of connecting to a single round-robin shard

### Migrate subcommand

```
rspamadm statistics_dump migrate [--dry-run] [--no-delete] [--batch-size N] [-c config]
```

- Scans all Redis shards, identifies misplaced prefix keys via `get_upstream_by_hash()`
- Moves data in batches using Redis Lua scripts (SCAN+HGETALL → msgpack → HMSET)
- `--dry-run`: show what would migrate without writing
- `--no-delete`: copy to target without removing from source
- Idempotent: safe to re-run after interruption

### Multi-class changes

- `check_redis_classifier()` now builds a `symbols` list with `{symbol, class_name, label}` for each statfile
- Class determined by priority: explicit `class` config → `spam` boolean → heuristic from symbol name
- CDB packing uses dynamic class labels instead of hardcoded S/H

## Test plan

- [x] `luacheck` passes clean
- [x] C++ unit tests pass (158/158)
- [x] Lua unit tests pass (818/821, 3 unassertive pre-existing)
- [x] Manual test: `rspamadm statistics_dump dump` with multi-class config
- [x] Manual test: `rspamadm statistics_dump migrate --dry-run` with sharded Redis
- [x] Manual test: full migration on test Redis cluster