### PR TITLE
[Minor] Log map's description and improve empty static maps handling

### DIFF
--- a/lualib/lua_cta.lua
+++ b/lualib/lua_cta.lua
@@ -70,10 +70,6 @@ local DEFAULT_STOPWORDS = {
   "mailerlite", "mailerq", "mailrelay", "mailup", "omnisend", "clickdimensions", "dotdigital", "pepipost"
 }
 
-local DEFAULT_WHITELIST = {
-  -- Intentionally empty by default. Users can add trusted eTLD+1 domains here
-}
-
 local DEFAULT_BLACKLIST = {
   -- Popular shorteners / redirection eTLD+1
   "t.co", "bit.ly", "goo.gl", "tinyurl.com", "lnkd.in", "buff.ly", "ow.ly", "rebrand.ly", "bitly.com", "is.gd", "v.gd",
@@ -112,8 +108,6 @@ local function load_settings()
     if type(settings.whitelist) ~= 'table' or not settings.whitelist.get_key then
       settings.whitelist = lua_maps.map_add_from_ucl(settings.whitelist, 'set', 'link affiliation whitelist')
     end
-  else
-    settings.whitelist = lua_maps.map_add_from_ucl(DEFAULT_WHITELIST, 'set', 'link affiliation whitelist (default)')
   end
   if settings.blacklist then
     if type(settings.blacklist) ~= 'table' or not settings.blacklist.get_key then

--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -391,6 +391,19 @@ local function rspamd_map_add_from_ucl(opt, mtype, description, callback)
       return maps_cache[cache_key]
     end
 
+    if not next(opt) then
+      -- Empty table: return a static empty map without involving C map infrastructure,
+      -- avoiding a spurious error log when an intentionally empty default is used.
+      rspamd_logger.warnx(rspamd_config, 'empty static map definition for: %s', description)
+      ret.get_key = function(_, _) return nil end
+      ret.foreach = function(_, _) return true end
+      ret.on_load = function(_, cb)
+        rspamd_config:add_on_load(function(_, _, _) cb() end)
+      end
+      maps_cache[cache_key] = ret
+      return ret
+    end
+
     if opt[1] then
       local function check_plain_map(line)
         return lua_util.str_startswith(line, 'http')

--- a/src/libserver/maps/map.c
+++ b/src/libserver/maps/map.c
@@ -3757,7 +3757,7 @@ rspamd_map_add_from_ucl(struct rspamd_config *cfg,
 		}
 
 		if (map->backends->len == 0) {
-			msg_err_config("map has no urls to be loaded: empty list");
+			msg_err_config("map '%s' has no urls to be loaded: empty list", description);
 			goto err;
 		}
 	}
@@ -3782,7 +3782,7 @@ rspamd_map_add_from_ucl(struct rspamd_config *cfg,
 
 		elt = ucl_object_lookup_any(obj, "upstreams", "url", "urls", NULL);
 		if (elt == NULL) {
-			msg_err_config("map has no urls to be loaded: no elt");
+			msg_err_config("map '%s' has no urls to be loaded: no elt", description);
 			goto err;
 		}
 
@@ -3814,7 +3814,7 @@ rspamd_map_add_from_ucl(struct rspamd_config *cfg,
 			ucl_object_iterate_free(it);
 
 			if (map->backends->len == 0) {
-				msg_err_config("map has no urls to be loaded: empty object list");
+				msg_err_config("map '%s' has no urls to be loaded: empty object list", description);
 				goto err;
 			}
 		}
@@ -3832,12 +3832,12 @@ rspamd_map_add_from_ucl(struct rspamd_config *cfg,
 		}
 
 		if (!map->backends || map->backends->len == 0) {
-			msg_err_config("map has no urls to be loaded: no valid backends");
+			msg_err_config("map '%s' has no urls to be loaded: no valid backends", description);
 			goto err;
 		}
 	}
 	else {
-		msg_err_config("map has invalid type for value: %s",
+		msg_err_config("map '%s' has invalid type for value: %s", description,
 					   ucl_object_type_to_string(ucl_object_type(obj)));
 		goto err;
 	}


### PR DESCRIPTION
This pull request improves how empty static maps are handled in the Lua map infrastructure, particularly to avoid unnecessary error logs and clarify error messages when maps are intentionally empty or misconfigured. The most important changes are grouped below:

**Error message clarity in C map code:**

* In `map.c`, error messages for map loading failures now include the map's description, making it easier to identify which map is misconfigured. This applies to various failure cases, such as empty URL lists, missing elements, empty object lists, no valid backends, or invalid value types.

**Lua map handling improvements:**

* In `lua_maps.lua`, when an empty table is provided for a map (such as a default whitelist), the code now creates a static empty map without invoking the C map infrastructure, preventing spurious error logs. A warning is still logged for visibility.
* The default whitelist in `lua_cta.lua` is now omitted entirely if empty, relying on the new static empty map logic rather than always creating a map from an empty table. 

