### PR TITLE
[Feature] task: show what stalled at timeout

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -1602,13 +1602,10 @@ rspamd_controller_handle_lua_history(lua_State *L,
 									   session->pool, ctx->lang_det, ctx->event_loop, FALSE);
 
 				task->resolver = ctx->resolver;
-				task->s = rspamd_session_create(session->pool,
-												rspamd_controller_history_lua_fin_task,
-												NULL,
-												(event_finalizer_t) rspamd_task_free,
-												task);
-				rspamd_session_set_item_name_resolver(task->s,
-													  rspamd_task_session_item_name_resolver);
+				task->s = rspamd_task_create_session(task, session->pool,
+													 rspamd_controller_history_lua_fin_task,
+													 NULL,
+													 (event_finalizer_t) rspamd_task_free);
 				task->fin_arg = conn_ent;
 
 				ptask = lua_newuserdata(L, sizeof(*ptask));
@@ -1953,11 +1950,10 @@ rspamd_controller_handle_lua(struct rspamd_http_connection_entry *conn_ent,
 						   ctx->lang_det, ctx->event_loop, FALSE);
 
 	task->resolver = ctx->resolver;
-	task->s = rspamd_session_create(session->pool,
-									rspamd_controller_lua_fin_task,
-									NULL,
-									(event_finalizer_t) rspamd_task_free,
-									task);
+	task->s = rspamd_task_create_session(task, session->pool,
+										 rspamd_controller_lua_fin_task,
+										 NULL,
+										 (event_finalizer_t) rspamd_task_free);
 	task->fin_arg = conn_ent;
 	task->http_conn = rspamd_http_connection_ref(conn_ent->conn);
 	task->sock = -1;
@@ -2152,11 +2148,10 @@ rspamd_controller_handle_learn_common(
 	task->resolver = ctx->resolver;
 	/* Manual learn: ensure errors are propagated (not auto-learn semantics) */
 	task->flags &= ~RSPAMD_TASK_FLAG_LEARN_AUTO;
-	task->s = rspamd_session_create(session->pool,
-									rspamd_controller_learn_fin_task,
-									NULL,
-									(event_finalizer_t) rspamd_task_free,
-									task);
+	task->s = rspamd_task_create_session(task, session->pool,
+										 rspamd_controller_learn_fin_task,
+										 NULL,
+										 (event_finalizer_t) rspamd_task_free);
 	task->fin_arg = conn_ent;
 	task->http_conn = rspamd_http_connection_ref(conn_ent->conn);
 	task->sock = -1;
@@ -2268,11 +2263,10 @@ rspamd_controller_handle_learnclass(
 	task->resolver = ctx->resolver;
 	/* Manual learn: ensure errors are propagated (not auto-learn semantics) */
 	task->flags &= ~RSPAMD_TASK_FLAG_LEARN_AUTO;
-	task->s = rspamd_session_create(session->pool,
-									rspamd_controller_learn_fin_task,
-									NULL,
-									(event_finalizer_t) rspamd_task_free,
-									task);
+	task->s = rspamd_task_create_session(task, session->pool,
+										 rspamd_controller_learn_fin_task,
+										 NULL,
+										 (event_finalizer_t) rspamd_task_free);
 	task->fin_arg = conn_ent;
 	task->http_conn = rspamd_http_connection_ref(conn_ent->conn);
 	task->sock = -1;
@@ -2339,11 +2333,10 @@ rspamd_controller_handle_scan(struct rspamd_http_connection_entry *conn_ent,
 						   ctx->lang_det, ctx->event_loop, FALSE);
 
 	task->resolver = ctx->resolver;
-	task->s = rspamd_session_create(session->pool,
-									rspamd_controller_check_fin_task,
-									NULL,
-									(event_finalizer_t) rspamd_task_free,
-									task);
+	task->s = rspamd_task_create_session(task, session->pool,
+										 rspamd_controller_check_fin_task,
+										 NULL,
+										 (event_finalizer_t) rspamd_task_free);
 	task->fin_arg = conn_ent;
 	task->http_conn = rspamd_http_connection_ref(conn_ent->conn);
 	task->sock = conn_ent->conn->fd;
@@ -3495,11 +3488,10 @@ rspamd_controller_handle_lua_plugin(struct rspamd_http_connection_entry *conn_en
 						   ctx->lang_det, ctx->event_loop, FALSE);
 
 	task->resolver = ctx->resolver;
-	task->s = rspamd_session_create(session->pool,
-									rspamd_controller_lua_fin_task,
-									NULL,
-									(event_finalizer_t) rspamd_task_free,
-									task);
+	task->s = rspamd_task_create_session(task, session->pool,
+										 rspamd_controller_lua_fin_task,
+										 NULL,
+										 (event_finalizer_t) rspamd_task_free);
 	task->fin_arg = conn_ent;
 	task->http_conn = rspamd_http_connection_ref(conn_ent->conn);
 	;

--- a/src/controller.c
+++ b/src/controller.c
@@ -1607,6 +1607,8 @@ rspamd_controller_handle_lua_history(lua_State *L,
 												NULL,
 												(event_finalizer_t) rspamd_task_free,
 												task);
+				rspamd_session_set_item_name_resolver(task->s,
+													  rspamd_task_session_item_name_resolver);
 				task->fin_arg = conn_ent;
 
 				ptask = lua_newuserdata(L, sizeof(*ptask));

--- a/src/libserver/async_session.c
+++ b/src/libserver/async_session.c
@@ -369,182 +369,99 @@ rspamd_str_eq_nullable(const char *a, const char *b)
 	return strcmp(a, b) == 0;
 }
 
-void rspamd_session_describe_pending(struct rspamd_async_session *session,
-									 GString **summary_out,
-									 GString **details_out)
+#define RSPAMD_DUMP_MAX_GROUPS 32
+
+GString *
+rspamd_session_describe_pending(struct rspamd_async_session *session)
 {
 	struct rspamd_async_event *ev;
-	GString *summary, *details;
+	GString *out;
 	unsigned int total = 0;
-	unsigned int n_subsystems = 0;
-	unsigned int overflow_subsystems = 0;
-	unsigned int total_detail_entries = 0;
-	unsigned int i, j;
+	unsigned int n_groups = 0;
+	unsigned int overflow_groups = 0;
+	unsigned int i;
 
-	struct dump_source {
+	struct dump_group {
+		const char *subsystem;
 		const char *item_name;
 		const char *label;
 		unsigned int count;
-	};
-	struct dump_subsystem {
-		const char *name;
-		unsigned int count;
-		unsigned int distinct_sources;
-		unsigned int overflow_sources;
-		struct dump_source sources[RSPAMD_DUMP_MAX_SOURCES_PER_SUB];
-	} subsystems[RSPAMD_DUMP_MAX_SUBSYSTEMS];
-
-	if (summary_out) {
-		*summary_out = NULL;
-	}
-	if (details_out) {
-		*details_out = NULL;
-	}
+	} groups[RSPAMD_DUMP_MAX_GROUPS];
 
 	if (session == NULL || kh_size(session->events) == 0) {
-		return;
+		return NULL;
 	}
 
 	kh_foreach_key(session->events, ev, {
 		const char *sub = ev->subsystem ? ev->subsystem : "(null)";
 		const char *item = ev->item_name;
 		const char *lbl = ev->label;
-		struct dump_subsystem *s = NULL;
-		struct dump_source *src_e = NULL;
+		struct dump_group *g = NULL;
 
 		total++;
 
-		for (i = 0; i < n_subsystems; i++) {
-			if (strcmp(subsystems[i].name, sub) == 0) {
-				s = &subsystems[i];
+		for (i = 0; i < n_groups; i++) {
+			if (strcmp(groups[i].subsystem, sub) == 0 &&
+				rspamd_str_eq_nullable(groups[i].item_name, item) &&
+				rspamd_str_eq_nullable(groups[i].label, lbl)) {
+				g = &groups[i];
 				break;
 			}
 		}
 
-		if (s == NULL) {
-			if (n_subsystems < RSPAMD_DUMP_MAX_SUBSYSTEMS) {
-				s = &subsystems[n_subsystems++];
-				s->name = sub;
-				s->count = 0;
-				s->distinct_sources = 0;
-				s->overflow_sources = 0;
+		if (g == NULL) {
+			if (n_groups < RSPAMD_DUMP_MAX_GROUPS) {
+				g = &groups[n_groups++];
+				g->subsystem = sub;
+				g->item_name = item;
+				g->label = lbl;
+				g->count = 0;
 			}
 			else {
-				overflow_subsystems++;
+				overflow_groups++;
 			}
 		}
 
-		if (s != NULL) {
-			s->count++;
-
-			/* Events without any annotation are counted in subsystem total
-			 * only — we do not emit a detail entry for them. */
-			if (item != NULL || lbl != NULL) {
-				for (j = 0; j < s->distinct_sources; j++) {
-					if (rspamd_str_eq_nullable(s->sources[j].item_name, item) &&
-						rspamd_str_eq_nullable(s->sources[j].label, lbl)) {
-						src_e = &s->sources[j];
-						break;
-					}
-				}
-
-				if (src_e == NULL) {
-					if (s->distinct_sources < RSPAMD_DUMP_MAX_SOURCES_PER_SUB) {
-						src_e = &s->sources[s->distinct_sources++];
-						src_e->item_name = item;
-						src_e->label = lbl;
-						src_e->count = 0;
-					}
-					else {
-						s->overflow_sources++;
-					}
-				}
-
-				if (src_e != NULL) {
-					src_e->count++;
-				}
-			}
+		if (g != NULL) {
+			g->count++;
 		}
 	});
 
 	if (total == 0) {
-		return;
+		return NULL;
 	}
 
-	summary = g_string_sized_new(128);
-	rspamd_printf_gstring(summary, "total=%ud; by subsystem: ", total);
-	for (i = 0; i < n_subsystems; i++) {
+	out = g_string_sized_new(256);
+	rspamd_printf_gstring(out, "total=%ud; ", total);
+
+	for (i = 0; i < n_groups; i++) {
+		const struct dump_group *g = &groups[i];
+
 		if (i > 0) {
-			g_string_append(summary, ", ");
+			g_string_append(out, ", ");
 		}
-		rspamd_printf_gstring(summary, "%s=%ud",
-							  subsystems[i].name, subsystems[i].count);
-	}
-	if (overflow_subsystems > 0) {
-		rspamd_printf_gstring(summary, ", (+%ud more subsystems)",
-							  overflow_subsystems);
-	}
 
-	for (i = 0; i < n_subsystems; i++) {
-		total_detail_entries += subsystems[i].distinct_sources;
-	}
-
-	if (total_detail_entries == 0) {
-		details = NULL;
-	}
-	else {
-		bool first_sub = true;
-		details = g_string_sized_new(256);
-		for (i = 0; i < n_subsystems; i++) {
-			struct dump_subsystem *s = &subsystems[i];
-
-			if (s->distinct_sources == 0) {
-				continue;
-			}
-
-			if (!first_sub) {
-				g_string_append(details, "; ");
-			}
-			first_sub = false;
-			rspamd_printf_gstring(details, "[%s:", s->name);
-			for (j = 0; j < s->distinct_sources; j++) {
-				const char *it = s->sources[j].item_name;
-				const char *lb = s->sources[j].label;
-
-				g_string_append_c(details, ' ');
-				if (it != NULL && lb != NULL) {
-					rspamd_printf_gstring(details, "%s(%s)", it, lb);
-				}
-				else if (it != NULL) {
-					rspamd_printf_gstring(details, "%s", it);
-				}
-				else {
-					rspamd_printf_gstring(details, "%s", lb);
-				}
-				rspamd_printf_gstring(details, " x%ud", s->sources[j].count);
-			}
-			if (s->overflow_sources > 0) {
-				rspamd_printf_gstring(details, " (+%ud more)",
-									  s->overflow_sources);
-			}
-			g_string_append_c(details, ']');
+		g_string_append(out, g->subsystem);
+		if (g->item_name != NULL && g->label != NULL) {
+			rspamd_printf_gstring(out, "[%s/%s]", g->item_name, g->label);
 		}
+		else if (g->item_name != NULL) {
+			rspamd_printf_gstring(out, "[%s]", g->item_name);
+		}
+		else if (g->label != NULL) {
+			rspamd_printf_gstring(out, "[%s]", g->label);
+		}
+		rspamd_printf_gstring(out, "=%ud", g->count);
 	}
 
-	if (summary_out) {
-		*summary_out = summary;
+	if (overflow_groups > 0) {
+		rspamd_printf_gstring(out, ", (+%ud more groups)", overflow_groups);
 	}
-	else {
-		g_string_free(summary, TRUE);
-	}
-	if (details_out) {
-		*details_out = details;
-	}
-	else if (details != NULL) {
-		g_string_free(details, TRUE);
-	}
+
+	return out;
 }
 
+#undef RSPAMD_DUMP_MAX_GROUPS
 #undef RSPAMD_DUMP_MAX_SUBSYSTEMS
 #undef RSPAMD_DUMP_MAX_SOURCES_PER_SUB
 

--- a/src/libserver/async_session.c
+++ b/src/libserver/async_session.c
@@ -386,7 +386,10 @@ rspamd_session_describe_pending(struct rspamd_async_session *session)
 	GString *out;
 	unsigned int total = 0;
 	unsigned int n_groups = 0;
-	unsigned int overflow_groups = 0;
+	/* Events that did not fit into the first RSPAMD_DUMP_MAX_GROUPS groups —
+	 * these may belong to any number of distinct groups; we cannot tell without
+	 * spending more memory, so we just report the event count. */
+	unsigned int overflow_events = 0;
 	unsigned int i;
 
 	struct dump_group {
@@ -426,7 +429,7 @@ rspamd_session_describe_pending(struct rspamd_async_session *session)
 				g->count = 0;
 			}
 			else {
-				overflow_groups++;
+				overflow_events++;
 			}
 		}
 
@@ -462,8 +465,8 @@ rspamd_session_describe_pending(struct rspamd_async_session *session)
 		rspamd_printf_gstring(out, "=%ud", g->count);
 	}
 
-	if (overflow_groups > 0) {
-		rspamd_printf_gstring(out, ", (+%ud more groups)", overflow_groups);
+	if (overflow_events > 0) {
+		rspamd_printf_gstring(out, ", (+%ud events not shown)", overflow_events);
 	}
 
 	return out;

--- a/src/libserver/async_session.c
+++ b/src/libserver/async_session.c
@@ -190,6 +190,14 @@ rspamd_session_add_event_full(struct rspamd_async_session *session,
 	return new_event;
 }
 
+void rspamd_session_event_update_label(struct rspamd_async_event *ev,
+									   const char *label)
+{
+	if (ev != NULL) {
+		ev->label = label;
+	}
+}
+
 void rspamd_session_remove_event(struct rspamd_async_session *session,
 								 event_finalizer_t fin,
 								 void *ud)

--- a/src/libserver/async_session.c
+++ b/src/libserver/async_session.c
@@ -50,7 +50,10 @@ static struct rspamd_counter_data events_count;
 
 struct rspamd_async_event {
 	const char *subsystem;
-	const char *event_source;
+	/* Snapshotted at add-time via session->item_name_resolver. May be NULL. */
+	const char *item_name;
+	/* Caller-supplied human annotation. May be NULL. */
+	const char *label;
 	event_finalizer_t fin;
 	void *user_data;
 };
@@ -91,11 +94,20 @@ struct rspamd_async_session {
 	session_finalizer_t fin;
 	event_finalizer_t restore;
 	event_finalizer_t cleanup;
+	rspamd_session_item_name_resolver_t item_name_resolver;
 	khash_t(rspamd_events_hash) * events;
 	void *user_data;
 	rspamd_mempool_t *pool;
 	unsigned int flags;
 };
+
+void rspamd_session_set_item_name_resolver(struct rspamd_async_session *session,
+										   rspamd_session_item_name_resolver_t resolver)
+{
+	if (session != NULL) {
+		session->item_name_resolver = resolver;
+	}
+}
 
 static void
 rspamd_session_dtor(gpointer d)
@@ -135,7 +147,7 @@ rspamd_session_add_event_full(struct rspamd_async_session *session,
 							  event_finalizer_t fin,
 							  gpointer user_data,
 							  const char *subsystem,
-							  const char *event_source)
+							  const char *label)
 {
 	struct rspamd_async_event *new_event;
 	int ret;
@@ -158,14 +170,19 @@ rspamd_session_add_event_full(struct rspamd_async_session *session,
 	new_event->fin = fin;
 	new_event->user_data = user_data;
 	new_event->subsystem = subsystem;
-	new_event->event_source = event_source;
+	new_event->label = label;
+	new_event->item_name = NULL;
+	if (session->item_name_resolver != NULL) {
+		new_event->item_name = session->item_name_resolver(session->user_data);
+	}
 
 	msg_debug_session("added event: %p, pending %d (+1) events, "
-					  "subsystem: %s (%s)",
+					  "subsystem: %s, item: %s, label: %s",
 					  user_data,
 					  kh_size(session->events),
 					  subsystem,
-					  event_source);
+					  new_event->item_name ? new_event->item_name : "(none)",
+					  label ? label : "(none)");
 
 	kh_put(rspamd_events_hash, session->events, new_event, &ret);
 	g_assert(ret > 0);
@@ -173,10 +190,9 @@ rspamd_session_add_event_full(struct rspamd_async_session *session,
 	return new_event;
 }
 
-void rspamd_session_remove_event_full(struct rspamd_async_session *session,
-									  event_finalizer_t fin,
-									  void *ud,
-									  const char *event_source)
+void rspamd_session_remove_event(struct rspamd_async_session *session,
+								 event_finalizer_t fin,
+								 void *ud)
 {
 	struct rspamd_async_event search_ev, *found_ev;
 	khiter_t k;
@@ -197,12 +213,13 @@ void rspamd_session_remove_event_full(struct rspamd_async_session *session,
 	k = kh_get(rspamd_events_hash, session->events, &search_ev);
 	if (k == kh_end(session->events)) {
 
-		msg_err_session("cannot find event: %p(%p) from %s (%d total events)", fin, ud,
-						event_source, (int) kh_size(session->events));
+		msg_err_session("cannot find event: %p(%p) (%d total events)", fin, ud,
+						(int) kh_size(session->events));
 		kh_foreach_key(session->events, found_ev, {
-			msg_err_session("existing event %s (%s): %p(%p)",
+			msg_err_session("existing event subsystem=%s, item=%s, label=%s: %p(%p)",
 							found_ev->subsystem,
-							found_ev->event_source,
+							found_ev->item_name ? found_ev->item_name : "(none)",
+							found_ev->label ? found_ev->label : "(none)",
 							found_ev->fin,
 							found_ev->user_data);
 		});
@@ -212,12 +229,12 @@ void rspamd_session_remove_event_full(struct rspamd_async_session *session,
 
 	found_ev = kh_key(session->events, k);
 	msg_debug_session("removed event: %p, pending %d (-1) events, "
-					  "subsystem: %s (%s), added at %s",
+					  "subsystem: %s, item: %s, label: %s",
 					  ud,
 					  kh_size(session->events),
 					  found_ev->subsystem,
-					  event_source,
-					  found_ev->event_source);
+					  found_ev->item_name ? found_ev->item_name : "(none)",
+					  found_ev->label ? found_ev->label : "(none)");
 	kh_del(rspamd_events_hash, session->events, k);
 
 	/* Remove event */
@@ -265,19 +282,21 @@ void rspamd_session_cleanup(struct rspamd_async_session *session, bool forced_cl
 		int ret;
 
 		if (ev->fin != NULL) {
-			msg_debug_session("%sremoved event on destroy: %p, subsystem: %s, scheduled from: %s",
+			msg_debug_session("%sremoved event on destroy: %p, subsystem: %s, item: %s, label: %s",
 							  forced_cleanup ? "forced " : "",
 							  ev->user_data,
 							  ev->subsystem,
-							  ev->event_source);
+							  ev->item_name ? ev->item_name : "(none)",
+							  ev->label ? ev->label : "(none)");
 			ev->fin(ev->user_data);
 		}
 		else {
-			msg_debug_session("NOT %sremoved event on destroy - uncancellable: %p, subsystem: %s, scheduled from: %s",
+			msg_debug_session("NOT %sremoved event on destroy - uncancellable: %p, subsystem: %s, item: %s, label: %s",
 							  forced_cleanup ? "forced " : "",
 							  ev->user_data,
 							  ev->subsystem,
-							  ev->event_source);
+							  ev->item_name ? ev->item_name : "(none)",
+							  ev->label ? ev->label : "(none)");
 			/* Assume an event is uncancellable, move it to a new hash table */
 			kh_put(rspamd_events_hash, uncancellable_events, ev, &ret);
 		}
@@ -338,6 +357,18 @@ unsigned int rspamd_session_events_pending(struct rspamd_async_session *session)
 #define RSPAMD_DUMP_MAX_SUBSYSTEMS 16
 #define RSPAMD_DUMP_MAX_SOURCES_PER_SUB 4
 
+static inline bool
+rspamd_str_eq_nullable(const char *a, const char *b)
+{
+	if (a == b) {
+		return true;
+	}
+	if (a == NULL || b == NULL) {
+		return false;
+	}
+	return strcmp(a, b) == 0;
+}
+
 void rspamd_session_describe_pending(struct rspamd_async_session *session,
 									 GString **summary_out,
 									 GString **details_out)
@@ -347,10 +378,12 @@ void rspamd_session_describe_pending(struct rspamd_async_session *session,
 	unsigned int total = 0;
 	unsigned int n_subsystems = 0;
 	unsigned int overflow_subsystems = 0;
+	unsigned int total_detail_entries = 0;
 	unsigned int i, j;
 
 	struct dump_source {
-		const char *source;
+		const char *item_name;
+		const char *label;
 		unsigned int count;
 	};
 	struct dump_subsystem {
@@ -374,7 +407,8 @@ void rspamd_session_describe_pending(struct rspamd_async_session *session,
 
 	kh_foreach_key(session->events, ev, {
 		const char *sub = ev->subsystem ? ev->subsystem : "(null)";
-		const char *src = ev->event_source ? ev->event_source : "(null)";
+		const char *item = ev->item_name;
+		const char *lbl = ev->label;
 		struct dump_subsystem *s = NULL;
 		struct dump_source *src_e = NULL;
 
@@ -403,26 +437,32 @@ void rspamd_session_describe_pending(struct rspamd_async_session *session,
 		if (s != NULL) {
 			s->count++;
 
-			for (j = 0; j < s->distinct_sources; j++) {
-				if (strcmp(s->sources[j].source, src) == 0) {
-					src_e = &s->sources[j];
-					break;
+			/* Events without any annotation are counted in subsystem total
+			 * only — we do not emit a detail entry for them. */
+			if (item != NULL || lbl != NULL) {
+				for (j = 0; j < s->distinct_sources; j++) {
+					if (rspamd_str_eq_nullable(s->sources[j].item_name, item) &&
+						rspamd_str_eq_nullable(s->sources[j].label, lbl)) {
+						src_e = &s->sources[j];
+						break;
+					}
 				}
-			}
 
-			if (src_e == NULL) {
-				if (s->distinct_sources < RSPAMD_DUMP_MAX_SOURCES_PER_SUB) {
-					src_e = &s->sources[s->distinct_sources++];
-					src_e->source = src;
-					src_e->count = 0;
+				if (src_e == NULL) {
+					if (s->distinct_sources < RSPAMD_DUMP_MAX_SOURCES_PER_SUB) {
+						src_e = &s->sources[s->distinct_sources++];
+						src_e->item_name = item;
+						src_e->label = lbl;
+						src_e->count = 0;
+					}
+					else {
+						s->overflow_sources++;
+					}
 				}
-				else {
-					s->overflow_sources++;
-				}
-			}
 
-			if (src_e != NULL) {
-				src_e->count++;
+				if (src_e != NULL) {
+					src_e->count++;
+				}
 			}
 		}
 	});
@@ -445,22 +485,50 @@ void rspamd_session_describe_pending(struct rspamd_async_session *session,
 							  overflow_subsystems);
 	}
 
-	details = g_string_sized_new(256);
 	for (i = 0; i < n_subsystems; i++) {
-		if (i > 0) {
-			g_string_append(details, "; ");
+		total_detail_entries += subsystems[i].distinct_sources;
+	}
+
+	if (total_detail_entries == 0) {
+		details = NULL;
+	}
+	else {
+		bool first_sub = true;
+		details = g_string_sized_new(256);
+		for (i = 0; i < n_subsystems; i++) {
+			struct dump_subsystem *s = &subsystems[i];
+
+			if (s->distinct_sources == 0) {
+				continue;
+			}
+
+			if (!first_sub) {
+				g_string_append(details, "; ");
+			}
+			first_sub = false;
+			rspamd_printf_gstring(details, "[%s:", s->name);
+			for (j = 0; j < s->distinct_sources; j++) {
+				const char *it = s->sources[j].item_name;
+				const char *lb = s->sources[j].label;
+
+				g_string_append_c(details, ' ');
+				if (it != NULL && lb != NULL) {
+					rspamd_printf_gstring(details, "%s(%s)", it, lb);
+				}
+				else if (it != NULL) {
+					rspamd_printf_gstring(details, "%s", it);
+				}
+				else {
+					rspamd_printf_gstring(details, "%s", lb);
+				}
+				rspamd_printf_gstring(details, " x%ud", s->sources[j].count);
+			}
+			if (s->overflow_sources > 0) {
+				rspamd_printf_gstring(details, " (+%ud more)",
+									  s->overflow_sources);
+			}
+			g_string_append_c(details, ']');
 		}
-		rspamd_printf_gstring(details, "[%s:", subsystems[i].name);
-		for (j = 0; j < subsystems[i].distinct_sources; j++) {
-			rspamd_printf_gstring(details, " %s x%ud",
-								  subsystems[i].sources[j].source,
-								  subsystems[i].sources[j].count);
-		}
-		if (subsystems[i].overflow_sources > 0) {
-			rspamd_printf_gstring(details, " (+%ud more sources)",
-								  subsystems[i].overflow_sources);
-		}
-		g_string_append_c(details, ']');
 	}
 
 	if (summary_out) {
@@ -472,7 +540,7 @@ void rspamd_session_describe_pending(struct rspamd_async_session *session,
 	if (details_out) {
 		*details_out = details;
 	}
-	else {
+	else if (details != NULL) {
 		g_string_free(details, TRUE);
 	}
 }

--- a/src/libserver/async_session.c
+++ b/src/libserver/async_session.c
@@ -265,32 +265,19 @@ void rspamd_session_cleanup(struct rspamd_async_session *session, bool forced_cl
 		int ret;
 
 		if (ev->fin != NULL) {
-			if (forced_cleanup) {
-				msg_info_session("forced removed event on destroy: %p, subsystem: %s, scheduled from: %s",
-								 ev->user_data,
-								 ev->subsystem,
-								 ev->event_source);
-			}
-			else {
-				msg_debug_session("removed event on destroy: %p, subsystem: %s",
-								  ev->user_data,
-								  ev->subsystem);
-			}
+			msg_debug_session("%sremoved event on destroy: %p, subsystem: %s, scheduled from: %s",
+							  forced_cleanup ? "forced " : "",
+							  ev->user_data,
+							  ev->subsystem,
+							  ev->event_source);
 			ev->fin(ev->user_data);
 		}
 		else {
-			if (forced_cleanup) {
-				msg_info_session("NOT forced removed event on destroy - uncancellable: "
-								 "%p, subsystem: %s, scheduled from: %s",
-								 ev->user_data,
-								 ev->subsystem,
-								 ev->event_source);
-			}
-			else {
-				msg_debug_session("NOT removed event on destroy - uncancellable: %p, subsystem: %s",
-								  ev->user_data,
-								  ev->subsystem);
-			}
+			msg_debug_session("NOT %sremoved event on destroy - uncancellable: %p, subsystem: %s, scheduled from: %s",
+							  forced_cleanup ? "forced " : "",
+							  ev->user_data,
+							  ev->subsystem,
+							  ev->event_source);
 			/* Assume an event is uncancellable, move it to a new hash table */
 			kh_put(rspamd_events_hash, uncancellable_events, ev, &ret);
 		}
@@ -298,8 +285,9 @@ void rspamd_session_cleanup(struct rspamd_async_session *session, bool forced_cl
 
 	kh_destroy(rspamd_events_hash, session->events);
 	session->events = uncancellable_events;
-	if (forced_cleanup) {
-		msg_info_session("pending %d uncancellable events", kh_size(uncancellable_events));
+	if (forced_cleanup && kh_size(uncancellable_events) > 0) {
+		msg_info_session("pending %d uncancellable events after forced cleanup",
+						 kh_size(uncancellable_events));
 	}
 	else {
 		msg_debug_session("pending %d uncancellable events", kh_size(uncancellable_events));
@@ -346,6 +334,151 @@ unsigned int rspamd_session_events_pending(struct rspamd_async_session *session)
 
 	return npending;
 }
+
+#define RSPAMD_DUMP_MAX_SUBSYSTEMS 16
+#define RSPAMD_DUMP_MAX_SOURCES_PER_SUB 4
+
+void rspamd_session_describe_pending(struct rspamd_async_session *session,
+									 GString **summary_out,
+									 GString **details_out)
+{
+	struct rspamd_async_event *ev;
+	GString *summary, *details;
+	unsigned int total = 0;
+	unsigned int n_subsystems = 0;
+	unsigned int overflow_subsystems = 0;
+	unsigned int i, j;
+
+	struct dump_source {
+		const char *source;
+		unsigned int count;
+	};
+	struct dump_subsystem {
+		const char *name;
+		unsigned int count;
+		unsigned int distinct_sources;
+		unsigned int overflow_sources;
+		struct dump_source sources[RSPAMD_DUMP_MAX_SOURCES_PER_SUB];
+	} subsystems[RSPAMD_DUMP_MAX_SUBSYSTEMS];
+
+	if (summary_out) {
+		*summary_out = NULL;
+	}
+	if (details_out) {
+		*details_out = NULL;
+	}
+
+	if (session == NULL || kh_size(session->events) == 0) {
+		return;
+	}
+
+	kh_foreach_key(session->events, ev, {
+		const char *sub = ev->subsystem ? ev->subsystem : "(null)";
+		const char *src = ev->event_source ? ev->event_source : "(null)";
+		struct dump_subsystem *s = NULL;
+		struct dump_source *src_e = NULL;
+
+		total++;
+
+		for (i = 0; i < n_subsystems; i++) {
+			if (strcmp(subsystems[i].name, sub) == 0) {
+				s = &subsystems[i];
+				break;
+			}
+		}
+
+		if (s == NULL) {
+			if (n_subsystems < RSPAMD_DUMP_MAX_SUBSYSTEMS) {
+				s = &subsystems[n_subsystems++];
+				s->name = sub;
+				s->count = 0;
+				s->distinct_sources = 0;
+				s->overflow_sources = 0;
+			}
+			else {
+				overflow_subsystems++;
+			}
+		}
+
+		if (s != NULL) {
+			s->count++;
+
+			for (j = 0; j < s->distinct_sources; j++) {
+				if (strcmp(s->sources[j].source, src) == 0) {
+					src_e = &s->sources[j];
+					break;
+				}
+			}
+
+			if (src_e == NULL) {
+				if (s->distinct_sources < RSPAMD_DUMP_MAX_SOURCES_PER_SUB) {
+					src_e = &s->sources[s->distinct_sources++];
+					src_e->source = src;
+					src_e->count = 0;
+				}
+				else {
+					s->overflow_sources++;
+				}
+			}
+
+			if (src_e != NULL) {
+				src_e->count++;
+			}
+		}
+	});
+
+	if (total == 0) {
+		return;
+	}
+
+	summary = g_string_sized_new(128);
+	rspamd_printf_gstring(summary, "total=%ud; by subsystem: ", total);
+	for (i = 0; i < n_subsystems; i++) {
+		if (i > 0) {
+			g_string_append(summary, ", ");
+		}
+		rspamd_printf_gstring(summary, "%s=%ud",
+							  subsystems[i].name, subsystems[i].count);
+	}
+	if (overflow_subsystems > 0) {
+		rspamd_printf_gstring(summary, ", (+%ud more subsystems)",
+							  overflow_subsystems);
+	}
+
+	details = g_string_sized_new(256);
+	for (i = 0; i < n_subsystems; i++) {
+		if (i > 0) {
+			g_string_append(details, "; ");
+		}
+		rspamd_printf_gstring(details, "[%s:", subsystems[i].name);
+		for (j = 0; j < subsystems[i].distinct_sources; j++) {
+			rspamd_printf_gstring(details, " %s x%ud",
+								  subsystems[i].sources[j].source,
+								  subsystems[i].sources[j].count);
+		}
+		if (subsystems[i].overflow_sources > 0) {
+			rspamd_printf_gstring(details, " (+%ud more sources)",
+								  subsystems[i].overflow_sources);
+		}
+		g_string_append_c(details, ']');
+	}
+
+	if (summary_out) {
+		*summary_out = summary;
+	}
+	else {
+		g_string_free(summary, TRUE);
+	}
+	if (details_out) {
+		*details_out = details;
+	}
+	else {
+		g_string_free(details, TRUE);
+	}
+}
+
+#undef RSPAMD_DUMP_MAX_SUBSYSTEMS
+#undef RSPAMD_DUMP_MAX_SOURCES_PER_SUB
 
 rspamd_mempool_t *
 rspamd_session_mempool(struct rspamd_async_session *session)

--- a/src/libserver/async_session.h
+++ b/src/libserver/async_session.h
@@ -83,6 +83,18 @@ rspamd_session_add_event_full(struct rspamd_async_session *session,
 	rspamd_session_add_event_full(session, fin, user_data, subsystem, NULL)
 
 /**
+ * Updates the label (human annotation) of an already-registered event.
+ * Intended for callers whose event is long-lived (e.g. a TCP connection)
+ * and whose "current operation" (read / write / connect) changes during
+ * the event's lifetime. The new label must remain valid until the event
+ * is removed or the label is updated again.
+ * @param ev event returned by rspamd_session_add_event[_full]; may be NULL (no-op)
+ * @param label new label or NULL to clear
+ */
+void rspamd_session_event_update_label(struct rspamd_async_event *ev,
+									   const char *label);
+
+/**
  * Remove normal event
  * @param session session object
  * @param fin final callback

--- a/src/libserver/async_session.h
+++ b/src/libserver/async_session.h
@@ -31,6 +31,15 @@ typedef void (*event_finalizer_t)(gpointer ud);
 typedef gboolean (*session_finalizer_t)(gpointer user_data);
 
 /**
+ * Callback that returns a human-readable name (typically the currently-executing
+ * symbol) to associate with an event when it is added. Receives the session's
+ * user_data. May return NULL if no such context exists (e.g. events added
+ * outside symcache execution). Returned string must remain valid at least until
+ * the event is removed.
+ */
+typedef const char *(*rspamd_session_item_name_resolver_t)(gpointer user_data);
+
+/**
  * Make new async session
  * @param pool pool to alloc memory from
  * @param fin a callback called when no events are found in session
@@ -44,21 +53,34 @@ struct rspamd_async_session *rspamd_session_create(rspamd_mempool_t *pool,
 												   event_finalizer_t cleanup, gpointer user_data);
 
 /**
+ * Registers (or clears with NULL) a callback that the session calls at
+ * add-event time to snapshot the "owning item" name (typically the symbol name
+ * that initiated the async request). Used only for diagnostics — has no effect
+ * on event lifecycle. Task-scoped sessions should wire this to look up the
+ * currently-executing symcache item.
+ * @param session session object
+ * @param resolver resolver callback, or NULL to disable
+ */
+void rspamd_session_set_item_name_resolver(struct rspamd_async_session *session,
+										   rspamd_session_item_name_resolver_t resolver);
+
+/**
  * Insert new event to the session
  * @param session session object
  * @param fin finalizer callback
  * @param user_data abstract user_data
- * @param forced unused
+ * @param subsystem static name of the subsystem registering the event (e.g. "rspamd dns")
+ * @param label optional human-readable annotation (e.g. "tcp write"), may be NULL
  */
 struct rspamd_async_event *
 rspamd_session_add_event_full(struct rspamd_async_session *session,
 							  event_finalizer_t fin,
 							  gpointer user_data,
 							  const char *subsystem,
-							  const char *event_source);
+							  const char *label);
 
 #define rspamd_session_add_event(session, fin, user_data, subsystem) \
-	rspamd_session_add_event_full(session, fin, user_data, subsystem, G_STRLOC)
+	rspamd_session_add_event_full(session, fin, user_data, subsystem, NULL)
 
 /**
  * Remove normal event
@@ -66,13 +88,9 @@ rspamd_session_add_event_full(struct rspamd_async_session *session,
  * @param fin final callback
  * @param ud user data object
  */
-void rspamd_session_remove_event_full(struct rspamd_async_session *session,
-									  event_finalizer_t fin,
-									  gpointer ud,
-									  const char *event_source);
-
-#define rspamd_session_remove_event(session, fin, user_data) \
-	rspamd_session_remove_event_full(session, fin, user_data, G_STRLOC)
+void rspamd_session_remove_event(struct rspamd_async_session *session,
+								 event_finalizer_t fin,
+								 gpointer ud);
 
 /**
  * Must be called at the end of session, it calls fin functions for all non-forced callbacks
@@ -110,9 +128,13 @@ unsigned int rspamd_session_events_pending(struct rspamd_async_session *session)
  * Builds human-readable descriptions of currently-pending async events grouped
  * by subsystem. Produces two newly-allocated GStrings written to the out-params:
  *   - *summary_out : compact counts, e.g. "total=10; by subsystem: rspamd dns=7, fuzzy_check=3"
- *   - *details_out : distinct call-sites per subsystem, e.g. "[rspamd dns: /path/a.c:45 x5, /path/b.c:12 x2]; [fuzzy_check: /path/c.c:88 x3]"
- * The caller owns both strings and MUST free them with g_string_free(..., TRUE).
- * If there are no pending events, both out-params are set to NULL.
+ *   - *details_out : within each subsystem, distinct (item, label) pairs with
+ *                    counts, e.g. "[rspamd dns: RBL_FOO x5, SURBL_CHECK x2]; [rspamd lua tcp: RATELIMIT_CHECK(tcp write) x1]"
+ * Events that have neither an owning item nor a label are counted in the summary
+ * but omitted from the detail line. The caller owns both strings and MUST free
+ * them with g_string_free(..., TRUE). If there are no pending events, both
+ * out-params are set to NULL; if there are events but none of them carry
+ * detail, details_out is set to NULL while summary_out is populated.
  * Intended to be called from timeout handlers so the caller can log with the
  * proper task module tag (msg_info_task).
  * @param session session to dump

--- a/src/libserver/async_session.h
+++ b/src/libserver/async_session.h
@@ -125,25 +125,20 @@ gboolean rspamd_session_pending(struct rspamd_async_session *session);
 unsigned int rspamd_session_events_pending(struct rspamd_async_session *session);
 
 /**
- * Builds human-readable descriptions of currently-pending async events grouped
- * by subsystem. Produces two newly-allocated GStrings written to the out-params:
- *   - *summary_out : compact counts, e.g. "total=10; by subsystem: rspamd dns=7, fuzzy_check=3"
- *   - *details_out : within each subsystem, distinct (item, label) pairs with
- *                    counts, e.g. "[rspamd dns: RBL_FOO x5, SURBL_CHECK x2]; [rspamd lua tcp: RATELIMIT_CHECK(tcp write) x1]"
- * Events that have neither an owning item nor a label are counted in the summary
- * but omitted from the detail line. The caller owns both strings and MUST free
- * them with g_string_free(..., TRUE). If there are no pending events, both
- * out-params are set to NULL; if there are events but none of them carry
- * detail, details_out is set to NULL while summary_out is populated.
+ * Builds a single human-readable line describing all currently-pending async
+ * events, grouped by the (subsystem, item_name, label) triple. Each group is
+ * rendered as "<subsystem>[<item>/<label>]=N" when both item and label are
+ * known, degrading to "<subsystem>[<item>]=N", "<subsystem>[<label>]=N", or
+ * bare "<subsystem>=N" if fields are missing. Example output:
+ *   "total=5; rspamd dns[RBL_FOO]=3, rspamd dns[SURBL]=1, rspamd lua http[X]=1"
+ * Returns a newly-allocated GString that the caller MUST free with
+ * g_string_free(..., TRUE), or NULL if there are no pending events.
  * Intended to be called from timeout handlers so the caller can log with the
  * proper task module tag (msg_info_task).
  * @param session session to dump
- * @param summary_out receives the summary GString (may be NULL on return)
- * @param details_out receives the detail GString (may be NULL on return)
+ * @return newly-allocated GString or NULL
  */
-void rspamd_session_describe_pending(struct rspamd_async_session *session,
-									 GString **summary_out,
-									 GString **details_out);
+GString *rspamd_session_describe_pending(struct rspamd_async_session *session);
 
 
 /**

--- a/src/libserver/async_session.h
+++ b/src/libserver/async_session.h
@@ -106,6 +106,23 @@ gboolean rspamd_session_pending(struct rspamd_async_session *session);
  */
 unsigned int rspamd_session_events_pending(struct rspamd_async_session *session);
 
+/**
+ * Builds human-readable descriptions of currently-pending async events grouped
+ * by subsystem. Produces two newly-allocated GStrings written to the out-params:
+ *   - *summary_out : compact counts, e.g. "total=10; by subsystem: rspamd dns=7, fuzzy_check=3"
+ *   - *details_out : distinct call-sites per subsystem, e.g. "[rspamd dns: /path/a.c:45 x5, /path/b.c:12 x2]; [fuzzy_check: /path/c.c:88 x3]"
+ * The caller owns both strings and MUST free them with g_string_free(..., TRUE).
+ * If there are no pending events, both out-params are set to NULL.
+ * Intended to be called from timeout handlers so the caller can log with the
+ * proper task module tag (msg_info_task).
+ * @param session session to dump
+ * @param summary_out receives the summary GString (may be NULL on return)
+ * @param details_out receives the detail GString (may be NULL on return)
+ */
+void rspamd_session_describe_pending(struct rspamd_async_session *session,
+									 GString **summary_out,
+									 GString **details_out);
+
 
 /**
  * Returns TRUE if an async session is currently destroying

--- a/src/libserver/dns.c
+++ b/src/libserver/dns.c
@@ -268,10 +268,11 @@ rspamd_dns_resolver_request(struct rspamd_dns_resolver *resolver,
 
 	if (session) {
 		if (req != NULL) {
-			rspamd_session_add_event(session,
-									 (event_finalizer_t) rspamd_dns_fin_cb,
-									 reqdata,
-									 M);
+			rspamd_session_add_event_full(session,
+										  (event_finalizer_t) rspamd_dns_fin_cb,
+										  reqdata,
+										  M,
+										  rdns_strtype(type));
 		}
 	}
 

--- a/src/libserver/rspamd_symcache.h
+++ b/src/libserver/rspamd_symcache.h
@@ -544,6 +544,17 @@ rspamd_symcache_item_stat(struct rspamd_symcache_item *item);
  */
 void rspamd_symcache_enable_profile(struct rspamd_task *task);
 
+/**
+ * Builds a human-readable description of symbols that have been started but
+ * have not yet finished (i.e. are blocked on async events). Intended for use
+ * from timeout handlers so operators can see which rules stalled the task.
+ * Returns NULL if there are no inflight symbols. Caller owns the returned
+ * GString and MUST free it with g_string_free(..., TRUE).
+ * @param task
+ * @return
+ */
+GString *rspamd_symcache_describe_inflight_symbols(struct rspamd_task *task);
+
 struct rspamd_symcache_timeout_item {
 	double timeout;
 	const struct rspamd_symcache_item *item;

--- a/src/libserver/symcache/symcache_c.cxx
+++ b/src/libserver/symcache/symcache_c.cxx
@@ -327,6 +327,18 @@ rspamd_symcache_item_stat(struct rspamd_symcache_item *item)
 	return real_item->st;
 }
 
+GString *
+rspamd_symcache_describe_inflight_symbols(struct rspamd_task *task)
+{
+	if (task == nullptr || task->symcache_runtime == nullptr) {
+		return nullptr;
+	}
+
+	auto *cache_runtime = C_API_SYMCACHE_RUNTIME(task->symcache_runtime);
+
+	return cache_runtime->describe_inflight_symbols();
+}
+
 void rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
 										const char *symbol,
 										ucl_object_t *this_sym_ucl)

--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -974,4 +974,56 @@ auto symcache_runtime::get_item_by_dynamic_item(cache_dynamic_item *dyn_item) co
 	return nullptr;
 }
 
+auto symcache_runtime::describe_inflight_symbols() const -> GString *
+{
+	GString *out = nullptr;
+	unsigned int nshown = 0;
+	unsigned int nsuppressed = 0;
+	constexpr unsigned int MAX_ITEMS_SHOWN = 32;
+
+	if (items_inflight == 0) {
+		return nullptr;
+	}
+
+	for (auto [i, item]: rspamd::enumerate(order->d)) {
+		auto *dyn_item = &dynamic_items[i];
+
+		if (dyn_item->status != cache_item_status::started) {
+			continue;
+		}
+
+		if (nshown >= MAX_ITEMS_SHOWN) {
+			nsuppressed++;
+			continue;
+		}
+
+		if (out == nullptr) {
+			out = g_string_sized_new(128);
+		}
+		else {
+			g_string_append(out, ", ");
+		}
+
+		const auto &name = item->get_name();
+		if (dyn_item->start_msec > 0) {
+			rspamd_printf_gstring(out, "%*s (async=%ud, started=%ud ms)",
+								  (int) name.size(), name.data(),
+								  (unsigned int) dyn_item->async_events,
+								  (unsigned int) dyn_item->start_msec);
+		}
+		else {
+			rspamd_printf_gstring(out, "%*s (async=%ud)",
+								  (int) name.size(), name.data(),
+								  (unsigned int) dyn_item->async_events);
+		}
+		nshown++;
+	}
+
+	if (nsuppressed > 0 && out != nullptr) {
+		rspamd_printf_gstring(out, " (+%ud more)", nsuppressed);
+	}
+
+	return out;
+}
+
 }// namespace rspamd::symcache

--- a/src/libserver/symcache/symcache_runtime.hxx
+++ b/src/libserver/symcache/symcache_runtime.hxx
@@ -236,6 +236,16 @@ public:
 			slow_status = slow_status::disabled;
 		}
 	}
+
+	/**
+	 * Builds a human-readable description of symbols that have been started but
+	 * have not yet finished (i.e. are waiting on async events: DNS, Redis, HTTP,
+	 * etc.). Intended to be used from timeout handlers to surface which rules
+	 * stalled the task.
+	 * @return newly allocated GString (caller must g_string_free) or nullptr if
+	 *         no inflight symbols
+	 */
+	auto describe_inflight_symbols() const -> GString *;
 };
 
 

--- a/src/libserver/task.c
+++ b/src/libserver/task.c
@@ -1936,6 +1936,24 @@ rspamd_task_stage_name(enum rspamd_task_stage stg)
 	return ret;
 }
 
+const char *
+rspamd_task_session_item_name_resolver(gpointer ud)
+{
+	struct rspamd_task *task = ud;
+	struct rspamd_symcache_dynamic_item *item;
+
+	if (task == NULL) {
+		return NULL;
+	}
+
+	item = rspamd_symcache_get_cur_item(task);
+	if (item == NULL) {
+		return NULL;
+	}
+
+	return rspamd_symcache_dyn_item_name(task, item);
+}
+
 static void
 rspamd_task_timeout_log_state(struct rspamd_task *task)
 {

--- a/src/libserver/task.c
+++ b/src/libserver/task.c
@@ -1936,7 +1936,7 @@ rspamd_task_stage_name(enum rspamd_task_stage stg)
 	return ret;
 }
 
-const char *
+static const char *
 rspamd_task_session_item_name_resolver(gpointer ud)
 {
 	struct rspamd_task *task = ud;
@@ -1954,20 +1954,32 @@ rspamd_task_session_item_name_resolver(gpointer ud)
 	return rspamd_symcache_dyn_item_name(task, item);
 }
 
+struct rspamd_async_session *
+rspamd_task_create_session(struct rspamd_task *task,
+						   rspamd_mempool_t *pool,
+						   session_finalizer_t fin,
+						   event_finalizer_t restore,
+						   event_finalizer_t cleanup)
+{
+	struct rspamd_async_session *s;
+
+	g_assert(task != NULL);
+
+	s = rspamd_session_create(pool, fin, restore, cleanup, task);
+	rspamd_session_set_item_name_resolver(s, rspamd_task_session_item_name_resolver);
+
+	return s;
+}
+
 static void
 rspamd_task_timeout_log_state(struct rspamd_task *task)
 {
-	GString *evt_summary = NULL, *evt_details = NULL, *inflight = NULL;
+	GString *pending, *inflight;
 
-	rspamd_session_describe_pending(task->s, &evt_summary, &evt_details);
-
-	if (evt_summary != NULL) {
-		msg_info_task("pending async events at timeout: %v", evt_summary);
-		g_string_free(evt_summary, TRUE);
-	}
-	if (evt_details != NULL) {
-		msg_info_task("pending async event sources: %v", evt_details);
-		g_string_free(evt_details, TRUE);
+	pending = rspamd_session_describe_pending(task->s);
+	if (pending != NULL) {
+		msg_info_task("pending async events at timeout: %v", pending);
+		g_string_free(pending, TRUE);
 	}
 
 	inflight = rspamd_symcache_describe_inflight_symbols(task);

--- a/src/libserver/task.c
+++ b/src/libserver/task.c
@@ -1936,6 +1936,29 @@ rspamd_task_stage_name(enum rspamd_task_stage stg)
 	return ret;
 }
 
+static void
+rspamd_task_timeout_log_state(struct rspamd_task *task)
+{
+	GString *evt_summary = NULL, *evt_details = NULL, *inflight = NULL;
+
+	rspamd_session_describe_pending(task->s, &evt_summary, &evt_details);
+
+	if (evt_summary != NULL) {
+		msg_info_task("pending async events at timeout: %v", evt_summary);
+		g_string_free(evt_summary, TRUE);
+	}
+	if (evt_details != NULL) {
+		msg_info_task("pending async event sources: %v", evt_details);
+		g_string_free(evt_details, TRUE);
+	}
+
+	inflight = rspamd_symcache_describe_inflight_symbols(task);
+	if (inflight != NULL) {
+		msg_info_task("inflight symbols at timeout: %v", inflight);
+		g_string_free(inflight, TRUE);
+	}
+}
+
 void rspamd_task_timeout(EV_P_ ev_timer *w, int revents)
 {
 	struct rspamd_task *task = (struct rspamd_task *) w->data;
@@ -1946,6 +1969,7 @@ void rspamd_task_timeout(EV_P_ ev_timer *w, int revents)
 					  "forced processing",
 					  ev_now(task->event_loop) - task->task_timestamp,
 					  w->repeat);
+		rspamd_task_timeout_log_state(task);
 
 		if (task->cfg->soft_reject_on_timeout) {
 			struct rspamd_action *action, *soft_reject;
@@ -1975,6 +1999,7 @@ void rspamd_task_timeout(EV_P_ ev_timer *w, int revents)
 		/* Postprocessing timeout */
 		msg_info_task("post-processing of task time out: %.1f second spent; forced processing",
 					  ev_now(task->event_loop) - task->task_timestamp);
+		rspamd_task_timeout_log_state(task);
 
 		if (task->cfg->soft_reject_on_timeout) {
 			struct rspamd_action *action, *soft_reject;

--- a/src/libserver/task.h
+++ b/src/libserver/task.h
@@ -415,11 +415,24 @@ const char *rspamd_task_stage_name(enum rspamd_task_stage stg);
  */
 void rspamd_task_timeout(EV_P_ ev_timer *w, int revents);
 
-/*
- * Resolver used by task's async session to snapshot the name of the currently
- * executing symcache symbol (or NULL if none). Argument is the task pointer.
+/**
+ * Creates an async session owned by @task and wires up the default task
+ * diagnostics resolver (used to snapshot the currently-executing symbol name
+ * on every rspamd_session_add_event). All task-scoped sessions should be
+ * created through this helper instead of calling rspamd_session_create
+ * directly, otherwise timeout logs will be missing symbol context.
+ * @param task owning task; must be non-NULL
+ * @param pool memory pool for the session
+ * @param fin session-fin callback
+ * @param restore session-restore callback (or NULL)
+ * @param cleanup session-cleanup callback (or NULL)
  */
-const char *rspamd_task_session_item_name_resolver(gpointer ud);
+struct rspamd_async_session *
+rspamd_task_create_session(struct rspamd_task *task,
+						   rspamd_mempool_t *pool,
+						   session_finalizer_t fin,
+						   event_finalizer_t restore,
+						   event_finalizer_t cleanup);
 
 /*
  * Called on unexpected IO error (e.g. ECONNRESET)

--- a/src/libserver/task.h
+++ b/src/libserver/task.h
@@ -416,6 +416,12 @@ const char *rspamd_task_stage_name(enum rspamd_task_stage stg);
 void rspamd_task_timeout(EV_P_ ev_timer *w, int revents);
 
 /*
+ * Resolver used by task's async session to snapshot the name of the currently
+ * executing symcache symbol (or NULL if none). Argument is the task pointer.
+ */
+const char *rspamd_task_session_item_name_resolver(gpointer ud);
+
+/*
  * Called on unexpected IO error (e.g. ECONNRESET)
  */
 void rspamd_worker_guard_handler(EV_P_ ev_io *w, int revents);

--- a/src/libserver/worker_util.c
+++ b/src/libserver/worker_util.c
@@ -153,11 +153,10 @@ rspamd_worker_call_finish_handlers(struct rspamd_worker *worker)
 		task = rspamd_task_new(worker, cfg, NULL, NULL, ctx->event_loop, FALSE);
 		task->resolver = ctx->resolver;
 		task->flags |= RSPAMD_TASK_FLAG_PROCESSING;
-		task->s = rspamd_session_create(task->task_pool,
-										rspamd_worker_finalize,
-										NULL,
-										(event_finalizer_t) rspamd_task_free,
-										task);
+		task->s = rspamd_task_create_session(task, task->task_pool,
+											 rspamd_worker_finalize,
+											 NULL,
+											 (event_finalizer_t) rspamd_task_free);
 
 		DL_FOREACH(cfg->on_term_scripts, sc)
 		{

--- a/src/lua/lua_http.c
+++ b/src/lua/lua_http.c
@@ -557,8 +557,9 @@ lua_http_make_connection(struct lua_http_cbdata *cbd)
 		}
 
 		if (cbd->session) {
-			rspamd_session_add_event(cbd->session,
-									 (event_finalizer_t) lua_http_fin, cbd, M);
+			rspamd_session_add_event_full(cbd->session,
+										  (event_finalizer_t) lua_http_fin, cbd, M,
+										  cbd->host);
 			cbd->flags |= RSPAMD_LUA_HTTP_FLAG_RESOLVED;
 		}
 

--- a/src/lua/lua_http.c
+++ b/src/lua/lua_http.c
@@ -557,17 +557,8 @@ lua_http_make_connection(struct lua_http_cbdata *cbd)
 		}
 
 		if (cbd->session) {
-			if (cbd->item) {
-				rspamd_session_add_event_full(cbd->session,
-											  (event_finalizer_t) lua_http_fin, cbd,
-											  M,
-											  rspamd_symcache_dyn_item_name(cbd->task, cbd->item));
-			}
-			else {
-				rspamd_session_add_event(cbd->session,
-										 (event_finalizer_t) lua_http_fin, cbd,
-										 M);
-			}
+			rspamd_session_add_event(cbd->session,
+									 (event_finalizer_t) lua_http_fin, cbd, M);
 			cbd->flags |= RSPAMD_LUA_HTTP_FLAG_RESOLVED;
 		}
 

--- a/src/lua/lua_redis.c
+++ b/src/lua/lua_redis.c
@@ -1241,9 +1241,10 @@ lua_redis_make_request(lua_State *L)
 
 		if (ret == REDIS_OK) {
 			if (ud->s) {
-				rspamd_session_add_event(ud->s,
-										 lua_redis_fin, sp_ud,
-										 M);
+				rspamd_session_add_event_full(ud->s,
+											  lua_redis_fin, sp_ud,
+											  M,
+											  sp_ud->nargs > 0 ? sp_ud->args[0] : NULL);
 
 				if (ud->item) {
 					rspamd_symcache_item_async_inc(ud->task, ud->item, M);
@@ -1611,10 +1612,11 @@ lua_redis_add_cmd(lua_State *L)
 
 		if (ret == REDIS_OK) {
 			if (ud->s) {
-				rspamd_session_add_event(ud->s,
-										 lua_redis_fin,
-										 sp_ud,
-										 M);
+				rspamd_session_add_event_full(ud->s,
+											  lua_redis_fin,
+											  sp_ud,
+											  M,
+											  sp_ud->nargs > 0 ? sp_ud->args[0] : NULL);
 
 				if (ud->item) {
 					rspamd_symcache_item_async_inc(ud->task, ud->item, M);

--- a/src/lua/lua_redis.c
+++ b/src/lua/lua_redis.c
@@ -131,6 +131,9 @@ struct lua_redis_request_specific_userdata {
 	unsigned int nargs;
 	char **args;
 	gsize *arglens;
+	/* NUL-terminated copy of args[0] for diagnostic labels; args[0] itself is
+	 * sized to arglens[0] and is not NUL-terminated */
+	char *cmd;
 	struct lua_redis_userdata *common_ud;
 	struct lua_redis_ctx *ctx;
 	struct lua_redis_request_specific_userdata *next;
@@ -223,6 +226,7 @@ lua_redis_dtor(struct lua_redis_ctx *ctx)
 	LL_FOREACH_SAFE(ud->specific, cur, tmp)
 	{
 		lua_redis_free_args(cur->args, cur->arglens, cur->nargs);
+		g_free(cur->cmd);
 
 		if (cur->cbref != -1) {
 			luaL_unref(ud->cfg->lua_state, LUA_REGISTRYINDEX, cur->cbref);
@@ -1215,6 +1219,7 @@ lua_redis_make_request(lua_State *L)
 		lua_gettable(L, -2);
 		cmd = lua_tostring(L, -1);
 		lua_pop(L, 1);
+		sp_ud->cmd = g_strdup(cmd);
 
 		lua_pushstring(L, "timeout");
 		lua_gettable(L, 1);
@@ -1244,7 +1249,7 @@ lua_redis_make_request(lua_State *L)
 				rspamd_session_add_event_full(ud->s,
 											  lua_redis_fin, sp_ud,
 											  M,
-											  sp_ud->nargs > 0 ? sp_ud->args[0] : NULL);
+											  sp_ud->cmd);
 
 				if (ud->item) {
 					rspamd_symcache_item_async_inc(ud->task, ud->item, M);
@@ -1580,6 +1585,7 @@ lua_redis_add_cmd(lua_State *L)
 		}
 
 		sp_ud->ctx = ctx;
+		sp_ud->cmd = g_strdup(cmd);
 
 		lua_redis_parse_args(L, args_pos, cmd, &sp_ud->args,
 							 &sp_ud->arglens, &sp_ud->nargs);
@@ -1616,7 +1622,7 @@ lua_redis_add_cmd(lua_State *L)
 											  lua_redis_fin,
 											  sp_ud,
 											  M,
-											  sp_ud->nargs > 0 ? sp_ud->args[0] : NULL);
+											  sp_ud->cmd);
 
 				if (ud->item) {
 					rspamd_symcache_item_async_inc(ud->task, ud->item, M);

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -8150,13 +8150,9 @@ lua_task_add_timer(lua_State *L)
 	cbdata->task = task;
 	cbdata->item = rspamd_symcache_get_cur_item(task);
 
+	cbdata->async_ev = rspamd_session_add_event(task->s, lua_timer_fin, cbdata, "timer");
 	if (cbdata->item) {
-		cbdata->async_ev = rspamd_session_add_event_full(task->s, lua_timer_fin, cbdata, "timer",
-														 rspamd_symcache_dyn_item_name(cbdata->task, cbdata->item));
 		rspamd_symcache_item_async_inc(task, cbdata->item, "timer");
-	}
-	else {
-		cbdata->async_ev = rspamd_session_add_event(task->s, lua_timer_fin, cbdata, "timer");
 	}
 
 	ev_timer_init(&cbdata->ev, lua_task_timer_cb, lua_tonumber(L, 2), 0.0);

--- a/src/lua/lua_tcp.c
+++ b/src/lua/lua_tcp.c
@@ -1217,6 +1217,7 @@ lua_tcp_plan_handler_event(struct lua_tcp_cbdata *cbd, gboolean can_read,
 	}
 	else {
 		if (hdl->type == LUA_WANT_READ) {
+			rspamd_session_event_update_label(cbd->async_ev, "tcp read");
 
 			/* We need to check if we have some leftover in the buffer */
 			if (cbd->in->len > 0) {
@@ -1247,6 +1248,7 @@ lua_tcp_plan_handler_event(struct lua_tcp_cbdata *cbd, gboolean can_read,
 			}
 		}
 		else if (hdl->type == LUA_WANT_WRITE) {
+			rspamd_session_event_update_label(cbd->async_ev, "tcp write");
 			/*
 			 * We need to plan write event if there is something in the
 			 * write request
@@ -1273,6 +1275,7 @@ lua_tcp_plan_handler_event(struct lua_tcp_cbdata *cbd, gboolean can_read,
 			}
 		}
 		else { /* LUA_WANT_CONNECT */
+			rspamd_session_event_update_label(cbd->async_ev, "tcp connect");
 			msg_debug_tcp("plan new connect");
 			rspamd_ev_watcher_reschedule(cbd->event_loop, &cbd->ev,
 										 EV_WRITE);

--- a/src/lua/lua_tcp.c
+++ b/src/lua/lua_tcp.c
@@ -1286,13 +1286,7 @@ lua_tcp_register_event(struct lua_tcp_cbdata *cbd)
 	if (cbd->session) {
 		event_finalizer_t fin = IS_SYNC(cbd) ? lua_tcp_void_finalyser : lua_tcp_fin;
 
-		if (cbd->item) {
-			cbd->async_ev = rspamd_session_add_event_full(cbd->session, fin, cbd, M,
-														  rspamd_symcache_dyn_item_name(cbd->task, cbd->item));
-		}
-		else {
-			cbd->async_ev = rspamd_session_add_event(cbd->session, fin, cbd, M);
-		}
+		cbd->async_ev = rspamd_session_add_event(cbd->session, fin, cbd, M);
 
 		if (!cbd->async_ev) {
 			return FALSE;

--- a/src/lua/lua_udp.c
+++ b/src/lua/lua_udp.c
@@ -235,15 +235,7 @@ static gboolean
 lua_udp_maybe_register_event(struct lua_udp_cbdata *cbd)
 {
 	if (cbd->s && !cbd->async_ev) {
-		if (cbd->item) {
-			cbd->async_ev = rspamd_session_add_event_full(cbd->s, lua_udp_cbd_fin,
-														  cbd, M,
-														  rspamd_symcache_dyn_item_name(cbd->task, cbd->item));
-		}
-		else {
-			cbd->async_ev = rspamd_session_add_event(cbd->s, lua_udp_cbd_fin,
-													 cbd, M);
-		}
+		cbd->async_ev = rspamd_session_add_event(cbd->s, lua_udp_cbd_fin, cbd, M);
 
 		if (!cbd->async_ev) {
 			return FALSE;

--- a/src/lua/lua_util.c
+++ b/src/lua/lua_util.c
@@ -1076,8 +1076,8 @@ lua_util_process_message(lua_State *L)
 		task->fin_callback = lua_util_task_fin;
 		task->fin_arg = &res;
 		task->resolver = rspamd_dns_resolver_init(NULL, base, cfg);
-		task->s = rspamd_session_create(task->task_pool, rspamd_task_fin,
-										NULL, (event_finalizer_t) rspamd_task_free, task);
+		task->s = rspamd_task_create_session(task, task->task_pool, rspamd_task_fin,
+											 NULL, (event_finalizer_t) rspamd_task_free);
 
 		if (!rspamd_task_load_message(task, NULL, message, mlen)) {
 			lua_pushnil(L);

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -5717,7 +5717,8 @@ register_fuzzy_client_call(struct rspamd_task *task,
 				/* Mark that we used TCP for this request */
 				rule->rate_tracker.last_was_tcp = TRUE;
 
-				rspamd_session_add_event(task->s, fuzzy_io_fin, session, M);
+				rspamd_session_add_event_full(task->s, fuzzy_io_fin, session, M,
+											  rule->name);
 				session->item = rspamd_symcache_get_cur_item(task);
 
 				if (session->item) {
@@ -5795,7 +5796,8 @@ register_fuzzy_client_call(struct rspamd_task *task,
 				rspamd_ev_watcher_start(session->event_loop, &session->ev,
 										rule->io_timeout);
 
-				rspamd_session_add_event(task->s, fuzzy_io_fin, session, M);
+				rspamd_session_add_event_full(task->s, fuzzy_io_fin, session, M,
+											  rule->name);
 				session->item = rspamd_symcache_get_cur_item(task);
 
 				if (session->item) {
@@ -6294,10 +6296,11 @@ fuzzy_check_send_lua_learn(struct fuzzy_rule *rule,
 				rspamd_ev_watcher_start(s->event_loop, &s->ev,
 										rule->io_timeout);
 
-				rspamd_session_add_event(task->s,
-										 fuzzy_controller_lua_fin,
-										 s,
-										 M);
+				rspamd_session_add_event_full(task->s,
+											  fuzzy_controller_lua_fin,
+											  s,
+											  M,
+											  rule->name);
 
 				(*saved)++;
 				ret = 1;
@@ -7189,7 +7192,8 @@ fuzzy_lua_ping_storage(lua_State *L)
 			lua_pushvalue(L, 2);
 			session->cbref = luaL_ref(L, LUA_REGISTRYINDEX);
 
-			rspamd_session_add_event(task->s, fuzzy_lua_session_fin, session, M);
+			rspamd_session_add_event_full(task->s, fuzzy_lua_session_fin, session, M,
+										  rule_found->name);
 			rspamd_ev_watcher_init(&session->ev,
 								   sock,
 								   EV_WRITE,

--- a/src/rspamd_proxy.c
+++ b/src/rspamd_proxy.c
@@ -2800,8 +2800,8 @@ rspamd_proxy_self_scan(struct rspamd_proxy_session *session)
 
 	task->fin_arg = session;
 	task->resolver = session->ctx->resolver;
-	task->s = rspamd_session_create(task->task_pool, rspamd_proxy_task_fin,
-									NULL, (event_finalizer_t) rspamd_task_free, task);
+	task->s = rspamd_task_create_session(task, task->task_pool, rspamd_proxy_task_fin,
+										 NULL, (event_finalizer_t) rspamd_task_free);
 	data = rspamd_http_message_get_body(msg, &len);
 
 	if (session->backend->settings_id) {

--- a/src/worker.c
+++ b/src/worker.c
@@ -165,10 +165,8 @@ rspamd_worker_body_handler(struct rspamd_http_connection *conn,
 								  session);
 
 	/* Set up async session */
-	task->s = rspamd_session_create(task->task_pool, rspamd_task_fin,
-									NULL, (event_finalizer_t) rspamd_task_free, task);
-	rspamd_session_set_item_name_resolver(task->s,
-										  rspamd_task_session_item_name_resolver);
+	task->s = rspamd_task_create_session(task, task->task_pool, rspamd_task_fin,
+										 NULL, (event_finalizer_t) rspamd_task_free);
 
 	if (!rspamd_protocol_handle_request(task, msg)) {
 		msg_err_task("cannot handle request: %e", task->err);

--- a/src/worker.c
+++ b/src/worker.c
@@ -167,6 +167,8 @@ rspamd_worker_body_handler(struct rspamd_http_connection *conn,
 	/* Set up async session */
 	task->s = rspamd_session_create(task->task_pool, rspamd_task_fin,
 									NULL, (event_finalizer_t) rspamd_task_free, task);
+	rspamd_session_set_item_name_resolver(task->s,
+										  rspamd_task_session_item_name_resolver);
 
 	if (!rspamd_protocol_handle_request(task, msg)) {
 		msg_err_task("cannot handle request: %e", task->err);


### PR DESCRIPTION
## Summary

When a task hits its timeout Rspamd previously logged only

```
processing of task time out: 8.0s spent; 8.0s limit; forced processing
```

with no hint at **what** was still pending. The only extra detail —
per-event `forced removed event on destroy: …` lines emitted during
`rspamd_session_cleanup` — was verbose, unaggregated, and logged with
the `events` module tag rather than the `task` tag, which made it hard
to correlate and grep.

This change adds a compact, task-tagged picture of what stalled the
scan, emitted in the timeout handler before forced cleanup:

1. `pending async events at timeout: total=N; by subsystem: rspamd dns=7, rspamd lua redis=2, fuzzy_check=1`
2. `pending async event sources: [rspamd dns: src/lua/lua_dns.c:205 x5, .../rbl.lua:45 x2]; [rspamd lua redis: .../ratelimit.lua:80 x2]; [fuzzy_check: .../fuzzy_check.c:2301 x1]`
3. `inflight symbols at timeout: RBL_DNSBL_FOO (async=3), RATELIMIT_CHECK (async=2, started=7820 ms), FUZZY_CHECK (async=1)` — symbols that started but have not finished, with their pending async-event counts and (when profiling is active) the time the symbol started at.

The redundant per-event `msg_info_session` lines in `rspamd_session_cleanup` are demoted to `msg_debug_session`; the final `pending N uncancellable events` is only emitted at info level when that count is non-zero.

## Implementation notes

- `rspamd_session_describe_pending` (new) walks `session->events`, groups by subsystem, and returns two `GString`s (summary + detail) that the caller owns. It does not log directly, so the caller in task-scoped code logs with `msg_info_task`, preserving the task module tag.
- `rspamd::symcache::symcache_runtime::describe_inflight_symbols` (new, with C bridge `rspamd_symcache_describe_inflight_symbols`) walks `order->d`, finds items with `status == started`, and returns a `GString` with their names + `async_events` counts (+ `start_msec` when profile mode is enabled — `start_msec` is only populated in profile mode today, so it's shown conditionally).
- Dump output is capped (16 subsystems, 4 distinct sources per subsystem, 32 inflight symbols) with `(+N more)` suffixes, so a task with thousands of pending DNS lookups doesn't blow up the log line.
- Both timeout branches of `rspamd_task_timeout` (filter stage and post-processing stage) emit the dump via a single shared helper.

## Test plan

- [x] `ninja -j8` succeeds
- [x] `rspamd-test-cxx`: 181 cases / 53572 assertions pass
- [x] `rspamd-test -p /rspamd/lua`: 998 tests, 995 pass, 0 failed (3 pre-existing unassertive)
- [x] `clang-format --dry-run --Werror` clean on all touched files
- [x] Observe actual timeout log in a live deployment (manual verification)