### PR TITLE
[Fix] Self-healing hyperscan cache

### DIFF
--- a/src/hs_helper.c
+++ b/src/hs_helper.c
@@ -249,6 +249,7 @@ struct hs_helper_ctx {
 	ucl_object_t *redis_config; /* Redis backend configuration */
 	ucl_object_t *http_config;  /* HTTP backend configuration */
 	int lua_backend_ref;        /* Lua reference to backend object */
+	ev_tstamp last_recompile_time; /* Timestamp of last recompile start for debounce */
 };
 
 /* Parse cache_backend string to enum */
@@ -792,6 +793,9 @@ rspamd_rs_compile(struct hs_helper_ctx *ctx, struct rspamd_worker *worker,
 	return TRUE;
 }
 
+/* Minimum interval between recompile requests to avoid thrashing */
+#define HS_RECOMPILE_DEBOUNCE_SEC 5.0
+
 static gboolean
 rspamd_hs_helper_reload(struct rspamd_main *rspamd_main,
 						struct rspamd_worker *worker, int fd,
@@ -802,11 +806,28 @@ rspamd_hs_helper_reload(struct rspamd_main *rspamd_main,
 	struct rspamd_control_reply rep;
 	struct hs_helper_ctx *ctx = ud;
 
-	msg_info("recompiling hyperscan expressions after receiving reload command");
 	memset(&rep, 0, sizeof(rep));
 	rep.type = RSPAMD_CONTROL_RECOMPILE;
 	rep.id = cmd->id;
 	rep.reply.recompile.status = 0;
+
+	/* Debounce: skip if we recompiled very recently */
+	ev_tstamp now = ev_now(ctx->event_loop);
+	if (ctx->last_recompile_time > 0 &&
+		now - ctx->last_recompile_time < HS_RECOMPILE_DEBOUNCE_SEC) {
+		msg_info("ignoring recompile request, last recompile was %.1fs ago (debounce: %.1fs)",
+				 now - ctx->last_recompile_time, HS_RECOMPILE_DEBOUNCE_SEC);
+
+		if (write(fd, &rep, sizeof(rep)) != sizeof(rep)) {
+			msg_err("cannot write reply to the control socket: %s",
+					strerror(errno));
+		}
+
+		return TRUE;
+	}
+
+	ctx->last_recompile_time = now;
+	msg_info("recompiling hyperscan expressions after receiving reload command");
 
 	/* We write reply before actual recompilation as it takes a lot of time */
 	if (write(fd, &rep, sizeof(rep)) != sizeof(rep)) {

--- a/src/libserver/hs_cache_backend.c
+++ b/src/libserver/hs_cache_backend.c
@@ -482,6 +482,73 @@ void rspamd_hs_cache_lua_exists_async(const char *cache_key,
 	lua_settop(L, err_idx - 1);
 }
 
+void rspamd_hs_cache_lua_delete_async(const char *cache_key,
+									  const char *entity_name,
+									  rspamd_hs_cache_async_cb cb,
+									  void *ud)
+{
+	lua_State *L = lua_backend_L;
+	int err_idx;
+
+	msg_debug_hyperscan("delete_async: entity='%s', key=%s",
+						entity_name ? entity_name : "unknown", cache_key);
+
+	if (rspamd_current_worker && rspamd_current_worker->state != rspamd_worker_state_running) {
+		msg_debug_hyperscan("delete_async: worker terminating, skipping");
+		if (cb) cb(FALSE, NULL, 0, "worker is terminating", ud);
+		return;
+	}
+
+	if (!rspamd_hs_cache_has_lua_backend()) {
+		msg_debug_hyperscan("delete_async: no Lua backend");
+		if (cb) cb(FALSE, NULL, 0, "Lua backend not initialized", ud);
+		return;
+	}
+
+	lua_pushcfunction(L, rspamd_lua_traceback);
+	err_idx = lua_gettop(L);
+
+	/* Get backend object */
+	lua_rawgeti(L, LUA_REGISTRYINDEX, lua_backend_ref);
+	if (!lua_istable(L, -1)) {
+		lua_settop(L, err_idx - 1);
+		if (cb) cb(FALSE, NULL, 0, "Invalid Lua backend reference", ud);
+		return;
+	}
+
+	/* Get delete method */
+	lua_getfield(L, -1, "delete");
+	if (!lua_isfunction(L, -1)) {
+		lua_settop(L, err_idx - 1);
+		if (cb) cb(FALSE, NULL, 0, "Lua backend has no delete method", ud);
+		return;
+	}
+
+	/* Push self (backend object) */
+	lua_pushvalue(L, -2);
+	/* Push cache_key */
+	lua_pushstring(L, cache_key);
+	/* Push platform_id */
+	lua_pushstring(L, lua_backend_platform_id ? lua_backend_platform_id : "default");
+
+	/* Push callback wrapper with 4 upvalues: cb, ud, entity_name, cache_key */
+	lua_pushlightuserdata(L, (void *) cb);
+	lua_pushlightuserdata(L, ud);
+	lua_pushstring(L, entity_name ? entity_name : "unknown");
+	lua_pushstring(L, cache_key);
+	lua_pushcclosure(L, lua_hs_cache_async_callback, 4);
+
+	/* Call backend:delete(cache_key, platform_id, callback) */
+	if (lua_pcall(L, 4, 0, err_idx) != 0) {
+		const char *lua_err = lua_tostring(L, -1);
+		if (cb) cb(FALSE, NULL, 0, lua_err ? lua_err : "Lua call failed", ud);
+		lua_settop(L, err_idx - 1);
+		return;
+	}
+
+	lua_settop(L, err_idx - 1);
+}
+
 gboolean rspamd_hs_cache_lua_load_sync(const char *cache_key,
 									   const char *entity_name,
 									   unsigned char **data,

--- a/src/libserver/hs_cache_backend.h
+++ b/src/libserver/hs_cache_backend.h
@@ -189,6 +189,18 @@ void rspamd_hs_cache_lua_exists_async(const char *cache_key,
 									  void *ud);
 
 /**
+ * Delete cache entry via Lua backend (asynchronous)
+ * @param cache_key unique cache key (hash)
+ * @param entity_name human-readable name of the entity (e.g., multimap name, re class)
+ * @param cb completion callback (may be NULL for fire-and-forget)
+ * @param ud userdata
+ */
+void rspamd_hs_cache_lua_delete_async(const char *cache_key,
+									  const char *entity_name,
+									  rspamd_hs_cache_async_cb cb,
+									  void *ud);
+
+/**
  * Load data from cache via Lua backend (synchronous)
  * Only works for backends that support synchronous operations (e.g., file backend).
  * For async-only backends (redis, http), returns FALSE immediately.

--- a/src/libserver/re_cache.c
+++ b/src/libserver/re_cache.c
@@ -25,6 +25,7 @@
 #include "libutil/regexp.h"
 #include "libutil/heap.h"
 #include "lua/lua_common.h"
+#include "libserver/worker_util.h"
 #include "libstat/stat_api.h"
 #include "contrib/uthash/utlist.h"
 #include "lua/lua_classnames.h"
@@ -106,7 +107,6 @@ struct rspamd_re_class {
 	hs_scratch_t *hs_scratch;
 	int *hs_ids;
 	unsigned int nhs;
-	gboolean needs_recompile; /* set when stale blob detected */
 #endif
 };
 
@@ -2359,55 +2359,43 @@ rspamd_re_cache_exists_cb(gboolean success, const unsigned char *data, gsize len
 		struct rspamd_re_cache *cache = cbdata->cache;
 		int n = g_hash_table_size(re_class->re);
 
-		if (re_class->needs_recompile) {
-			/* Stale blob was detected during load, force recompilation */
-			msg_info_re_cache(
-				"forcing recompilation of class %s (%6s), %d regexps: "
-				"stale blob detected during previous load",
-				rspamd_re_cache_type_to_string(re_class->type),
-				re_class->hash, n);
-			re_class->needs_recompile = FALSE;
-			cbdata->state = RSPAMD_RE_CACHE_COMPILE_STATE_COMPILING;
+		if (!lua_backend) {
+			rspamd_snprintf(path, sizeof(path), "%s%c%s.hs", cbdata->cache_dir,
+							G_DIR_SEPARATOR, re_class->hash);
+		}
+
+		if (re_class->type_len > 0) {
+			if (!cbdata->silent) {
+				msg_info_re_cache(
+					"skip already valid class %s(%*s) to cache %6s (%s), %d regexps%s%s%s",
+					rspamd_re_cache_type_to_string(re_class->type),
+					(int) re_class->type_len - 1,
+					re_class->type_data,
+					re_class->hash,
+					lua_backend ? "Lua backend" : path,
+					n,
+					cache->scope ? " for scope '" : "",
+					cache->scope ? cache->scope : "",
+					cache->scope ? "'" : "");
+			}
 		}
 		else {
-			if (!lua_backend) {
-				rspamd_snprintf(path, sizeof(path), "%s%c%s.hs", cbdata->cache_dir,
-								G_DIR_SEPARATOR, re_class->hash);
+			if (!cbdata->silent) {
+				msg_info_re_cache(
+					"skip already valid class %s to cache %6s (%s), %d regexps%s%s%s",
+					rspamd_re_cache_type_to_string(re_class->type),
+					re_class->hash,
+					lua_backend ? "Lua backend" : path,
+					n,
+					cache->scope ? " for scope '" : "",
+					cache->scope ? cache->scope : "",
+					cache->scope ? "'" : "");
 			}
-
-			if (re_class->type_len > 0) {
-				if (!cbdata->silent) {
-					msg_info_re_cache(
-						"skip already valid class %s(%*s) to cache %6s (%s), %d regexps%s%s%s",
-						rspamd_re_cache_type_to_string(re_class->type),
-						(int) re_class->type_len - 1,
-						re_class->type_data,
-						re_class->hash,
-						lua_backend ? "Lua backend" : path,
-						n,
-						cache->scope ? " for scope '" : "",
-						cache->scope ? cache->scope : "",
-						cache->scope ? "'" : "");
-				}
-			}
-			else {
-				if (!cbdata->silent) {
-					msg_info_re_cache(
-						"skip already valid class %s to cache %6s (%s), %d regexps%s%s%s",
-						rspamd_re_cache_type_to_string(re_class->type),
-						re_class->hash,
-						lua_backend ? "Lua backend" : path,
-						n,
-						cache->scope ? " for scope '" : "",
-						cache->scope ? cache->scope : "",
-						cache->scope ? "'" : "");
-				}
-			}
-
-			/* Skip compilation */
-			cbdata->state = RSPAMD_RE_CACHE_COMPILE_STATE_INIT;
-			cbdata->current_class = NULL;
 		}
+
+		/* Skip compilation */
+		cbdata->state = RSPAMD_RE_CACHE_COMPILE_STATE_INIT;
+		cbdata->current_class = NULL;
 	}
 	else {
 		/* Not exists, proceed */
@@ -3770,14 +3758,19 @@ rspamd_re_cache_hs_load_cb(gboolean success, const unsigned char *data, gsize le
 {
 	struct rspamd_re_cache_hs_load_item *it = (struct rspamd_re_cache_hs_load_item *) ud;
 	struct rspamd_re_cache_hs_load_scope *sctx = it->scope_ctx;
+	struct rspamd_re_cache *cache = it->cache;
 
 	if (success && data && len > 0) {
-		if (rspamd_re_cache_apply_hyperscan_blob(it->cache, it->re_class, data, len, sctx->try_load)) {
+		if (rspamd_re_cache_apply_hyperscan_blob(cache, it->re_class, data, len, sctx->try_load)) {
 			sctx->loaded++;
 			sctx->total_regexps += it->re_class->nhs;
 		}
 		else {
-			it->re_class->needs_recompile = TRUE;
+			/* Blob is corrupt/stale - delete from cache so hs_helper recompiles */
+			msg_warn_re_cache("deleting stale hyperscan blob for class %s",
+							  it->re_class->hash);
+			rspamd_hs_cache_lua_delete_async(it->cache_key,
+											 "stale_blob_cleanup", NULL, NULL);
 			sctx->all_loaded = FALSE;
 		}
 	}
@@ -3792,7 +3785,6 @@ rspamd_re_cache_hs_load_cb(gboolean success, const unsigned char *data, gsize le
 	}
 
 	if (sctx->pending == 0) {
-		struct rspamd_re_cache *cache = sctx->cache;
 
 		if (sctx->loaded > 0) {
 			cache->hyperscan_loaded = sctx->all_loaded ? RSPAMD_HYPERSCAN_LOADED_FULL : RSPAMD_HYPERSCAN_LOADED_PARTIAL;
@@ -3821,6 +3813,22 @@ rspamd_re_cache_hs_load_cb(gboolean success, const unsigned char *data, gsize le
 							  cache->scope ? cache->scope : "",
 							  cache->scope ? "'" : "");
 		}
+
+		/* If some classes failed to load, request hs_helper to recompile */
+		if (!sctx->all_loaded && rspamd_current_worker &&
+			rspamd_current_worker->state == rspamd_worker_state_running) {
+			struct rspamd_srv_command srv_cmd;
+			memset(&srv_cmd, 0, sizeof(srv_cmd));
+			srv_cmd.type = RSPAMD_SRV_RECOMPILE_REQUEST;
+			rspamd_srv_send_command(rspamd_current_worker,
+									sctx->event_loop, &srv_cmd, -1, NULL, NULL);
+			msg_info_re_cache("requested hs_helper recompile due to %ud/%ud failed class loads%s%s%s",
+							  sctx->total - sctx->loaded, sctx->total,
+							  cache->scope ? " for scope '" : "",
+							  cache->scope ? cache->scope : "",
+							  cache->scope ? "'" : "");
+		}
+
 		g_free(sctx);
 	}
 

--- a/src/libserver/rspamd_control.c
+++ b/src/libserver/rspamd_control.c
@@ -1266,6 +1266,15 @@ rspamd_srv_handler(EV_P_ ev_io *w, int revents)
 					worker->hb.busy_reason[0] = '\0';
 				}
 				break;
+			case RSPAMD_SRV_RECOMPILE_REQUEST:
+				msg_info_main("received hyperscan recompile request from worker %P",
+							  worker->pid);
+				rdata->rep.reply.recompile_request.status = 0;
+				memset(&wcmd, 0, sizeof(wcmd));
+				wcmd.type = RSPAMD_CONTROL_RECOMPILE;
+				rspamd_control_broadcast_cmd(rspamd_main, &wcmd, rfd,
+											 rspamd_control_ignore_io_handler, NULL, 0);
+				break;
 			case RSPAMD_SRV_HEALTH:
 				rspamd_fill_health_reply(rspamd_main, &rdata->rep);
 				break;
@@ -1843,6 +1852,9 @@ const char *rspamd_srv_command_to_string(enum rspamd_srv_type cmd)
 		break;
 	case RSPAMD_SRV_BUSY:
 		reply = "busy";
+		break;
+	case RSPAMD_SRV_RECOMPILE_REQUEST:
+		reply = "recompile_request";
 		break;
 	default:
 		break;

--- a/src/libserver/rspamd_control.h
+++ b/src/libserver/rspamd_control.h
@@ -58,6 +58,7 @@ enum rspamd_srv_type {
 	RSPAMD_SRV_MULTIPATTERN_LOADED, /* Multipattern HS compiled and ready */
 	RSPAMD_SRV_REGEXP_MAP_LOADED,   /* Regexp map HS compiled and ready */
 	RSPAMD_SRV_BUSY,                /* Worker is busy with long-running operation */
+	RSPAMD_SRV_RECOMPILE_REQUEST,   /* Worker requests hs_helper to recompile (stale cache) */
 };
 
 enum rspamd_log_pipe_type {
@@ -251,6 +252,9 @@ struct rspamd_srv_command {
 			gboolean is_busy;
 			char reason[32];
 		} busy;
+		struct {
+			unsigned int unused;
+		} recompile_request;
 	} cmd;
 };
 
@@ -291,6 +295,9 @@ struct rspamd_srv_reply {
 		struct {
 			int status;
 		} workers_spawned;
+		struct {
+			int status;
+		} recompile_request;
 	} reply;
 };
 


### PR DESCRIPTION
## Summary

- When workers fail to deserialize a cached hyperscan blob (version mismatch, corruption), they now **delete the stale cache entry** and **send a recompile request** to hs_helper
- Added `rspamd_hs_cache_lua_delete_async()` C wrapper for the Lua backend's existing `delete` method (file/redis/http)
- New `RSPAMD_SRV_RECOMPILE_REQUEST` control command: worker → main → broadcast `RSPAMD_CONTROL_RECOMPILE` → hs_helper
- 5-second debounce in `rspamd_hs_helper_reload` to prevent thrashing from multiple workers
- Removed dead `needs_recompile` flag (was set on worker's `re_class` but checked in hs_helper — different process, never worked)

Previously the system would get permanently stuck in PCRE fallback because hs_helper's `exists` check would pass for stale entries and skip recompilation.

## Test plan

- [x] Build succeeds (`ninja -j8 install`)
- [x] C++ tests pass (170/170)
- [x] Lua tests pass (948/951, 3 unassertive, 0 failed)
- [ ] Manual: corrupt an hs cache file, verify logs show deletion + recompile + successful reload