### PR TITLE
[Minor] Fix default date description in rspamadm dmarc_report help

### DIFF
--- a/lualib/rspamadm/dmarc_report.lua
+++ b/lualib/rspamadm/dmarc_report.lua
@@ -47,7 +47,7 @@ parser:flag "-n --no-opt"
       :description "Do not reset reporting data/send reports"
 
 parser:argument "date"
-      :description "Date to process (today by default)"
+      :description "Date to process (yesterday by default)"
       :argname "<YYYYMMDD>"
       :args "*"
 parser:option "-b --batch-size"


### PR DESCRIPTION
This PR changes the help text for the `date` argument of `rspamadm dmarc_report` from "today" to "yesterday". When the command is run without specifying a date, it actually processes reports for yesterday, so this update makes the help message match the command's behavior.

Per the source the code, `yesterday_midnight()` is used when no `date` argument is provided:

https://github.com/rspamd/rspamd/blob/c51c5bcea60a4be440cf11dcf869a8c6fb2be9b3/lualib/rspamadm/dmarc_report.lua#L782-L785

Related: #4062, #4053