### PR TITLE
[Fix] Separate greylisting period from Redis connection timeout in gr…

### DIFF
--- a/conf/modules.d/greylist.conf
+++ b/conf/modules.d/greylist.conf
@@ -20,7 +20,8 @@ greylist {
   ];
 
   expire = 1d; # 1 day by default
-  timeout = 5min; # 5 minutes by default
+  timeout = 5min; # greylisting period (how long to greylist a new sender)
+  #redis_timeout = 1.0; # Redis connection timeout in seconds
   key_prefix = "rg"; # default hash name
   max_data_len = 10k; # default data limit to hash
   message = "Try again later"; # default greylisted message

--- a/src/plugins/lua/greylist.lua
+++ b/src/plugins/lua/greylist.lua
@@ -42,8 +42,10 @@ if confighelp then
 greylist {
   # Buckets expire (1 day by default)
   expire = 1d;
-  # Greylisting timeout
+  # Greylisting period (how long to greylist a new sender)
   timeout = 5m;
+  # Redis connection timeout in seconds
+  # redis_timeout = 1.0;
   # Redis prefix
   key_prefix = 'rg';
   # Use body hash up to this value of bytes for greylisting
@@ -79,7 +81,8 @@ local whitelist_domains_map
 local toint = math.ifloor or math.floor
 local settings = {
   expire = 86400, -- 1 day by default
-  timeout = 300, -- 5 minutes by default
+  timeout = 300, -- greylisting period: 5 minutes by default
+  redis_timeout = 1.0, -- Redis connection timeout in seconds
   key_prefix = 'rg', -- default hash name
   max_data_len = 10240, -- default data limit to hash
   message = 'Try again later', -- default greylisted message
@@ -570,6 +573,9 @@ if opts then
     rspamd_logger.infox(rspamd_config, 'no servers are specified, disabling module')
     rspamd_lua_utils.disable_module(N, "redis")
   else
+    -- settings.timeout is the greylisting period, not a Redis connection timeout;
+    -- override to prevent it from being misused as such by lua_redis
+    redis_params.timeout = settings.redis_timeout
     lua_redis.register_prefix(settings.key_prefix .. 'b[a-z0-9]{20}', N,
         'Greylisting elements (body hashes)"', {
           type = 'string',

--- a/src/plugins/lua/greylist.lua
+++ b/src/plugins/lua/greylist.lua
@@ -574,6 +574,14 @@ if opts then
   -- enrich_defaults since settings.redis_timeout equals lua_redis's default_timeout (1.0).
   local redis_opts = lua_util.shallowcopy(opts)
   redis_opts.timeout = settings.redis_timeout
+  if redis_opts.redis then
+    -- When Redis is configured in a nested greylist.redis{} block, parse_redis_server
+    -- uses opts.redis and never reads opts.timeout, so propagate redis_timeout there too.
+    redis_opts.redis = lua_util.shallowcopy(redis_opts.redis)
+    if not redis_opts.redis.timeout then
+      redis_opts.redis.timeout = settings.redis_timeout
+    end
+  end
   redis_params = lua_redis.parse_redis_server(N, redis_opts)
   if not redis_params then
     rspamd_logger.infox(rspamd_config, 'no servers are specified, disabling module')

--- a/src/plugins/lua/greylist.lua
+++ b/src/plugins/lua/greylist.lua
@@ -568,14 +568,17 @@ if opts then
   whitelist_domains_map = lua_map.rspamd_map_add(N, 'whitelist_domains_url',
       'map', 'Greylist whitelist domains map')
 
-  redis_params = lua_redis.parse_redis_server(N)
+  -- Pass opts with redis_timeout instead of the greylisting period (settings.timeout),
+  -- so lua_redis does not mistake the greylisting period for a Redis connection timeout.
+  -- redis.greylist.timeout or the global redis.timeout can still override this via
+  -- enrich_defaults since settings.redis_timeout equals lua_redis's default_timeout (1.0).
+  local redis_opts = lua_util.shallowcopy(opts)
+  redis_opts.timeout = settings.redis_timeout
+  redis_params = lua_redis.parse_redis_server(N, redis_opts)
   if not redis_params then
     rspamd_logger.infox(rspamd_config, 'no servers are specified, disabling module')
     rspamd_lua_utils.disable_module(N, "redis")
   else
-    -- settings.timeout is the greylisting period, not a Redis connection timeout;
-    -- override to prevent it from being misused as such by lua_redis
-    redis_params.timeout = settings.redis_timeout
     lua_redis.register_prefix(settings.key_prefix .. 'b[a-z0-9]{20}', N,
         'Greylisting elements (body hashes)"', {
           type = 'string',


### PR DESCRIPTION
…eylist

settings.timeout (greylisting period, 5 min) was being picked up by lua_redis as the Redis connection timeout, inflating the symbol's augmentation timeout to 300s. Add redis_timeout (default 1.0s) and explicitly set redis_params.timeout after parse_redis_server.