### PR TITLE
[Feature] Prevent SIGSEGV when sign_headers is not a string

### DIFF
--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -3646,6 +3646,14 @@ rspamd_create_dkim_sign_context(struct rspamd_task *task,
 	nctx->common.is_sign = true;
 
 	if (type != RSPAMD_DKIM_ARC_SEAL) {
+		if (headers == NULL || headers[0] == '\0') {
+			g_set_error(err,
+						DKIM_ERROR,
+						DKIM_SIGERROR_EMPTY_H,
+						"empty or NULL sign headers list");
+			return NULL;
+		}
+
 		if (!rspamd_dkim_parse_hdrlist_common(&nctx->common, headers,
 											  strlen(headers), true,
 											  err)) {

--- a/src/plugins/dkim_check.c
+++ b/src/plugins/dkim_check.c
@@ -538,16 +538,34 @@ int dkim_module_config(struct rspamd_config *cfg, bool validate)
 	 */
 	if ((value =
 			 rspamd_config_get_module_opt(cfg, "dkim_signing", "sign_headers")) != NULL) {
-		dkim_module_ctx->sign_headers = ucl_object_tostring(value);
+		if (ucl_object_type(value) != UCL_STRING) {
+			msg_err_config("sign_headers in dkim_signing must be a colon-delimited string, got %s",
+						   ucl_object_type_to_string(ucl_object_type(value)));
+		}
+		else {
+			dkim_module_ctx->sign_headers = ucl_object_tostring(value);
+		}
 	}
 	else if ((value =
 				  rspamd_config_get_module_opt(cfg, "dkim", "sign_headers")) != NULL) {
-		dkim_module_ctx->sign_headers = ucl_object_tostring(value);
+		if (ucl_object_type(value) != UCL_STRING) {
+			msg_err_config("sign_headers in dkim must be a colon-delimited string, got %s",
+						   ucl_object_type_to_string(ucl_object_type(value)));
+		}
+		else {
+			dkim_module_ctx->sign_headers = ucl_object_tostring(value);
+		}
 	}
 
 	if ((value =
 			 rspamd_config_get_module_opt(cfg, "arc", "sign_headers")) != NULL) {
-		dkim_module_ctx->arc_sign_headers = ucl_object_tostring(value);
+		if (ucl_object_type(value) != UCL_STRING) {
+			msg_err_config("sign_headers in arc must be a colon-delimited string, got %s",
+						   ucl_object_type_to_string(ucl_object_type(value)));
+		}
+		else {
+			dkim_module_ctx->arc_sign_headers = ucl_object_tostring(value);
+		}
 	}
 
 	if (cache_size > 0) {


### PR DESCRIPTION
Replaces #5910 (closed due to branch rework pre-coffee).  Sorry about the git shenanigans.   😅   

`ucl_object_tostring()` returns NULL for non-string UCL types (arrays, objects, etc.),
but DKIM signing passes this NULL to `strlen()`, causing a SIGSEGV on the first
signing attempt. Difficult to diagnose — in Kubernetes, manifests as CrashLoopBackOff.

Changes:
- **dkim.c**: NULL guard before `strlen(headers)` — returns `GError` with
  `DKIM_SIGERROR_EMPTY_H` instead of crashing
- **dkim_check.c**: Type validation at config load time for `sign_headers` in
  dkim_signing, dkim, and arc modules — rejects non-string types with a clear
  error message
  
-jess