### PR TITLE
[Test] Skip scheduled integration tests in forks

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   integration-test:
     name: Integration & Load Test
+    if: github.event_name != 'schedule' || github.repository == 'rspamd/rspamd'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
Limit scheduled integration-test runs to rspamd/rspamd while keeping manual start available in forks. This avoids unnecessary fork cron runs and reduces noisy CI failures unrelated to upstream.