### PR TITLE
[Fix] Do not block allowed clients on TCP fuzzy

### DIFF
--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -2374,7 +2374,8 @@ accept_tcp_socket(EV_P_ ev_io *w, int revents)
 	}
 
 	/* Check if client is allowed */
-	if (!rspamd_fuzzy_check_client(ctx, addr)) {
+	int block_code = rspamd_fuzzy_check_client(ctx, addr);
+	if (block_code > 0) {
 		msg_info("refusing TCP connection from %s (blacklisted)",
 				 rspamd_inet_address_to_string(addr));
 		rspamd_inet_address_free(addr);


### PR DESCRIPTION
### Problem

Every TCP connection to the fuzzy worker is rejected with refusing TCP connection from <ip> (blacklisted) regardless of configuration. A freshly started worker with no blocked map, no dynamic_blocked_nets entries, and no blocked_ip configured still refuses every TCP client at accept time. UDP traffic is unaffected.

### Root

The TCP accept path at fuzzy_storage.c:2377 inverted the semantics with !:


if (!rspamd_fuzzy_check_client(ctx, addr)) { /* log "(blacklisted)" and close */ }
!0 == true, so every ALLOWED client entered the reject branch; !503 == false, so actually-blocked clients would slip through.
