### PR TITLE
[Feature] rspamadm control memstat: full memory dump across workers

### DIFF
--- a/lualib/rspamadm/memstat.lua
+++ b/lualib/rspamadm/memstat.lua
@@ -1,0 +1,267 @@
+--[[
+Copyright (c) 2026, Vsevolod Stakhov <vsevolod@rspamd.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]] --
+
+local rspamd_util = require "rspamd_util"
+local argparse = require "argparse"
+
+local parser = argparse()
+    :name "rspamadm control memstat"
+    :description "Show memory usage statistics across all workers"
+    :help_description_margin(32)
+parser:flag "-n --number"
+      :description "Disable numbers humanization"
+parser:option "--top"
+      :description "Show top-N mempool callsites per worker (default 20)"
+      :convert(tonumber)
+      :default(20)
+parser:flag "--no-callsites"
+      :description "Skip per-callsite mempool breakdown"
+parser:flag "--no-jemalloc"
+      :description "Skip jemalloc text dump"
+
+local function bytes(n, raw)
+  if not n then
+    return '-'
+  end
+  if raw then
+    return tostring(n)
+  end
+  return rspamd_util.humanize_number(n)
+end
+
+local function pid_sort(a, b)
+  return tonumber(a) < tonumber(b)
+end
+
+local function sorted_keys(t, cmp)
+  local out = {}
+  for k in pairs(t) do
+    table.insert(out, k)
+  end
+  table.sort(out, cmp)
+  return out
+end
+
+local function print_summary(workers, total, opts)
+  print("Memory usage by worker:")
+  print("")
+  print(string.format("  %-7s %-13s %10s %10s %10s %12s",
+      "pid", "type", "RSS", "Lua", "mempool", "jemalloc"))
+  print("  " .. string.rep("-", 67))
+
+  for _, pid in ipairs(sorted_keys(workers, pid_sort)) do
+    local w = workers[pid]
+    print(string.format("  %-7s %-13s %10s %10s %10s %12s",
+        pid,
+        w.type or "?",
+        bytes((w.rss_kb or 0) * 1024, opts.number),
+        bytes((w.lua_kb or 0) * 1024, opts.number),
+        bytes(w.mempool_bytes or 0, opts.number),
+        bytes(w.jemalloc_allocated or 0, opts.number)))
+  end
+
+  if total then
+    print("  " .. string.rep("-", 67))
+    print(string.format("  %-7s %-13s %10s %10s %10s %12s",
+        "total", "",
+        bytes((total.rss_kb or 0) * 1024, opts.number),
+        bytes((total.lua_kb or 0) * 1024, opts.number),
+        bytes(total.mempool_bytes or 0, opts.number),
+        bytes(total.jemalloc_allocated or 0, opts.number)))
+  end
+  print("")
+end
+
+local function print_process(workers, opts)
+  local any = false
+  for _, pid in ipairs(sorted_keys(workers, pid_sort)) do
+    local w = workers[pid]
+    local proc = w.data and w.data.process
+    if proc then
+      if not any then
+        print("Process memory:")
+        any = true
+      end
+      print(string.format("  %s (%s):", pid, w.type or "?"))
+      local fields = {
+        { "vm_size",   proc.vm_size },
+        { "vm_rss",    proc.vm_rss },
+        { "rss_anon",  proc.rss_anon },
+        { "rss_file",  proc.rss_file },
+        { "rss_shmem", proc.rss_shmem },
+        { "vm_data",   proc.vm_data },
+        { "vm_stack",  proc.vm_stack },
+        { "vm_text",   proc.vm_text },
+        { "vm_lib",    proc.vm_lib },
+        { "vm_pte",    proc.vm_pte },
+      }
+      local parts = {}
+      for _, kv in ipairs(fields) do
+        if kv[2] and kv[2] > 0 then
+          table.insert(parts, string.format("%s=%s", kv[1], bytes(kv[2], opts.number)))
+        end
+      end
+      print("    " .. table.concat(parts, "  "))
+    end
+  end
+  if any then
+    print("")
+  end
+end
+
+local function print_mempool_aggregate(workers, opts)
+  local any = false
+  for _, pid in ipairs(sorted_keys(workers, pid_sort)) do
+    local w = workers[pid]
+    local mp = w.data and w.data.mempool
+    if mp and mp.aggregate then
+      if not any then
+        print("Mempool aggregate:")
+        any = true
+      end
+      local a = mp.aggregate
+      print(string.format("  %s (%s):", pid, w.type or "?"))
+      print(string.format(
+          "    pools=%d/%d  bytes=%s  chunks=%d/%d  shared=%d  oversized=%d  fragmented=%s",
+          a.pools_allocated or 0, a.pools_freed or 0,
+          bytes(a.bytes_allocated or 0, opts.number),
+          a.chunks_allocated or 0, a.chunks_freed or 0,
+          a.shared_chunks_allocated or 0,
+          a.oversized_chunks or 0,
+          bytes(a.fragmented_size or 0, opts.number)))
+    end
+  end
+  if any then
+    print("")
+  end
+end
+
+local function print_callsites(workers, opts)
+  if opts.no_callsites then
+    return
+  end
+  local limit = opts.top or 20
+  local any = false
+  for _, pid in ipairs(sorted_keys(workers, pid_sort)) do
+    local w = workers[pid]
+    local entries = w.data and w.data.mempool and w.data.mempool.entries
+    if entries and #entries > 0 then
+      if not any then
+        print(string.format("Top %d mempool callsites by suggestion:", limit))
+        any = true
+      end
+      table.sort(entries, function(a, b)
+        return (a.cur_suggestion or 0) > (b.cur_suggestion or 0)
+      end)
+      print(string.format("  %s (%s):", pid, w.type or "?"))
+      for i = 1, math.min(limit, #entries) do
+        local e = entries[i]
+        print(string.format(
+            "    [%-9s] %-50s elts=%-4d vars=%-4d dtors=%-4d avg_frag=%-9s avg_left=%-9s n=%d",
+            bytes(e.cur_suggestion or 0, opts.number),
+            e.src or "?",
+            e.cur_elts or 0,
+            e.cur_vars or 0,
+            e.cur_dtors or 0,
+            bytes(e.avg_fragmentation or 0, opts.number),
+            bytes(e.avg_leftover or 0, opts.number),
+            e.samples or 0))
+      end
+    end
+  end
+  if any then
+    print("")
+  end
+end
+
+local function print_lua(workers, opts)
+  local any = false
+  for _, pid in ipairs(sorted_keys(workers, pid_sort)) do
+    local w = workers[pid]
+    local lua = w.data and w.data.lua
+    if lua then
+      if not any then
+        print("Lua heap:")
+        any = true
+      end
+      print(string.format("  %s (%s): %s",
+          pid, w.type or "?",
+          bytes(lua.used_bytes or 0, opts.number)))
+    end
+  end
+  if any then
+    print("")
+  end
+end
+
+local function print_jemalloc(workers, opts)
+  local any = false
+  for _, pid in ipairs(sorted_keys(workers, pid_sort)) do
+    local w = workers[pid]
+    local j = w.data and w.data.jemalloc
+    if j then
+      if not any then
+        print("Jemalloc:")
+        any = true
+      end
+      print(string.format("  %s (%s):", pid, w.type or "?"))
+      if j.stats then
+        local parts = {}
+        for _, k in ipairs({ "allocated", "active", "metadata", "resident", "mapped", "retained" }) do
+          if j.stats[k] then
+            table.insert(parts, string.format("%s=%s", k, bytes(j.stats[k], opts.number)))
+          end
+        end
+        if #parts > 0 then
+          print("    " .. table.concat(parts, "  "))
+        end
+      end
+      if j.config then
+        local parts = {}
+        for k, v in pairs(j.config) do
+          table.insert(parts, string.format("%s=%s", k, tostring(v)))
+        end
+        table.sort(parts)
+        if #parts > 0 then
+          print("    config: " .. table.concat(parts, "  "))
+        end
+      end
+      if not opts.no_jemalloc and j.text and #j.text > 0 then
+        print("    --- malloc_stats_print ---")
+        for line in tostring(j.text):gmatch("[^\r\n]+") do
+          print("    " .. line)
+        end
+        print("    --- end ---")
+      end
+    end
+  end
+  if any then
+    print("")
+  end
+end
+
+return function(args, res)
+  local opts = parser:parse(args or {})
+  local workers = res and res.workers or {}
+  local total = res and res.total
+
+  print_summary(workers, total, opts)
+  print_process(workers, opts)
+  print_mempool_aggregate(workers, opts)
+  print_callsites(workers, opts)
+  print_lua(workers, opts)
+  print_jemalloc(workers, opts)
+end

--- a/src/libserver/CMakeLists.txt
+++ b/src/libserver/CMakeLists.txt
@@ -47,6 +47,7 @@ SET(LIBRSPAMDSERVERSRC
         ${CMAKE_CURRENT_SOURCE_DIR}/http/http_context.c
         ${CMAKE_CURRENT_SOURCE_DIR}/maps/map.c
         ${CMAKE_CURRENT_SOURCE_DIR}/maps/map_helpers.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/memory_stat.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/html/html_entities.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/html/html_url.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/html/html_cta.cxx

--- a/src/libserver/memory_stat.cxx
+++ b/src/libserver/memory_stat.cxx
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include "memory_stat.h"
+#include "rspamd.h"
+#include "rspamd_control.h"
+#include "worker_util.h"
+#include "libutil/util.h"
+#include "libutil/mem_pool.h"
+#include "libutil/printf.h"
+#include "libutil/addr.h"
+#include "lua/lua_common.h"
+#include "logger.h"
+#include "ucl.h"
+#include "unix-std.h"
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <netinet/in.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <limits.h>
+#include <cerrno>
+#include <cstring>
+
+#ifdef WITH_JEMALLOC
+#include <jemalloc/jemalloc.h>
+#endif
+
+namespace {
+
+void emit_process_info(ucl_object_t *parent)
+{
+	struct rspamd_proc_mem_info info;
+
+	if (!rspamd_get_process_memory_info(&info)) {
+		return;
+	}
+
+	auto *obj = ucl_object_typed_new(UCL_OBJECT);
+
+	ucl_object_insert_key(obj, ucl_object_fromint(info.vm_size), "vm_size", 0, false);
+	ucl_object_insert_key(obj, ucl_object_fromint(info.vm_rss), "vm_rss", 0, false);
+
+	if (info.vm_data) {
+		ucl_object_insert_key(obj, ucl_object_fromint(info.vm_data), "vm_data", 0, false);
+	}
+	if (info.vm_stack) {
+		ucl_object_insert_key(obj, ucl_object_fromint(info.vm_stack), "vm_stack", 0, false);
+	}
+	if (info.vm_text) {
+		ucl_object_insert_key(obj, ucl_object_fromint(info.vm_text), "vm_text", 0, false);
+	}
+	if (info.vm_lib) {
+		ucl_object_insert_key(obj, ucl_object_fromint(info.vm_lib), "vm_lib", 0, false);
+	}
+	if (info.vm_pte) {
+		ucl_object_insert_key(obj, ucl_object_fromint(info.vm_pte), "vm_pte", 0, false);
+	}
+	if (info.rss_anon) {
+		ucl_object_insert_key(obj, ucl_object_fromint(info.rss_anon), "rss_anon", 0, false);
+	}
+	if (info.rss_file) {
+		ucl_object_insert_key(obj, ucl_object_fromint(info.rss_file), "rss_file", 0, false);
+	}
+	if (info.rss_shmem) {
+		ucl_object_insert_key(obj, ucl_object_fromint(info.rss_shmem), "rss_shmem", 0, false);
+	}
+
+	ucl_object_insert_key(parent, obj, "process", 0, false);
+}
+
+uint64_t
+emit_mempool_info(ucl_object_t *parent)
+{
+	rspamd_mempool_stat_t agg;
+	memset(&agg, 0, sizeof(agg));
+	rspamd_mempool_stat(&agg);
+
+	auto *mp = ucl_object_typed_new(UCL_OBJECT);
+
+	auto *aggregate = ucl_object_typed_new(UCL_OBJECT);
+	ucl_object_insert_key(aggregate, ucl_object_fromint(agg.pools_allocated),
+						  "pools_allocated", 0, false);
+	ucl_object_insert_key(aggregate, ucl_object_fromint(agg.pools_freed),
+						  "pools_freed", 0, false);
+	ucl_object_insert_key(aggregate, ucl_object_fromint(agg.bytes_allocated),
+						  "bytes_allocated", 0, false);
+	ucl_object_insert_key(aggregate, ucl_object_fromint(agg.chunks_allocated),
+						  "chunks_allocated", 0, false);
+	ucl_object_insert_key(aggregate, ucl_object_fromint(agg.shared_chunks_allocated),
+						  "shared_chunks_allocated", 0, false);
+	ucl_object_insert_key(aggregate, ucl_object_fromint(agg.chunks_freed),
+						  "chunks_freed", 0, false);
+	ucl_object_insert_key(aggregate, ucl_object_fromint(agg.oversized_chunks),
+						  "oversized_chunks", 0, false);
+	ucl_object_insert_key(aggregate, ucl_object_fromint(agg.fragmented_size),
+						  "fragmented_size", 0, false);
+	ucl_object_insert_key(mp, aggregate, "aggregate", 0, false);
+
+	auto *entries = ucl_object_typed_new(UCL_ARRAY);
+	struct foreach_ctx {
+		ucl_object_t *array;
+	} ctx{entries};
+
+	rspamd_mempool_entries_foreach(
+		[](const rspamd_mempool_entry_stat_t *st, void *ud) {
+			auto *c = static_cast<foreach_ctx *>(ud);
+			auto *e = ucl_object_typed_new(UCL_OBJECT);
+
+			ucl_object_insert_key(e, ucl_object_fromstring(st->src), "src", 0, false);
+			ucl_object_insert_key(e, ucl_object_fromint(st->cur_suggestion),
+								  "cur_suggestion", 0, false);
+			ucl_object_insert_key(e, ucl_object_fromint(st->cur_elts),
+								  "cur_elts", 0, false);
+			ucl_object_insert_key(e, ucl_object_fromint(st->cur_vars),
+								  "cur_vars", 0, false);
+			ucl_object_insert_key(e, ucl_object_fromint(st->cur_dtors),
+								  "cur_dtors", 0, false);
+			ucl_object_insert_key(e, ucl_object_fromint(st->avg_fragmentation),
+								  "avg_fragmentation", 0, false);
+			ucl_object_insert_key(e, ucl_object_fromint(st->avg_leftover),
+								  "avg_leftover", 0, false);
+			ucl_object_insert_key(e, ucl_object_fromint(st->samples),
+								  "samples", 0, false);
+
+			ucl_array_append(c->array, e);
+		},
+		&ctx);
+
+	ucl_object_insert_key(mp, entries, "entries", 0, false);
+
+	ucl_object_insert_key(parent, mp, "mempool", 0, false);
+
+	return agg.bytes_allocated;
+}
+
+uint64_t
+emit_lua_info(ucl_object_t *parent, struct rspamd_config *cfg)
+{
+	if (cfg == nullptr || cfg->lua_state == nullptr) {
+		return 0;
+	}
+
+	auto *L = static_cast<lua_State *>(cfg->lua_state);
+	auto used = rspamd_lua_get_memory_used(L);
+
+	auto *obj = ucl_object_typed_new(UCL_OBJECT);
+	ucl_object_insert_key(obj, ucl_object_fromint(used), "used_bytes", 0, false);
+	ucl_object_insert_key(parent, obj, "lua", 0, false);
+
+	return used;
+}
+
+#ifdef WITH_JEMALLOC
+void jemalloc_text_cb(void *ud, const char *msg)
+{
+	auto *out = static_cast<rspamd_fstring_t **>(ud);
+	rspamd_printf_fstring(out, "%s", msg);
+}
+#endif
+
+uint64_t
+emit_jemalloc_info(ucl_object_t *parent)
+{
+	uint64_t allocated = 0;
+#ifdef WITH_JEMALLOC
+	auto *obj = ucl_object_typed_new(UCL_OBJECT);
+
+	/*
+	 * Refresh internal counters before reading them; without this jemalloc
+	 * would return stale values that were captured at the previous epoch.
+	 */
+	uint64_t epoch = 1;
+	size_t epoch_sz = sizeof(epoch);
+	(void) mallctl("epoch", &epoch, &epoch_sz, &epoch, epoch_sz);
+
+	auto *stats = ucl_object_typed_new(UCL_OBJECT);
+
+	auto read_size_stat = [&](const char *name, const char *key) {
+		size_t val = 0;
+		size_t sz = sizeof(val);
+		if (mallctl(name, &val, &sz, nullptr, 0) == 0) {
+			ucl_object_insert_key(stats, ucl_object_fromint(val), key, 0, false);
+			return val;
+		}
+		return (size_t) 0;
+	};
+
+	allocated = read_size_stat("stats.allocated", "allocated");
+	read_size_stat("stats.active", "active");
+	read_size_stat("stats.metadata", "metadata");
+	read_size_stat("stats.resident", "resident");
+	read_size_stat("stats.mapped", "mapped");
+	read_size_stat("stats.retained", "retained");
+
+	ucl_object_insert_key(obj, stats, "stats", 0, false);
+
+	auto *config = ucl_object_typed_new(UCL_OBJECT);
+
+	{
+		unsigned int narenas = 0;
+		size_t sz = sizeof(narenas);
+		if (mallctl("opt.narenas", &narenas, &sz, nullptr, 0) == 0) {
+			ucl_object_insert_key(config, ucl_object_fromint(narenas), "narenas",
+								  0, false);
+		}
+	}
+
+	{
+		ssize_t v = 0;
+		size_t sz = sizeof(v);
+		if (mallctl("opt.dirty_decay_ms", &v, &sz, nullptr, 0) == 0) {
+			ucl_object_insert_key(config, ucl_object_fromint(v), "dirty_decay_ms",
+								  0, false);
+		}
+		if (mallctl("opt.muzzy_decay_ms", &v, &sz, nullptr, 0) == 0) {
+			ucl_object_insert_key(config, ucl_object_fromint(v), "muzzy_decay_ms",
+								  0, false);
+		}
+	}
+
+	ucl_object_insert_key(obj, config, "config", 0, false);
+
+	/* Capture the human-readable summary as well */
+	rspamd_fstring_t *text = rspamd_fstring_sized_new(4096);
+	malloc_stats_print(jemalloc_text_cb, &text, "Jmdablxe");
+	if (text->len > 0) {
+		ucl_object_insert_key(obj,
+							  ucl_object_fromlstring(text->str, text->len),
+							  "text", 0, false);
+	}
+	rspamd_fstring_free(text);
+
+	ucl_object_insert_key(parent, obj, "jemalloc", 0, false);
+#else
+	(void) parent;
+#endif
+	return allocated;
+}
+
+}// namespace
+
+extern "C" gboolean
+rspamd_memory_stat_collect_and_send(struct rspamd_main *rspamd_main,
+									struct rspamd_worker *worker,
+									int fd,
+									struct rspamd_control_command *cmd)
+{
+	struct rspamd_control_reply rep;
+	memset(&rep, 0, sizeof(rep));
+	rep.type = RSPAMD_CONTROL_MEMORY_STAT;
+	rep.id = cmd->id;
+
+	const char *temp_dir = (rspamd_main->cfg && rspamd_main->cfg->temp_dir)
+							   ? rspamd_main->cfg->temp_dir
+							   : "/tmp";
+	char tmppath[PATH_MAX];
+	rspamd_snprintf(tmppath, sizeof(tmppath), "%s%c%s-XXXXXXXXXX",
+					temp_dir, G_DIR_SEPARATOR, "memstat");
+
+	int outfd = mkstemp(tmppath);
+	if (outfd == -1) {
+		rep.reply.memory_stat.status = errno;
+		msg_err_main("cannot make temporary memstat file: %s", strerror(errno));
+		ssize_t r = write(fd, &rep, sizeof(rep));
+		if (r != (ssize_t) sizeof(rep)) {
+			msg_err_main("cannot write memstat reply: %s", strerror(errno));
+		}
+		return FALSE;
+	}
+
+	auto *root = ucl_object_typed_new(UCL_OBJECT);
+
+	emit_process_info(root);
+	uint64_t mempool_bytes = emit_mempool_info(root);
+	uint64_t lua_used = emit_lua_info(root, rspamd_main->cfg);
+	uint64_t jemalloc_allocated = emit_jemalloc_info(root);
+
+	auto *emit_subr = ucl_object_emit_fd_funcs(outfd);
+	ucl_object_emit_full(root, UCL_EMIT_JSON_COMPACT, emit_subr, nullptr);
+	ucl_object_emit_funcs_free(emit_subr);
+	ucl_object_unref(root);
+
+	close(outfd);
+
+	int read_fd = open(tmppath, O_RDONLY);
+	unlink(tmppath);
+
+	struct rspamd_proc_mem_info pm;
+	memset(&pm, 0, sizeof(pm));
+	rspamd_get_process_memory_info(&pm);
+
+	rep.reply.memory_stat.status = 0;
+	rep.reply.memory_stat.rss_kb = pm.vm_rss / 1024;
+	rep.reply.memory_stat.lua_kb = lua_used / 1024;
+	rep.reply.memory_stat.mempool_bytes = mempool_bytes;
+	rep.reply.memory_stat.jemalloc_allocated = jemalloc_allocated;
+
+	struct msghdr msg;
+	memset(&msg, 0, sizeof(msg));
+	struct iovec iov;
+	iov.iov_base = &rep;
+	iov.iov_len = sizeof(rep);
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	unsigned char fdspace[CMSG_SPACE(sizeof(int))];
+	if (read_fd != -1) {
+		memset(fdspace, 0, sizeof(fdspace));
+		msg.msg_control = fdspace;
+		msg.msg_controllen = sizeof(fdspace);
+		struct cmsghdr *cm = CMSG_FIRSTHDR(&msg);
+		if (cm) {
+			cm->cmsg_level = SOL_SOCKET;
+			cm->cmsg_type = SCM_RIGHTS;
+			cm->cmsg_len = CMSG_LEN(sizeof(int));
+			memcpy(CMSG_DATA(cm), &read_fd, sizeof(int));
+		}
+	}
+
+	gboolean ok = TRUE;
+	if (sendmsg(fd, &msg, 0) == -1) {
+		msg_err_main("cannot send memstat reply: %s", strerror(errno));
+		ok = FALSE;
+	}
+
+	if (read_fd != -1) {
+		close(read_fd);
+	}
+
+	(void) worker;
+
+	return ok;
+}

--- a/src/libserver/memory_stat.h
+++ b/src/libserver/memory_stat.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef RSPAMD_MEMORY_STAT_H
+#define RSPAMD_MEMORY_STAT_H
+
+#include "config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct rspamd_main;
+struct rspamd_worker;
+struct rspamd_control_command;
+
+/**
+ * Collect a memory dump for the current worker and send it back over the
+ * control pipe. The function builds a UCL document with mempool statistics,
+ * Lua heap usage, process memory information and (when compiled in) jemalloc
+ * stats; it serializes the document to a temporary file and passes the file
+ * descriptor over @fd via SCM_RIGHTS together with a short summary reply.
+ *
+ * Returns TRUE if the reply was successfully sent (regardless of how much
+ * detail was collected).
+ */
+gboolean rspamd_memory_stat_collect_and_send(struct rspamd_main *rspamd_main,
+											 struct rspamd_worker *worker,
+											 int fd,
+											 struct rspamd_control_command *cmd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libserver/rspamd_control.c
+++ b/src/libserver/rspamd_control.c
@@ -84,6 +84,7 @@ static const struct rspamd_control_cmd_match {
 	{.name = {.begin = "/fuzzystat", .len = sizeof("/fuzzystat") - 1}, .type = RSPAMD_CONTROL_FUZZY_STAT},
 	{.name = {.begin = "/fuzzysync", .len = sizeof("/fuzzysync") - 1}, .type = RSPAMD_CONTROL_FUZZY_SYNC},
 	{.name = {.begin = "/compositesstats", .len = sizeof("/compositesstats") - 1}, .type = RSPAMD_CONTROL_COMPOSITES_STATS},
+	{.name = {.begin = "/memstat", .len = sizeof("/memstat") - 1}, .type = RSPAMD_CONTROL_MEMORY_STAT},
 };
 
 static void rspamd_control_ignore_io_handler(int fd, short what, void *ud);
@@ -185,6 +186,9 @@ rspamd_control_write_reply(struct rspamd_control_session *session)
 	unsigned int total_conns = 0;
 	/* Composites stats aggregation */
 	uint64_t total_checked_slow = 0, total_checked_fast = 0, total_matched = 0;
+	/* Memory stat aggregation */
+	uint64_t total_rss_kb = 0, total_lua_kb = 0, total_mempool_bytes = 0,
+			 total_jemalloc_allocated = 0;
 
 	rep = ucl_object_typed_new(UCL_OBJECT);
 	workers = ucl_object_typed_new(UCL_OBJECT);
@@ -294,6 +298,43 @@ rspamd_control_write_reply(struct rspamd_control_session *session)
 			total_checked_fast += elt->reply.reply.composites_stats.checked_fast;
 			total_matched += elt->reply.reply.composites_stats.matched;
 			break;
+		case RSPAMD_CONTROL_MEMORY_STAT:
+			ucl_object_insert_key(cur,
+								  ucl_object_fromint(elt->reply.reply.memory_stat.status),
+								  "status", 0, false);
+			ucl_object_insert_key(cur,
+								  ucl_object_fromint(elt->reply.reply.memory_stat.rss_kb),
+								  "rss_kb", 0, false);
+			ucl_object_insert_key(cur,
+								  ucl_object_fromint(elt->reply.reply.memory_stat.lua_kb),
+								  "lua_kb", 0, false);
+			ucl_object_insert_key(cur,
+								  ucl_object_fromint(elt->reply.reply.memory_stat.mempool_bytes),
+								  "mempool_bytes", 0, false);
+			ucl_object_insert_key(cur,
+								  ucl_object_fromint(elt->reply.reply.memory_stat.jemalloc_allocated),
+								  "jemalloc_allocated", 0, false);
+
+			if (elt->attached_fd != -1) {
+				parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+
+				if (ucl_parser_add_fd(parser, elt->attached_fd)) {
+					ucl_object_insert_key(cur, ucl_parser_get_object(parser),
+										  "data", 0, false);
+				}
+				else {
+					ucl_object_insert_key(cur,
+										  ucl_object_fromstring(ucl_parser_get_error(parser)),
+										  "error", 0, false);
+				}
+				ucl_parser_free(parser);
+			}
+
+			total_rss_kb += elt->reply.reply.memory_stat.rss_kb;
+			total_lua_kb += elt->reply.reply.memory_stat.lua_kb;
+			total_mempool_bytes += elt->reply.reply.memory_stat.mempool_bytes;
+			total_jemalloc_allocated += elt->reply.reply.memory_stat.jemalloc_allocated;
+			break;
 		default:
 			break;
 		}
@@ -323,6 +364,18 @@ rspamd_control_write_reply(struct rspamd_control_session *session)
 		ucl_object_insert_key(cur, ucl_object_fromint(total_checked_slow), "checked_slow", 0, false);
 		ucl_object_insert_key(cur, ucl_object_fromint(total_checked_fast), "checked_fast", 0, false);
 		ucl_object_insert_key(cur, ucl_object_fromint(total_matched), "matched", 0, false);
+
+		ucl_object_insert_key(rep, cur, "total", 0, false);
+	}
+	else if (session->cmd.type == RSPAMD_CONTROL_MEMORY_STAT) {
+		/* Total memory stats */
+		cur = ucl_object_typed_new(UCL_OBJECT);
+		ucl_object_insert_key(cur, ucl_object_fromint(total_rss_kb), "rss_kb", 0, false);
+		ucl_object_insert_key(cur, ucl_object_fromint(total_lua_kb), "lua_kb", 0, false);
+		ucl_object_insert_key(cur, ucl_object_fromint(total_mempool_bytes),
+							  "mempool_bytes", 0, false);
+		ucl_object_insert_key(cur, ucl_object_fromint(total_jemalloc_allocated),
+							  "jemalloc_allocated", 0, false);
 
 		ucl_object_insert_key(rep, cur, "total", 0, false);
 	}

--- a/src/libserver/rspamd_control.c
+++ b/src/libserver/rspamd_control.c
@@ -24,6 +24,7 @@
 #include "utlist.h"
 #include "khash.h"
 #include "composites/composites.h"
+#include "memory_stat.h"
 
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
@@ -822,6 +823,17 @@ rspamd_control_default_cmd_handler(int fd,
 	rspamd_main = cd->worker->srv;
 
 	switch (cmd->type) {
+	case RSPAMD_CONTROL_MEMORY_STAT:
+		/*
+		 * Memory stat needs to attach a file descriptor with the full UCL
+		 * dump, so it has its own send path and bypasses the trailing
+		 * write() below.
+		 */
+		rspamd_memory_stat_collect_and_send(rspamd_main, cd->worker, fd, cmd);
+		if (attached_fd != -1) {
+			close(attached_fd);
+		}
+		return;
 	case RSPAMD_CONTROL_STAT:
 		if (getrusage(RUSAGE_SELF, &rusg) == -1) {
 			msg_err_main("cannot get rusage stats: %s",

--- a/src/libserver/rspamd_control.h
+++ b/src/libserver/rspamd_control.h
@@ -41,6 +41,7 @@ enum rspamd_control_type {
 	RSPAMD_CONTROL_COMPOSITES_STATS,
 	RSPAMD_CONTROL_MULTIPATTERN_LOADED,
 	RSPAMD_CONTROL_REGEXP_MAP_LOADED,
+	RSPAMD_CONTROL_MEMORY_STAT,
 	RSPAMD_CONTROL_MAX
 };
 
@@ -128,6 +129,9 @@ struct rspamd_control_command {
 		struct {
 			unsigned int unused;
 		} composites_stats;
+		struct {
+			unsigned int unused;
+		} memory_stat;
 	} cmd;
 };
 
@@ -182,6 +186,13 @@ struct rspamd_control_reply {
 			double time_fast_mean;   /**< EMA mean time in fast path (ms) */
 			double time_fast_stddev; /**< EMA stddev time in fast path (ms) */
 		} composites_stats;
+		struct {
+			unsigned int status;
+			uint64_t rss_kb;             /**< process resident set, KiB           */
+			uint64_t lua_kb;             /**< Lua heap usage, KiB                 */
+			uint64_t mempool_bytes;      /**< rspamd_mempool aggregate bytes      */
+			uint64_t jemalloc_allocated; /**< jemalloc stats.allocated; 0 if N/A  */
+		} memory_stat;
 	} reply;
 };
 

--- a/src/libutil/mem_pool.c
+++ b/src/libutil/mem_pool.c
@@ -1026,6 +1026,46 @@ void rspamd_mempool_stat_reset(void)
 	}
 }
 
+void rspamd_mempool_entries_foreach(rspamd_mempool_entry_cb cb, void *ud)
+{
+	khiter_t k;
+
+	if (cb == NULL || mempool_entries == NULL) {
+		return;
+	}
+
+	for (k = kh_begin(mempool_entries); k != kh_end(mempool_entries); ++k) {
+		if (!kh_exist(mempool_entries, k)) {
+			continue;
+		}
+
+		struct rspamd_mempool_entry_point *elt = kh_value(mempool_entries, k);
+		rspamd_mempool_entry_stat_t st;
+		uint64_t sum_frag = 0;
+		uint64_t sum_left = 0;
+		unsigned int valid = 0;
+
+		for (unsigned int i = 0; i < G_N_ELEMENTS(elt->elts); i++) {
+			if (elt->elts[i].fragmentation != 0 || elt->elts[i].leftover != 0) {
+				sum_frag += elt->elts[i].fragmentation;
+				sum_left += elt->elts[i].leftover;
+				valid++;
+			}
+		}
+
+		st.src = elt->src;
+		st.cur_suggestion = elt->cur_suggestion;
+		st.cur_elts = elt->cur_elts;
+		st.cur_vars = elt->cur_vars;
+		st.cur_dtors = elt->cur_dtors;
+		st.samples = valid;
+		st.avg_fragmentation = valid ? (uint32_t) (sum_frag / valid) : 0;
+		st.avg_leftover = valid ? (uint32_t) (sum_left / valid) : 0;
+
+		cb(&st, ud);
+	}
+}
+
 gsize rspamd_mempool_suggest_size_(const char *loc)
 {
 	return 0;

--- a/src/libutil/mem_pool.h
+++ b/src/libutil/mem_pool.h
@@ -374,6 +374,30 @@ void rspamd_mempool_stat(rspamd_mempool_stat_t *st);
 void rspamd_mempool_stat_reset(void);
 
 /**
+ * Per-callsite mempool statistics, aggregated from the rolling history
+ */
+typedef struct rspamd_mempool_entry_stat_s {
+	const char *src;            /**< callsite location string (file:line)    */
+	uint32_t cur_suggestion;    /**< current suggested pool size              */
+	uint32_t cur_elts;          /**< suggested number of preallocated elts    */
+	uint32_t cur_vars;          /**< suggested number of preallocated vars    */
+	uint32_t cur_dtors;         /**< suggested number of preallocated dtors   */
+	uint32_t avg_fragmentation; /**< average fragmentation across history     */
+	uint32_t avg_leftover;      /**< average leftover across history          */
+	uint32_t samples;           /**< number of valid samples used for averages */
+} rspamd_mempool_entry_stat_t;
+
+typedef void (*rspamd_mempool_entry_cb)(const rspamd_mempool_entry_stat_t *stat,
+										void *ud);
+
+/**
+ * Iterate over all currently registered mempool callsite entries.
+ * The callback is invoked synchronously for each entry; the rspamd_mempool_entry_stat_t
+ * pointer and its src field are valid only for the duration of the callback.
+ */
+void rspamd_mempool_entries_foreach(rspamd_mempool_entry_cb cb, void *ud);
+
+/**
  * Get optimal pool size based on page size for this system
  * @return size of memory page in system
  */

--- a/src/libutil/util.c
+++ b/src/libutil/util.c
@@ -36,6 +36,8 @@
 #include <mach/mach_init.h>
 #include <mach/thread_act.h>
 #include <mach/mach_port.h>
+#include <mach/task.h>
+#include <mach/task_info.h>
 #endif
 /* poll */
 #ifdef HAVE_POLL_H
@@ -1416,8 +1418,7 @@ restart:
 	/* Restore terminal state */
 	if (memcmp(&term, &oterm, sizeof(term)) != 0) {
 		while (tcsetattr(input, TCSAFLUSH, &oterm) == -1 &&
-			   errno == EINTR && !saved_signo[SIGTTOU])
-			;
+			   errno == EINTR && !saved_signo[SIGTTOU]);
 	}
 
 	/* Restore signal handlers */
@@ -2825,4 +2826,119 @@ void rspamd_normalize_path_inplace(char *path, unsigned int len, gsize *nlen)
 	if (nlen) {
 		*nlen = (o - path);
 	}
+}
+
+#ifdef __linux__
+static gboolean
+rspamd_proc_mem_info_linux(struct rspamd_proc_mem_info *info)
+{
+	FILE *f;
+	char line[256];
+	gboolean got_rss = FALSE;
+
+	f = fopen("/proc/self/status", "r");
+	if (f == NULL) {
+		return FALSE;
+	}
+
+	while (fgets(line, sizeof(line), f) != NULL) {
+		uint64_t val_kb = 0;
+
+		/*
+		 * All Vm* / Rss* fields in /proc/self/status are reported in kB.
+		 * Format: "<Field>:\t<value> kB\n"
+		 */
+		if (sscanf(line, "VmSize: %" SCNu64 " kB", &val_kb) == 1) {
+			info->vm_size = val_kb * 1024;
+		}
+		else if (sscanf(line, "VmRSS: %" SCNu64 " kB", &val_kb) == 1) {
+			info->vm_rss = val_kb * 1024;
+			got_rss = TRUE;
+		}
+		else if (sscanf(line, "VmData: %" SCNu64 " kB", &val_kb) == 1) {
+			info->vm_data = val_kb * 1024;
+		}
+		else if (sscanf(line, "VmStk: %" SCNu64 " kB", &val_kb) == 1) {
+			info->vm_stack = val_kb * 1024;
+		}
+		else if (sscanf(line, "VmExe: %" SCNu64 " kB", &val_kb) == 1) {
+			info->vm_text = val_kb * 1024;
+		}
+		else if (sscanf(line, "VmLib: %" SCNu64 " kB", &val_kb) == 1) {
+			info->vm_lib = val_kb * 1024;
+		}
+		else if (sscanf(line, "VmPTE: %" SCNu64 " kB", &val_kb) == 1) {
+			info->vm_pte = val_kb * 1024;
+		}
+		else if (sscanf(line, "RssAnon: %" SCNu64 " kB", &val_kb) == 1) {
+			info->rss_anon = val_kb * 1024;
+		}
+		else if (sscanf(line, "RssFile: %" SCNu64 " kB", &val_kb) == 1) {
+			info->rss_file = val_kb * 1024;
+		}
+		else if (sscanf(line, "RssShmem: %" SCNu64 " kB", &val_kb) == 1) {
+			info->rss_shmem = val_kb * 1024;
+		}
+	}
+
+	fclose(f);
+	return got_rss;
+}
+#endif
+
+#ifdef __APPLE__
+static gboolean
+rspamd_proc_mem_info_macos(struct rspamd_proc_mem_info *info)
+{
+	struct mach_task_basic_info ti;
+	mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+
+	if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+				  (task_info_t) &ti, &count) != KERN_SUCCESS) {
+		return FALSE;
+	}
+
+	info->vm_size = ti.virtual_size;
+	info->vm_rss = ti.resident_size;
+	return TRUE;
+}
+#endif
+
+gboolean rspamd_get_process_memory_info(struct rspamd_proc_mem_info *info)
+{
+	if (info == NULL) {
+		return FALSE;
+	}
+
+	memset(info, 0, sizeof(*info));
+
+#if defined(__linux__)
+	if (rspamd_proc_mem_info_linux(info)) {
+		return TRUE;
+	}
+#elif defined(__APPLE__)
+	if (rspamd_proc_mem_info_macos(info)) {
+		return TRUE;
+	}
+#endif
+
+	/* Fallback: use getrusage to fill at least vm_rss */
+#ifdef HAVE_RUSAGE_SELF
+	{
+		struct rusage ru;
+
+		if (getrusage(RUSAGE_SELF, &ru) == 0) {
+#ifdef __APPLE__
+			/* macOS reports ru_maxrss in bytes */
+			info->vm_rss = (uint64_t) ru.ru_maxrss;
+#else
+			/* Most Unixes report ru_maxrss in kilobytes */
+			info->vm_rss = (uint64_t) ru.ru_maxrss * 1024;
+#endif
+			return TRUE;
+		}
+	}
+#endif
+
+	return FALSE;
 }

--- a/src/libutil/util.h
+++ b/src/libutil/util.h
@@ -594,6 +594,30 @@ float rspamd_sum_floats(float *ar, gsize *nelts);
  */
 void rspamd_normalize_path_inplace(char *path, unsigned int len, gsize *nlen);
 
+/**
+ * Per-process memory information collected from OS-specific sources.
+ * All fields are in bytes; unsupported fields are left at zero.
+ */
+struct rspamd_proc_mem_info {
+	uint64_t vm_size;   /**< total virtual memory size                       */
+	uint64_t vm_rss;    /**< resident set size                                */
+	uint64_t vm_data;   /**< data segment size (Linux only)                   */
+	uint64_t vm_stack;  /**< stack size (Linux only)                          */
+	uint64_t vm_text;   /**< text/code size (Linux only)                      */
+	uint64_t vm_lib;    /**< shared library size (Linux only)                 */
+	uint64_t vm_pte;    /**< page table entries size (Linux only)             */
+	uint64_t rss_anon;  /**< anonymous resident pages (Linux only)            */
+	uint64_t rss_file;  /**< file-backed resident pages (Linux only)          */
+	uint64_t rss_shmem; /**< shared memory resident pages (Linux only)        */
+};
+
+/**
+ * Fill the structure with current process memory info using OS-specific APIs.
+ * Returns TRUE if at least vm_rss could be obtained. Fields that are not
+ * available on the current platform are left set to zero.
+ */
+gboolean rspamd_get_process_memory_info(struct rspamd_proc_mem_info *info);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lua/lua_common.c
+++ b/src/lua/lua_common.c
@@ -1105,6 +1105,28 @@ void rspamd_lua_start_gc(struct rspamd_config *cfg)
 	lua_gc(L, LUA_GCRESTART, 0);
 }
 
+gsize rspamd_lua_get_memory_used(lua_State *L)
+{
+	int kb;
+	int rem;
+
+	if (L == NULL) {
+		return 0;
+	}
+
+	kb = lua_gc(L, LUA_GCCOUNT, 0);
+	rem = lua_gc(L, LUA_GCCOUNTB, 0);
+
+	if (kb < 0) {
+		kb = 0;
+	}
+	if (rem < 0) {
+		rem = 0;
+	}
+
+	return (gsize) kb * 1024 + (gsize) rem;
+}
+
 
 void rspamd_plugins_table_push_elt(lua_State *L, const char *field_name,
 								   const char *new_elt)

--- a/src/lua/lua_common.h
+++ b/src/lua/lua_common.h
@@ -251,6 +251,12 @@ void rspamd_lua_close(lua_State *L);
 void rspamd_lua_start_gc(struct rspamd_config *cfg);
 
 /**
+ * Returns the total amount of memory currently used by the Lua heap, in bytes.
+ * Combines LUA_GCCOUNT (kilobytes) and LUA_GCCOUNTB (bytes remainder).
+ */
+gsize rspamd_lua_get_memory_used(lua_State *L);
+
+/**
 * Sets field in a global variable
 * @param L
 * @param global_name

--- a/src/rspamadm/control.c
+++ b/src/rspamadm/control.c
@@ -85,7 +85,8 @@ rspamadm_control_help(gboolean full_help, const struct rspamadm_command *cmd)
 				   "recompile - recompile hyperscan regexes\n"
 				   "fuzzystat - show fuzzy statistics\n"
 				   "fuzzysync - immediately sync fuzzy database to storage\n"
-				   "compositesstats - show composites processing statistics\n";
+				   "compositesstats - show composites processing statistics\n"
+				   "memstat - show memory usage statistics across all workers\n";
 	}
 	else {
 		help_str = "Manage rspamd main control interface";
@@ -136,6 +137,18 @@ rspamd_control_finish_handler(struct rspamd_http_connection *conn,
 											  &cbdata->argv[1],
 											  obj,
 											  "fuzzy_stat",
+											  TRUE);
+
+				rspamd_fstring_free(out);
+				ucl_object_unref(obj);
+				ucl_parser_free(parser);
+				goto end;
+			}
+			else if (strcmp(cbdata->path, "/memstat") == 0) {
+				rspamadm_execute_lua_ucl_subr(cbdata->argc - 1,
+											  &cbdata->argv[1],
+											  obj,
+											  "memstat",
 											  TRUE);
 
 				rspamd_fstring_free(out);
@@ -219,6 +232,10 @@ rspamadm_control(int argc, char **argv, const struct rspamadm_command *_cmd)
 	else if (g_ascii_strcasecmp(cmd, "compositesstats") == 0 ||
 			 g_ascii_strcasecmp(cmd, "composites_stats") == 0) {
 		path = "/compositesstats";
+	}
+	else if (g_ascii_strcasecmp(cmd, "memstat") == 0 ||
+			 g_ascii_strcasecmp(cmd, "mem_stat") == 0) {
+		path = "/memstat";
 	}
 	else {
 		rspamd_fprintf(stderr, "unknown command: %s\n", cmd);


### PR DESCRIPTION
## Summary

Add a new control command, ``rspamadm control memstat`` (HTTP ``/memstat``), that fans out across every worker over the existing control IPC and returns a structured memory snapshot. Today the only worker-level visibility we expose is the aggregate mempool counters surfaced under ``/stat``; for diagnosing leaks or oversized configs we needed something richer.

For each worker pid the response includes:

- Process-level: ``vm_size``, ``vm_rss`` plus Linux extras (``RssAnon`` / ``RssFile`` / ``RssShmem`` / ``VmData`` / ``VmStk`` / ``VmExe`` / ``VmLib`` / ``VmPTE``) on Linux, ``task_info`` on macOS, ``getrusage`` fallback elsewhere.
- Mempool aggregate via ``rspamd_mempool_stat`` and per-callsite breakdown via the newly-exposed ``rspamd_mempool_entries_foreach`` (cur_suggestion, cur_elts, cur_vars, cur_dtors, plus rolling-window averages of fragmentation/leftover).
- Lua heap bytes via ``LUA_GCCOUNT + LUA_GCCOUNTB``.
- jemalloc (when ``WITH_JEMALLOC`` is on): structured ``stats.allocated/active/metadata/resident/mapped/retained``, opt config (narenas, dirty/muzzy decay), and the textual ``malloc_stats_print`` dump.

The fixed-size reply slot carries a short summary (status, RSS kB, Lua kB, mempool bytes, jemalloc.allocated) so callers can read totals without parsing the bulk payload; the full UCL document is serialized to a temp file and the descriptor is passed back via ``SCM_RIGHTS`` (mirrors the ``fuzzy_stat`` pattern).

The ``rspamadm`` side ships ``lualib/rspamadm/memstat.lua`` with a table-formatted view (per-worker summary + total, process breakdown, mempool aggregate, top-N callsites, Lua heap, jemalloc); ``--json`` / ``--compact`` still emit the raw UCL.

## Commits

1. ``mem_pool``: expose per-callsite entries iteration.
2. ``util``: process memory info shim (Linux ``/proc/self/status``, macOS ``task_info``, ``getrusage`` fallback).
3. ``lua_common``: ``rspamd_lua_get_memory_used`` helper.
4. ``rspamd_control``: ``/memstat`` enum, cmd/reply union, write_reply case + totals.
5. ``memory_stat``: collector module (``memory_stat.cxx`` / ``memory_stat.h``) wired through ``default_cmd_handler``.
6. ``rspamadm``: ``memstat`` subcommand and ``memstat.lua`` pretty-printer.

## Test plan

- [x] ``ninja install`` builds cleanly on macOS arm64.
- [x] ``rspamd-test-cxx`` passes (200/200 cases, 62861/62861 assertions).
- [x] ``rspamd-test -p /rspamd/lua`` passes (1003/1014; the 8 remaining errors are a pre-existing ``lua_redis.prepare_setup.lua`` infra issue, reproduces without this branch).
- [x] ``luacheck lualib/rspamadm/memstat.lua`` clean.
- [x] Manual ``rspamadm control memstat`` against a running rspamd: summary table, per-worker process/mempool/lua/jemalloc sections render correctly.
- [ ] Same against a build with ``-DENABLE_JEMALLOC=ON`` to verify the jemalloc section.
- [ ] Linux verification of ``/proc/self/status`` parsing path (this branch was developed on macOS).