### PR TITLE
[Minor] Skip empty In-Reply-To header in replies check

### DIFF
--- a/src/plugins/lua/replies.lua
+++ b/src/plugins/lua/replies.lua
@@ -216,9 +216,9 @@ local function replies_check(task)
       end
     end
   end
-  -- If in-reply-to header not present return
+  -- If in-reply-to header not present or empty return
   in_reply_to = task:get_header_raw('in-reply-to')
-  if not in_reply_to then
+  if not in_reply_to or #in_reply_to == 0 then
     return
   end
   -- Create hash of in-reply-to and query redis
@@ -322,9 +322,9 @@ local function replies_check_cookie(task)
     end
   end
 
-  -- If in-reply-to header not present return
+  -- If in-reply-to header not present or empty return
   local irt = task:get_header('in-reply-to')
-  if irt == nil then
+  if not irt or #irt == 0 then
     return
   end
   local cr = require "rspamd_cryptobox"


### PR DESCRIPTION
An empty `In-Reply-To` header value ("") is truthy in Lua, bypassing the `nil` check. In `replies_check` this caused a misleading log entry "ignoring reply to  as no recipients are matching hash ". In `replies_check_cookie` it triggered an unnecessary `decrypt_cookie` call.