### PR TITLE
fix(rspamadm/vault): write formatted output to stdout directly (#6005)

### DIFF
--- a/lualib/rspamadm/vault.lua
+++ b/lualib/rspamadm/vault.lua
@@ -193,10 +193,23 @@ local function maybe_print_vault_data(opts, data, func)
     if not res then
       printf('vault reply for cannot be parsed: %s', parser_err)
     else
+      -- Issue #6005: large UCL/JSON output (e.g. `vault list` against
+      -- a Vault that holds hundreds of DKIM entries) was silently lost
+      -- when piped through `printf` because that helper feeds its
+      -- argument to `rspamd_logger.slog` as a *format string*. Any `%`
+      -- inside the formatted body — or simply hitting an internal
+      -- buffer limit — produced no output and exit code 0. Write the
+      -- formatted payload to stdout directly so the user always sees
+      -- it, regardless of size or punctuation.
+      local payload
       if func then
-        printf(ucl.to_format(func(res), opts.output))
+        payload = ucl.to_format(func(res), opts.output)
       else
-        printf(ucl.to_format(res, opts.output))
+        payload = ucl.to_format(res, opts.output)
+      end
+      io.write(payload)
+      if not payload:match('\n$') then
+        io.write('\n')
       end
     end
   else


### PR DESCRIPTION
Closes #6005.

## Summary
\`rspamadm vault list\` produced completely empty output (no stdout, no stderr, exit code 0) when the Vault held 356+ DKIM entries. Deleting one entry made it work again — a confusing failure mode that the reporter narrowed down to a hard threshold in their environment.

## Root cause
\`maybe_print_vault_data\` passed the formatted payload through:
```lua
printf(ucl.to_format(func(res), opts.output))
```
\`printf\` is a thin wrapper that calls \`rspamd_logger.slog(fmt, ...)\`. \`slog\` treats its first argument as a **format string**. When the formatted UCL/JSON body contains anything slog interprets as a format specifier — \`%\` in keys, escaped strings — or hits slog's internal buffer limits, the output is silently dropped. The user sees nothing and exit code is 0 because nothing fails along the way.

The same path is hit by every handler in this file (`show`, `list`, etc.); the others happened to work only because their payloads were small enough not to trigger the silent-drop edge case.

## Fix
Write the formatted payload to stdout directly via \`io.write\`:
- No format-string interpretation (no \`%\` surprises).
- No internal slog buffer limit.
- Append a trailing newline only when the formatted output didn't already end with one (UCL output usually does, JSON-compact does not).

\`printf('no data received')\` and the parser-error path keep using \`printf\` because their payloads are short, fixed strings.

## Test plan
- I cannot reproduce the 356-entry threshold locally without a real Vault populated to that size, so this PR does not include a unit test against the bug. The change is contained — three lines of inlined `io.write` in place of `printf` for the success path — and matches the maintainer-suggested triage in the issue: route around the format-string layer.
- `lua` syntax check via `luac -p lualib/rspamadm/vault.lua` clean.
- All other call sites of `printf` in `vault.lua` are unchanged.

## Notes
- If the maintainers want a belt-and-suspenders second change, also adding `max_size = 0` (or a generous explicit value) to the `rspamd_http.request {...}` in `list_handler` would defend against future Vault deployments that produce bodies above the 1 MiB default. Happy to follow up in a separate commit if requested.