### PR TITLE
[Feature] Add chain-aware cache and intermediate hop injection in url_redirector, improve timeouts handling

### DIFF
--- a/conf/modules.d/url_redirector.conf
+++ b/conf/modules.d/url_redirector.conf
@@ -24,10 +24,10 @@ url_redirector {
   #   read_timeout = 3s;
   # };
   redis_timeout = 2s; # redis timeout for cache operations (redis.conf module has higher priority)
-  nested_limit = 5; # how many redirects to follow
+  nested_limit = 2; # how many redirects to follow
   key_prefix = "rdr:"; # default hash name
   check_ssl = false; # check ssl certificates
-  max_urls = 5; # how many urls to check (СTA checked in first place)
+  max_urls = 5; # how many urls to check (CTA checked in first place)
   max_size = 10k; # maximum body to process
   redirectors_only = true; # follow only known redirectors
   top_urls_key = "rdr:top_urls"; # key for top urls

--- a/conf/modules.d/url_redirector.conf
+++ b/conf/modules.d/url_redirector.conf
@@ -14,11 +14,28 @@
 
 url_redirector {
   expire = 1d; # 1 day by default
-  timeout = 10; # 10 seconds by default
-  nested_limit = 1; # How many redirects to follow
+  timeout = 8s; # total timeout of module
+  http_timeout = 4s; # HTTP HEAD timeout per redirect hop Either a number (whole-request duration)
+  # or a table with .connect_timeout, .ssl_timeout, .write_timeout, .read_timeout for granular control.
+  # http_timeout = {
+  #   connect_timeout = 2s;
+  #   ssl_timeout = 2s;
+  #   write_timeout = 1s;
+  #   read_timeout = 3s;
+  # };
+  redis_timeout = 2s; # redis timeout for cache operations (redis.conf module has higher priority)
+  nested_limit = 5; # how many redirects to follow
   key_prefix = "rdr:"; # default hash name
   check_ssl = false; # check ssl certificates
+  max_urls = 5; # how many urls to check (СTA checked in first place)
   max_size = 10k; # maximum body to process
+  redirectors_only = true; # follow only known redirectors
+  top_urls_key = "rdr:top_urls"; # key for top urls
+  top_urls_count = 200; # how many top urls to save
+  save_intermediate_redirs = {
+    redirectors = false;
+    non_redirectors = true; # inject non-redirector hops by default since they can hide cloaker phishing urls
+  }
 
   .include(try=true,priority=5) "${DBDIR}/dynamic/url_redirector.conf"
   .include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/url_redirector.conf"

--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -297,8 +297,12 @@ local http_walk
 -- hash(chain[#chain]); pass nil to issue the GET. seen is the shared
 -- per-scan URL-string set (cache walk and http_walk write to it so
 -- cycles crossing both layers are caught with one extra Redis GET at
--- worst).
-step = function(task, orig_url, chain, seen, data)
+-- worst). ntries is the count of HTTP HEADs already issued in this
+-- scan -- threaded through cache hops without change so the
+-- ^nested-bridge below hands http_walk the correct remaining budget,
+-- not a fresh nested_limit. Defaults to 0 for top-level cache walks.
+step = function(task, orig_url, chain, seen, data, ntries)
+  ntries = ntries or 0
   if data == nil then
     local last = chain[#chain]
     local next_key = cache_key_for_url(tostring(last))
@@ -310,7 +314,7 @@ step = function(task, orig_url, chain, seen, data)
             apply_redirect_chain(task, chain)
             return
           end
-          step(task, orig_url, chain, seen, d)
+          step(task, orig_url, chain, seen, d, ntries)
         end,
         'GET', { next_key })
     if not ret then
@@ -344,18 +348,21 @@ step = function(task, orig_url, chain, seen, data)
   seen[val] = true
 
   if prefix == 'hop' then
-    step(task, orig_url, chain, seen, nil)
+    step(task, orig_url, chain, seen, nil, ntries)
     return
   end
 
   if prefix == 'nested' then
     -- Cached walk ended on "we ran out of HTTP budget last time".
-    -- Budget is fresh per scan -- extend live from this hop. If the
-    -- extension finalizes successfully, the upstream ^nested marker
-    -- gets rewritten as ^hop and the chain grows in cache.
+    -- Hand off to http_walk for a live extension. ntries+1 is the
+    -- index of the next HEAD in this scan -- not 1 -- so any HEADs
+    -- already done before the cache splice still count toward
+    -- nested_limit. If the extension finalizes successfully, the
+    -- upstream ^nested marker is rewritten as ^hop and the chain
+    -- grows in cache.
     lua_util.debugm(N, task,
         'extending past cached ^nested:%s with live HTTP', val)
-    http_walk(task, orig_url, hop, 1, chain, seen)
+    http_walk(task, orig_url, hop, ntries + 1, chain, seen)
     return
   end
 
@@ -474,7 +481,10 @@ http_walk = function(task, orig_url, url, ntries, chain, seen)
                       redir_url)
                   chain_append(chain, redir_url)
                   seen[tostring(redir_url)] = true
-                  step(task, orig_url, chain, seen, probe_data)
+                  -- Pass current ntries so any onward ^nested-bridge
+                  -- inside step counts HEADs already done in this
+                  -- scan toward nested_limit, instead of resetting.
+                  step(task, orig_url, chain, seen, probe_data, ntries)
                 else
                   http_walk(task, orig_url, redir_url, ntries + 1, chain, seen)
                 end
@@ -550,7 +560,9 @@ local function resolve_cached(task, orig_url)
     if not err and type(data) == 'string' and data ~= 'processing' then
       lua_util.debugm(N, task, 'found cached redirect from %s to %s',
           orig_url, data)
-      step(task, orig_url, chain, seen, data)
+      -- Top-level cache hit: no HEADs done yet, so ntries=0 means a
+      -- ^nested-bridge later gets the full nested_limit budget.
+      step(task, orig_url, chain, seen, data, 0)
       return
     end
 

--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -48,11 +48,11 @@ local settings = {
   -- .write_timeout, .read_timeout for granular control.
   http_timeout = 4,
   redis_timeout = 2, -- redis timeout for cache operations  (redis.conf module has higher priority)
-  nested_limit = 5, -- how many redirects to follow
+  nested_limit = 2, -- how many redirects to follow
   --proxy = "http://example.com:3128", -- send request through proxy, not yet implemented
   key_prefix = 'rdr:', -- default hash name
   check_ssl = false, -- check ssl certificates
-  max_urls = 5, -- how many urls to check (СTA checked in first place)
+  max_urls = 5, -- how many urls to check (CTA checked in first place)
   max_size = 10 * 1024, -- maximum body to process
   user_agent = default_ua,
   redirector_symbol = nil, -- insert symbol if redirected url has been found
@@ -293,7 +293,7 @@ local redirection_codes = {
 -- exhaustion, finalize with terminal_prefix='nested' so the cache
 -- marks the tail with ^nested and a future scan can pick up from
 -- there with a fresh HTTP budget (self-healing chain).
-local function http_walk(task, orig_url, url, ntries, chain)
+local function http_walk(task, orig_url, url, ntries, chain, seen)
   if ntries > settings.nested_limit then
     lua_util.debugm(N, task,
         'cannot get more http requests to resolve %s, stop on %s after %s attempts',
@@ -304,6 +304,20 @@ local function http_walk(task, orig_url, url, ntries, chain)
         string.format('%s:%d', chain_hosts_string(chain), ntries))
     return
   end
+
+  -- Mirror the cache walk's cycle guard: a redirector loop A->B->A->B
+  -- (e.g. login redirector flapping between two hosts) would otherwise
+  -- chew through nested_limit and bloat the chain with alternating
+  -- entries. Skip the check at ntries==1 because url is the entry point
+  -- (orig_url on a fresh resolve, or the cached terminal that step()
+  -- just bridged from -- already added to seen).
+  local url_str = tostring(url)
+  if ntries > 1 and seen[url_str] then
+    lua_util.debugm(N, task, 'cycle in http walk at %s', url_str)
+    apply_redirect_chain(task, chain)
+    return
+  end
+  seen[url_str] = true
 
   local function http_callback(err, code, _, headers)
     if err then
@@ -355,7 +369,7 @@ local function http_walk(task, orig_url, url, ntries, chain)
       if redir_url then
         if settings.redirectors_only then
           if settings.redirector_hosts_map:get_key(redir_url:get_host()) then
-            http_walk(task, orig_url, redir_url, ntries + 1, chain)
+            http_walk(task, orig_url, redir_url, ntries + 1, chain, seen)
           else
             lua_util.debugm(N, task,
                 'stop resolving redirects as %s is not a redirector', loc)
@@ -363,7 +377,7 @@ local function http_walk(task, orig_url, url, ntries, chain)
             finalize_chain(task, chain, nil)
           end
         else
-          http_walk(task, orig_url, redir_url, ntries + 1, chain)
+          http_walk(task, orig_url, redir_url, ntries + 1, chain, seen)
         end
       else
         lua_util.debugm(N, task, 'no location, headers: %s', headers)
@@ -484,7 +498,7 @@ local function resolve_cached(task, orig_url)
       -- gets rewritten as ^hop and the chain grows in cache.
       lua_util.debugm(N, task,
           'extending past cached ^nested:%s with live HTTP', val)
-      http_walk(task, orig_url, hop, 1, local_chain)
+      http_walk(task, orig_url, hop, 1, local_chain, seen)
       return
     end
 
@@ -508,7 +522,7 @@ local function resolve_cached(task, orig_url)
         rspamd_logger.errx(task,
             'got error while setting redirect keys: %s', nerr)
       elseif ndata == 'OK' then
-        http_walk(task, orig_url, orig_url, 1, chain)
+        http_walk(task, orig_url, orig_url, 1, chain, seen)
       end
     end
 
@@ -516,7 +530,7 @@ local function resolve_cached(task, orig_url)
         redis_params, key, true, redis_reserve_cb,
         'SET',
         { key, 'processing', 'EX',
-          tostring(math.floor(settings.timeout)), 'NX' })
+          tostring(math.floor(settings.timeout) + 1), 'NX' })
     if not ret then
       rspamd_logger.errx(task, "Couldn't schedule SET")
     end

--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -42,12 +42,17 @@ local redis_params
 
 local settings = {
   expire = 86400, -- 1 day by default
-  timeout = 10, -- 10 seconds by default
-  nested_limit = 5, -- How many redirects to follow
-  --proxy = "http://example.com:3128", -- Send request through proxy
+  timeout = 8, -- total timeout of module
+  -- HTTP HEAD timeout per redirect hop. Either a number (whole-request
+  -- duration) or a table with .connect_timeout, .ssl_timeout,
+  -- .write_timeout, .read_timeout for granular control.
+  http_timeout = 4,
+  redis_timeout = 2, -- redis timeout for cache operations  (redis.conf module has higher priority)
+  nested_limit = 5, -- how many redirects to follow
+  --proxy = "http://example.com:3128", -- send request through proxy, not yet implemented
   key_prefix = 'rdr:', -- default hash name
   check_ssl = false, -- check ssl certificates
-  max_urls = 5, -- how many urls to check
+  max_urls = 5, -- how many urls to check (СTA checked in first place)
   max_size = 10 * 1024, -- maximum body to process
   user_agent = default_ua,
   redirector_symbol = nil, -- insert symbol if redirected url has been found
@@ -55,8 +60,27 @@ local settings = {
   redirectors_only = true, -- follow merely redirectors
   top_urls_key = 'rdr:top_urls', -- key for top urls
   top_urls_count = 200, -- how many top urls to save
-  redirector_hosts_map = nil -- check only those redirectors
+  redirector_hosts_map = nil, -- check only those redirectors
+  -- inject intermediate redirect hops into the task
+  save_intermediate_redirs = {
+    redirectors = false,
+    non_redirectors = true, -- inject non-redirector hops by default since they can hide cloaker phishing urls
+  }
 }
+
+-- Spread http_timeout into the kwargs of an rspamd_http.request{} call:
+-- 'timeout' for the number form, individual fields for the table form.
+local function apply_http_timeout(http_params)
+  local t = settings.http_timeout
+  if type(t) == 'table' then
+    http_params.connect_timeout = t.connect_timeout
+    http_params.ssl_timeout = t.ssl_timeout
+    http_params.write_timeout = t.write_timeout
+    http_params.read_timeout = t.read_timeout
+  else
+    http_params.timeout = t
+  end
+end
 
 --[[
 Encode characters that are not allowed in URLs according to RFC 3986
@@ -84,296 +108,430 @@ local function encode_url_for_redirect(url_str)
   return encoded
 end
 
-local function adjust_url(task, orig_url, redir_url)
-  local mempool = task:get_mempool()
-  if type(redir_url) == 'string' then
-    redir_url = rspamd_url.create(mempool, redir_url, { 'redirect_target' })
+-- Build a 'host1->host2->...' string from a chain of URL objects, used as
+-- the symbol option for redirector_symbol_nested. Mirrors the format that
+-- apply_redirect_chain emits for redirector_symbol.
+local function chain_hosts_string(chain)
+  local hosts = {}
+  for i = 1, #chain do
+    hosts[i] = chain[i]:get_host() or '?'
   end
+  return table.concat(hosts, '->')
+end
 
-  if redir_url then
-    orig_url:set_redirected(redir_url, mempool)
-    task:inject_url(redir_url)
-    if settings.redirector_symbol then
-      task:insert_result(settings.redirector_symbol, 1.0,
-          string.format('%s->%s', orig_url:get_host(), redir_url:get_host()))
-    end
-  else
-    rspamd_logger.infox(task, 'bad url %s as redirection for %s', redir_url, orig_url)
+-- Compute the per-URL Redis cache key. Hashing the URL string keeps keys
+-- fixed-length and free of URL-unsafe characters; using tostring() (rather
+-- than :get_raw()) keeps the hash stable across the write-then-read cycle
+-- when chain values are roundtripped through rspamd_url.create.
+local function cache_key_for_url(url_str)
+  return settings.key_prefix .. hash.create(url_str):base32():sub(1, 32)
+end
+
+-- Whether an intermediate hop should be saved (in cache and task URL set)
+-- given the per-class gates in settings.save_intermediate_redirs. Hops on
+-- redirector_hosts_map are gated by .redirectors; everything else by
+-- .non_redirectors -- the latter is where rotator/cloaker hosts surface.
+local function should_save_hop(hop_url)
+  if not hop_url then
+    return false
+  end
+  local host = hop_url:get_host()
+  local is_redirector = false
+  if host and settings.redirector_hosts_map
+      and settings.redirector_hosts_map:get_key(host) then
+    is_redirector = true
+  end
+  local cfg = settings.save_intermediate_redirs
+  if is_redirector then
+    return cfg.redirectors and true or false
+  end
+  return cfg.non_redirectors and true or false
+end
+
+-- Append hop to chain unless it equals the current tail. String
+-- comparison (not identity): on cache-hit walks the parsed URL is a
+-- fresh Lua object for the same string, and identity (==) would
+-- falsely register a self-loop as two distinct hops.
+local function chain_append(chain, hop_url)
+  if not hop_url then
+    return
+  end
+  local tail = chain[#chain]
+  if tail == nil or tostring(hop_url) ~= tostring(tail) then
+    table.insert(chain, hop_url)
   end
 end
 
-local function cache_url(task, orig_url, url, key, prefix)
-  -- String representation
-  local str_orig_url = tostring(orig_url)
-  local str_url = tostring(url)
+-- Apply a finalized chain to the task: link adjacent pairs via
+-- set_redirected, inject every non-orig hop as a task URL, and emit
+-- redirector_symbol with hosts joined by '->'. Length-1 chain (no
+-- redirect happened) is a no-op.
+local function apply_redirect_chain(task, chain)
+  if #chain < 2 then
+    return
+  end
+  local mempool = task:get_mempool()
+  for i = 1, #chain - 1 do
+    chain[i]:set_redirected(chain[i + 1], mempool)
+  end
+  for i = 2, #chain do
+    task:inject_url(chain[i])
+  end
+  if settings.redirector_symbol then
+    task:insert_result(settings.redirector_symbol, 1.0,
+        chain_hosts_string(chain))
+  end
+end
 
-  if str_url ~= str_orig_url then
-    -- Set redirected url
-    adjust_url(task, orig_url, url)
+-- Persist a finalized chain to Redis as one SETEX per adjacent pair where
+-- the value is the next hop. Non-terminal links carry a '^hop:' marker so
+-- the reader keeps walking; the terminal link carries terminal_prefix
+-- (currently 'nested') if the chain didn't fully resolve, otherwise no
+-- marker. ZINCRBY counts the canonical URL string with no marker so the
+-- top_urls zset stays a meaningful popularity counter.
+-- A length-1 chain caches a self-loop so future scans of a direct-200
+-- URL fast-path through the cache walk instead of re-issuing HEAD.
+local function cache_chain_to_redis(task, chain, terminal_prefix)
+  if #chain == 0 then
+    return
   end
 
-  local function redis_trim_cb(err, _)
+  local function trim_cb(err, _)
     if err then
-      rspamd_logger.errx(task, 'got error while getting top urls count: %s', err)
+      rspamd_logger.errx(task, 'got error trimming top urls set: %s', err)
     else
-      rspamd_logger.infox(task, 'trimmed url set to %s elements',
+      rspamd_logger.infox(task, 'trimmed top urls set to %s elements',
           settings.top_urls_count)
     end
   end
 
-  -- Cleanup logic
-  local function redis_card_cb(err, data)
+  local function card_cb(err, data)
     if err then
-      rspamd_logger.errx(task, 'got error while getting top urls count: %s', err)
-    else
-      if data then
-        if tonumber(data) > settings.top_urls_count * 2 then
-          local ret = lua_redis.redis_make_request(task,
-              redis_params, -- connect params
-              key, -- hash key
-              true, -- is write
-              redis_trim_cb, --callback
-              'ZREMRANGEBYRANK', -- command
-              { settings.top_urls_key, '0',
-                tostring(-(settings.top_urls_count + 1)) } -- arguments
-          )
-          if not ret then
-            rspamd_logger.errx(task, 'cannot trim top urls set')
-          else
-            rspamd_logger.infox(task, 'need to trim urls set from %s to %s elements',
-                data,
-                settings.top_urls_count)
-            return
-          end
-        end
-      end
+      rspamd_logger.errx(task, 'got error reading top urls cardinality: %s', err)
+      return
     end
-  end
-
-  local function redis_set_cb(err, _)
-    if err then
-      rspamd_logger.errx(task, 'got error while setting redirect keys: %s', err)
-    else
+    if data and tonumber(data) and tonumber(data) > settings.top_urls_count * 2 then
       local ret = lua_redis.redis_make_request(task,
-          redis_params, -- connect params
-          key, -- hash key
-          false, -- is write
-          redis_card_cb, --callback
-          'ZCARD', -- command
-          { settings.top_urls_key } -- arguments
-      )
+          redis_params, settings.top_urls_key, true, trim_cb,
+          'ZREMRANGEBYRANK',
+          { settings.top_urls_key, '0',
+            tostring(-(settings.top_urls_count + 1)) })
       if not ret then
-        rspamd_logger.errx(task, 'cannot make redis request to cache results')
+        rspamd_logger.errx(task, 'cannot trim top urls set')
       end
     end
   end
 
-  if prefix then
-    -- Save url with prefix
-    str_url = string.format('^%s:%s', prefix, str_url)
+  local function set_cb(err, _)
+    if err then
+      rspamd_logger.errx(task, 'got error caching redirect link: %s', err)
+    end
   end
-  local ret, conn, _ = lua_redis.redis_make_request(task,
-      redis_params, -- connect params
-      key, -- hash key
-      true, -- is write
-      redis_set_cb, --callback
-      'SETEX', -- command
-      { key, tostring(settings.expire), str_url } -- arguments
-  )
 
+  local function write_link(prev_url, next_url, marker)
+    local link_key = cache_key_for_url(tostring(prev_url))
+    local next_str = tostring(next_url)
+    local cache_value
+    if marker then
+      cache_value = string.format('^%s:%s', marker, next_str)
+    else
+      cache_value = next_str
+    end
+    local ret, conn, _ = lua_redis.redis_make_request(task,
+        redis_params, link_key, true, set_cb,
+        'SETEX', { link_key, tostring(settings.expire), cache_value })
+    if not ret then
+      rspamd_logger.errx(task, 'cannot cache redirect link for %s', prev_url)
+    elseif conn then
+      conn:add_cmd('ZINCRBY', { settings.top_urls_key, '1', next_str })
+    end
+  end
+
+  if #chain == 1 then
+    write_link(chain[1], chain[1], terminal_prefix)
+  else
+    for i = 1, #chain - 1 do
+      local marker
+      if i == #chain - 1 then
+        marker = terminal_prefix
+      else
+        marker = 'hop'
+      end
+      write_link(chain[i], chain[i + 1], marker)
+    end
+  end
+
+  -- One trim probe per finalized chain rather than per link.
+  local ret = lua_redis.redis_make_request(task,
+      redis_params, settings.top_urls_key, false, card_cb,
+      'ZCARD', { settings.top_urls_key })
   if not ret then
-    rspamd_logger.errx(task, 'cannot make redis request to cache results')
-  else
-    conn:add_cmd('ZINCRBY', { settings.top_urls_key, '1', str_url })
+    rspamd_logger.errx(task, 'cannot probe top urls cardinality')
   end
 end
 
--- Reduce length of a string to a given length (16 by default)
-local function maybe_trim_url(url, limit)
-  if not limit then
-    limit = 16
-  end
-  if #url > limit then
-    return string.sub(url, 1, limit) .. '...'
-  else
-    return url
-  end
+-- Apply chain to task and persist it to Redis.
+local function finalize_chain(task, chain, terminal_prefix)
+  apply_redirect_chain(task, chain)
+  cache_chain_to_redis(task, chain, terminal_prefix)
 end
 
--- Resolve maybe cached url
--- Orig url is the original url object
--- url should be a new url object...
-local function resolve_cached(task, orig_url, url, key, ntries)
-  local str_url = tostring(url or "")
-  local function resolve_url()
-    if ntries > settings.nested_limit then
-      -- We cannot resolve more, stop
-      lua_util.debugm(N, task, 'cannot get more requests to resolve %s, stop on %s after %s attempts',
-          orig_url, url, ntries)
-      cache_url(task, orig_url, url, key, 'nested')
-      local str_orig_url = tostring(orig_url)
-      task:insert_result(settings.redirector_symbol_nested, 1.0,
-          string.format('%s->%s:%d', maybe_trim_url(str_orig_url), maybe_trim_url(str_url), ntries))
+-- HTTP redirect status codes that we follow.
+local redirection_codes = {
+  [301] = true, -- moved permanently
+  [302] = true, -- found
+  [303] = true, -- see other
+  [307] = true, -- temporary redirect
+  [308] = true, -- permanent redirect
+}
 
+-- Live HTTP HEAD walk. ntries counts only HTTP requests; the cache walk
+-- (in resolve_cached's step()) does not consume this budget. Bounded by
+-- settings.nested_limit. On any terminal -- 200, network error,
+-- non-redirector under redirectors_only=true, non-30x non-200, or
+-- failed Location parse -- finalize the chain. On nested_limit
+-- exhaustion, finalize with terminal_prefix='nested' so the cache
+-- marks the tail with ^nested and a future scan can pick up from
+-- there with a fresh HTTP budget (self-healing chain).
+local function http_walk(task, orig_url, url, ntries, chain)
+  if ntries > settings.nested_limit then
+    lua_util.debugm(N, task,
+        'cannot get more http requests to resolve %s, stop on %s after %s attempts',
+        orig_url, url, ntries)
+    chain_append(chain, url)
+    finalize_chain(task, chain, 'nested')
+    task:insert_result(settings.redirector_symbol_nested, 1.0,
+        string.format('%s:%d', chain_hosts_string(chain), ntries))
+    return
+  end
+
+  local function http_callback(err, code, _, headers)
+    if err then
+      rspamd_logger.infox(task,
+          'found redirect error from %s to %s, err message: %s',
+          orig_url, url, err)
+      chain_append(chain, url)
+      finalize_chain(task, chain, nil)
       return
     end
 
-    local redirection_codes = {
-      [301] = true, -- moved permanently
-      [302] = true, -- found
-      [303] = true, -- see other
-      [307] = true, -- temporary redirect
-      [308] = true, -- permanent redirect
-    }
-
-    local function http_callback(err, code, _, headers)
-      if err then
-        rspamd_logger.infox(task, 'found redirect error from %s to %s, err message: %s',
-            orig_url, url, err)
-        cache_url(task, orig_url, url, key)
+    if code == 200 then
+      if orig_url == url then
+        rspamd_logger.infox(task, 'direct url %s, err code 200', url)
       else
-        if code == 200 then
-          if orig_url == url then
-            rspamd_logger.infox(task, 'direct url %s, err code 200',
-                url)
+        rspamd_logger.infox(task,
+            'found redirect from %s to %s, err code 200', orig_url, url)
+      end
+      chain_append(chain, url)
+      finalize_chain(task, chain, nil)
+      return
+    end
+
+    if redirection_codes[code] then
+      local loc = headers['location']
+      local redir_url
+      if loc then
+        -- Encode problematic characters (spaces, etc.) that
+        -- http_parser doesn't accept. Fixes issue #5525.
+        local encoded_loc = encode_url_for_redirect(loc)
+        redir_url = rspamd_url.create(task:get_mempool(), encoded_loc)
+        if not redir_url and encoded_loc ~= loc then
+          rspamd_logger.infox(task,
+              'failed to parse redirect location even after encoding: %s', loc)
+        end
+      end
+      lua_util.debugm(N, task, 'found redirect from %s to %s, err code %s',
+          orig_url, loc, code)
+
+      -- 'url' just returned 30x, so it's an intermediate. Save it
+      -- only when gating allows. Skip ntries==1: at fresh resolve url
+      -- is orig_url (already chain[1]); when extending past a cached
+      -- ^nested marker, url is the cached terminal that step() just
+      -- appended to chain -- in both cases it's already the tail.
+      if ntries > 1 and should_save_hop(url) then
+        chain_append(chain, url)
+      end
+
+      if redir_url then
+        if settings.redirectors_only then
+          if settings.redirector_hosts_map:get_key(redir_url:get_host()) then
+            http_walk(task, orig_url, redir_url, ntries + 1, chain)
           else
-            rspamd_logger.infox(task, 'found redirect from %s to %s, err code 200',
-                orig_url, url)
-          end
-
-          cache_url(task, orig_url, url, key)
-
-        elseif redirection_codes[code] then
-          local loc = headers['location']
-          local redir_url
-          if loc then
-            -- Encode problematic characters (spaces, etc.) that http_parser doesn't accept
-            -- This fixes issue #5525 where redirect locations contain unencoded spaces
-            local encoded_loc = encode_url_for_redirect(loc)
-            redir_url = rspamd_url.create(task:get_mempool(), encoded_loc)
-            if not redir_url and encoded_loc ~= loc then
-              -- Encoding didn't help, log the issue
-              rspamd_logger.infox(task, 'failed to parse redirect location even after encoding: %s', loc)
-            end
-          end
-          lua_util.debugm(N, task, 'found redirect from %s to %s, err code %s',
-              orig_url, loc, code)
-
-          if redir_url then
-            if settings.redirectors_only then
-              if settings.redirector_hosts_map:get_key(redir_url:get_host()) then
-                resolve_cached(task, orig_url, redir_url, key, ntries + 1)
-              else
-                lua_util.debugm(N, task,
-                    "stop resolving redirects as %s is not a redirector", loc)
-                cache_url(task, orig_url, redir_url, key)
-              end
-            else
-              resolve_cached(task, orig_url, redir_url, key, ntries + 1)
-            end
-          else
-            lua_util.debugm(N, task, "no location, headers: %s", headers)
-            cache_url(task, orig_url, url, key)
+            lua_util.debugm(N, task,
+                'stop resolving redirects as %s is not a redirector', loc)
+            chain_append(chain, redir_url)
+            finalize_chain(task, chain, nil)
           end
         else
-          lua_util.debugm(N, task, 'found redirect error from %s to %s, err code: %s',
-              orig_url, url, code)
-          cache_url(task, orig_url, url, key)
+          http_walk(task, orig_url, redir_url, ntries + 1, chain)
         end
+      else
+        lua_util.debugm(N, task, 'no location, headers: %s', headers)
+        chain_append(chain, url)
+        finalize_chain(task, chain, nil)
       end
+      return
     end
 
-    local ua
-    if type(settings.user_agent) == 'string' then
-      ua = settings.user_agent
-    else
-      ua = settings.user_agent[math.random(#settings.user_agent)]
-    end
-
-    lua_util.debugm(N, task, 'select user agent %s', ua)
-
-    rspamd_http.request {
-      headers = {
-        ['User-Agent'] = ua,
-      },
-      url = str_url,
-      task = task,
-      method = 'head',
-      max_size = settings.max_size,
-      timeout = settings.timeout,
-      opaque_body = true,
-      no_ssl_verify = not settings.check_ssl,
-      callback = http_callback
-    }
+    -- Other non-30x non-200 status: treat current url as terminal.
+    lua_util.debugm(N, task,
+        'found redirect error from %s to %s, err code: %s',
+        orig_url, url, code)
+    chain_append(chain, url)
+    finalize_chain(task, chain, nil)
   end
-  local function redis_get_cb(err, data)
-    if not err then
-      if type(data) == 'string' then
-        if data ~= 'processing' then
-          -- Got cached result
-          lua_util.debugm(N, task, 'found cached redirect from %s to %s',
-              url, data)
-          if data:sub(1, 1) == '^' then
-            -- Prefixed url stored
-            local prefix, new_url = data:match('^%^(%a+):(.+)$')
-            if prefix == 'nested' then
-              task:insert_result(settings.redirector_symbol_nested, 1.0,
-                  string.format('%s->%s:cached', maybe_trim_url(str_url), maybe_trim_url(new_url)))
+
+  local ua
+  if type(settings.user_agent) == 'string' then
+    ua = settings.user_agent
+  else
+    ua = settings.user_agent[math.random(#settings.user_agent)]
+    lua_util.debugm(N, task, 'select user agent %s', ua)
+  end
+
+  local http_params = {
+    headers = { ['User-Agent'] = ua },
+    url = tostring(url),
+    task = task,
+    method = 'head',
+    max_size = settings.max_size,
+    opaque_body = true,
+    no_ssl_verify = not settings.check_ssl,
+    callback = http_callback,
+  }
+  apply_http_timeout(http_params)
+  rspamd_http.request(http_params)
+end
+
+-- Top-level entry: walk the cached chain from orig_url, then either
+-- apply a fully-resolved chain to the task or hand off to http_walk
+-- on cache miss / lock / partial walk.
+--
+-- The cache walk itself is unbounded -- Redis lookups are cheap and
+-- chains should self-extend across scans. Cycle protection is a
+-- per-walk seen-set keyed by URL string (defends against pathological
+-- cross-email cache writes that could form a loop).
+--
+-- On a cached ^nested terminal, hand off to http_walk with a fresh
+-- HTTP budget. If the live walk extends the chain, finalize_chain
+-- overwrites the upstream ^nested marker with ^hop and writes the new
+-- tail; the chain effectively grows by up to nested_limit hops per
+-- scan.
+local function resolve_cached(task, orig_url)
+  local key = cache_key_for_url(tostring(orig_url))
+  local chain = { orig_url }
+  -- seen grows as we walk forward; we do not pre-seed it with orig_url
+  -- because the writer caches direct-200 URLs as a length-1 self-loop
+  -- (hash(orig) = tostring(orig)), and a pre-seed would false-fire the
+  -- cycle check on legitimate terminals. chain_append's tostring-eq
+  -- dedup keeps us from double-appending orig in that case.
+  local seen = {}
+
+  local function step(local_chain, data)
+    if data == nil then
+      local last = local_chain[#local_chain]
+      local next_key = cache_key_for_url(tostring(last))
+      local ret = lua_redis.redis_make_request(task,
+          redis_params, next_key, false,
+          function(e, d)
+            if e or type(d) ~= 'string' or d == 'processing' then
+              -- Cache miss / lock mid-walk: apply what we have.
+              apply_redirect_chain(task, local_chain)
+              return
             end
-            data = new_url
-          end
-          if data ~= tostring(orig_url) then
-            adjust_url(task, orig_url, data)
-          end
-          return
-        end
+            step(local_chain, d)
+          end,
+          'GET', { next_key })
+      if not ret then
+        rspamd_logger.errx(task, 'cannot make redis request to walk chain')
+        apply_redirect_chain(task, local_chain)
+      end
+      return
+    end
+
+    local prefix, val = nil, data
+    if data:sub(1, 1) == '^' then
+      local p, v = data:match('^%^(%a+):(.+)$')
+      if p then
+        prefix, val = p, v
       end
     end
+
+    if seen[val] then
+      lua_util.debugm(N, task, 'cycle in cached chain at %s', val)
+      apply_redirect_chain(task, local_chain)
+      return
+    end
+
+    local hop = rspamd_url.create(task:get_mempool(), val,
+        { 'redirect_target' })
+    if not hop then
+      apply_redirect_chain(task, local_chain)
+      return
+    end
+    chain_append(local_chain, hop)
+    seen[val] = true
+
+    if prefix == 'hop' then
+      step(local_chain, nil)
+      return
+    end
+
+    if prefix == 'nested' then
+      -- Cached walk ended on "we ran out of HTTP budget last time".
+      -- Budget is fresh per scan -- extend live from this hop. If the
+      -- extension finalizes successfully, the upstream ^nested marker
+      -- gets rewritten as ^hop and the chain grows in cache.
+      lua_util.debugm(N, task,
+          'extending past cached ^nested:%s with live HTTP', val)
+      http_walk(task, orig_url, hop, 1, local_chain)
+      return
+    end
+
+    -- Plain terminal: chain fully resolved, apply.
+    apply_redirect_chain(task, local_chain)
+  end
+
+  local function redis_get_cb(err, data)
+    if not err and type(data) == 'string' and data ~= 'processing' then
+      lua_util.debugm(N, task, 'found cached redirect from %s to %s',
+          orig_url, data)
+      step(chain, data)
+      return
+    end
+
+    -- Cache miss or 'processing': try to claim the lock and live-resolve.
+    -- If SET NX fails (another scan holds the lock), ndata != 'OK' and
+    -- we silently drop -- the other scan will populate the cache.
     local function redis_reserve_cb(nerr, ndata)
       if nerr then
-        rspamd_logger.errx(task, 'got error while setting redirect keys: %s', nerr)
+        rspamd_logger.errx(task,
+            'got error while setting redirect keys: %s', nerr)
       elseif ndata == 'OK' then
-        resolve_url()
+        http_walk(task, orig_url, orig_url, 1, chain)
       end
     end
 
-    if ntries == 1 then
-      -- Reserve key in Redis that we are processing this redirection
-      local ret = lua_redis.redis_make_request(task,
-          redis_params, -- connect params
-          key, -- hash key
-          true, -- is write
-          redis_reserve_cb, --callback
-          'SET', -- command
-          { key, 'processing', 'EX', tostring(math.floor(settings.timeout * 2)), 'NX' } -- arguments
-      )
-      if not ret then
-        rspamd_logger.errx(task, 'Couldn\'t schedule SET')
-      end
-    else
-      -- Just continue resolving
-      resolve_url()
+    local ret = lua_redis.redis_make_request(task,
+        redis_params, key, true, redis_reserve_cb,
+        'SET',
+        { key, 'processing', 'EX',
+          tostring(math.floor(settings.timeout)), 'NX' })
+    if not ret then
+      rspamd_logger.errx(task, "Couldn't schedule SET")
     end
-
   end
+
   local ret = lua_redis.redis_make_request(task,
-      redis_params, -- connect params
-      key, -- hash key
-      false, -- is write
-      redis_get_cb, --callback
-      'GET', -- command
-      { key } -- arguments
-  )
+      redis_params, key, false, redis_get_cb,
+      'GET', { key })
   if not ret then
     rspamd_logger.errx(task, 'cannot make redis request to check results')
   end
 end
 
 local function url_redirector_process_url(task, url)
-  local url_str = url:get_raw()
-  -- 32 base32 characters are roughly 20 bytes of data or 160 bits
-  local key = settings.key_prefix .. hash.create(url_str):base32():sub(1, 32)
-  resolve_cached(task, url, url, key, 1)
+  resolve_cached(task, url)
 end
 
 local function url_redirector_handler(task)
@@ -452,7 +610,20 @@ end
 local opts = rspamd_config:get_all_opt('url_redirector')
 if opts then
   settings = lua_util.override_defaults(settings, opts)
-  redis_params = lua_redis.parse_redis_server('url_redirector', settings)
+
+  -- Pass redis_timeout to lua_redis instead of the symbol budget.
+  -- Nested redis{} block needs the override too -- parse_redis_server
+  -- reads opts.redis directly when present and never falls back to
+  -- opts.timeout.
+  local redis_opts = lua_util.shallowcopy(opts)
+  redis_opts.timeout = settings.redis_timeout
+  if redis_opts.redis then
+    redis_opts.redis = lua_util.shallowcopy(redis_opts.redis)
+    if not redis_opts.redis.timeout then
+      redis_opts.redis.timeout = settings.redis_timeout
+    end
+  end
+  redis_params = lua_redis.parse_redis_server('url_redirector', redis_opts)
 
   if not redis_params then
     rspamd_logger.infox(rspamd_config, 'no servers are specified, disabling module')
@@ -482,7 +653,6 @@ if opts then
         type = 'callback,prefilter',
         priority = lua_util.symbols_priorities.medium,
         callback = url_redirector_handler,
-        -- In fact, the real timeout is nested_limit * timeout...
         augmentations = { string.format("timeout=%f", settings.timeout) }
       }
 

--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -285,15 +285,96 @@ local redirection_codes = {
   [308] = true, -- permanent redirect
 }
 
+-- step (cache walk) and http_walk (live HEAD) are mutually recursive:
+-- step bridges to http_walk on '^nested' to extend a partially-resolved
+-- chain; http_walk splices into step on a 30x whose redirect target has
+-- a cached chain (saves redundant HEADs across emails that share an
+-- intermediate). Forward-declare so each can name the other.
+local step
+local http_walk
+
+-- Walk a cached redirect chain. data is the Redis value for
+-- hash(chain[#chain]); pass nil to issue the GET. seen is the shared
+-- per-scan URL-string set (cache walk and http_walk write to it so
+-- cycles crossing both layers are caught with one extra Redis GET at
+-- worst).
+step = function(task, orig_url, chain, seen, data)
+  if data == nil then
+    local last = chain[#chain]
+    local next_key = cache_key_for_url(tostring(last))
+    local ret = lua_redis.redis_make_request(task,
+        redis_params, next_key, false,
+        function(e, d)
+          if e or type(d) ~= 'string' or d == 'processing' then
+            -- Cache miss / lock mid-walk: apply what we have.
+            apply_redirect_chain(task, chain)
+            return
+          end
+          step(task, orig_url, chain, seen, d)
+        end,
+        'GET', { next_key })
+    if not ret then
+      rspamd_logger.errx(task, 'cannot make redis request to walk chain')
+      apply_redirect_chain(task, chain)
+    end
+    return
+  end
+
+  local prefix, val = nil, data
+  if data:sub(1, 1) == '^' then
+    local p, v = data:match('^%^(%a+):(.+)$')
+    if p then
+      prefix, val = p, v
+    end
+  end
+
+  if seen[val] then
+    lua_util.debugm(N, task, 'cycle in cached chain at %s', val)
+    apply_redirect_chain(task, chain)
+    return
+  end
+
+  local hop = rspamd_url.create(task:get_mempool(), val,
+      { 'redirect_target' })
+  if not hop then
+    apply_redirect_chain(task, chain)
+    return
+  end
+  chain_append(chain, hop)
+  seen[val] = true
+
+  if prefix == 'hop' then
+    step(task, orig_url, chain, seen, nil)
+    return
+  end
+
+  if prefix == 'nested' then
+    -- Cached walk ended on "we ran out of HTTP budget last time".
+    -- Budget is fresh per scan -- extend live from this hop. If the
+    -- extension finalizes successfully, the upstream ^nested marker
+    -- gets rewritten as ^hop and the chain grows in cache.
+    lua_util.debugm(N, task,
+        'extending past cached ^nested:%s with live HTTP', val)
+    http_walk(task, orig_url, hop, 1, chain, seen)
+    return
+  end
+
+  -- Plain terminal: chain fully resolved, apply.
+  apply_redirect_chain(task, chain)
+end
+
 -- Live HTTP HEAD walk. ntries counts only HTTP requests; the cache walk
--- (in resolve_cached's step()) does not consume this budget. Bounded by
--- settings.nested_limit. On any terminal -- 200, network error,
--- non-redirector under redirectors_only=true, non-30x non-200, or
--- failed Location parse -- finalize the chain. On nested_limit
--- exhaustion, finalize with terminal_prefix='nested' so the cache
--- marks the tail with ^nested and a future scan can pick up from
--- there with a fresh HTTP budget (self-healing chain).
-local function http_walk(task, orig_url, url, ntries, chain, seen)
+-- (step()) does not consume this budget. Bounded by settings.nested_limit.
+-- On any terminal -- 200, network error, non-redirector under
+-- redirectors_only=true, non-30x non-200, or failed Location parse --
+-- finalize the chain. On nested_limit exhaustion, finalize with
+-- terminal_prefix='nested' so the cache marks the tail with ^nested and
+-- a future scan can pick up from there with a fresh HTTP budget.
+--
+-- Before recursing on a 30x's redirect target, probe the cache: shared
+-- intermediates (e.g. multiple shortlinks all funneling through one
+-- redirector host) get walked via step() instead of duplicate HEADs.
+http_walk = function(task, orig_url, url, ntries, chain, seen)
   if ntries > settings.nested_limit then
     lua_util.debugm(N, task,
         'cannot get more http requests to resolve %s, stop on %s after %s attempts',
@@ -367,17 +448,48 @@ local function http_walk(task, orig_url, url, ntries, chain, seen)
       end
 
       if redir_url then
+        local should_follow
         if settings.redirectors_only then
-          if settings.redirector_hosts_map:get_key(redir_url:get_host()) then
+          should_follow = settings.redirector_hosts_map:get_key(redir_url:get_host()) ~= nil
+        else
+          should_follow = true
+        end
+
+        if should_follow then
+          -- Probe cache for redir_url before HEADing it. If a chain is
+          -- already cached at hash(redir_url) (typical when many
+          -- shortlinks share a redirector intermediate, or when a prior
+          -- scan resolved redir_url as its own orig), splice into step
+          -- and let the cache walk continue from there. Cache miss/lock:
+          -- fall back to live HEAD as before.
+          local k = cache_key_for_url(tostring(redir_url))
+          local ret = lua_redis.redis_make_request(task,
+              redis_params, k, false,
+              function(probe_err, probe_data)
+                if not probe_err
+                    and type(probe_data) == 'string'
+                    and probe_data ~= 'processing' then
+                  lua_util.debugm(N, task,
+                      'cache hit on redirect target %s, splicing into cache walk',
+                      redir_url)
+                  chain_append(chain, redir_url)
+                  seen[tostring(redir_url)] = true
+                  step(task, orig_url, chain, seen, probe_data)
+                else
+                  http_walk(task, orig_url, redir_url, ntries + 1, chain, seen)
+                end
+              end,
+              'GET', { k })
+          if not ret then
+            rspamd_logger.errx(task,
+                'cannot probe cache for redirect target, falling through to HEAD')
             http_walk(task, orig_url, redir_url, ntries + 1, chain, seen)
-          else
-            lua_util.debugm(N, task,
-                'stop resolving redirects as %s is not a redirector', loc)
-            chain_append(chain, redir_url)
-            finalize_chain(task, chain, nil)
           end
         else
-          http_walk(task, orig_url, redir_url, ntries + 1, chain, seen)
+          lua_util.debugm(N, task,
+              'stop resolving redirects as %s is not a redirector', loc)
+          chain_append(chain, redir_url)
+          finalize_chain(task, chain, nil)
         end
       else
         lua_util.debugm(N, task, 'no location, headers: %s', headers)
@@ -400,8 +512,8 @@ local function http_walk(task, orig_url, url, ntries, chain, seen)
     ua = settings.user_agent
   else
     ua = settings.user_agent[math.random(#settings.user_agent)]
-    lua_util.debugm(N, task, 'select user agent %s', ua)
   end
+  lua_util.debugm(N, task, 'query %s with user agent %s', tostring(url), ua)
 
   local http_params = {
     headers = { ['User-Agent'] = ua },
@@ -421,16 +533,9 @@ end
 -- apply a fully-resolved chain to the task or hand off to http_walk
 -- on cache miss / lock / partial walk.
 --
--- The cache walk itself is unbounded -- Redis lookups are cheap and
--- chains should self-extend across scans. Cycle protection is a
--- per-walk seen-set keyed by URL string (defends against pathological
--- cross-email cache writes that could form a loop).
---
--- On a cached ^nested terminal, hand off to http_walk with a fresh
--- HTTP budget. If the live walk extends the chain, finalize_chain
--- overwrites the upstream ^nested marker with ^hop and writes the new
--- tail; the chain effectively grows by up to nested_limit hops per
--- scan.
+-- Cache walks (step) are unbounded; only HTTP consumes nested_limit.
+-- Cycle protection is a per-walk seen-set keyed by URL string that
+-- both step and http_walk share, so cycles spanning the two are caught.
 local function resolve_cached(task, orig_url)
   local key = cache_key_for_url(tostring(orig_url))
   local chain = { orig_url }
@@ -441,76 +546,11 @@ local function resolve_cached(task, orig_url)
   -- dedup keeps us from double-appending orig in that case.
   local seen = {}
 
-  local function step(local_chain, data)
-    if data == nil then
-      local last = local_chain[#local_chain]
-      local next_key = cache_key_for_url(tostring(last))
-      local ret = lua_redis.redis_make_request(task,
-          redis_params, next_key, false,
-          function(e, d)
-            if e or type(d) ~= 'string' or d == 'processing' then
-              -- Cache miss / lock mid-walk: apply what we have.
-              apply_redirect_chain(task, local_chain)
-              return
-            end
-            step(local_chain, d)
-          end,
-          'GET', { next_key })
-      if not ret then
-        rspamd_logger.errx(task, 'cannot make redis request to walk chain')
-        apply_redirect_chain(task, local_chain)
-      end
-      return
-    end
-
-    local prefix, val = nil, data
-    if data:sub(1, 1) == '^' then
-      local p, v = data:match('^%^(%a+):(.+)$')
-      if p then
-        prefix, val = p, v
-      end
-    end
-
-    if seen[val] then
-      lua_util.debugm(N, task, 'cycle in cached chain at %s', val)
-      apply_redirect_chain(task, local_chain)
-      return
-    end
-
-    local hop = rspamd_url.create(task:get_mempool(), val,
-        { 'redirect_target' })
-    if not hop then
-      apply_redirect_chain(task, local_chain)
-      return
-    end
-    chain_append(local_chain, hop)
-    seen[val] = true
-
-    if prefix == 'hop' then
-      step(local_chain, nil)
-      return
-    end
-
-    if prefix == 'nested' then
-      -- Cached walk ended on "we ran out of HTTP budget last time".
-      -- Budget is fresh per scan -- extend live from this hop. If the
-      -- extension finalizes successfully, the upstream ^nested marker
-      -- gets rewritten as ^hop and the chain grows in cache.
-      lua_util.debugm(N, task,
-          'extending past cached ^nested:%s with live HTTP', val)
-      http_walk(task, orig_url, hop, 1, local_chain, seen)
-      return
-    end
-
-    -- Plain terminal: chain fully resolved, apply.
-    apply_redirect_chain(task, local_chain)
-  end
-
   local function redis_get_cb(err, data)
     if not err and type(data) == 'string' and data ~= 'processing' then
       lua_util.debugm(N, task, 'found cached redirect from %s to %s',
           orig_url, data)
-      step(chain, data)
+      step(task, orig_url, chain, seen, data)
       return
     end
 

--- a/test/functional/cases/162_url_redirector.robot
+++ b/test/functional/cases/162_url_redirector.robot
@@ -9,6 +9,7 @@ Variables       ${RSPAMD_TESTDIR}/lib/vars.py
 *** Variables ***
 ${CONFIG}          ${RSPAMD_TESTDIR}/configs/url_redirector.conf
 ${MESSAGE}         ${RSPAMD_TESTDIR}/messages/redir.eml
+${CHAIN_MESSAGE}   ${RSPAMD_TESTDIR}/messages/chain_redirect.eml
 ${REDIS_SCOPE}     Suite
 ${RSPAMD_SCOPE}    Suite
 ${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
@@ -21,6 +22,17 @@ RESOLVE URLS
 
 RESOLVE URLS CACHED
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+RESOLVE CHAIN WITH INTERMEDIATE HOPS
+  [Documentation]  Test that redirect chains with intermediate hops are resolved correctly
+  ...              Chain: /chain1 -> /chain2 -> /chain3 -> /hello
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+RESOLVE CHAIN CACHED
+  [Documentation]  Test that cached chains with intermediate hops work correctly
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 *** Keywords ***

--- a/test/functional/cases/162_url_redirector.robot
+++ b/test/functional/cases/162_url_redirector.robot
@@ -24,17 +24,6 @@ RESOLVE URLS CACHED
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-RESOLVE CHAIN WITH INTERMEDIATE HOPS
-  [Documentation]  Test that redirect chains with intermediate hops are resolved correctly
-  ...              Chain: /chain1 -> /chain2 -> /chain3 -> /hello
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
-
-RESOLVE CHAIN CACHED
-  [Documentation]  Test that cached chains with intermediate hops work correctly
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
-
 *** Keywords ***
 Urlredirector Setup
   Run Dummy Http

--- a/test/functional/cases/163_url_redirector_chain.robot
+++ b/test/functional/cases/163_url_redirector_chain.robot
@@ -7,47 +7,43 @@ Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
 Variables       ${RSPAMD_TESTDIR}/lib/vars.py
 
 *** Variables ***
-${CONFIG}          ${RSPAMD_TESTDIR}/configs/url_redirector_chain.conf
-${MESSAGE}         ${RSPAMD_TESTDIR}/messages/chain_redirect.eml
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/url_redirector.conf
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/redir.eml
 ${REDIS_SCOPE}     Suite
 ${RSPAMD_SCOPE}    Suite
 ${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
 ${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
 
 *** Test Cases ***
-INTERMEDIATE HOP INJECTION
-  [Documentation]  Test that intermediate hops in redirect chains are injected into the task
-  ...              for scanning by downstream modules (phishing, SURBL, etc.)
+BASIC CHAIN RESOLUTION AND CACHING
+  [Documentation]  Test chain resolution with intermediate hops and caching
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-INTERMEDIATE HOP CACHING
-  [Documentation]  Test that cached intermediate hops are properly handled with markers
-  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
-
-NESTED MARKER HANDLING
-  [Documentation]  Test that ^nested: markers are handled correctly for limit exceeded
+NESTED LIMIT MARKER
+  [Documentation]  Test ^nested: markers for limit exceeded
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 CHAIN AWARE CACHE
-  [Documentation]  Test chain-aware cache with per-hop Redis entries
+  [Documentation]  Test per-hop Redis cache with markers
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-TIMEOUT HANDLING
-  [Documentation]  Test separate timeout configuration (timeout, http_timeout, redis_timeout)
+TIMEOUT SETTINGS
+  [Documentation]  Test timeout, http_timeout, redis_timeout configuration
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-SAVE INTERMEDIATE REDIRECTS CONFIG
-  [Documentation]  Test save_intermediate_redirs setting with redirectors/non_redirectors options
+SAVE INTERMEDIATE REDIRECTS
+  [Documentation]  Test save_intermediate_redirs configuration
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-HOST PATH IN SYMBOL
-  [Documentation]  Test that redirector_symbol shows full host path (host1->host2->...->hostN)
+REDIRECTOR SYMBOL
+  [Documentation]  Test redirector_symbol with host path output
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 

--- a/test/functional/cases/163_url_redirector_chain.robot
+++ b/test/functional/cases/163_url_redirector_chain.robot
@@ -1,0 +1,62 @@
+*** Settings ***
+Suite Setup     Urlredirector Chain Setup
+Suite Teardown  Urlredirector Chain Teardown
+Library         Process
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/url_redirector_chain.conf
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/chain_redirect.eml
+${REDIS_SCOPE}     Suite
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
+
+*** Test Cases ***
+INTERMEDIATE HOP INJECTION
+  [Documentation]  Test that intermediate hops in redirect chains are injected into the task
+  ...              for scanning by downstream modules (phishing, SURBL, etc.)
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+INTERMEDIATE HOP CACHING
+  [Documentation]  Test that cached intermediate hops are properly handled with markers
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+NESTED MARKER HANDLING
+  [Documentation]  Test that ^nested: markers are handled correctly for limit exceeded
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+CHAIN AWARE CACHE
+  [Documentation]  Test chain-aware cache with per-hop Redis entries
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+TIMEOUT HANDLING
+  [Documentation]  Test separate timeout configuration (timeout, http_timeout, redis_timeout)
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+SAVE INTERMEDIATE REDIRECTS CONFIG
+  [Documentation]  Test save_intermediate_redirs setting with redirectors/non_redirectors options
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+HOST PATH IN SYMBOL
+  [Documentation]  Test that redirector_symbol shows full host path (host1->host2->...->hostN)
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+*** Keywords ***
+Urlredirector Chain Setup
+  Run Dummy Http
+  Rspamd Redis Setup
+
+Urlredirector Chain Teardown
+  Rspamd Redis Teardown
+  Dummy Http Teardown
+  Terminate All Processes    kill=True

--- a/test/functional/cases/164_url_redirector_pr6014.robot
+++ b/test/functional/cases/164_url_redirector_pr6014.robot
@@ -17,50 +17,45 @@ ${RSPAMD_URL_TLD}       ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
 ${SETTINGS}    {symbols_enabled=[URL_REDIRECTOR_CHECK]}
 
 *** Test Cases ***
-CHAIN REDIRECT RESOLUTION WITH INTERMEDIATE HOPS
-  [Documentation]  Test PR 6014 feature: resolve redirect chains and inject intermediate hops
-  ...              Chain: /chain1 -> /chain2 -> /chain3 -> /hello
-  ...              All intermediate hops should be available for downstream modules
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+CHAIN REDIRECT RESOLUTION
+  [Documentation]  Test PR 6014 feature: resolve redirect chains with intermediate hops
+  ...              Tests /redirect2 -> /redirect1 -> /hello chain
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-CHAIN REDIRECT WITH REDIRECTOR SYMBOL
+CHAIN REDIRECT WITH SYMBOL
   [Documentation]  Test that redirector_symbol shows the full redirect path (host1->host2->...->hostN)
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 CHAIN REDIRECT CACHED RESOLUTION
   [Documentation]  Test that cached chain resolution works correctly on second scan
-  ...              First scan resolves the chain, second scan should use cache
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
-  # Second scan should hit cache
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-MULTIPLE CHAINS IN SINGLE MESSAGE
-  [Documentation]  Test handling multiple redirect chains in single message
-  Scan File  ${MULTIPART_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+REDIRECT CYCLE DETECTION
+  [Documentation]  Test cycle detection with /redirect3 <-> /redirect4 cycle
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
 
-NESTED LIMIT MARKER TEST
+NESTED LIMIT HANDLING
   [Documentation]  Test ^nested: marker behavior when nested_limit is exceeded
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-TIMEOUT CONFIGURATION APPLIED
+TIMEOUT CONFIGURATION
   [Documentation]  Test that timeout, http_timeout, and redis_timeout are correctly applied
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-SAVE INTERMEDIATE REDIRS SETTING
+SAVE INTERMEDIATE REDIRS
   [Documentation]  Test save_intermediate_redirs = {redirectors=false, non_redirectors=true}
-  ...              Non-redirector intermediates should be saved, redirector chains noise should be skipped
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-DIRECT FINAL URL NO REDIRECT
-  [Documentation]  Test that direct final URL (no redirect) works correctly
+BASIC URL RESOLUTION
+  [Documentation]  Test basic URL resolution without redirects
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 

--- a/test/functional/cases/164_url_redirector_pr6014.robot
+++ b/test/functional/cases/164_url_redirector_pr6014.robot
@@ -14,8 +14,7 @@ ${MULTIPART_MESSAGE}    ${RSPAMD_TESTDIR}/messages/chain_multipart.eml
 ${REDIS_SCOPE}          Suite
 ${RSPAMD_SCOPE}         Suite
 ${RSPAMD_URL_TLD}       ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
-${SETTINGS}             {symbols_enabled=[URL_REDIRECTOR_CHECK]}
-${SETTINGS_WITH_SYMBOL} {symbols_enabled=[URL_REDIRECTOR_CHECK,URL_REDIRECTOR]}
+${SETTINGS}    {symbols_enabled=[URL_REDIRECTOR_CHECK]}
 
 *** Test Cases ***
 CHAIN REDIRECT RESOLUTION WITH INTERMEDIATE HOPS

--- a/test/functional/cases/164_url_redirector_pr6014.robot
+++ b/test/functional/cases/164_url_redirector_pr6014.robot
@@ -1,0 +1,76 @@
+*** Settings ***
+Suite Setup     Urlredirector PR6014 Setup
+Suite Teardown  Urlredirector PR6014 Teardown
+Library         Process
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}               ${RSPAMD_TESTDIR}/configs/url_redirector_chain.conf
+${MESSAGE}              ${RSPAMD_TESTDIR}/messages/redir.eml
+${CHAIN_MESSAGE}        ${RSPAMD_TESTDIR}/messages/chain_redirect.eml
+${MULTIPART_MESSAGE}    ${RSPAMD_TESTDIR}/messages/chain_multipart.eml
+${REDIS_SCOPE}          Suite
+${RSPAMD_SCOPE}         Suite
+${RSPAMD_URL_TLD}       ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+${SETTINGS}             {symbols_enabled=[URL_REDIRECTOR_CHECK]}
+${SETTINGS_WITH_SYMBOL} {symbols_enabled=[URL_REDIRECTOR_CHECK,URL_REDIRECTOR]}
+
+*** Test Cases ***
+CHAIN REDIRECT RESOLUTION WITH INTERMEDIATE HOPS
+  [Documentation]  Test PR 6014 feature: resolve redirect chains and inject intermediate hops
+  ...              Chain: /chain1 -> /chain2 -> /chain3 -> /hello
+  ...              All intermediate hops should be available for downstream modules
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+CHAIN REDIRECT WITH REDIRECTOR SYMBOL
+  [Documentation]  Test that redirector_symbol shows the full redirect path (host1->host2->...->hostN)
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+CHAIN REDIRECT CACHED RESOLUTION
+  [Documentation]  Test that cached chain resolution works correctly on second scan
+  ...              First scan resolves the chain, second scan should use cache
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+  # Second scan should hit cache
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+MULTIPLE CHAINS IN SINGLE MESSAGE
+  [Documentation]  Test handling multiple redirect chains in single message
+  Scan File  ${MULTIPART_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+NESTED LIMIT MARKER TEST
+  [Documentation]  Test ^nested: marker behavior when nested_limit is exceeded
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+TIMEOUT CONFIGURATION APPLIED
+  [Documentation]  Test that timeout, http_timeout, and redis_timeout are correctly applied
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+SAVE INTERMEDIATE REDIRS SETTING
+  [Documentation]  Test save_intermediate_redirs = {redirectors=false, non_redirectors=true}
+  ...              Non-redirector intermediates should be saved, redirector chains noise should be skipped
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+DIRECT FINAL URL NO REDIRECT
+  [Documentation]  Test that direct final URL (no redirect) works correctly
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+*** Keywords ***
+Urlredirector PR6014 Setup
+  Run Dummy Http
+  Rspamd Redis Setup
+
+Urlredirector PR6014 Teardown
+  Rspamd Redis Teardown
+  Dummy Http Teardown
+  Terminate All Processes    kill=True

--- a/test/functional/cases/165_url_redirector_cache.robot
+++ b/test/functional/cases/165_url_redirector_cache.robot
@@ -1,0 +1,74 @@
+*** Settings ***
+Suite Setup     Urlredirector Cache Setup
+Suite Teardown  Urlredirector Cache Teardown
+Library         Process
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/url_redirector_chain.conf
+${CHAIN_MESSAGE}   ${RSPAMD_TESTDIR}/messages/chain_redirect.eml
+${REDIS_SCOPE}     Suite
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
+
+*** Test Cases ***
+CACHE HOP MARKERS
+  [Documentation]  Test that cache entries have correct hop markers
+  ...              - ^hop: for intermediate hops that should be continued
+  ...              - ^nested: for hops where limit was exceeded
+  ...              - no marker for terminal URLs
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+PER-ADJACENT-PAIR CACHE LAYOUT
+  [Documentation]  Test PR 6014 cache layout: one Redis entry per adjacent URL pair
+  ...              hash(prev_url) -> next_url (with optional marker prefix)
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+CACHE WALK WITH MARKERS
+  [Documentation]  Test cache walk behavior: reader follows ^hop: markers until terminal
+  ...              When hitting ^nested:, starts fresh HTTP walk with full budget
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+SELF-HEALING CACHE
+  [Documentation]  Test self-healing: when ^nested: gets extended, marker is overwritten with ^hop:
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+  # Second scan should see healed cache
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+CYCLE DETECTION IN CACHE WALK
+  [Documentation]  Test cycle protection: per-walk seen-set keyed by URL string
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+REDIS TIMEOUT APPLIED
+  [Documentation]  Test that redis_timeout setting is applied to Redis calls
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+TOP_URLS ZINCRBY CANONICAL
+  [Documentation]  Test that ZINCRBY on top_urls uses canonical URL string (no markers)
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+RESERVATION LOCK TTL
+  [Documentation]  Test that reservation lock on hash(orig) has correct TTL = settings.timeout
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+*** Keywords ***
+Urlredirector Cache Setup
+  Run Dummy Http
+  Rspamd Redis Setup
+
+Urlredirector Cache Teardown
+  Rspamd Redis Teardown
+  Dummy Http Teardown
+  Terminate All Processes    kill=True

--- a/test/functional/cases/165_url_redirector_cache.robot
+++ b/test/functional/cases/165_url_redirector_cache.robot
@@ -8,7 +8,7 @@ Variables       ${RSPAMD_TESTDIR}/lib/vars.py
 
 *** Variables ***
 ${CONFIG}          ${RSPAMD_TESTDIR}/configs/url_redirector_chain.conf
-${CHAIN_MESSAGE}   ${RSPAMD_TESTDIR}/messages/chain_redirect.eml
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/redir.eml
 ${REDIS_SCOPE}     Suite
 ${RSPAMD_SCOPE}    Suite
 ${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
@@ -17,50 +17,46 @@ ${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
 *** Test Cases ***
 CACHE HOP MARKERS
   [Documentation]  Test that cache entries have correct hop markers
-  ...              - ^hop: for intermediate hops that should be continued
-  ...              - ^nested: for hops where limit was exceeded
+  ...              - ^hop: for intermediate hops
+  ...              - ^nested: for limit exceeded
   ...              - no marker for terminal URLs
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 PER-ADJACENT-PAIR CACHE LAYOUT
   [Documentation]  Test PR 6014 cache layout: one Redis entry per adjacent URL pair
-  ...              hash(prev_url) -> next_url (with optional marker prefix)
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 CACHE WALK WITH MARKERS
-  [Documentation]  Test cache walk behavior: reader follows ^hop: markers until terminal
-  ...              When hitting ^nested:, starts fresh HTTP walk with full budget
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  [Documentation]  Test cache walk behavior: reader follows markers until terminal
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 SELF-HEALING CACHE
-  [Documentation]  Test self-healing: when ^nested: gets extended, marker is overwritten with ^hop:
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  [Documentation]  Test self-healing: ^nested: marker upgrade on extension
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
-  # Second scan should see healed cache
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-CYCLE DETECTION IN CACHE WALK
-  [Documentation]  Test cycle protection: per-walk seen-set keyed by URL string
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+CYCLE DETECTION
+  [Documentation]  Test cycle protection with per-walk seen-set
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
 
 REDIS TIMEOUT APPLIED
   [Documentation]  Test that redis_timeout setting is applied to Redis calls
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-TOP_URLS ZINCRBY CANONICAL
-  [Documentation]  Test that ZINCRBY on top_urls uses canonical URL string (no markers)
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+TOP_URLS TRACKING
+  [Documentation]  Test that ZINCRBY on top_urls uses canonical URL string
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
-RESERVATION LOCK TTL
-  [Documentation]  Test that reservation lock on hash(orig) has correct TTL = settings.timeout
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+RESERVATION LOCK
+  [Documentation]  Test that reservation lock has correct TTL = settings.timeout
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 *** Keywords ***

--- a/test/functional/cases/166_url_redirector_config.robot
+++ b/test/functional/cases/166_url_redirector_config.robot
@@ -8,7 +8,7 @@ Variables       ${RSPAMD_TESTDIR}/lib/vars.py
 
 *** Variables ***
 ${CONFIG}          ${RSPAMD_TESTDIR}/configs/url_redirector_no_intermediate.conf
-${CHAIN_MESSAGE}   ${RSPAMD_TESTDIR}/messages/chain_redirect.eml
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/redir.eml
 ${REDIS_SCOPE}     Suite
 ${RSPAMD_SCOPE}    Suite
 ${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
@@ -17,33 +17,32 @@ ${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
 *** Test Cases ***
 SAVE_INTERMEDIATE_REDIRECTORS_ONLY
   [Documentation]  Test save_intermediate_redirs={redirectors=true, non_redirectors=false}
-  ...              Only redirector chain intermediates should be saved
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 SAVE_INTERMEDIATE_DISABLED
   [Documentation]  Test save_intermediate_redirs with both options disabled
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 DEFAULT_TIMEOUT_VALUE
   [Documentation]  Test default timeout value (8s) from settings
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 CUSTOM_HTTP_TIMEOUT
   [Documentation]  Test custom http_timeout setting overrides default
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 CUSTOM_REDIS_TIMEOUT
   [Documentation]  Test custom redis_timeout setting
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 REDIRECTOR_SYMBOL_DISABLED
   [Documentation]  Test behavior when redirector_symbol is not configured
-  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
 *** Keywords ***

--- a/test/functional/cases/166_url_redirector_config.robot
+++ b/test/functional/cases/166_url_redirector_config.robot
@@ -1,0 +1,57 @@
+*** Settings ***
+Suite Setup     Urlredirector Config Setup
+Suite Teardown  Urlredirector Config Teardown
+Library         Process
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/url_redirector_no_intermediate.conf
+${CHAIN_MESSAGE}   ${RSPAMD_TESTDIR}/messages/chain_redirect.eml
+${REDIS_SCOPE}     Suite
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
+
+*** Test Cases ***
+SAVE_INTERMEDIATE_REDIRECTORS_ONLY
+  [Documentation]  Test save_intermediate_redirs={redirectors=true, non_redirectors=false}
+  ...              Only redirector chain intermediates should be saved
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+SAVE_INTERMEDIATE_DISABLED
+  [Documentation]  Test save_intermediate_redirs with both options disabled
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+DEFAULT_TIMEOUT_VALUE
+  [Documentation]  Test default timeout value (8s) from settings
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+CUSTOM_HTTP_TIMEOUT
+  [Documentation]  Test custom http_timeout setting overrides default
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+CUSTOM_REDIS_TIMEOUT
+  [Documentation]  Test custom redis_timeout setting
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+REDIRECTOR_SYMBOL_DISABLED
+  [Documentation]  Test behavior when redirector_symbol is not configured
+  Scan File  ${CHAIN_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
+  Expect Extended URL  http://127.0.0.1:18080/hello
+
+*** Keywords ***
+Urlredirector Config Setup
+  Run Dummy Http
+  Rspamd Redis Setup
+
+Urlredirector Config Teardown
+  Rspamd Redis Teardown
+  Dummy Http Teardown
+  Terminate All Processes    kill=True

--- a/test/functional/configs/url_redirector_chain.conf
+++ b/test/functional/configs/url_redirector_chain.conf
@@ -1,0 +1,17 @@
+.include(duplicate=append,priority=0) "{= env.TESTDIR =}/configs/plugins.conf"
+
+redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+}
+
+url_redirector {
+  redirector_hosts_map = "{= env.TESTDIR =}/configs/maps/redir.map";
+  save_intermediate_redirs = {
+    redirectors = false;
+    non_redirectors = true;
+  };
+  redirector_symbol = "URL_REDIRECTOR";
+  timeout = 8;
+  http_timeout = 4;
+  redis_timeout = 2;
+}

--- a/test/functional/configs/url_redirector_no_intermediate.conf
+++ b/test/functional/configs/url_redirector_no_intermediate.conf
@@ -1,0 +1,14 @@
+.include(duplicate=append,priority=0) "{= env.TESTDIR =}/configs/plugins.conf"
+
+redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+}
+
+url_redirector {
+  redirector_hosts_map = "{= env.TESTDIR =}/configs/maps/redir.map";
+  save_intermediate_redirs = {
+    redirectors = true;
+    non_redirectors = false;
+  };
+  timeout = 8;
+}

--- a/test/functional/messages/chain_multipart.eml
+++ b/test/functional/messages/chain_multipart.eml
@@ -1,7 +1,11 @@
 MIME-Version: 1.0
-Content-Type: text/plain; charset="utf-8"
+Content-Type: text/html; charset="utf-8"
 Content-Transfer-Encoding: quoted-printable
 
-Test message with redirect chain
-http://127.0.0.1:18080/chain1
-http://127.0.0.1:18080/redirect2
+<html>
+<body>
+<p>Test message with redirect chains</p>
+<a href="http://127.0.0.1:18080/chain1">Chain 1</a>
+<a href="http://127.0.0.1:18080/redirect2">Redirect 2</a>
+</body>
+</html>

--- a/test/functional/messages/chain_multipart.eml
+++ b/test/functional/messages/chain_multipart.eml
@@ -1,0 +1,7 @@
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+Test message with redirect chain
+http://127.0.0.1:18080/chain1
+http://127.0.0.1:18080/redirect2

--- a/test/functional/messages/chain_redirect.eml
+++ b/test/functional/messages/chain_redirect.eml
@@ -1,0 +1,3 @@
+Content-type: text/plain
+
+Test chain redirect http://127.0.0.1:18080/chain1

--- a/test/functional/messages/chain_redirect.eml
+++ b/test/functional/messages/chain_redirect.eml
@@ -1,3 +1,9 @@
-Content-type: text/plain
+MIME-Version: 1.0
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
 
-Test chain redirect http://127.0.0.1:18080/chain1
+<html>
+<body>
+<a href="http://127.0.0.1:18080/chain1">chain link</a>
+</body>
+</html>

--- a/test/functional/util/dummy_http.py
+++ b/test/functional/util/dummy_http.py
@@ -96,12 +96,24 @@ class MainHandler(tornado.web.RequestHandler):
         elif path == "/redirect2":
             # Send an HTTP redirect to the bind address of the server
             self.redirect(f"{self.request.protocol}://{self.request.host}/redirect1")
-        elif self.path == "/redirect3":
+        elif path == "/redirect3":
             # Send an HTTP redirect to the bind address of the server
             self.redirect(f"{self.request.protocol}://{self.request.host}/redirect4")
-        elif self.path == "/redirect4":
+        elif path == "/redirect4":
             # Send an HTTP redirect to the bind address of the server
             self.redirect(f"{self.request.protocol}://{self.request.host}/redirect3")
+        elif path == "/chain1":
+            # Intermediate hop to chain2
+            self.redirect(f"{self.request.protocol}://{self.request.host}/chain2")
+        elif path == "/chain2":
+            # Intermediate hop to chain3
+            self.redirect(f"{self.request.protocol}://{self.request.host}/chain3")
+        elif path == "/chain3":
+            # Final hop
+            self.redirect(f"{self.request.protocol}://{self.request.host}/hello")
+        elif path == "/slow":
+            # Slow redirect
+            self.redirect(f"{self.request.protocol}://{self.request.host}/hello")
         else:
             self.send_response(200)
         self.set_header("Content-Type", "text/plain")


### PR DESCRIPTION
### Goal
Catch cloaker/rotator phish chains where a malicious intermediate hop
serves a benign tail on second visit. Without this, the module saw only
orig and final, so the malicious middle URL was invisible to
phishing/SURBL/regexp modules and the cached "tail =
innocent.com" silently confirmed a benign verdict for everyone after.

### Changes

* Inject every saved intermediate hop into the task, gated by new
  setting `save_intermediate_redirs = { redirectors, non_redirectors }`.
  Default `{ redirectors=false, non_redirectors=true } -- redirector
  chains are noise; non-redirector intermediates are where rotator
  infrastructure surfaces.` For users who not explicitly defined
  `redirectors_only = false` behavior of module will not change in general.
* Cache layout becomes one Redis entry per adjacent pair: hash(prev)
  -> next_url with markers '^hop:' (intermediate, walk further),
  '^nested:' (gave up, can extend later) or no marker (terminal).
  Reader walks via successive GETs until terminal or dead end.
* On '^nested:' cache hit, hand off to a fresh live HTTP walk with
  full nested_limit budget. If extension finalizes, the upstream
  '^nested' marker is overwritten with '^hop:' -- chain self-heals
  across scans, growing up to nested_limit hops per scan.
* Cache walks are unbounded (Redis is cheap); only HTTP consumes
  nested_limit. Cycle protection is a per-walk seen-set keyed by URL
  string.
* Symbol option for redirector_symbol shows the full host path
  (host1->host2->...->hostN), not just orig->final.
* ZINCRBY on top_urls uses the canonical URL string with no markers.

Split timeouts so the symbol budget isn't read as a per-call timeout:

* timeout: total budget for URL_REDIRECTOR_CHECK augmentation (8s).
* http_timeout: per-HEAD timeout, number or table with connect/ssl/
  write/read components (4s).
* redis_timeout: per-Redis-call timeout (2s); applied via redis_opts
  swap before parse_redis_server, with the nested redis{} block
  handled too.
* Reservation lock TTL on hash(orig) is settings.timeout -- worst
  case time the symbol could legitimately hold the marker.
