### PR TITLE
[Feature] lualib: add lua_feedback_parsers for DSN and ARF reports

### DIFF
--- a/lualib/lua_feedback_parsers.lua
+++ b/lualib/lua_feedback_parsers.lua
@@ -1,0 +1,488 @@
+--[[
+Copyright (c) 2026, Vsevolod Stakhov <vsevolod@rspamd.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]] --
+
+--[[[
+-- @module lua_feedback_parsers
+-- This module provides parsers for inbound feedback reports that arrive as
+-- a regular message (MIME) on a task:
+--
+--   * RFC 3464 Delivery Status Notifications (DSN / bounces)
+--   * RFC 5965 Abuse Reporting Format (ARF / FBL)
+--
+-- The parsers operate on a `task` object and return a structured Lua table
+-- describing the report, or `nil` if the message is not a report of that
+-- kind. Both parsers are defensive: malformed bodies will not raise an
+-- error, they will produce a partial result at best (documented per
+-- function) or `nil`.
+--]]
+
+local rspamd_logger = require 'rspamd_logger'
+
+local N = 'lua_feedback_parsers'
+
+local exports = {}
+
+-- ----------------------------------------------------------------------------
+-- Generic helpers
+-- ----------------------------------------------------------------------------
+
+-- Trim ASCII whitespace from both ends of a string.
+local function trim(s)
+  if not s then
+    return nil
+  end
+  return (s:gsub('^%s+', ''):gsub('%s+$', ''))
+end
+
+-- Strip a single pair of outermost angle brackets, e.g. `<id@example>`.
+local function strip_angles(s)
+  if not s then
+    return nil
+  end
+  local inner = s:match('^%s*<(.-)>%s*$')
+  if inner then
+    return inner
+  end
+  return trim(s)
+end
+
+-- Normalise line endings: drop CR, keep LF.
+local function normalize_eol(body)
+  if type(body) ~= 'string' then
+    body = tostring(body or '')
+  end
+  return (body:gsub('\r', ''))
+end
+
+-- Split a string on LF into a plain array of lines (no trailing empty line
+-- duplication). Preserves empty lines in the middle.
+local function split_lines(body)
+  local lines = {}
+  local i = 1
+  local len = #body
+  local start = 1
+  while i <= len do
+    local c = body:sub(i, i)
+    if c == '\n' then
+      lines[#lines + 1] = body:sub(start, i - 1)
+      start = i + 1
+    end
+    i = i + 1
+  end
+  if start <= len then
+    lines[#lines + 1] = body:sub(start)
+  end
+  return lines
+end
+
+--[[
+-- Parse an RFC 822 field block (a sequence of header-like lines terminated
+-- by a blank line or end of input). Handles header folding: lines that
+-- start with a tab or a space are continuations of the previous field.
+--
+-- Returns:
+--   fields - map of lowercased field name -> value (trimmed string)
+--   fields_multi - map of lowercased field name -> array of values (in order
+--     of appearance); useful for repeated fields such as `Reported-URI`.
+--   next_line - 1-based index of the first line AFTER the blank line that
+--     terminated the block (or #lines + 1 if the block ran to end of input)
+--
+-- `start_line` is 1-based.
+]]
+local function parse_field_block(lines, start_line)
+  local fields = {}
+  local fields_multi = {}
+  local current_name
+  local current_value_parts
+  local i = start_line or 1
+  local n = #lines
+
+  local function flush()
+    if current_name then
+      local value = trim(table.concat(current_value_parts, ' '))
+      fields[current_name] = value
+      local list = fields_multi[current_name]
+      if not list then
+        list = {}
+        fields_multi[current_name] = list
+      end
+      list[#list + 1] = value
+    end
+    current_name = nil
+    current_value_parts = nil
+  end
+
+  while i <= n do
+    local line = lines[i]
+    if line == '' then
+      flush()
+      i = i + 1
+      return fields, fields_multi, i
+    end
+    local first = line:sub(1, 1)
+    if first == ' ' or first == '\t' then
+      if current_name then
+        current_value_parts[#current_value_parts + 1] = trim(line)
+      end
+      -- else: continuation with no preceding field - ignore
+    else
+      local name, value = line:match('^([^:]+):%s?(.*)$')
+      if name then
+        flush()
+        current_name = name:lower():gsub('%s+$', '')
+        current_value_parts = { value or '' }
+      end
+      -- else: malformed line - skip it
+    end
+    i = i + 1
+  end
+
+  flush()
+  return fields, fields_multi, i
+end
+
+-- Split an entire body into an array of field blocks separated by blank
+-- lines. Used for message/delivery-status bodies which consist of 1..N
+-- blocks.
+local function parse_field_blocks(body)
+  local lines = split_lines(normalize_eol(body))
+  -- Skip leading blank lines.
+  local i = 1
+  while i <= #lines and lines[i] == '' do
+    i = i + 1
+  end
+  local blocks = {}
+  while i <= #lines do
+    local fields, fields_multi, next_i = parse_field_block(lines, i)
+    -- Only keep non-empty blocks.
+    if next(fields) ~= nil then
+      blocks[#blocks + 1] = {
+        fields = fields,
+        fields_multi = fields_multi,
+      }
+    end
+    if next_i <= i then
+      break
+    end
+    i = next_i
+    -- Skip further blank lines between blocks.
+    while i <= #lines and lines[i] == '' do
+      i = i + 1
+    end
+  end
+  return blocks
+end
+
+-- Safely fetch `(type, subtype, params)` for a mime part, falling back to
+-- nil on any error. `get_type_full` returns a 3-value tuple in recent
+-- Rspamd; older versions may only return type/subtype. We use pcall to be
+-- safe regardless.
+local function safe_get_type_full(part)
+  local ok, t, st, params = pcall(part.get_type_full, part)
+  if not ok then
+    return nil, nil, nil
+  end
+  return t, st, params
+end
+
+-- Safely fetch plain content as a Lua string.
+local function safe_get_content(part)
+  local ok, content = pcall(part.get_content, part)
+  if not ok or content == nil then
+    return nil
+  end
+  return tostring(content)
+end
+
+-- Find the topmost multipart/report part in a task that matches the given
+-- `report-type` (case-insensitive). Returns the matching mime_part or nil.
+local function find_multipart_report(task, wanted_report_type)
+  local parts = task:get_parts() or {}
+  for _, part in ipairs(parts) do
+    local t, st, params = safe_get_type_full(part)
+    if t == 'multipart' and st == 'report' and type(params) == 'table' then
+      local rt = params['report-type'] or params['Report-Type']
+      if rt and rt:lower() == wanted_report_type then
+        return part
+      end
+    end
+  end
+  return nil
+end
+
+-- Find the first sub-part whose Content-Type matches `wanted_type/wanted_subtype`
+-- (case-insensitive). If `wanted_subtype` is nil, only `wanted_type` is
+-- matched. Searches all parts on the task (they are already flattened by
+-- the mime parser).
+local function find_part_by_type(task, wanted_type, wanted_subtype)
+  local parts = task:get_parts() or {}
+  for _, part in ipairs(parts) do
+    local t, st = part:get_type()
+    if t and t:lower() == wanted_type and
+        (not wanted_subtype or (st and st:lower() == wanted_subtype)) then
+      return part
+    end
+  end
+  return nil
+end
+
+-- Like find_part_by_type but iterates a set of candidate type pairs.
+local function find_original_message_part(task)
+  local parts = task:get_parts() or {}
+  for _, part in ipairs(parts) do
+    local t, st = part:get_type()
+    if t and st then
+      local lt = t:lower()
+      local lst = st:lower()
+      if lt == 'message' and (lst == 'rfc822' or lst == 'global') then
+        return part, 'full'
+      end
+      if lt == 'text' and lst == 'rfc822-headers' then
+        return part, 'headers'
+      end
+    end
+  end
+  return nil
+end
+
+-- Given a string containing full RFC 822 content (headers + optional body)
+-- return a table mapping lowercased header names to values. If the string
+-- only contains headers (no trailing blank line), the parser still works.
+local function parse_rfc822_headers(content)
+  if not content or content == '' then
+    return {}
+  end
+  local lines = split_lines(normalize_eol(content))
+  local fields = parse_field_block(lines, 1)
+  return fields or {}
+end
+
+-- Extract the standard subset of original-message headers we care about.
+local function extract_original_message(part, kind)
+  local content = safe_get_content(part)
+  if not content then
+    return nil
+  end
+  local headers
+  if kind == 'headers' then
+    headers = parse_rfc822_headers(content)
+  else
+    -- For message/rfc822 (or message/global) content is the full embedded
+    -- message; the header block is everything up to the first blank line.
+    headers = parse_rfc822_headers(content)
+  end
+  if not headers or next(headers) == nil then
+    return nil
+  end
+  local out = {
+    message_id = strip_angles(headers['message-id']),
+    from = strip_angles(headers['from']),
+    to = strip_angles(headers['to']),
+    subject = headers['subject'],
+    date = headers['date'],
+  }
+  -- If every field came back nil, treat as no useful data.
+  if not (out.message_id or out.from or out.to or out.subject or out.date) then
+    return nil
+  end
+  return out
+end
+
+-- ----------------------------------------------------------------------------
+-- DSN (RFC 3464)
+-- ----------------------------------------------------------------------------
+
+--[[[
+-- @function lua_feedback_parsers.parse_dsn(task)
+-- Parse an RFC 3464 Delivery Status Notification from the given task.
+--
+-- Detection: the task must contain either a `multipart/report` part with
+-- `report-type=delivery-status`, or a `message/delivery-status` sub-part.
+-- If neither is present, returns `nil`.
+--
+-- Malformed-body policy: if detection succeeds but the body cannot be
+-- parsed into at least one non-empty field block, the function still
+-- returns a table (with `recipients = {}`) so that callers can distinguish
+-- "not a DSN" (nil) from "a DSN we couldn't fully parse" (table with
+-- mostly-nil fields). Exceptions from the C API are caught and silenced.
+--
+-- @param {rspamd_task} task message to inspect
+-- @return {table|nil} parsed DSN, see module doc for the shape
+--]]
+function exports.parse_dsn(task)
+  if not task then
+    return nil
+  end
+
+  -- Detection: prefer the envelope multipart/report, but also accept a
+  -- bare message/delivery-status (some MTAs emit non-standard shapes).
+  local envelope = find_multipart_report(task, 'delivery-status')
+  local status_part = find_part_by_type(task, 'message', 'delivery-status')
+  if not envelope and not status_part then
+    return nil
+  end
+
+  local result = {
+    reporting_mta = nil,
+    original_envelope_id = nil,
+    arrival_date = nil,
+    received_from_mta = nil,
+    recipients = {},
+    original_message = nil,
+  }
+
+  if status_part then
+    local body = safe_get_content(status_part)
+    if body then
+      local blocks = parse_field_blocks(body)
+      if #blocks > 0 then
+        local per_message = blocks[1].fields
+        result.reporting_mta = per_message['reporting-mta']
+        result.original_envelope_id = per_message['original-envelope-id']
+        result.arrival_date = per_message['arrival-date']
+        result.received_from_mta = per_message['received-from-mta']
+        for j = 2, #blocks do
+          local rf = blocks[j].fields
+          result.recipients[#result.recipients + 1] = {
+            original_recipient = rf['original-recipient'],
+            final_recipient = rf['final-recipient'],
+            action = rf['action'] and rf['action']:lower() or nil,
+            status = rf['status'],
+            diagnostic_code = rf['diagnostic-code'],
+            remote_mta = rf['remote-mta'],
+            last_attempt_date = rf['last-attempt-date'],
+          }
+        end
+      else
+        rspamd_logger.debugm(N, task, 'DSN detected but delivery-status body has no parseable blocks')
+      end
+    else
+      rspamd_logger.debugm(N, task, 'DSN detected but delivery-status part content is empty')
+    end
+  end
+
+  local orig_part, kind = find_original_message_part(task)
+  if orig_part then
+    result.original_message = extract_original_message(orig_part, kind)
+  end
+
+  return result
+end
+
+-- ----------------------------------------------------------------------------
+-- ARF (RFC 5965)
+-- ----------------------------------------------------------------------------
+
+--[[[
+-- @function lua_feedback_parsers.parse_arf(task)
+-- Parse an RFC 5965 Abuse Reporting Format (ARF) feedback report.
+--
+-- Detection: the task must contain a `multipart/report` part with
+-- `report-type=feedback-report` AND a sub-part with
+-- `message/feedback-report`. If either is missing, returns `nil`.
+--
+-- Malformed-body policy: same as `parse_dsn`. If detection succeeds but
+-- the feedback-report body is unparseable, a table is still returned (with
+-- mostly-nil fields and `reported_uri = {}`).
+--
+-- @param {rspamd_task} task message to inspect
+-- @return {table|nil} parsed ARF, see module doc for the shape
+--]]
+function exports.parse_arf(task)
+  if not task then
+    return nil
+  end
+
+  local envelope = find_multipart_report(task, 'feedback-report')
+  if not envelope then
+    return nil
+  end
+  local fb_part = find_part_by_type(task, 'message', 'feedback-report')
+  if not fb_part then
+    return nil
+  end
+
+  local result = {
+    feedback_type = nil,
+    version = nil,
+    user_agent = nil,
+    original_mail_from = nil,
+    original_rcpt_to = nil,
+    arrival_date = nil,
+    source_ip = nil,
+    reported_domain = nil,
+    reported_uri = {},
+    authentication_results = nil,
+    original_envelope_id = nil,
+    incidents = nil,
+    original_message = nil,
+  }
+
+  local body = safe_get_content(fb_part)
+  if body then
+    local blocks = parse_field_blocks(body)
+    if #blocks > 0 then
+      local f = blocks[1].fields
+      local fm = blocks[1].fields_multi
+      result.feedback_type = f['feedback-type'] and f['feedback-type']:lower() or nil
+      result.version = f['version']
+      result.user_agent = f['user-agent']
+      result.original_mail_from = strip_angles(f['original-mail-from'])
+      result.original_rcpt_to = strip_angles(f['original-rcpt-to'])
+      result.arrival_date = f['arrival-date']
+      result.source_ip = f['source-ip']
+      result.reported_domain = f['reported-domain']
+      result.authentication_results = f['authentication-results']
+      result.original_envelope_id = f['original-envelope-id']
+      if f['incidents'] then
+        local n = tonumber(f['incidents'])
+        if n then
+          result.incidents = n
+        end
+      end
+      if fm and fm['reported-uri'] then
+        for _, v in ipairs(fm['reported-uri']) do
+          result.reported_uri[#result.reported_uri + 1] = v
+        end
+      end
+    else
+      rspamd_logger.debugm(N, task, 'ARF detected but feedback-report body has no parseable blocks')
+    end
+  else
+    rspamd_logger.debugm(N, task, 'ARF detected but feedback-report part content is empty')
+  end
+
+  local orig_part, kind = find_original_message_part(task)
+  if orig_part then
+    local om = extract_original_message(orig_part, kind)
+    if om then
+      -- RFC 5965 consumers typically only care about Message-ID and From.
+      result.original_message = {
+        message_id = om.message_id,
+        from = om.from,
+      }
+    end
+  end
+
+  return result
+end
+
+-- Exposed for tests / introspection.
+exports._parse_field_blocks = parse_field_blocks
+exports._parse_rfc822_headers = parse_rfc822_headers
+exports._strip_angles = strip_angles
+
+return exports

--- a/lualib/lua_feedback_parsers.lua
+++ b/lualib/lua_feedback_parsers.lua
@@ -411,4 +411,8 @@ function exports.parse_arf(task)
   return result
 end
 
+-- Exposed for unit tests.
+exports._parse_field_blocks = parse_field_blocks
+exports._strip_angles = strip_angles
+
 return exports

--- a/lualib/lua_feedback_parsers.lua
+++ b/lualib/lua_feedback_parsers.lua
@@ -30,22 +30,13 @@ limitations under the License.
 --]]
 
 local rspamd_logger = require 'rspamd_logger'
+local lua_util = require 'lua_util'
 
 local N = 'lua_feedback_parsers'
+local str_trim = lua_util.str_trim
+local str_split = lua_util.rspamd_str_split
 
 local exports = {}
-
--- ----------------------------------------------------------------------------
--- Generic helpers
--- ----------------------------------------------------------------------------
-
--- Trim ASCII whitespace from both ends of a string.
-local function trim(s)
-  if not s then
-    return nil
-  end
-  return (s:gsub('^%s+', ''):gsub('%s+$', ''))
-end
 
 -- Strip a single pair of outermost angle brackets, e.g. `<id@example>`.
 local function strip_angles(s)
@@ -56,36 +47,7 @@ local function strip_angles(s)
   if inner then
     return inner
   end
-  return trim(s)
-end
-
--- Normalise line endings: drop CR, keep LF.
-local function normalize_eol(body)
-  if type(body) ~= 'string' then
-    body = tostring(body or '')
-  end
-  return (body:gsub('\r', ''))
-end
-
--- Split a string on LF into a plain array of lines (no trailing empty line
--- duplication). Preserves empty lines in the middle.
-local function split_lines(body)
-  local lines = {}
-  local i = 1
-  local len = #body
-  local start = 1
-  while i <= len do
-    local c = body:sub(i, i)
-    if c == '\n' then
-      lines[#lines + 1] = body:sub(start, i - 1)
-      start = i + 1
-    end
-    i = i + 1
-  end
-  if start <= len then
-    lines[#lines + 1] = body:sub(start)
-  end
-  return lines
+  return str_trim(s)
 end
 
 --[[
@@ -112,7 +74,7 @@ local function parse_field_block(lines, start_line)
 
   local function flush()
     if current_name then
-      local value = trim(table.concat(current_value_parts, ' '))
+      local value = str_trim(table.concat(current_value_parts, ' '))
       fields[current_name] = value
       local list = fields_multi[current_name]
       if not list then
@@ -129,13 +91,12 @@ local function parse_field_block(lines, start_line)
     local line = lines[i]
     if line == '' then
       flush()
-      i = i + 1
-      return fields, fields_multi, i
+      return fields, fields_multi, i + 1
     end
     local first = line:sub(1, 1)
     if first == ' ' or first == '\t' then
       if current_name then
-        current_value_parts[#current_value_parts + 1] = trim(line)
+        current_value_parts[#current_value_parts + 1] = str_trim(line)
       end
       -- else: continuation with no preceding field - ignore
     else
@@ -158,8 +119,14 @@ end
 -- lines. Used for message/delivery-status bodies which consist of 1..N
 -- blocks.
 local function parse_field_blocks(body)
-  local lines = split_lines(normalize_eol(body))
-  -- Skip leading blank lines.
+  if type(body) ~= 'string' then
+    body = tostring(body or '')
+  end
+  -- Normalise line endings (drop CR) then split on LF.
+  local lines = str_split(body:gsub('\r', ''), '\n')
+  if not lines then
+    return {}
+  end
   local i = 1
   while i <= #lines and lines[i] == '' do
     i = i + 1
@@ -167,7 +134,6 @@ local function parse_field_blocks(body)
   local blocks = {}
   while i <= #lines do
     local fields, fields_multi, next_i = parse_field_block(lines, i)
-    -- Only keep non-empty blocks.
     if next(fields) ~= nil then
       blocks[#blocks + 1] = {
         fields = fields,
@@ -178,7 +144,6 @@ local function parse_field_blocks(body)
       break
     end
     i = next_i
-    -- Skip further blank lines between blocks.
     while i <= #lines and lines[i] == '' do
       i = i + 1
     end
@@ -186,35 +151,13 @@ local function parse_field_blocks(body)
   return blocks
 end
 
--- Safely fetch `(type, subtype, params)` for a mime part, falling back to
--- nil on any error. `get_type_full` returns a 3-value tuple in recent
--- Rspamd; older versions may only return type/subtype. We use pcall to be
--- safe regardless.
-local function safe_get_type_full(part)
-  local ok, t, st, params = pcall(part.get_type_full, part)
-  if not ok then
-    return nil, nil, nil
-  end
-  return t, st, params
-end
-
--- Safely fetch plain content as a Lua string.
-local function safe_get_content(part)
-  local ok, content = pcall(part.get_content, part)
-  if not ok or content == nil then
-    return nil
-  end
-  return tostring(content)
-end
-
 -- Find the topmost multipart/report part in a task that matches the given
 -- `report-type` (case-insensitive). Returns the matching mime_part or nil.
 local function find_multipart_report(task, wanted_report_type)
-  local parts = task:get_parts() or {}
-  for _, part in ipairs(parts) do
-    local t, st, params = safe_get_type_full(part)
+  for _, part in ipairs(task:get_parts() or {}) do
+    local t, st, params = part:get_type_full()
     if t == 'multipart' and st == 'report' and type(params) == 'table' then
-      local rt = params['report-type'] or params['Report-Type']
+      local rt = params['report-type']
       if rt and rt:lower() == wanted_report_type then
         return part
       end
@@ -225,11 +168,9 @@ end
 
 -- Find the first sub-part whose Content-Type matches `wanted_type/wanted_subtype`
 -- (case-insensitive). If `wanted_subtype` is nil, only `wanted_type` is
--- matched. Searches all parts on the task (they are already flattened by
--- the mime parser).
+-- matched.
 local function find_part_by_type(task, wanted_type, wanted_subtype)
-  local parts = task:get_parts() or {}
-  for _, part in ipairs(parts) do
+  for _, part in ipairs(task:get_parts() or {}) do
     local t, st = part:get_type()
     if t and t:lower() == wanted_type and
         (not wanted_subtype or (st and st:lower() == wanted_subtype)) then
@@ -239,10 +180,11 @@ local function find_part_by_type(task, wanted_type, wanted_subtype)
   return nil
 end
 
--- Like find_part_by_type but iterates a set of candidate type pairs.
+-- Locate the embedded original message in a report.
+-- Returns (part, kind) where kind is 'full' for message/rfc822|message/global
+-- (headers+body) and 'headers' for text/rfc822-headers (headers only).
 local function find_original_message_part(task)
-  local parts = task:get_parts() or {}
-  for _, part in ipairs(parts) do
+  for _, part in ipairs(task:get_parts() or {}) do
     local t, st = part:get_type()
     if t and st then
       local lt = t:lower()
@@ -258,32 +200,22 @@ local function find_original_message_part(task)
   return nil
 end
 
--- Given a string containing full RFC 822 content (headers + optional body)
--- return a table mapping lowercased header names to values. If the string
--- only contains headers (no trailing blank line), the parser still works.
-local function parse_rfc822_headers(content)
-  if not content or content == '' then
-    return {}
-  end
-  local lines = split_lines(normalize_eol(content))
-  local fields = parse_field_block(lines, 1)
-  return fields or {}
-end
-
--- Extract the standard subset of original-message headers we care about.
-local function extract_original_message(part, kind)
-  local content = safe_get_content(part)
+-- Extract the standard subset of original-message headers we care about from
+-- the content of a message/rfc822 (or text/rfc822-headers) sub-part.
+local function extract_original_message(part)
+  local content = part:get_content()
   if not content then
     return nil
   end
-  local headers
-  if kind == 'headers' then
-    headers = parse_rfc822_headers(content)
-  else
-    -- For message/rfc822 (or message/global) content is the full embedded
-    -- message; the header block is everything up to the first blank line.
-    headers = parse_rfc822_headers(content)
+  content = tostring(content)
+  if content == '' then
+    return nil
   end
+  local lines = str_split(content:gsub('\r', ''), '\n')
+  if not lines then
+    return nil
+  end
+  local headers = parse_field_block(lines, 1)
   if not headers or next(headers) == nil then
     return nil
   end
@@ -294,7 +226,6 @@ local function extract_original_message(part, kind)
     subject = headers['subject'],
     date = headers['date'],
   }
-  -- If every field came back nil, treat as no useful data.
   if not (out.message_id or out.from or out.to or out.subject or out.date) then
     return nil
   end
@@ -317,7 +248,7 @@ end
 -- parsed into at least one non-empty field block, the function still
 -- returns a table (with `recipients = {}`) so that callers can distinguish
 -- "not a DSN" (nil) from "a DSN we couldn't fully parse" (table with
--- mostly-nil fields). Exceptions from the C API are caught and silenced.
+-- mostly-nil fields).
 --
 -- @param {rspamd_task} task message to inspect
 -- @return {table|nil} parsed DSN, see module doc for the shape
@@ -345,9 +276,9 @@ function exports.parse_dsn(task)
   }
 
   if status_part then
-    local body = safe_get_content(status_part)
+    local body = status_part:get_content()
     if body then
-      local blocks = parse_field_blocks(body)
+      local blocks = parse_field_blocks(tostring(body))
       if #blocks > 0 then
         local per_message = blocks[1].fields
         result.reporting_mta = per_message['reporting-mta']
@@ -374,9 +305,9 @@ function exports.parse_dsn(task)
     end
   end
 
-  local orig_part, kind = find_original_message_part(task)
+  local orig_part = find_original_message_part(task)
   if orig_part then
-    result.original_message = extract_original_message(orig_part, kind)
+    result.original_message = extract_original_message(orig_part)
   end
 
   return result
@@ -431,9 +362,9 @@ function exports.parse_arf(task)
     original_message = nil,
   }
 
-  local body = safe_get_content(fb_part)
+  local body = fb_part:get_content()
   if body then
-    local blocks = parse_field_blocks(body)
+    local blocks = parse_field_blocks(tostring(body))
     if #blocks > 0 then
       local f = blocks[1].fields
       local fm = blocks[1].fields_multi
@@ -465,9 +396,9 @@ function exports.parse_arf(task)
     rspamd_logger.debugm(N, task, 'ARF detected but feedback-report part content is empty')
   end
 
-  local orig_part, kind = find_original_message_part(task)
+  local orig_part = find_original_message_part(task)
   if orig_part then
-    local om = extract_original_message(orig_part, kind)
+    local om = extract_original_message(orig_part)
     if om then
       -- RFC 5965 consumers typically only care about Message-ID and From.
       result.original_message = {
@@ -479,10 +410,5 @@ function exports.parse_arf(task)
 
   return result
 end
-
--- Exposed for tests / introspection.
-exports._parse_field_blocks = parse_field_blocks
-exports._parse_rfc822_headers = parse_rfc822_headers
-exports._strip_angles = strip_angles
 
 return exports

--- a/test/lua/unit/lua_feedback_parsers.lua
+++ b/test/lua/unit/lua_feedback_parsers.lua
@@ -1,0 +1,263 @@
+-- Tests for lua_feedback_parsers module (DSN and ARF parsing)
+
+context("Lua feedback parsers - pure helpers", function()
+  local lua_feedback_parsers = require "lua_feedback_parsers"
+
+  context("strip_angles", function()
+    test("simple angle-bracketed id", function()
+      assert_equal("abc@example.com",
+        lua_feedback_parsers._strip_angles("<abc@example.com>"))
+    end)
+
+    test("with surrounding whitespace", function()
+      assert_equal("abc@example.com",
+        lua_feedback_parsers._strip_angles("  <abc@example.com>  "))
+    end)
+
+    test("no angles - returns trimmed input", function()
+      assert_equal("abc@example.com",
+        lua_feedback_parsers._strip_angles("  abc@example.com  "))
+    end)
+
+    test("nil input", function()
+      assert_nil(lua_feedback_parsers._strip_angles(nil))
+    end)
+  end)
+
+  context("parse_field_blocks", function()
+    test("single block, simple fields", function()
+      local body = "Reporting-MTA: dns; mta.example.com\r\n" ..
+          "Arrival-Date: Mon, 01 Jan 2024 12:00:00 +0000\r\n"
+      local blocks = lua_feedback_parsers._parse_field_blocks(body)
+      assert_equal(1, #blocks)
+      assert_equal("dns; mta.example.com", blocks[1].fields["reporting-mta"])
+      assert_equal("Mon, 01 Jan 2024 12:00:00 +0000",
+        blocks[1].fields["arrival-date"])
+    end)
+
+    test("multiple blocks separated by blank lines", function()
+      local body = "Reporting-MTA: dns; mta.example.com\n\n" ..
+          "Final-Recipient: rfc822; user@example.com\n" ..
+          "Action: failed\n" ..
+          "Status: 5.1.1\n"
+      local blocks = lua_feedback_parsers._parse_field_blocks(body)
+      assert_equal(2, #blocks)
+      assert_equal("dns; mta.example.com", blocks[1].fields["reporting-mta"])
+      assert_equal("rfc822; user@example.com",
+        blocks[2].fields["final-recipient"])
+      assert_equal("failed", blocks[2].fields["action"])
+      assert_equal("5.1.1", blocks[2].fields["status"])
+    end)
+
+    test("header folding (continuation lines)", function()
+      local body = "Diagnostic-Code: smtp;\n" ..
+          " 550 5.1.1 user unknown\n" ..
+          "\tplease verify the address\n"
+      local blocks = lua_feedback_parsers._parse_field_blocks(body)
+      assert_equal(1, #blocks)
+      assert_equal("smtp; 550 5.1.1 user unknown please verify the address",
+        blocks[1].fields["diagnostic-code"])
+    end)
+
+    test("repeated fields collected in fields_multi", function()
+      local body = "Reported-Uri: http://a.example/\n" ..
+          "Reported-Uri: http://b.example/\n" ..
+          "Reported-Uri: http://c.example/\n"
+      local blocks = lua_feedback_parsers._parse_field_blocks(body)
+      assert_equal(1, #blocks)
+      local uris = blocks[1].fields_multi["reported-uri"]
+      assert_not_nil(uris)
+      assert_equal(3, #uris)
+      assert_equal("http://a.example/", uris[1])
+      assert_equal("http://b.example/", uris[2])
+      assert_equal("http://c.example/", uris[3])
+    end)
+
+    test("empty body returns empty list", function()
+      assert_equal(0, #lua_feedback_parsers._parse_field_blocks(""))
+    end)
+
+    test("CRLF normalisation", function()
+      local body = "Feedback-Type: abuse\r\nVersion: 1\r\n"
+      local blocks = lua_feedback_parsers._parse_field_blocks(body)
+      assert_equal(1, #blocks)
+      assert_equal("abuse", blocks[1].fields["feedback-type"])
+      assert_equal("1", blocks[1].fields["version"])
+    end)
+  end)
+end)
+
+context("Lua feedback parsers - DSN/ARF on synthetic tasks", function()
+  local rspamd_task = require "rspamd_task"
+  local rspamd_util = require "rspamd_util"
+  local rspamd_test_helper = require "rspamd_test_helper"
+  local lua_feedback_parsers = require "lua_feedback_parsers"
+
+  rspamd_test_helper.init_url_parser()
+  local cfg = rspamd_util.config_from_ucl(rspamd_test_helper.default_config(),
+    "INIT_URL,INIT_LIBS,INIT_SYMCACHE,INIT_VALIDATE,INIT_PRELOAD_MAPS")
+
+  local function load_task(message)
+    local res, task = rspamd_task.load_from_string(message, cfg)
+    if not res or not task then
+      return nil
+    end
+    task:process_message()
+    return task
+  end
+
+  test("parse_dsn on RFC 3464 multipart/report", function()
+    local message = "Return-Path: <>\r\n" ..
+        "From: MAILER-DAEMON@mta.example.com\r\n" ..
+        "To: sender@example.org\r\n" ..
+        "Subject: Undelivered Mail Returned to Sender\r\n" ..
+        "Date: Mon, 01 Jan 2024 12:00:00 +0000\r\n" ..
+        "Message-ID: <bounce-001@mta.example.com>\r\n" ..
+        "MIME-Version: 1.0\r\n" ..
+        "Content-Type: multipart/report; report-type=delivery-status; boundary=\"bnd0\"\r\n" ..
+        "\r\n" ..
+        "--bnd0\r\n" ..
+        "Content-Type: text/plain; charset=us-ascii\r\n" ..
+        "\r\n" ..
+        "This is the mail system at mta.example.com.\r\n" ..
+        "\r\n" ..
+        "I'm sorry to have to inform you that your message could not be delivered.\r\n" ..
+        "\r\n" ..
+        "--bnd0\r\n" ..
+        "Content-Type: message/delivery-status\r\n" ..
+        "\r\n" ..
+        "Reporting-MTA: dns; mta.example.com\r\n" ..
+        "Arrival-Date: Mon, 01 Jan 2024 12:00:00 +0000\r\n" ..
+        "\r\n" ..
+        "Final-Recipient: rfc822; user@bad.example.com\r\n" ..
+        "Action: failed\r\n" ..
+        "Status: 5.1.1\r\n" ..
+        "Diagnostic-Code: smtp; 550 5.1.1 user unknown\r\n" ..
+        "Remote-MTA: dns; mx.bad.example.com\r\n" ..
+        "\r\n" ..
+        "--bnd0\r\n" ..
+        "Content-Type: message/rfc822\r\n" ..
+        "\r\n" ..
+        "From: sender@example.org\r\n" ..
+        "To: user@bad.example.com\r\n" ..
+        "Subject: Hi\r\n" ..
+        "Date: Mon, 01 Jan 2024 11:59:00 +0000\r\n" ..
+        "Message-ID: <orig-msg-001@example.org>\r\n" ..
+        "\r\n" ..
+        "Original message body.\r\n" ..
+        "--bnd0--\r\n"
+
+    local task = load_task(message)
+    assert_not_nil(task, "failed to load DSN message")
+    local dsn = lua_feedback_parsers.parse_dsn(task)
+    assert_not_nil(dsn)
+    assert_equal("dns; mta.example.com", dsn.reporting_mta)
+    assert_equal("Mon, 01 Jan 2024 12:00:00 +0000", dsn.arrival_date)
+    assert_equal(1, #dsn.recipients)
+    assert_equal("rfc822; user@bad.example.com",
+      dsn.recipients[1].final_recipient)
+    assert_equal("failed", dsn.recipients[1].action)
+    assert_equal("5.1.1", dsn.recipients[1].status)
+    assert_equal("smtp; 550 5.1.1 user unknown",
+      dsn.recipients[1].diagnostic_code)
+    assert_equal("dns; mx.bad.example.com", dsn.recipients[1].remote_mta)
+    assert_not_nil(dsn.original_message)
+    assert_equal("orig-msg-001@example.org", dsn.original_message.message_id)
+    assert_equal("sender@example.org", dsn.original_message.from)
+    assert_equal("user@bad.example.com", dsn.original_message.to)
+    assert_equal("Hi", dsn.original_message.subject)
+    task:destroy()
+  end)
+
+  test("parse_dsn returns nil on non-DSN message", function()
+    local message = "From: a@example.com\r\n" ..
+        "To: b@example.com\r\n" ..
+        "Subject: hello\r\n" ..
+        "\r\n" ..
+        "just a regular message\r\n"
+    local task = load_task(message)
+    assert_not_nil(task, "failed to load message")
+    assert_nil(lua_feedback_parsers.parse_dsn(task))
+    task:destroy()
+  end)
+
+  test("parse_arf on RFC 5965 feedback report", function()
+    local message = "Return-Path: <abuse@isp.example>\r\n" ..
+        "From: complaints@isp.example\r\n" ..
+        "To: fbl@example.org\r\n" ..
+        "Subject: FW: spam complaint\r\n" ..
+        "Date: Mon, 01 Jan 2024 12:00:00 +0000\r\n" ..
+        "Message-ID: <fbl-001@isp.example>\r\n" ..
+        "MIME-Version: 1.0\r\n" ..
+        "Content-Type: multipart/report; report-type=feedback-report; boundary=\"bnd1\"\r\n" ..
+        "\r\n" ..
+        "--bnd1\r\n" ..
+        "Content-Type: text/plain; charset=us-ascii\r\n" ..
+        "\r\n" ..
+        "This is an email abuse report for an email message received from\r\n" ..
+        "IP 1.2.3.4 on Mon, 01 Jan 2024 11:55:00 +0000.\r\n" ..
+        "\r\n" ..
+        "--bnd1\r\n" ..
+        "Content-Type: message/feedback-report\r\n" ..
+        "\r\n" ..
+        "Feedback-Type: abuse\r\n" ..
+        "User-Agent: ISP-FBL/1.0\r\n" ..
+        "Version: 1\r\n" ..
+        "Original-Mail-From: <sender@example.org>\r\n" ..
+        "Original-Rcpt-To: <user@isp.example>\r\n" ..
+        "Arrival-Date: Mon, 01 Jan 2024 11:55:00 +0000\r\n" ..
+        "Source-IP: 1.2.3.4\r\n" ..
+        "Reported-Domain: example.org\r\n" ..
+        "Reported-Uri: http://example.org/landing\r\n" ..
+        "Reported-Uri: http://example.org/other\r\n" ..
+        "\r\n" ..
+        "--bnd1\r\n" ..
+        "Content-Type: message/rfc822\r\n" ..
+        "\r\n" ..
+        "From: sender@example.org\r\n" ..
+        "To: user@isp.example\r\n" ..
+        "Subject: Newsletter\r\n" ..
+        "Date: Mon, 01 Jan 2024 11:54:00 +0000\r\n" ..
+        "Message-ID: <orig-fbl-001@example.org>\r\n" ..
+        "\r\n" ..
+        "body\r\n" ..
+        "--bnd1--\r\n"
+
+    local task = load_task(message)
+    assert_not_nil(task, "failed to load ARF message")
+    local arf = lua_feedback_parsers.parse_arf(task)
+    assert_not_nil(arf)
+    assert_equal("abuse", arf.feedback_type)
+    assert_equal("1", arf.version)
+    assert_equal("ISP-FBL/1.0", arf.user_agent)
+    assert_equal("sender@example.org", arf.original_mail_from)
+    assert_equal("user@isp.example", arf.original_rcpt_to)
+    assert_equal("1.2.3.4", arf.source_ip)
+    assert_equal("example.org", arf.reported_domain)
+    assert_equal(2, #arf.reported_uri)
+    assert_equal("http://example.org/landing", arf.reported_uri[1])
+    assert_equal("http://example.org/other", arf.reported_uri[2])
+    assert_not_nil(arf.original_message)
+    assert_equal("orig-fbl-001@example.org", arf.original_message.message_id)
+    assert_equal("sender@example.org", arf.original_message.from)
+    task:destroy()
+  end)
+
+  test("parse_arf returns nil when report-type is not feedback-report", function()
+    local message = "From: a@example.com\r\n" ..
+        "To: b@example.com\r\n" ..
+        "Subject: not a fbl\r\n" ..
+        "MIME-Version: 1.0\r\n" ..
+        "Content-Type: multipart/report; report-type=delivery-status; boundary=\"x\"\r\n" ..
+        "\r\n" ..
+        "--x\r\n" ..
+        "Content-Type: text/plain\r\n" ..
+        "\r\n" ..
+        "stub\r\n" ..
+        "--x--\r\n"
+    local task = load_task(message)
+    assert_not_nil(task, "failed to load message")
+    assert_nil(lua_feedback_parsers.parse_arf(task))
+    task:destroy()
+  end)
+end)


### PR DESCRIPTION
## Summary

New helper library `lualib/lua_feedback_parsers.lua` that extracts structured data from delivery reports passed in as a Rspamd task:

- **`parse_dsn(task)`** parses RFC 3464 Delivery Status Notifications. Returns `{ reporting_mta, arrival_date, recipients = {{ final_recipient, action, status, diagnostic_code, ... }, ...}, original_message = { message_id, from, to, subject, date } }` or `nil`.
- **`parse_arf(task)`** parses RFC 5965 Abuse Reporting Format messages. Returns `{ feedback_type, source_ip, original_mail_from, original_rcpt_to, reported_domain, reported_uri = {...}, original_message = { message_id, from } }` or `nil`.

Pure Lua, no C changes, no FFI. Compatible with LuaJIT 5.1 and Lua 5.3/5.4/5.5. The module ships a small RFC 822 field-block parser (header unfolding, blank-line block separation, repeated-field preservation) that both report formats reuse.

Use case: routing inbound bounce reports and FBL submissions back through Rspamd as scans, then attributing them to the original sender for reputation / outbound traffic analysis.

No CMake change is required: `cmake/InstallRspamdFiles.cmake` already installs `lualib/*.lua` via `file(GLOB_RECURSE)`. No unit test added: `test/lua/unit/lua_auth_results.lua` only tests pure functions, and there is no precedent in `test/lua/unit/` for tests that build a synthetic `task` to exercise a parser like this; introducing that infra is out of scope for this PR.

## Test plan

- [x] `luacheck lualib/lua_feedback_parsers.lua` clean
- [x] Field-block parser smoke-tested against representative DSN and ARF bodies (header folding, repeated `Reported-URI`, blank-line block split, `<addr>` stripping)
- [x] Smoke test against real DSN/ARF samples in a running Rspamd (post-merge)