### PR TITLE
[Test] Use Node.js 22 for legacy Playwright 1.45.3 job

### DIFF
--- a/.github/workflows/ci_webui_e2e_playwright.yml
+++ b/.github/workflows/ci_webui_e2e_playwright.yml
@@ -29,6 +29,7 @@ jobs:
         include:
           - version: 1.45.3
             label: legacy
+            node-version: '22'
           - version: latest
             label: latest
     steps:
@@ -99,7 +100,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version || 'lts/*' }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4


### PR DESCRIPTION
Playwright 1.45.3 predates Node.js 24 support (added in v1.55), causing an immediate crash on startup. Use Node.js 22 for the legacy matrix entry.