### PR TITLE
[Fix] Add missing #include <memory> in redis_backend.cxx

### DIFF
--- a/src/libstat/backends/redis_backend.cxx
+++ b/src/libstat/backends/redis_backend.cxx
@@ -30,6 +30,7 @@
 #include <string>
 #include <cstdint>
 #include <vector>
+#include <memory>
 #include <optional>
 
 #define msg_debug_stat_redis(...) rspamd_conditional_debug_fast(nullptr, nullptr,                                                 \


### PR DESCRIPTION
## Summary

- Add explicit `#include <memory>` to `src/libstat/backends/redis_backend.cxx`
- `std::make_unique` is used at line 584 but `<memory>` was not directly included
- This causes compilation failures on platforms where `<memory>` is not transitively included by other headers (e.g. gcc-toolset-12 on Rocky Linux 8)

## Details

The C++ standard requires `#include <memory>` for `std::make_unique` and `std::unique_ptr`. Currently the code compiles on some toolchains because `<memory>` happens to be pulled in transitively, but this is not guaranteed by the standard.