### PR TITLE
[Feature] upstream: defer DNS resolution for unreachable hosts

### DIFF
--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -167,6 +167,14 @@ local function query_external_map(map_config, upstreams, key, callback, task_or_
     log_obj = task_or_ctx.config
   end
 
+  if not upstream then
+    rspamd_logger.errx(log_obj,
+        'no upstream available for external map %s (all backends dead or pending DNS resolution)',
+        map_config.backend)
+    callback(false, 'no upstream available', 502, task_or_ctx)
+    return
+  end
+
   if type(key) == 'string' or type(key) == 'userdata' then
     if map_config.method == 'body' then
       http_body = key

--- a/lualib/lua_redis.lua
+++ b/lualib/lua_redis.lua
@@ -1421,8 +1421,16 @@ local function prepare_redis_call(script)
   end
 
   for idx, s in ipairs(servers) do
+    local server_addr = s:get_addr()
+    if not server_addr then
+      -- Pending DNS resolution; mark as tempfail so the next attempt retries
+      script.servers_ready[idx] = "tempfail"
+      logger.infox(rspamd_config,
+          'skipping SCRIPT LOAD for upstream %s: address not resolved yet',
+          s:get_name())
+    else
     local cur_opts = {
-      host = s:get_addr(),
+      host = server_addr,
       timeout = script.redis_params['timeout'],
       cmd = 'SCRIPT',
       args = { 'LOAD', script.script },
@@ -1447,6 +1455,7 @@ local function prepare_redis_call(script)
     end
 
     table.insert(options, cur_opts)
+    end
   end
 
   return options

--- a/lualib/lua_redis.lua
+++ b/lualib/lua_redis.lua
@@ -270,6 +270,12 @@ local function redis_query_sentinel(ev_base, params, initialised)
   local sentinels = params.sentinels
   local addr = sentinels:get_upstream_round_robin()
 
+  if not addr then
+    logger.errx(rspamd_config,
+        'no sentinel upstream available (all dead or pending DNS resolution); skipping sentinel watch tick')
+    return
+  end
+
   local host = addr:get_addr()
   local masters = {}
   local process_masters -- Function that is called to process masters data
@@ -1200,7 +1206,9 @@ local function rspamd_redis_make_request(task, redis_params, key, is_write,
   end
 
   if not addr then
-    logger.errx(task, 'cannot select server to make redis request')
+    logger.errx(task,
+        'cannot select redis server (all dead or pending DNS resolution)')
+    return false, nil, nil
   end
 
   if redis_params['expand_keys'] then
@@ -1312,7 +1320,9 @@ local function redis_make_request_taskless(ev_base, cfg, redis_params, key,
   end
 
   if not addr then
-    logger.errx(cfg, 'cannot select server to make redis request')
+    logger.errx(cfg,
+        'cannot select redis server (all dead or pending DNS resolution)')
+    return false, nil, nil
   end
 
   local options = {
@@ -1816,7 +1826,9 @@ local function redis_connect_sync(redis_params, is_write, key, cfg, ev_base)
   end
 
   if not addr then
-    logger.errx(cfg, 'cannot select server to make redis request')
+    logger.errx(cfg or rspamd_config,
+        'cannot select redis server (all dead or pending DNS resolution)')
+    return false, nil
   end
 
   local options = {
@@ -1955,7 +1967,9 @@ exports.request = function(redis_params, attrs, req)
   end
 
   if not addr then
-    logger.errx(log_obj, 'cannot select server to make redis request')
+    logger.errx(log_obj,
+        'cannot select redis server (all dead or pending DNS resolution)')
+    return false, nil, nil
   end
 
   opts.host = addr:get_addr()
@@ -2077,7 +2091,9 @@ exports.connect = function(redis_params, attrs)
   end
 
   if not addr then
-    logger.errx(log_obj, 'cannot select server to make redis connect')
+    logger.errx(log_obj,
+        'cannot select redis server (all dead or pending DNS resolution)')
+    return false, nil, nil
   end
 
   opts.host = addr:get_addr()

--- a/lualib/lua_redis.lua
+++ b/lualib/lua_redis.lua
@@ -1423,38 +1423,43 @@ local function prepare_redis_call(script)
   for idx, s in ipairs(servers) do
     local server_addr = s:get_addr()
     if not server_addr then
-      -- Pending DNS resolution; mark as tempfail so the next attempt retries
+      -- Pending DNS resolution; mark as tempfail so the next attempt retries.
+      -- Insert a placeholder opt (server_idx-aligned) so options/servers_ready
+      -- indexing stays consistent for the consumer loop in load_script_task /
+      -- load_script_taskless. The placeholder is detected via .skip = true.
       script.servers_ready[idx] = "tempfail"
       logger.infox(rspamd_config,
           'skipping SCRIPT LOAD for upstream %s: address not resolved yet',
           s:get_name())
+      table.insert(options, { skip = true, upstream = s, server_idx = idx })
     else
-    local cur_opts = {
-      host = server_addr,
-      timeout = script.redis_params['timeout'],
-      cmd = 'SCRIPT',
-      args = { 'LOAD', script.script },
-      upstream = s
-    }
+      local cur_opts = {
+        host = server_addr,
+        timeout = script.redis_params['timeout'],
+        cmd = 'SCRIPT',
+        args = { 'LOAD', script.script },
+        upstream = s,
+        server_idx = idx,
+      }
 
-    -- By default we start from unsent status
-    if not script.servers_ready[idx] then
-      script.servers_ready[idx] = "unsent"
-    end
+      -- By default we start from unsent status
+      if not script.servers_ready[idx] then
+        script.servers_ready[idx] = "unsent"
+      end
 
-    if script.redis_params['username'] then
-      cur_opts['username'] = script.redis_params['username']
-    end
+      if script.redis_params['username'] then
+        cur_opts['username'] = script.redis_params['username']
+      end
 
-    if script.redis_params['password'] then
-      cur_opts['password'] = script.redis_params['password']
-    end
+      if script.redis_params['password'] then
+        cur_opts['password'] = script.redis_params['password']
+      end
 
-    if script.redis_params['db'] then
-      cur_opts['dbname'] = script.redis_params['db']
-    end
+      if script.redis_params['db'] then
+        cur_opts['dbname'] = script.redis_params['db']
+      end
 
-    table.insert(options, cur_opts)
+      table.insert(options, cur_opts)
     end
   end
 
@@ -1490,7 +1495,9 @@ local function load_script_task(script, task, is_write)
   local opts = prepare_redis_call(script)
 
   for idx, opt in ipairs(opts) do
-    if script.servers_ready[idx] ~= 'done' then
+    -- opt.skip means the upstream was not resolved when prepare_redis_call ran;
+    -- servers_ready is already tempfailed and will be retried on the next pass.
+    if not opt.skip and script.servers_ready[idx] ~= 'done' then
       opt.task = task
       opt.is_write = is_write
       opt.callback = function(err, data)
@@ -1553,7 +1560,7 @@ local function load_script_taskless(script, cfg, ev_base, is_write)
   local opts = prepare_redis_call(script)
 
   for idx, opt in ipairs(opts) do
-    if script.servers_ready[idx] ~= 'done' then
+    if not opt.skip and script.servers_ready[idx] ~= 'done' then
       opt.config = cfg
       opt.ev_base = ev_base
       opt.is_write = is_write

--- a/lualib/lua_scanners/avast.lua
+++ b/lualib/lua_scanners/avast.lua
@@ -83,7 +83,10 @@ end
 
 local function avast_check(task, content, digest, rule, maybe_part)
   local function avast_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local CRLF = '\r\n'
@@ -155,6 +158,11 @@ local function avast_check(task, content, digest, rule, maybe_part)
       end
 
       upstream = rule.upstreams:get_upstream_round_robin()
+      if not upstream then
+        common.yield_result(task, rule,
+            'no upstream available for retry', 0.0, 'fail', maybe_part)
+        return
+      end
       addr = upstream:get_addr()
       tcp_opts.upstream = upstream
       tcp_opts.callback = avast_helo_cb

--- a/lualib/lua_scanners/clamav.lua
+++ b/lualib/lua_scanners/clamav.lua
@@ -81,7 +81,10 @@ end
 
 local function clamav_check(task, content, digest, rule, maybe_part)
   local function clamav_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local header = rspamd_util.pack("c9 c1 >I4", "zINSTREAM", "\0",
@@ -98,6 +101,11 @@ local function clamav_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.name, task, '%s: error: %s; retry IP: %s; retries left: %s',

--- a/lualib/lua_scanners/cloudmark.lua
+++ b/lualib/lua_scanners/cloudmark.lua
@@ -55,6 +55,11 @@ end
 -- Detect cloudmark max size
 local function cloudmark_preload(rule, cfg, ev_base, _)
   local upstream = rule.upstreams:get_upstream_round_robin()
+  if not upstream then
+    rspamd_logger.errx(ev_base or rspamd_config,
+        'cloudmark preload: no upstream available, will retry on next scan')
+    return
+  end
   local addr = upstream:get_addr()
   local function max_message_size_cb(http_err, code, body, _)
     if http_err then
@@ -258,7 +263,10 @@ end
 
 local function cloudmark_check(task, content, digest, rule, maybe_part)
   local function cloudmark_check_uncached()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
 
@@ -336,6 +344,11 @@ local function cloudmark_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
           url = cloudmark_url(rule, addr)
 

--- a/lualib/lua_scanners/common.lua
+++ b/lualib/lua_scanners/common.lua
@@ -509,6 +509,26 @@ local function check_metric_results(task, rule)
   end
 end
 
+--[[
+Pick a round-robin upstream from `rule.upstreams` and emit `symbol_fail` if
+none is currently usable (e.g. all hostnames are still pending DNS resolution
+or every backend has been marked dead). Returns the upstream on success or
+nil on failure — in the nil case `symbol_fail` has already been recorded, so
+the caller should just return.
+--]]
+local function get_upstream_or_fail(task, rule, maybe_part, reason)
+  local upstream = rule.upstreams and rule.upstreams:get_upstream_round_robin()
+
+  if not upstream then
+    yield_result(task, rule,
+        reason or 'no upstream available (DNS pending or all dead)',
+        0.0, 'fail', maybe_part)
+    return nil
+  end
+
+  return upstream
+end
+
 exports.log_clean = log_clean
 exports.yield_result = yield_result
 exports.match_patterns = match_patterns
@@ -517,6 +537,7 @@ exports.save_cache = save_cache
 exports.create_regex_table = create_regex_table
 exports.check_parts_match = check_parts_match
 exports.check_metric_results = check_metric_results
+exports.get_upstream_or_fail = get_upstream_or_fail
 
 setmetatable(exports, {
   __call = function(t, override)

--- a/lualib/lua_scanners/dcc.lua
+++ b/lualib/lua_scanners/dcc.lua
@@ -85,7 +85,10 @@ local function dcc_config(opts)
 end
 
 local function dcc_check(task, content, digest, rule)
-  local upstream = rule.upstreams:get_upstream_round_robin()
+  local upstream = common.get_upstream_or_fail(task, rule, nil)
+  if not upstream then
+    return
+  end
   local addr = upstream:get_addr()
   local retransmits = rule.retransmits
   local client = rule.client
@@ -144,6 +147,11 @@ local function dcc_check(task, content, digest, rule)
 
         -- Select a different upstream!
         upstream = rule.upstreams:get_upstream_round_robin()
+        if not upstream then
+          common.yield_result(task, rule,
+              'no upstream available for retry', 0.0, 'fail')
+          return
+        end
         addr = upstream:get_addr()
 
         lua_util.debugm(rule.name, task, '%s: error: %s; retry IP: %s; retries left: %s',

--- a/lualib/lua_scanners/expurgate.lua
+++ b/lualib/lua_scanners/expurgate.lua
@@ -145,7 +145,10 @@ local function expurgate_check(task, content, digest, rule, maybe_part)
       return url
     end
 
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
 
@@ -205,6 +208,11 @@ local function expurgate_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
           url = expurgate_spamd_url(addr)
 

--- a/lualib/lua_scanners/fprot.lua
+++ b/lualib/lua_scanners/fprot.lua
@@ -80,7 +80,10 @@ end
 
 local function fprot_check(task, content, digest, rule, maybe_part)
   local function fprot_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local scan_id = task:get_queue_id()
@@ -100,6 +103,11 @@ local function fprot_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.name, task, '%s: error: %s; retry IP: %s; retries left: %s',

--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -166,7 +166,10 @@ end
 
 local function icap_check(task, content, digest, rule, maybe_part)
   local function icap_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local http_headers = {}
@@ -218,6 +221,11 @@ local function icap_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule, 'no upstream available for retry', 0.0,
+                'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.name, task, '%s: retry IP: %s:%s',
@@ -239,7 +247,7 @@ local function icap_check(task, content, digest, rule, maybe_part)
         end
       end
 
-      local function get_req_headers()                
+      local function get_req_headers()
         local in_client_ip = task:get_from_ip()
         local in_client_ip_str = in_client_ip:to_string()
         local req_hlen = 2

--- a/lualib/lua_scanners/kaspersky_av.lua
+++ b/lualib/lua_scanners/kaspersky_av.lua
@@ -81,7 +81,10 @@ end
 
 local function kaspersky_check(task, content, digest, rule, maybe_part)
   local function kaspersky_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local fname = string.format('%s/%s.tmp',
@@ -117,6 +120,11 @@ local function kaspersky_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.name, task, '%s: error: %s; retry IP: %s; retries left: %s',

--- a/lualib/lua_scanners/kaspersky_se.lua
+++ b/lualib/lua_scanners/kaspersky_se.lua
@@ -110,7 +110,10 @@ local function kaspersky_se_check(task, content, digest, rule, maybe_part)
       return url
     end
 
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
 
@@ -189,6 +192,11 @@ local function kaspersky_se_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
           url = make_url(addr)
 

--- a/lualib/lua_scanners/oletools.lua
+++ b/lualib/lua_scanners/oletools.lua
@@ -89,7 +89,10 @@ end
 
 local function oletools_check(task, content, digest, rule, maybe_part)
   local function oletools_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local protocol = 'OLEFY/1.0\nMethod: oletools\nRspamd-ID: ' .. task:get_uid() .. '\n\n'
@@ -106,6 +109,11 @@ local function oletools_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.name, task, '%s: error: %s; retry IP: %s; retries left: %s',

--- a/lualib/lua_scanners/pyzor.lua
+++ b/lualib/lua_scanners/pyzor.lua
@@ -77,7 +77,10 @@ end
 
 local function pyzor_check(task, content, digest, rule)
   local function pyzor_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, nil)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
 
@@ -92,6 +95,11 @@ local function pyzor_check(task, content, digest, rule)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail')
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(N, task, '%s: retry IP: %s:%s err: %s',

--- a/lualib/lua_scanners/razor.lua
+++ b/lualib/lua_scanners/razor.lua
@@ -82,7 +82,10 @@ end
 
 local function razor_check(task, content, digest, rule)
   local function razor_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, nil)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
 
@@ -99,6 +102,11 @@ local function razor_check(task, content, digest, rule)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail')
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.name, task, '%s: retry IP: %s:%s',

--- a/lualib/lua_scanners/savapi.lua
+++ b/lualib/lua_scanners/savapi.lua
@@ -83,7 +83,10 @@ end
 
 local function savapi_check(task, content, digest, rule)
   local function savapi_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, nil)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local fname = string.format('%s/%s.tmp',
@@ -205,6 +208,11 @@ local function savapi_check(task, content, digest, rule)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail')
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.name, task, '%s: error: %s; retry IP: %s; retries left: %s',

--- a/lualib/lua_scanners/sophos.lua
+++ b/lualib/lua_scanners/sophos.lua
@@ -80,7 +80,10 @@ end
 
 local function sophos_check(task, content, digest, rule, maybe_part)
   local function sophos_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
     local protocol = 'SSSP/1.0\n'
@@ -97,6 +100,11 @@ local function sophos_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.name, task, '%s: error: %s; retry IP: %s; retries left: %s',

--- a/lualib/lua_scanners/spamassassin.lua
+++ b/lualib/lua_scanners/spamassassin.lua
@@ -86,7 +86,10 @@ end
 
 local function spamassassin_check(task, content, digest, rule)
   local function spamassassin_check_uncached ()
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, nil)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
 
@@ -114,6 +117,11 @@ local function spamassassin_check(task, content, digest, rule)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail')
+            return
+          end
           addr = upstream:get_addr()
 
           lua_util.debugm(rule.N, task, '%s: retry IP: %s:%s',

--- a/lualib/lua_scanners/vadesecure.lua
+++ b/lualib/lua_scanners/vadesecure.lua
@@ -167,7 +167,10 @@ local function vade_check(task, content, digest, rule, maybe_part)
       return url
     end
 
-    local upstream = rule.upstreams:get_upstream_round_robin()
+    local upstream = common.get_upstream_or_fail(task, rule, maybe_part)
+    if not upstream then
+      return
+    end
     local addr = upstream:get_addr()
     local retransmits = rule.retransmits
 
@@ -241,6 +244,11 @@ local function vade_check(task, content, digest, rule, maybe_part)
 
           -- Select a different upstream!
           upstream = rule.upstreams:get_upstream_round_robin()
+          if not upstream then
+            common.yield_result(task, rule,
+                'no upstream available for retry', 0.0, 'fail', maybe_part)
+            return
+          end
           addr = upstream:get_addr()
           url = vade_url(addr)
 

--- a/lualib/rspamadm/clickhouse.lua
+++ b/lualib/rspamadm/clickhouse.lua
@@ -304,6 +304,10 @@ local function handle_neural_profile(args)
     table.insert(conditions, string.format("Date = '%s'", query_day))
     local query = string.format(query_fmt, table.concat(conditions, ' AND '), limit)
     local upstream = args.upstream:get_upstream_round_robin()
+    if not upstream then
+      io.stderr:write('No clickhouse upstream available (DNS pending or all dead)\n')
+      os.exit(1)
+    end
     local err = lua_clickhouse.select_sync(upstream, args, http_params, query, process_row)
     if err ~= nil then
       io.stderr:write(string.format('Error querying Clickhouse: %s\n', err))
@@ -447,6 +451,10 @@ local function handle_neural_train(args)
       table.insert(conditions, string.format("Date = '%s'", query_day))
       local query = string.format(query_fmt, args.column_name_vector, table.concat(conditions, ' AND '), limit)
       local upstream = args.upstream:get_upstream_round_robin()
+      if not upstream then
+        io.stderr:write('No clickhouse upstream available (DNS pending or all dead)\n')
+        os.exit(1)
+      end
       local err = lua_clickhouse.select_sync(upstream, args, http_params, query, process_row)
       if err ~= nil then
         io.stderr:write(string.format('Error querying Clickhouse: %s\n', err))

--- a/lualib/rspamadm/statistics_dump.lua
+++ b/lualib/rspamadm/statistics_dump.lua
@@ -1151,6 +1151,11 @@ local function migrate_handler(opts)
           for _, prefix in ipairs(prefixes) do
             stats.checked = stats.checked + 1
             local target_up = write_servers:get_upstream_by_hash(prefix)
+            if not target_up then
+              rspamd_logger.errx('no upstream available for prefix %s; aborting redistribute scan',
+                  prefix)
+              return false
+            end
             local target_name = target_up:get_name()
 
             if target_name == shard.name then

--- a/lualib/rspamadm/statistics_dump.lua
+++ b/lualib/rspamadm/statistics_dump.lua
@@ -260,8 +260,14 @@ end
 
 local function connect_to_upstream(up, redis_params)
   local rspamd_redis = require "rspamd_redis"
+  local up_addr = up:get_addr()
+  if not up_addr then
+    rspamd_logger.errx("cannot connect to redis %s: address not resolved yet",
+        up:get_name())
+    return false, nil
+  end
   local ret, conn = rspamd_redis.connect_sync({
-    host = up:get_addr(),
+    host = up_addr,
     timeout = redis_params.timeout,
     config = rspamd_config,
     ev_base = rspamadm_ev_base,

--- a/src/libserver/fuzzy_backend/fuzzy_backend_redis.c
+++ b/src/libserver/fuzzy_backend/fuzzy_backend_redis.c
@@ -753,6 +753,8 @@ void rspamd_fuzzy_backend_check_redis(struct rspamd_fuzzy_backend *bk,
 							 0);
 
 	if (up == NULL) {
+		msg_err_redis_session("cannot select fuzzy redis upstream: "
+							  "all backends are dead or pending DNS resolution");
 		rspamd_fuzzy_redis_session_dtor(session, TRUE);
 		if (cb) {
 			memset(&mf_result, 0, sizeof(mf_result));
@@ -901,6 +903,8 @@ void rspamd_fuzzy_backend_count_redis(struct rspamd_fuzzy_backend *bk,
 							 0);
 
 	if (up == NULL) {
+		msg_err_redis_session("cannot select fuzzy redis upstream for count: "
+							  "all backends are dead or pending DNS resolution");
 		rspamd_fuzzy_redis_session_dtor(session, TRUE);
 		if (cb) {
 			cb(0, ud);
@@ -1047,6 +1051,8 @@ void rspamd_fuzzy_backend_version_redis(struct rspamd_fuzzy_backend *bk,
 							 0);
 
 	if (up == NULL) {
+		msg_err_redis_session("cannot select fuzzy redis upstream for version: "
+							  "all backends are dead or pending DNS resolution");
 		rspamd_fuzzy_redis_session_dtor(session, TRUE);
 		if (cb) {
 			cb(0, ud);

--- a/src/libserver/http/http_connection.c
+++ b/src/libserver/http/http_connection.c
@@ -1335,6 +1335,16 @@ rspamd_http_connection_new_client(struct rspamd_http_context *ctx,
 													 RSPAMD_HTTP_CONN_OWN_SOCKET | RSPAMD_HTTP_CONN_FLAG_PROXY,
 													 up);
 		}
+		else {
+			/*
+			 * Proxies are configured but none usable right now (all dead or
+			 * pending DNS resolution). Surface this so the admin knows
+			 * traffic is going direct instead of silently bypassing the
+			 * configured proxy chain.
+			 */
+			msg_info("no http proxy upstream available "
+					 "(all dead or pending DNS); falling back to direct connect");
+		}
 	}
 
 	/* Unproxied version */

--- a/src/libutil/upstream.c
+++ b/src/libutil/upstream.c
@@ -1406,8 +1406,8 @@ rspamd_upstream_dtor(struct upstream *up)
 rspamd_inet_addr_t *
 rspamd_upstream_addr_next(struct upstream *up)
 {
-	unsigned int idx = up->addrs.cur, next_idx = up->addrs.cur, cur_af,
-				 min_errors, min_errors_idx;
+	unsigned int idx, next_idx, cur_af,
+		min_errors, min_errors_idx;
 	struct upstream_addr_elt *e1, *e2;
 
 	/*
@@ -1418,6 +1418,14 @@ rspamd_upstream_addr_next(struct upstream *up)
 	 * 4) If we cannot find such element, then we return the next element (switching AF)
 	 */
 
+	if (up == NULL || up->addrs.addr == NULL ||
+		up->addrs.addr->len == 0) {
+		/* Pending DNS resolution or never had any addresses */
+		return NULL;
+	}
+
+	idx = up->addrs.cur;
+	next_idx = up->addrs.cur;
 	e1 = g_ptr_array_index(up->addrs.addr, up->addrs.cur);
 	cur_af = rspamd_inet_address_get_af(e1->addr);
 	min_errors = e1->errors;
@@ -1467,6 +1475,11 @@ rspamd_upstream_addr_cur(const struct upstream *up)
 {
 	struct upstream_addr_elt *elt;
 
+	if (up == NULL || up->addrs.addr == NULL ||
+		up->addrs.addr->len == 0) {
+		return NULL;
+	}
+
 	elt = g_ptr_array_index(up->addrs.addr, up->addrs.cur);
 
 	return elt->addr;
@@ -1481,6 +1494,12 @@ rspamd_upstream_name(struct upstream *up)
 int rspamd_upstream_port(struct upstream *up)
 {
 	struct upstream_addr_elt *elt;
+
+	if (up == NULL || up->addrs.addr == NULL ||
+		up->addrs.addr->len == 0) {
+		/* Pending or never resolved: fall back to the parsed port if known */
+		return up != NULL ? (int) up->deferred_port : -1;
+	}
 
 	elt = g_ptr_array_index(up->addrs.addr, up->addrs.cur);
 	return rspamd_inet_address_get_port(elt->addr);

--- a/src/libutil/upstream.c
+++ b/src/libutil/upstream.c
@@ -95,6 +95,12 @@ struct upstream {
 	struct upstream_inet_addr_entry *new_addrs;
 	gpointer data;
 	char uid[8];
+	/*
+	 * Port to apply to addresses returned by the first DNS resolution when
+	 * the upstream was created in PENDING_RESOLVE state (no initial addrs
+	 * to copy the port from). Zero otherwise.
+	 */
+	uint16_t deferred_port;
 	ref_entry_t ref;
 
 	/* Token bucket fields for weighted load balancing */
@@ -216,6 +222,13 @@ static const double default_probe_jitter = DEFAULT_PROBE_JITTER;
 #define DEFAULT_TOKEN_BUCKET_MIN 1
 #define DEFAULT_TOKEN_BUCKET_BASE_COST 10
 
+/*
+ * Initial delay before retrying DNS for a PENDING_RESOLVE upstream, and the
+ * cap for the exponential back-off used while the upstream stays pending.
+ */
+#define UPSTREAM_PENDING_RESOLVE_INITIAL_DELAY 1.0
+#define UPSTREAM_PENDING_RESOLVE_MAX_DELAY 60.0
+
 static const struct upstream_limits default_limits = {
 	.revive_time = DEFAULT_REVIVE_TIME,
 	.revive_jitter = DEFAULT_REVIVE_JITTER,
@@ -298,6 +311,10 @@ void rspamd_upstreams_library_config(struct rspamd_config *cfg,
 				if (upstream->flags & RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE) {
 					/* Resolve them immediately ! */
 					when = 0.0;
+				}
+				else if (upstream->flags & RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE) {
+					when = rspamd_time_jitter(UPSTREAM_PENDING_RESOLVE_INITIAL_DELAY,
+											  UPSTREAM_PENDING_RESOLVE_INITIAL_DELAY * .25);
 				}
 				else {
 					when = rspamd_time_jitter(upstream->ls->limits->lazy_resolve_time,
@@ -402,30 +419,41 @@ rspamd_upstream_addr_sort_func(gconstpointer a, gconstpointer b)
 static void
 rspamd_upstream_set_active(struct upstream_list *ls, struct upstream *upstream)
 {
+	gboolean is_pending;
+
 	RSPAMD_UPSTREAM_LOCK(ls);
-	g_ptr_array_add(ls->alive, upstream);
-	upstream->active_idx = ls->alive->len - 1;
 
-	/* Invalidate ring hash */
-	ls->ring_dirty = TRUE;
+	is_pending = (upstream->flags & RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE) != 0;
 
-	/* Initialize token bucket state */
-	upstream->heap_idx = UINT_MAX;
-	if (ls->rot_alg == RSPAMD_UPSTREAM_TOKEN_BUCKET) {
-		upstream->max_tokens = ls->limits->token_bucket_max;
-		upstream->available_tokens = upstream->max_tokens;
-		upstream->inflight_tokens = 0;
+	if (!is_pending) {
+		g_ptr_array_add(ls->alive, upstream);
+		upstream->active_idx = ls->alive->len - 1;
 
-		/* Add to token heap if already initialized */
-		if (ls->token_bucket_initialized) {
-			struct upstream_token_heap_entry entry;
-			entry.pri = 0;
-			entry.idx = 0;
-			entry.up = upstream;
-			rspamd_heap_push_safe(upstream_token_heap, &ls->token_heap, &entry, skip_heap);
-			upstream->heap_idx = rspamd_heap_size(upstream_token_heap, &ls->token_heap) - 1;
-		skip_heap:;
+		/* Invalidate ring hash */
+		ls->ring_dirty = TRUE;
+
+		/* Initialize token bucket state */
+		upstream->heap_idx = UINT_MAX;
+		if (ls->rot_alg == RSPAMD_UPSTREAM_TOKEN_BUCKET) {
+			upstream->max_tokens = ls->limits->token_bucket_max;
+			upstream->available_tokens = upstream->max_tokens;
+			upstream->inflight_tokens = 0;
+
+			/* Add to token heap if already initialized */
+			if (ls->token_bucket_initialized) {
+				struct upstream_token_heap_entry entry;
+				entry.pri = 0;
+				entry.idx = 0;
+				entry.up = upstream;
+				rspamd_heap_push_safe(upstream_token_heap, &ls->token_heap, &entry, skip_heap);
+				upstream->heap_idx = rspamd_heap_size(upstream_token_heap, &ls->token_heap) - 1;
+			skip_heap:;
+			}
 		}
+	}
+	else {
+		upstream->active_idx = -1;
+		upstream->heap_idx = UINT_MAX;
 	}
 
 	if (upstream->ctx && upstream->ctx->configured &&
@@ -443,6 +471,11 @@ rspamd_upstream_set_active(struct upstream_list *ls, struct upstream *upstream)
 			/* Resolve them immediately ! */
 			when = 0.0;
 		}
+		else if (is_pending) {
+			/* Retry quickly while we have no addresses */
+			when = rspamd_time_jitter(UPSTREAM_PENDING_RESOLVE_INITIAL_DELAY,
+									  UPSTREAM_PENDING_RESOLVE_INITIAL_DELAY * .25);
+		}
 		else {
 			when = rspamd_time_jitter(upstream->ls->limits->lazy_resolve_time,
 									  upstream->ls->limits->lazy_resolve_time * .1);
@@ -450,7 +483,8 @@ rspamd_upstream_set_active(struct upstream_list *ls, struct upstream *upstream)
 		ev_timer_init(&upstream->ev, rspamd_upstream_lazy_resolve_cb,
 					  when, 0);
 		upstream->ev.data = upstream;
-		msg_debug_upstream("start lazy resolving for %s in %.0f seconds",
+		msg_debug_upstream("start %s resolving for %s in %.0f seconds",
+						   is_pending ? "deferred" : "lazy",
 						   upstream->name, when);
 		ev_timer_start(upstream->ctx->event_loop, &upstream->ev);
 	}
@@ -469,25 +503,41 @@ rspamd_upstream_addr_elt_dtor(gpointer a)
 	}
 }
 
+/* Forward decl: defined a few lines below */
+static void rspamd_upstream_promote_pending(struct upstream *upstream);
+
 static void
 rspamd_upstream_update_addrs(struct upstream *upstream)
 {
 	unsigned int addr_cnt, i, port;
-	gboolean seen_addr, reset_errors = FALSE;
+	gboolean seen_addr, reset_errors = FALSE, was_pending = FALSE;
 	struct upstream_inet_addr_entry *cur, *tmp;
 	GPtrArray *new_addrs;
 	struct upstream_addr_elt *addr_elt, *naddr;
 
 	/*
 	 * We need first of all get the saved port, since DNS gives us no
-	 * idea about what port has been used previously
+	 * idea about what port has been used previously. For PENDING_RESOLVE
+	 * upstreams there is no prior address: use the port stashed at parse
+	 * time on `upstream->deferred_port`.
 	 */
 	RSPAMD_UPSTREAM_LOCK(upstream);
 
-	if (upstream->addrs.addr->len > 0 && upstream->new_addrs) {
+	if (upstream->new_addrs &&
+		(upstream->addrs.addr == NULL || upstream->addrs.addr->len == 0)) {
+		was_pending = (upstream->flags & RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE) != 0;
+		port = upstream->deferred_port;
+	}
+	else if (upstream->addrs.addr && upstream->addrs.addr->len > 0 &&
+			 upstream->new_addrs) {
 		addr_elt = g_ptr_array_index(upstream->addrs.addr, 0);
 		port = rspamd_inet_address_get_port(addr_elt->addr);
+	}
+	else {
+		port = 0;
+	}
 
+	if (upstream->new_addrs) {
 		/* Now calculate new addrs count */
 		addr_cnt = 0;
 		LL_FOREACH(upstream->new_addrs, cur)
@@ -512,15 +562,17 @@ rspamd_upstream_update_addrs(struct upstream *upstream)
 			/* Ports are problematic, set to compare in the next block */
 			rspamd_inet_address_set_port(cur->addr, port);
 
-			PTR_ARRAY_FOREACH(upstream->addrs.addr, i, addr_elt)
-			{
-				if (rspamd_inet_address_compare(addr_elt->addr, cur->addr, FALSE) == 0) {
-					naddr = g_malloc0(sizeof(*naddr));
-					naddr->addr = cur->addr;
-					naddr->errors = reset_errors ? 0 : addr_elt->errors;
-					seen_addr = TRUE;
+			if (upstream->addrs.addr) {
+				PTR_ARRAY_FOREACH(upstream->addrs.addr, i, addr_elt)
+				{
+					if (rspamd_inet_address_compare(addr_elt->addr, cur->addr, FALSE) == 0) {
+						naddr = g_malloc0(sizeof(*naddr));
+						naddr->addr = cur->addr;
+						naddr->errors = reset_errors ? 0 : addr_elt->errors;
+						seen_addr = TRUE;
 
-					break;
+						break;
+					}
 				}
 			}
 
@@ -542,7 +594,9 @@ rspamd_upstream_update_addrs(struct upstream *upstream)
 		}
 
 		/* Free old addresses */
-		g_ptr_array_free(upstream->addrs.addr, TRUE);
+		if (upstream->addrs.addr) {
+			g_ptr_array_free(upstream->addrs.addr, TRUE);
+		}
 
 		upstream->addrs.cur = 0;
 		upstream->addrs.addr = new_addrs;
@@ -557,6 +611,70 @@ rspamd_upstream_update_addrs(struct upstream *upstream)
 
 	upstream->new_addrs = NULL;
 	RSPAMD_UPSTREAM_UNLOCK(upstream);
+
+	if (was_pending && upstream->addrs.addr && upstream->addrs.addr->len > 0) {
+		rspamd_upstream_promote_pending(upstream);
+	}
+}
+
+/*
+ * Move a previously PENDING_RESOLVE upstream into the alive list now that
+ * addresses have been resolved. Mirrors the alive-side bookkeeping of
+ * rspamd_upstream_set_active without re-entering the resolution-scheduling
+ * branch (the lazy-resolve timer is already running).
+ */
+static void
+rspamd_upstream_promote_pending(struct upstream *upstream)
+{
+	struct upstream_list *ls = upstream->ls;
+	struct upstream_list_watcher *w;
+
+	if (ls == NULL) {
+		return;
+	}
+
+	RSPAMD_UPSTREAM_LOCK(ls);
+
+	if (!(upstream->flags & RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE)) {
+		RSPAMD_UPSTREAM_UNLOCK(ls);
+		return;
+	}
+
+	upstream->flags &= ~RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE;
+
+	g_ptr_array_add(ls->alive, upstream);
+	upstream->active_idx = ls->alive->len - 1;
+	ls->ring_dirty = TRUE;
+
+	upstream->heap_idx = UINT_MAX;
+	if (ls->rot_alg == RSPAMD_UPSTREAM_TOKEN_BUCKET) {
+		upstream->max_tokens = ls->limits->token_bucket_max;
+		upstream->available_tokens = upstream->max_tokens;
+		upstream->inflight_tokens = 0;
+
+		if (ls->token_bucket_initialized) {
+			struct upstream_token_heap_entry entry;
+			entry.pri = 0;
+			entry.idx = 0;
+			entry.up = upstream;
+			rspamd_heap_push_safe(upstream_token_heap, &ls->token_heap, &entry, skip_heap);
+			upstream->heap_idx = rspamd_heap_size(upstream_token_heap, &ls->token_heap) - 1;
+		skip_heap:;
+		}
+	}
+
+	msg_info_upstream("resolved deferred upstream %s; promoted to alive",
+					  upstream->name);
+
+	DL_FOREACH(ls->watchers, w)
+	{
+		if (w->events_mask & RSPAMD_UPSTREAM_WATCH_ONLINE) {
+			w->func(upstream, RSPAMD_UPSTREAM_WATCH_ONLINE, upstream->errors,
+					w->ud);
+		}
+	}
+
+	RSPAMD_UPSTREAM_UNLOCK(ls);
 }
 
 static void
@@ -908,7 +1026,22 @@ rspamd_upstream_lazy_resolve_cb(struct ev_loop *loop, ev_timer *w, int revents)
 	if (up->ls) {
 		rspamd_upstream_resolve_addrs(up->ls, up);
 
-		if (up->ttl == 0 || up->ttl > up->ls->limits->lazy_resolve_time) {
+		if (up->flags & RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE) {
+			/*
+			 * Still no addresses — back off exponentially but cap so we keep
+			 * trying every minute or so. Once update_addrs runs successfully
+			 * the flag is cleared and the next branch takes over.
+			 */
+			double next = w->repeat * 2.0;
+			if (next < UPSTREAM_PENDING_RESOLVE_INITIAL_DELAY) {
+				next = UPSTREAM_PENDING_RESOLVE_INITIAL_DELAY;
+			}
+			if (next > UPSTREAM_PENDING_RESOLVE_MAX_DELAY) {
+				next = UPSTREAM_PENDING_RESOLVE_MAX_DELAY;
+			}
+			w->repeat = rspamd_time_jitter(next, next * .25);
+		}
+		else if (up->ttl == 0 || up->ttl > up->ls->limits->lazy_resolve_time) {
 			w->repeat = rspamd_time_jitter(up->ls->limits->lazy_resolve_time,
 										   up->ls->limits->lazy_resolve_time * .1);
 		}
@@ -1353,6 +1486,62 @@ int rspamd_upstream_port(struct upstream *up)
 	return rspamd_inet_address_get_port(elt->addr);
 }
 
+/*
+ * Fallback parser used when DNS resolution fails for a hostname-style upstream.
+ * Extracts host and port from "host[:port[:priority]]" so the upstream can be
+ * created in PENDING_RESOLVE state and resolved later.
+ *
+ * Returns TRUE on a syntactically valid hostname; FALSE otherwise (in which
+ * case the upstream cannot be deferred and creation must fail).
+ */
+static gboolean
+rspamd_upstream_parse_pending_host(const char *str, char **out_host,
+								   uint16_t *out_port, uint16_t def_port,
+								   rspamd_mempool_t *pool)
+{
+	const char *colon, *host_end;
+	size_t hlen;
+	uint16_t port = def_port;
+
+	if (str == NULL || str[0] == '\0' || str[0] == '[' || str[0] == '/' ||
+		str[0] == '.' || str[0] == '*' || str[0] == ':') {
+		return FALSE;
+	}
+
+	colon = strchr(str, ':');
+
+	if (colon != NULL) {
+		host_end = colon;
+		if (colon[1] != '\0') {
+			char *endptr = NULL;
+			unsigned long pn = strtoul(colon + 1, &endptr, 10);
+			if (pn == 0 || pn > UINT16_MAX) {
+				return FALSE;
+			}
+			port = (uint16_t) pn;
+		}
+	}
+	else {
+		host_end = str + strlen(str);
+	}
+
+	hlen = host_end - str;
+	if (hlen == 0 || hlen > 253) {
+		return FALSE;
+	}
+
+	if (pool) {
+		*out_host = rspamd_mempool_alloc(pool, hlen + 1);
+	}
+	else {
+		*out_host = g_malloc(hlen + 1);
+	}
+	rspamd_strlcpy(*out_host, str, hlen + 1);
+	*out_port = port;
+
+	return TRUE;
+}
+
 gboolean
 rspamd_upstreams_add_upstream(struct upstream_list *ups, const char *str,
 							  uint16_t def_port, enum rspamd_upstream_parse_type parse_type,
@@ -1419,6 +1608,38 @@ rspamd_upstreams_add_upstream(struct upstream_list *ups, const char *str,
 												  &upstream->name, def_port,
 												  FALSE,
 												  ups->ctx ? ups->ctx->pool : NULL);
+
+			if (ret == RSPAMD_PARSE_ADDR_FAIL) {
+				char *pending_host = NULL;
+				uint16_t pending_port = 0;
+
+				if (rspamd_upstream_parse_pending_host(str, &pending_host,
+													   &pending_port, def_port,
+													   ups->ctx ? ups->ctx->pool : NULL)) {
+					/*
+					 * DNS failed but the input looks like a hostname.
+					 * Create the upstream in PENDING_RESOLVE state so the
+					 * lazy resolver can populate addresses later. The upstream
+					 * stays out of the alive list until resolution succeeds.
+					 */
+					upstream->name = pending_host;
+					upstream->deferred_port = pending_port;
+					upstream->flags |= RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE;
+					addrs = g_ptr_array_sized_new(0);
+					if (ups->ctx) {
+						rspamd_mempool_add_destructor(ups->ctx->pool,
+													  (rspamd_mempool_destruct_t) rspamd_ptr_array_free_hard,
+													  addrs);
+					}
+					ret = RSPAMD_PARSE_ADDR_RESOLVED;
+					rspamd_default_log_function(G_LOG_LEVEL_WARNING,
+												"upstream", NULL, G_STRFUNC,
+												"address resolution for %s "
+												"failed at config time; "
+												"deferring (will retry asynchronously)",
+												pending_host);
+				}
+			}
 		}
 		break;
 	case RSPAMD_UPSTREAM_PARSE_NAMESERVER:
@@ -1561,8 +1782,10 @@ rspamd_upstreams_add_upstream(struct upstream_list *ups, const char *str,
 							 upstream->uid, sizeof(upstream->uid) - 1, RSPAMD_BASE32_DEFAULT);
 
 	msg_debug_upstream("added upstream %s (%s)", upstream->name,
-					   upstream->flags & RSPAMD_UPSTREAM_FLAG_NORESOLVE ? "numeric ip" : "DNS name");
-	g_ptr_array_sort(upstream->addrs.addr, rspamd_upstream_addr_sort_func);
+					   upstream->flags & RSPAMD_UPSTREAM_FLAG_NORESOLVE ? "numeric ip" : (upstream->flags & RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE ? "DNS name (deferred)" : "DNS name"));
+	if (upstream->addrs.addr) {
+		g_ptr_array_sort(upstream->addrs.addr, rspamd_upstream_addr_sort_func);
+	}
 	rspamd_upstream_set_active(ups, upstream);
 
 	return TRUE;
@@ -2067,6 +2290,14 @@ rspamd_upstream_get_common(struct upstream_list *ups,
 		for (unsigned int i = 0; i < ups->ups->len; i++) {
 			struct upstream *cur = g_ptr_array_index(ups->ups, i);
 			if (cur->active_idx >= 0 || (except && cur == except)) {
+				continue;
+			}
+			/*
+			 * Pending-resolve upstreams have no addresses yet — they can't
+			 * be probed. The lazy resolver will move them into `alive` once
+			 * DNS comes back.
+			 */
+			if (cur->flags & RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE) {
 				continue;
 			}
 

--- a/src/libutil/upstream.h
+++ b/src/libutil/upstream.h
@@ -43,6 +43,13 @@ enum rspamd_upstream_flag {
 	RSPAMD_UPSTREAM_FLAG_NORESOLVE = (1 << 0),
 	RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE = (1 << 1),
 	RSPAMD_UPSTREAM_FLAG_DNS = (1 << 2),
+	/*
+	 * Upstream was created with a hostname that could not be resolved at
+	 * config-parse time. It is kept out of the `alive` list until a later
+	 * lazy/forced resolution succeeds, at which point the flag is cleared
+	 * and the upstream becomes selectable.
+	 */
+	RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE = (1 << 3),
 };
 
 struct rspamd_config;

--- a/src/lua/lua_upstream.c
+++ b/src/lua/lua_upstream.c
@@ -113,7 +113,14 @@ lua_upstream_get_addr(lua_State *L)
 	struct rspamd_lua_upstream *up = lua_check_upstream(L, 1);
 
 	if (up) {
-		rspamd_lua_ip_push(L, rspamd_upstream_addr_next(up->up));
+		rspamd_inet_addr_t *addr = rspamd_upstream_addr_next(up->up);
+		if (addr) {
+			rspamd_lua_ip_push(L, addr);
+		}
+		else {
+			/* Upstream has no addresses yet (pending DNS resolution) */
+			lua_pushnil(L);
+		}
 	}
 	else {
 		lua_pushnil(L);

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -7163,6 +7163,12 @@ fuzzy_lua_ping_storage(lua_State *L)
 	else {
 		struct upstream *selected = rspamd_upstream_get(rule_found->read_servers,
 														RSPAMD_UPSTREAM_ROUND_ROBIN, NULL, 0);
+		if (selected == NULL) {
+			lua_pushboolean(L, FALSE);
+			lua_pushfstring(L, "no fuzzy storage upstream available for rule %s",
+							rule_found->name);
+			return 2;
+		}
 		addr = rspamd_upstream_addr_next(selected);
 	}
 

--- a/src/plugins/lua/aws_s3.lua
+++ b/src/plugins/lua/aws_s3.lua
@@ -196,6 +196,12 @@ local function s3_aws_callback(task)
       secret_key = settings.s3_secret_key,
       method = 'PUT',
     }, content)
+    local s3_upstream = settings.upstreams:get_upstream_round_robin()
+    if not s3_upstream then
+      rspamd_logger.warnx(task,
+          'no S3 upstream available for %s; falling back to URL-only connect',
+          path)
+    end
     rspamd_http.request({
       url = uri .. path,
       task = task,
@@ -203,7 +209,7 @@ local function s3_aws_callback(task)
       body = content,
       callback = gen_s3_http_callback(path, 'structured message'),
       headers = hdrs,
-      upstream = settings.upstreams:get_upstream_round_robin(),
+      upstream = s3_upstream,
       timeout = settings.s3_timeout,
     })
 
@@ -219,10 +225,16 @@ local function s3_aws_callback(task)
         secret_key = settings.s3_secret_key,
         method = 'PUT',
       }, part_content)
+      local part_upstream = settings.upstreams:get_upstream_round_robin()
+      if not part_upstream then
+        rspamd_logger.warnx(task,
+            'no S3 upstream available for part %s; falling back to URL-only connect',
+            ref)
+      end
       rspamd_http.request({
         url = uri .. ref,
         task = task,
-        upstream = settings.upstreams:get_upstream_round_robin(),
+        upstream = part_upstream,
         method = 'PUT',
         body = part_content,
         callback = gen_s3_http_callback(ref, 'part content'),

--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -477,6 +477,12 @@ end
 local function clickhouse_send_data(task, ev_base, why, gen_rows, cust_rows, extra_rows)
   local log_object = task or rspamd_config
   local upstream = settings.upstream:get_upstream_round_robin()
+  if not upstream then
+    rspamd_logger.errx(log_object,
+        "no clickhouse upstream available (DNS pending or all dead); skipping send (%s)",
+        why)
+    return
+  end
   local ip_addr = upstream:get_addr():to_string(true)
   rspamd_logger.infox(log_object, "trying to send %s rows to clickhouse server %s; started as %s",
       #gen_rows + #cust_rows, ip_addr, why)
@@ -1173,6 +1179,12 @@ end
 local function do_remove_partition(ev_base, cfg, table_name, partition, method_override)
   lua_util.debugm(N, rspamd_config, "removing partition %s.%s", table_name, partition)
   local upstream = settings.upstream:get_upstream_round_robin()
+  if not upstream then
+    rspamd_logger.errx(rspamd_config,
+        "no clickhouse upstream available; cannot remove partition %s.%s",
+        table_name, partition)
+    return
+  end
   local remove_partition_sql = "ALTER TABLE ${table_name} ${remove_method} PARTITION '${partition}'"
   local method = method_override or settings.retention.method
   local remove_method = (method == 'drop') and 'DROP' or 'DETACH'
@@ -1330,6 +1342,11 @@ local function clickhouse_remove_old_partitions(cfg, ev_base)
   end
 
   local upstream = settings.upstream:get_upstream_round_robin()
+  if not upstream then
+    rspamd_logger.errx(rspamd_config,
+        "no clickhouse upstream available; cannot run retention pass")
+    return false
+  end
   local partition_to_remove_sql = "SELECT partition, table " ..
       "FROM system.parts WHERE table IN ('${tables}') " ..
       "GROUP BY partition, table " ..

--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -1594,6 +1594,12 @@ local function check_rspamd_table(upstream, ev_base, cfg)
 end
 
 local function check_clickhouse_upstream(upstream, ev_base, cfg)
+  if not upstream:get_addr() then
+    rspamd_logger.infox(rspamd_config,
+        'skipping clickhouse upstream %s: address not resolved yet',
+        upstream:get_name())
+    return
+  end
   local ch_params = {
     ev_base = ev_base,
     config = cfg,

--- a/src/plugins/lua/elastic.lua
+++ b/src/plugins/lua/elastic.lua
@@ -349,6 +349,11 @@ local function elastic_send_data(flush_all, task, cfg, ev_base)
     es_index = settings['index_template']['name'] .. '-' .. os.date(settings['index_template']['pattern'])
 
     upstream = settings.upstream:get_upstream_round_robin()
+    if not upstream then
+      rspamd_logger.errx(log_object,
+          'no elastic upstream available (DNS pending or all dead); will retry next tick')
+      return
+    end
     host = upstream:get_name():gsub(":[1-9][0-9]*$", "")
     local ip_addr = upstream:get_addr():to_string(true)
     push_url = connect_prefix .. ip_addr .. '/' .. es_index .. '/_bulk'
@@ -717,6 +722,11 @@ end
 
 local function configure_geoip_pipeline(cfg, ev_base)
   local upstream = settings.upstream:get_upstream_round_robin()
+  if not upstream then
+    rspamd_logger.errx(rspamd_config,
+        'no elastic upstream available; cannot configure geoip pipeline')
+    return
+  end
   local host = upstream:get_name():gsub(":[1-9][0-9]*$", "")
   local ip_addr = upstream:get_addr():to_string(true)
   local geoip_url = connect_prefix .. ip_addr .. '/_ingest/pipeline/' .. settings['geoip']['pipeline_name']
@@ -912,6 +922,11 @@ end
 
 local function configure_index_policy(cfg, ev_base)
   local upstream = settings.upstream:get_upstream_round_robin()
+  if not upstream then
+    rspamd_logger.errx(rspamd_config,
+        'no elastic upstream available; cannot configure index policy')
+    return
+  end
   local host = upstream:get_name():gsub(":[1-9][0-9]*$", "")
   local ip_addr = upstream:get_addr():to_string(true)
   local index_policy_path = nil
@@ -1185,6 +1200,11 @@ end
 
 local function configure_index_template(cfg, ev_base)
   local upstream = settings.upstream:get_upstream_round_robin()
+  if not upstream then
+    rspamd_logger.errx(rspamd_config,
+        'no elastic upstream available; cannot configure index template')
+    return
+  end
   local host = upstream:get_name():gsub(":[1-9][0-9]*$", "")
   local ip_addr = upstream:get_addr():to_string(true)
   local template_url = connect_prefix .. ip_addr .. '/_index_template/' .. settings['index_template']['name']
@@ -1461,6 +1481,11 @@ local function configure_distro(cfg, ev_base)
   end
 
   local upstream = settings.upstream:get_upstream_round_robin()
+  if not upstream then
+    rspamd_logger.errx(rspamd_config,
+        'no elastic upstream available; will retry distro detection on next tick')
+    return
+  end
   local host = upstream:get_name():gsub(":[1-9][0-9]*$", "")
   local ip_addr = upstream:get_addr():to_string(true)
   local root_url = connect_prefix .. ip_addr .. '/'

--- a/src/plugins/lua/external_services.lua
+++ b/src/plugins/lua/external_services.lua
@@ -108,28 +108,46 @@ local function add_scanner_rule(sym, opts)
     return nil
   end
 
+  -- Resolve symbol names up-front so a failed configure() can still register
+  -- the fail symbol and surface the misconfiguration on every scan.
+  local symbol = opts.symbol or sym:upper()
+  local symbol_fail = opts.symbol_fail or (symbol .. '_FAIL')
+  local symbol_encrypted = opts.symbol_encrypted or (symbol .. '_ENCRYPTED')
+  local symbol_macro = opts.symbol_macro or (symbol .. '_MACRO')
+
   local rule = cfg.configure(opts)
 
   if not rule then
-    rspamd_logger.errx(rspamd_config, 'cannot configure %s for %s',
-        opts.type, rule.symbol or sym:upper())
-    return nil
+    rspamd_logger.errx(rspamd_config,
+        'cannot configure %s for %s; registering fail-only rule that always emits %s',
+        opts.type, symbol, symbol_fail)
+
+    local fail_reason = string.format('%s: configuration failed (see startup log)',
+        opts.type)
+
+    local stub_rule = {
+      type = opts.type,
+      name = opts.name or sym,
+      symbol = symbol,
+      symbol_fail = symbol_fail,
+      symbol_encrypted = symbol_encrypted,
+      symbol_macro = symbol_macro,
+      log_prefix = opts.name or sym,
+      configuration_failed = true,
+    }
+
+    local function fail_cb(task)
+      task:insert_result(symbol_fail, 1.0, fail_reason)
+    end
+
+    return fail_cb, stub_rule
   end
 
   rule.type = opts.type
-  -- Fill missing symbols
-  if not rule.symbol then
-    rule.symbol = sym:upper()
-  end
-  if not rule.symbol_fail then
-    rule.symbol_fail = rule.symbol .. '_FAIL'
-  end
-  if not rule.symbol_encrypted then
-    rule.symbol_encrypted = rule.symbol .. '_ENCRYPTED'
-  end
-  if not rule.symbol_macro then
-    rule.symbol_macro = rule.symbol .. '_MACRO'
-  end
+  rule.symbol = symbol
+  rule.symbol_fail = symbol_fail
+  rule.symbol_encrypted = symbol_encrypted
+  rule.symbol_macro = symbol_macro
 
   rule.redis_params = redis_params
 

--- a/src/plugins/lua/gpt.lua
+++ b/src/plugins/lua/gpt.lua
@@ -1032,6 +1032,13 @@ local function openai_check(task, content, sel_part, context_snippet)
     body.model = model
 
     upstream = settings.upstreams:get_upstream_round_robin()
+    if not upstream then
+      rspamd_logger.errx(task,
+          'no GPT upstream available (DNS pending or all dead); skipping model %s',
+          model)
+      results[idx].checked = true
+      results[idx].error = 'no upstream available'
+    else
     local http_params = {
       url = settings.url,
       method = 'post',
@@ -1056,6 +1063,7 @@ local function openai_check(task, content, sel_part, context_snippet)
 
     if not rspamd_http.request(http_params) then
       results[idx].checked = true
+    end
     end
   end
 end
@@ -1169,6 +1177,13 @@ local function ollama_check(task, content, sel_part, context_snippet)
     body.model = model
 
     upstream = settings.upstreams:get_upstream_round_robin()
+    if not upstream then
+      rspamd_logger.errx(task,
+          'no Ollama upstream available (DNS pending or all dead); skipping model %s',
+          model)
+      results[idx].checked = true
+      results[idx].error = 'no upstream available'
+    else
     local http_params = {
       url = settings.url,
       method = 'post',
@@ -1190,6 +1205,7 @@ local function ollama_check(task, content, sel_part, context_snippet)
 
     if not rspamd_http.request(http_params) then
       results[idx].checked = true
+    end
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #6000 and the broader class of \"a single DNS hiccup at startup
disables a whole module\" bugs.

Previously `rspamd_upstreams_add_upstream()` returned FALSE whenever
`rspamd_parse_host_port_priority()` could not resolve a hostname, so a
brief resolver outage at config time dropped entire upstream lists and
cascaded into module-init failures (Redis, fuzzy storage, ClamAV, ICAP,
ClickHouse, external services, ...).

This branch:

1. **Adds a deferred-DNS state to the upstream layer.** A new
   `RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE` keeps the parsed host/port
   around when initial DNS fails. Pending upstreams stay out of the
   `alive` list so existing selectors (round-robin, hashed, master/slave,
   ring/heap rotators) keep seeing only usable hosts. `set_active()`
   schedules a fast initial resolve (1s + jitter); `lazy_resolve_cb()`
   backs off exponentially up to 60s while still pending. On success,
   `rspamd_upstream_promote_pending` clears the flag, populates the
   `alive` list, initialises token-bucket state, and fires
   `WATCH_ONLINE`.

2. **Audits and tightens every consumer that could now legitimately see
   a nil/NULL upstream.** Before this branch, an empty alive list at
   startup was rare enough that several Lua call sites simply
   dereferenced `:get_addr()` and crashed; with deferred DNS this is now
   normal early-life behaviour, so every selector caller is updated.

## What changed

### Upstream layer (C)
- `src/libutil/upstream.{c,h}`: `PENDING_RESOLVE` flag, deferred host/
  port stash, fast-then-backoff lazy resolve, pending-aware
  `update_addrs` / `promote_pending`, probe-mode walk skips pending.
- Address accessors (`rspamd_upstream_addr_next/_cur`,
  `rspamd_upstream_port`) made pending-safe so `:all_upstreams()` callers
  cannot accidentally NULL-deref through them.
- `src/lua/lua_upstream.c`: `:get_addr()` returns nil when there is no
  address.

### C consumers
- `fuzzy_backend_redis.c`: read / count / version paths now log the
  reason when no upstream is available instead of silently invoking the
  callback with empty results.
- `http/http_connection.c`: when every configured `http_proxies` upstream
  is unavailable, surface the direct-connection fallback with an
  `msg_info` (admin-visible signal that proxy enforcement was bypassed).
- `plugins/fuzzy_check.c`: `fuzzy_lua_ping_storage` no longer NULL-derefs
  when every storage upstream is dead/pending.
- `plugins/lua/external_services.lua`: when `configure()` fails, register
  a fail-only stub rule that emits the `*_FAIL` symbol on every scan
  instead of silently disabling the whole module.

### Lua scanners
- New shared helper `lua_scanners/common.get_upstream_or_fail()` that
  selects an upstream and, on nil, emits the configured `*_FAIL` symbol
  via `yield_result` with reason
  \"no upstream available (DNS pending or all dead)\".
- All scanners (avast, clamav, cloudmark, dcc, expurgate, fprot, icap,
  kaspersky_av, kaspersky_se, oletools, pyzor, razor, savapi, sophos,
  spamassassin, vadesecure) updated to use the helper for initial
  selection plus inline guards on retry-on-error sites that pick a
  different upstream. Cloudmark's config-time max-message-size preload
  now logs and bails instead of crashing.

### Lua plugins / lualib
- `lua_redis.lua`: all four selection sites now `return false, nil, nil`
  on nil upstream so callers see a real failure. The `:all_upstreams()`
  SCRIPT LOAD broadcast inserts a `{ skip = true, upstream = s }`
  placeholder so the consumer-loop indexes stay aligned with
  `servers_ready` (previously a successful upload could write \"done\"
  into the wrong slot).
- `lua_maps.lua`: external-map HTTP path invokes the caller's callback
  with `(false, \"no upstream available\", 502, ctx)`.
- `aws_s3.lua`, `clickhouse.lua`, `elastic.lua`, `gpt.lua`: every
  `get_upstream_round_robin` site logs and returns from its enclosing
  function (send / retention / distro detect / geoip / index policy /
  GPT/Ollama dispatch).
- `rspamadm/clickhouse.lua`, `rspamadm/statistics_dump.lua`: print to
  stderr and exit / abort the redistribute scan; the connect helper
  bails before opening a Redis connection with a nil host.

## Behavioural impact

- A misconfigured or briefly-down resolver no longer prevents rspamd
  from starting. Modules whose backends are still pending recover
  automatically without a restart.
- Scans against scanners whose backend is pending/dead now produce the
  scanner's `*_FAIL` symbol instead of silently aborting.
- HTTP-proxy fallback to direct is now logged (visibility regression
  fix that surfaced during the audit).

## Test plan

- [ ] Start rspamd with a Redis / ClamAV upstream pointing at a hostname
      that resolves only after startup; confirm the daemon comes up,
      the upstream is visible in counters as pending, and recovers when
      DNS returns.
- [ ] Start rspamd with a hostname that never resolves; confirm the
      module is still loaded, scans emit the `*_FAIL` symbol, and
      lazy-resolve keeps backing off without log floods.
- [ ] Force every upstream in a scanner rule dead and confirm scans now
      emit `*_FAIL` (previously: silent abort).
- [ ] Run the functional suite (`test/functional`) with focus on
      fuzzy_check, external_services, clickhouse, elastic, gpt.
- [ ] Run `test/rspamd-test-cxx` and `test/rspamd-test -p /rspamd/lua`.
- [ ] `luacheck src/plugins/lua/ lualib/ rules/`.