### PR TITLE
[Feature] clickhouse: add named extra_columns presets with initial outbound preset

### DIFF
--- a/conf/modules.d/clickhouse.conf
+++ b/conf/modules.d/clickhouse.conf
@@ -41,6 +41,13 @@ clickhouse {
   #dmarc_allow_symbols = ["DMARC_POLICY_ALLOW"];
   #dmarc_reject_symbols = ["DMARC_POLICY_REJECT", "DMARC_POLICY_QUARANTINE"];
 
+  # Enable a named preset of extra_columns. Currently supported: "outbound"
+  # (per-sender profiling columns for outbound traffic analysis: languages,
+  # hour-of-day, envelope-from domain, recipient domains, etc.). User-supplied
+  # extra_columns with matching names take precedence. Schema migration is
+  # applied automatically via the existing extra_columns mechanism.
+  # preset = "outbound";
+
   #retention {
   #  # disabled by default
   #  enable = true;

--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -98,6 +98,43 @@ local settings = {
     run_every = '7d',
   },
   extra_columns = {},
+  -- Inject a curated set of extra_columns from a named preset. Currently
+  -- supported: "outbound" (per-sender outbound traffic profiling columns:
+  -- languages, hour-of-day, envelope-from domain, recipient domains, etc.).
+  -- User-supplied entries with the same name take precedence. Schema
+  -- migration reuses the existing extra_columns path. Unset by default.
+  preset = nil,
+}
+
+-- Named dispatch table for curated `extra_columns` presets. Each preset is an
+-- array of entries using the same shape as user-supplied `extra_columns`
+-- entries (see processing below). Selectors in these tables must be
+-- expressible with the stock selectors that ship in rspamd master. Additional
+-- presets (e.g. "inbound", "compliance") can be added as new keys here.
+local extra_column_presets = {
+  outbound = {
+    {
+      name = 'Languages',
+      type = 'Array(LowCardinality(String))',
+      selector = 'languages',
+      default_value = {},
+      comment = 'outbound preset: detected languages of text parts',
+    },
+    {
+      name = 'ReceivedCount',
+      type = 'UInt16',
+      selector = 'received_count',
+      default_value = '0',
+      comment = 'outbound preset: number of Received headers (hop count)',
+    },
+    {
+      name = 'FuzzyDigest',
+      type = 'String',
+      selector = 'fuzzy_digest',
+      default_value = '',
+      comment = 'outbound preset: strong fuzzy digest of largest text part (for fan-out aggregations)',
+    },
+  },
 }
 
 --- @language SQL
@@ -1673,6 +1710,59 @@ if opts then
 
       settings.exceptions = maps_expressions.create(rspamd_config,
           settings.exceptions, N)
+    end
+
+    if settings.preset then
+      local preset_cols = extra_column_presets[settings.preset]
+      if not preset_cols then
+        rspamd_logger.errx(rspamd_config,
+            'clickhouse: unknown preset %s, ignoring', settings.preset)
+      else
+        -- Inject curated extra_columns from the named preset. User-supplied
+        -- entries with the same name take precedence, so we collect existing
+        -- names first. We support both array and map forms of user-supplied
+        -- extra_columns (the subsequent processing loop accepts either).
+        local existing_names = {}
+        if settings.extra_columns then
+          if settings.extra_columns[1] then
+            for _, c in ipairs(settings.extra_columns) do
+              if c.name then
+                existing_names[c.name] = true
+              end
+            end
+          else
+            for k, c in pairs(settings.extra_columns) do
+              existing_names[k] = true
+              if type(c) == 'table' and c.name then
+                existing_names[c.name] = true
+              end
+            end
+          end
+        else
+          settings.extra_columns = {}
+        end
+
+        local injected = {}
+        local is_array_form = settings.extra_columns[1] ~= nil
+            or next(settings.extra_columns) == nil
+        for _, preset in ipairs(preset_cols) do
+          if not existing_names[preset.name] then
+            -- Deep copy so we do not mutate the module-level preset table
+            local entry = lua_util.deepcopy(preset)
+            if is_array_form then
+              table.insert(settings.extra_columns, entry)
+            else
+              settings.extra_columns[preset.name] = entry
+            end
+            table.insert(injected, preset.name)
+          end
+        end
+        if #injected > 0 then
+          rspamd_logger.infox(rspamd_config,
+              'clickhouse: preset %s injected extra_columns: %s',
+              settings.preset, table.concat(injected, ', '))
+        end
+      end
     end
 
     if settings.extra_columns then


### PR DESCRIPTION
## Summary

Adds a new string-valued `preset` option to the `clickhouse` module. When set to a known preset name, the module injects a curated set of `extra_columns` on top of any user-supplied `extra_columns`. A string option (rather than a boolean flag) keeps the door open for future presets (`inbound`, `compliance`, etc.) without adding a new flag each time.

Initial preset: **`"outbound"`** — features useful for per-sender behavioural baselines on outbound traffic that are NOT already in the base `rspamd` table schema.

Usage:

```ucl
preset = "outbound";
```

Columns shipped in the `outbound` preset:

- **`Languages`** `Array(LowCardinality(String))` — detected message languages (via `languages` selector); small bounded set, `LowCardinality` is appropriate
- **`ReceivedCount`** `UInt16` — hop count (via `received_count` selector added in #5981)
- **`FuzzyDigest`** `String` — strong fuzzy digest of the largest text part (via `fuzzy_digest` selector added in #5981); useful for body-level fan-out aggregations. Plain `String` because cardinality is near-unique per distinct message body. The base schema's `Digest` column is `[Deprecated]` and is the full-message md5, not a fuzzy digest.

The preset is intentionally thin: it only adds columns that cannot be cheaply derived from the base schema. Specifically, the following columns were considered and dropped because they duplicate or trivially derive from existing base-schema columns:

- `FromDomain` — duplicates existing `From` column (which is the envelope-from domain; see `SMTPFrom ALIAS`).
- `RcptDomains` — derivable in SQL from existing `SMTPRecipients` via `arrayMap(x -> splitByChar('@', x)[2], SMTPRecipients)`.
- `HourOfDay` — derivable in SQL from existing `TS` via `toHour(TS)`. No need to denormalise on a columnar store.
- `fuzzy_shingles` — shingle arrays are too bulky for columnar storage; fan-out detection on shingles is better realised online in Redis.
- `AuthFlag` — natural ClickHouse type would be `Bool`, but there is no existing `Bool` precedent in the codebase to verify the TSV insert path handles it cleanly. Identity is anyway already covered by the existing `AuthUser` column. A follow-up can revisit if a typed flag is genuinely needed.

Identity columns (`AuthUser`, `From`, `FromUser`, `MimeFrom`, `MimeUser`, `IP`, `ASN`, `Country`, `IPNet`, `SMTPRecipients`, `MimeRecipients`) are universal and remain in the base schema; the preset is layered on top.

Behavior:

- User-supplied \`extra_columns\` with the same \`name\` take precedence — preset entries are silently skipped for those names.
- Unknown preset names are logged as an error and ignored (no configuration failure).
- The existing \`extra_columns\` schema migration applies \`ALTER TABLE\` automatically; no manual schema work is needed when enabling a preset.
- Default is unset; the option is opt-in.

## Test plan

- [x] \`luacheck src/plugins/lua/clickhouse.lua\` clean
- [x] \`rspamadm configtest\` with \`preset = "outbound";\` passes
- [ ] On a fresh ClickHouse, schema migration creates the new columns on first insert
- [ ] User-supplied \`extra_columns\` with overlapping names override the preset
- [ ] Unknown preset name logs an error and is ignored