### PR TITLE
[Fix] Warn on task_timeout less than symcache symbol timeout

### DIFF
--- a/conf/modules.d/mx_check.conf
+++ b/conf/modules.d/mx_check.conf
@@ -21,7 +21,9 @@
 # You also need to define redis servers for this module
 
 mx_check {
-  # connection timeout in seconds
+  # TCP connection timeout in seconds. The effective symbol timeout is
+  # timeout + dns.timeout (see options.inc), so task_timeout must be set
+  # higher than their sum to avoid forced task termination.
   timeout = 1.0;
   # symbol yielded if no MX is connectable
   symbol_bad_mx = "MX_INVALID";

--- a/src/libserver/symcache/symcache_c.cxx
+++ b/src/libserver/symcache/symcache_c.cxx
@@ -104,6 +104,13 @@ bool rspamd_symcache_add_symbol_augmentation(struct rspamd_symcache *cache,
 
 	/* Handle empty or absent strings equally */
 	if (value == nullptr || value[0] == '\0') {
+		/* Check if augmentation uses "key=value" format */
+		const char *eq = strchr(augmentation, '=');
+		if (eq != nullptr && eq != augmentation && eq[1] != '\0') {
+			return item->add_augmentation(*real_cache,
+										  std::string_view{augmentation, static_cast<size_t>(eq - augmentation)},
+										  std::string_view{eq + 1});
+		}
 		return item->add_augmentation(*real_cache, augmentation, std::nullopt);
 	}
 

--- a/src/libserver/worker_util.c
+++ b/src/libserver/worker_util.c
@@ -2668,7 +2668,7 @@ rspamd_worker_check_and_adjust_timeout(struct rspamd_config *cfg, double timeout
 	g_assert(tres != 0);
 
 	if (tres->max_timeout > timeout) {
-		msg_info_config("configured task_timeout %.2f is less than maximum symbols cache timeout %.2f; "
+		msg_warn_config("configured task_timeout %.2f is less than maximum symbols cache timeout %.2f; "
 						"some symbols can be terminated before checks",
 						timeout, tres->max_timeout);
 		GString *buf = g_string_sized_new(512);
@@ -2686,7 +2686,7 @@ rspamd_worker_check_and_adjust_timeout(struct rspamd_config *cfg, double timeout
 									  tres->items[i].timeout);
 			}
 		}
-		msg_info_config("list of top %d symbols by execution time: %v",
+		msg_warn_config("list of top %d symbols by execution time: %v",
 						(int) MIN(tres->nitems, max_displayed_items),
 						buf);
 

--- a/src/rspamadm/configtest.c
+++ b/src/rspamadm/configtest.c
@@ -156,6 +156,19 @@ rspamadm_configtest(int argc, char **argv, const struct rspamadm_command *cmd)
 
 		if (ret) {
 			rspamd_worker_check_and_adjust_timeout(cfg, cfg->task_timeout);
+			/* Also check per-worker task_timeout overrides */
+			for (GList *cur = cfg->workers; cur != NULL; cur = g_list_next(cur)) {
+				struct rspamd_worker_conf *wcf = (struct rspamd_worker_conf *) cur->data;
+				if (wcf->options) {
+					const ucl_object_t *to = ucl_object_lookup(wcf->options, "task_timeout");
+					if (to == NULL) {
+						to = ucl_object_lookup(wcf->options, "check_timeout");
+					}
+					if (to != NULL) {
+						rspamd_worker_check_and_adjust_timeout(cfg, ucl_object_todouble(to));
+					}
+				}
+			}
 		}
 
 		if (ret) {

--- a/src/rspamadm/configtest.c
+++ b/src/rspamadm/configtest.c
@@ -19,6 +19,7 @@
 #include "cfg_rcl.h"
 #include "rspamd.h"
 #include "lua/lua_common.h"
+#include "worker_util.h"
 
 static gboolean quiet = FALSE;
 static char *config = NULL;
@@ -151,6 +152,10 @@ rspamadm_configtest(int argc, char **argv, const struct rspamadm_command *cmd)
 											 cfg,
 											 FALSE)) {
 			ret = FALSE;
+		}
+
+		if (ret) {
+			rspamd_worker_check_and_adjust_timeout(cfg, cfg->task_timeout);
 		}
 
 		if (ret) {


### PR DESCRIPTION
Call rspamd_worker_check_and_adjust_timeout during configtest so misconfigured plugin timeouts are reported at configuration validation time. Elevate the diagnostic from info to warning level.

Fix rspamd_symcache_add_symbol_augmentation to parse "key=value" format in augmentation strings, allowing numeric timeout augmentations from Lua plugins to be stored and compared correctly.

Clarify mx_check timeout comment to explain that the effective symbol timeout includes dns.timeout in addition to the configured value.