### PR TITLE
[Feature] lua_extras: structured custom lua loader

### DIFF
--- a/conf/lua.local.d/maps/example.lua.example
+++ b/conf/lua.local.d/maps/example.lua.example
@@ -1,0 +1,24 @@
+-- Custom map definitions loaded by lua_extras at config time.
+--
+-- Each file in $LOCAL_CONFDIR/lua.local.d/maps/*.lua must return a table
+-- where keys are map names and values are the argument table accepted by
+-- rspamd_config:add_map{...}, see https://rspamd.com/doc/lua/config.html.
+--
+-- Registered maps are stored in the global `rspamd_maps` table so other
+-- lua code can look them up by name.
+
+return {
+  -- A simple set map loaded from a file (URL can also be http(s):// etc).
+  example_local_domains = {
+    type        = 'set',
+    description = 'Locally hosted domains',
+    url         = '${LOCAL_CONFDIR}/local_domains.list',
+  },
+
+  -- A regexp map of keys to string values.
+  example_brand_regexps = {
+    type        = 'regexp',
+    description = 'Brand name regexps',
+    url         = '${LOCAL_CONFDIR}/brand_regexps.list',
+  },
+}

--- a/conf/lua.local.d/regexps/example.lua.example
+++ b/conf/lua.local.d/regexps/example.lua.example
@@ -1,0 +1,28 @@
+-- Custom regexp rules loaded by lua_extras at config time.
+--
+-- Each file in $LOCAL_CONFDIR/lua.local.d/regexps/*.lua must return a table
+-- where keys are symbol names and values are regexp rule definitions equivalent
+-- to assigning into config['regexp'][SYMBOL] from rspamd.local.lua.
+--
+-- See https://rspamd.com/doc/developers/writing_rules.html for the full DSL.
+
+local re_from_foo = 'From=/foo@/H'
+local re_subject_blah = '/blah/P'
+
+return {
+  EXAMPLE_FROM_FOO = {
+    re          = re_from_foo,
+    score       = 1.2,
+    description = 'Sender contains foo@',
+  },
+
+  EXAMPLE_FROM_FOO_NO_BLAH = {
+    re          = string.format('(%s) && !(%s)', re_from_foo, re_subject_blah),
+    score       = 0.5,
+    description = 'foo@ sender without "blah" in subject',
+    -- Optional condition gating the rule:
+    condition   = function(task)
+      return task:has_from('mime')
+    end,
+  },
+}

--- a/conf/lua.local.d/selectors/example.lua.example
+++ b/conf/lua.local.d/selectors/example.lua.example
@@ -1,16 +1,21 @@
 -- Custom selector definitions loaded by lua_extras at config time.
 --
 -- Each file in $LOCAL_CONFDIR/lua.local.d/selectors/*.lua must return a table
--- where keys are selector names and values are either:
---   * a function(task) returning the value, or
+-- where keys are selector names and values are one of:
+--   * a function(task) returning the value (shortcut for { get_value = fn });
 --   * a full selector definition table:
 --       { get_value = function(task, args) ... end,
 --         description = '...',         -- optional
 --         type        = 'string',      -- optional, default 'string'
---         args_schema = { ... } }      -- optional argument validation
+--         args_schema = { ... } };     -- optional argument validation
+--   * lua_extras.deferred(function(cfg) return def end) when the definition
+--     needs to inspect entries from earlier kinds (typical: capture a map ref
+--     from rspamd_maps or compile an rspamd_regexp from map data).
 --
 -- Selectors registered here are available anywhere selectors are accepted
 -- (settings, multimap, ratelimit, redirector, classifiers, ...).
+
+local lua_extras = require "lua_extras"
 
 return {
   -- A trivial selector returning the message id with a fixed prefix.
@@ -30,4 +35,25 @@ return {
       return task:get_helo()
     end,
   },
+
+  -- A selector that captures a map registered by lua.local.d/maps/*.lua.
+  -- The factory runs after all maps are registered, so the closure binds the
+  -- live map object once instead of looking it up on every task.
+  example_from_in_local_domains = lua_extras.deferred(function(_cfg)
+    local domains = rspamd_maps['example_local_domains']
+    return {
+      description = 'matched local-domains map: <domain> or nil',
+      type        = 'string',
+      get_value   = function(task)
+        if not domains then
+          return nil
+        end
+        local from = task:get_from('mime')
+        if not from or not from[1] or not from[1].domain then
+          return nil
+        end
+        return domains:get_key(from[1].domain) and from[1].domain or nil
+      end,
+    }
+  end),
 }

--- a/conf/lua.local.d/selectors/example.lua.example
+++ b/conf/lua.local.d/selectors/example.lua.example
@@ -1,0 +1,33 @@
+-- Custom selector definitions loaded by lua_extras at config time.
+--
+-- Each file in $LOCAL_CONFDIR/lua.local.d/selectors/*.lua must return a table
+-- where keys are selector names and values are either:
+--   * a function(task) returning the value, or
+--   * a full selector definition table:
+--       { get_value = function(task, args) ... end,
+--         description = '...',         -- optional
+--         type        = 'string',      -- optional, default 'string'
+--         args_schema = { ... } }      -- optional argument validation
+--
+-- Selectors registered here are available anywhere selectors are accepted
+-- (settings, multimap, ratelimit, redirector, classifiers, ...).
+
+return {
+  -- A trivial selector returning the message id with a fixed prefix.
+  example_msgid = function(task)
+    local mid = task:get_message_id()
+    if not mid then
+      return nil
+    end
+    return 'mid:' .. mid
+  end,
+
+  -- A selector with a description and explicit return type.
+  example_helo = {
+    description = 'SMTP HELO/EHLO string',
+    type        = 'string',
+    get_value   = function(task)
+      return task:get_helo()
+    end,
+  },
+}

--- a/lualib/lua_extras.lua
+++ b/lualib/lua_extras.lua
@@ -17,12 +17,19 @@ limitations under the License.
 --[[[
 -- @module lua_extras
 -- Helpers and a directory loader for shipping custom selectors, maps and
--- regexp rules from $LOCAL_CONFDIR/lua.local.d/{selectors,maps,regexps}/*.lua
+-- regexp rules from $LOCAL_CONFDIR/lua.local.d/{maps,selectors,regexps}/*.lua
 -- without touching rspamd.local.lua.
 --
--- Each structured file is expected to `return` a table whose entries are
--- registered with the matching helper. Errors in any single file are logged
--- and do not abort startup.
+-- Loading is two-phase: phase 1 collects every entry from every file into
+-- staging buffers; phase 2 resolves and registers them in dependency order
+-- (maps -> selectors -> regexps). Entries that need to inspect siblings
+-- registered earlier in the same pass (typical example: a selector that
+-- captures `rspamd_maps[name]` or compiles an `rspamd_regexp` from map data)
+-- can wrap their definition in `lua_extras.deferred(factory_fn)` so the
+-- factory runs after all earlier-kind entries are registered.
+--
+-- Errors in any single file or entry are logged and skipped; they never
+-- abort startup.
 --]]
 
 local exports = {}
@@ -31,11 +38,38 @@ local rspamd_logger = require "rspamd_logger"
 local rspamd_util = require "rspamd_util"
 local lua_selectors = require "lua_selectors"
 
+local DEFERRED_MARKER = '__lua_extras_deferred'
+
+--[[[
+-- @function lua_extras.deferred(factory)
+-- Wraps a factory function so the loader calls it during phase 2, after all
+-- earlier-kind entries have been registered, and uses the returned table as
+-- the concrete definition. The factory receives `(cfg)`.
+--]]
+exports.deferred = function(factory)
+  if type(factory) ~= 'function' then
+    error('lua_extras.deferred: expected a function, got ' .. type(factory))
+  end
+  return { [DEFERRED_MARKER] = true, factory = factory }
+end
+
+local function is_deferred(v)
+  return type(v) == 'table' and v[DEFERRED_MARKER] == true
+end
+
 --[[[
 -- @function lua_extras.register_selector(cfg, name, def)
 -- Registers a selector extractor.
--- `def` may be a function (treated as `get_value`) or a full selector table
--- (`{ get_value = fn, description = '...', type = '...' }`).
+-- `def` may be:
+--   * a function - treated as `get_value`;
+--   * a full selector table - `{ get_value = fn, description = ..., type = ... }`.
+--
+-- An optional `re_selector` field opts the selector into the regexp DSL by
+-- calling `cfg:register_re_selector(name, selector_str, delimiter)` after the
+-- extractor is registered. It accepts either:
+--   * `true` - bind alias `name` to the selector pipeline `name` with delimiter ' ';
+--   * `{ selector = '<pipeline>', delimiter = ' ' }` - explicit binding.
+--
 -- Returns true on success, false on error.
 --]]
 exports.register_selector = function(cfg, name, def)
@@ -49,7 +83,36 @@ exports.register_selector = function(cfg, name, def)
     return false
   end
 
-  return lua_selectors.register_extractor(cfg, name, def)
+  local re_sel = def.re_selector
+  -- lua_selectors does not need this field
+  def.re_selector = nil
+
+  if not lua_selectors.register_extractor(cfg, name, def) then
+    return false
+  end
+
+  if re_sel then
+    local pipeline, delimiter
+    if re_sel == true then
+      pipeline, delimiter = name, ' '
+    elseif type(re_sel) == 'table' then
+      pipeline = re_sel.selector or name
+      delimiter = re_sel.delimiter or ' '
+    else
+      rspamd_logger.errx(cfg,
+          'lua_extras: bad re_selector for selector %s: expected true or table', name)
+      return true
+    end
+    local ok, err = pcall(function()
+      cfg:register_re_selector(name, pipeline, delimiter)
+    end)
+    if not ok then
+      rspamd_logger.errx(cfg,
+          'lua_extras: register_re_selector failed for %s: %s', name, err)
+    end
+  end
+
+  return true
 end
 
 --[[[
@@ -105,24 +168,18 @@ exports.register_regexp = function(cfg, symbol, def)
 end
 
 local kind_handlers = {
-  selectors = exports.register_selector,
   maps = exports.register_map,
+  selectors = exports.register_selector,
   regexps = exports.register_regexp,
 }
 
---[[[
--- @function lua_extras.load_dir(cfg, dir, kind)
--- Loads every *.lua file in `dir`, expecting each to return a table of
--- { name = def } pairs. Each pair is dispatched to the helper for `kind`
--- (one of 'selectors', 'maps', 'regexps'). Errors are logged and skipped.
---]]
-exports.load_dir = function(cfg, dir, kind)
-  local handler = kind_handlers[kind]
-  if not handler then
-    rspamd_logger.errx(cfg, 'lua_extras: unknown kind %s for dir %s', kind, dir)
-    return
-  end
+-- Resolution order for cross-kind dependencies:
+--   maps     - register first (no deps)
+--   selectors - may consume maps (rspamd_maps[name]) at definition or task time
+--   regexps  - may reference selectors via the {name} expansion syntax
+local KIND_ORDER = { 'maps', 'selectors', 'regexps' }
 
+local function preload_one_dir(cfg, dir, kind, sink)
   local files = rspamd_util.glob(dir .. '/*.lua') or {}
   -- Stable ordering across platforms
   table.sort(files)
@@ -144,10 +201,74 @@ exports.load_dir = function(cfg, dir, kind)
             rspamd_logger.errx(cfg,
                 'lua_extras: %s contains non-string key (kind=%s), skipped entry', path, kind)
           else
-            handler(cfg, name, def)
+            table.insert(sink, { name = name, def = def, path = path })
           end
         end
       end
+    end
+  end
+end
+
+local function resolve_entry(cfg, entry, kind)
+  local def = entry.def
+  if is_deferred(def) then
+    local ok, ret = pcall(def.factory, cfg)
+    if not ok then
+      rspamd_logger.errx(cfg,
+          'lua_extras: deferred factory for %s/%s in %s failed: %s',
+          kind, entry.name, entry.path, ret)
+      return nil
+    end
+    return ret
+  end
+  return def
+end
+
+--[[[
+-- @function lua_extras.load_extras(cfg, base_dir)
+-- Two-phase loader: globs `base_dir/{maps,selectors,regexps}/*.lua`,
+-- collects every returned entry, then registers them in dependency order
+-- (maps -> selectors -> regexps). Deferred entries (see lua_extras.deferred)
+-- are evaluated during phase 2 so they can see entries from earlier kinds.
+--]]
+exports.load_extras = function(cfg, base_dir)
+  local staged = {}
+  for _, kind in ipairs(KIND_ORDER) do
+    staged[kind] = {}
+    preload_one_dir(cfg, base_dir .. '/' .. kind, kind, staged[kind])
+  end
+
+  for _, kind in ipairs(KIND_ORDER) do
+    local handler = kind_handlers[kind]
+    for _, entry in ipairs(staged[kind]) do
+      local resolved = resolve_entry(cfg, entry, kind)
+      if resolved ~= nil then
+        handler(cfg, entry.name, resolved)
+      end
+    end
+  end
+end
+
+--[[[
+-- @function lua_extras.load_dir(cfg, dir, kind)
+-- Single-kind loader. Useful when a closed plugin or other code wants to
+-- ingest a structured directory of one specific kind. For the standard
+-- $LOCAL_CONFDIR/lua.local.d tree, prefer lua_extras.load_extras() which
+-- handles cross-kind ordering.
+--]]
+exports.load_dir = function(cfg, dir, kind)
+  local handler = kind_handlers[kind]
+  if not handler then
+    rspamd_logger.errx(cfg, 'lua_extras: unknown kind %s for dir %s', kind, dir)
+    return
+  end
+
+  local sink = {}
+  preload_one_dir(cfg, dir, kind, sink)
+  for _, entry in ipairs(sink) do
+    local resolved = resolve_entry(cfg, entry, kind)
+    if resolved ~= nil then
+      handler(cfg, entry.name, resolved)
     end
   end
 end

--- a/lualib/lua_extras.lua
+++ b/lualib/lua_extras.lua
@@ -1,0 +1,155 @@
+--[[
+Copyright (c) 2026, Vsevolod Stakhov <vsevolod@rspamd.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]] --
+
+--[[[
+-- @module lua_extras
+-- Helpers and a directory loader for shipping custom selectors, maps and
+-- regexp rules from $LOCAL_CONFDIR/lua.local.d/{selectors,maps,regexps}/*.lua
+-- without touching rspamd.local.lua.
+--
+-- Each structured file is expected to `return` a table whose entries are
+-- registered with the matching helper. Errors in any single file are logged
+-- and do not abort startup.
+--]]
+
+local exports = {}
+
+local rspamd_logger = require "rspamd_logger"
+local rspamd_util = require "rspamd_util"
+local lua_selectors = require "lua_selectors"
+
+--[[[
+-- @function lua_extras.register_selector(cfg, name, def)
+-- Registers a selector extractor.
+-- `def` may be a function (treated as `get_value`) or a full selector table
+-- (`{ get_value = fn, description = '...', type = '...' }`).
+-- Returns true on success, false on error.
+--]]
+exports.register_selector = function(cfg, name, def)
+  if type(def) == 'function' then
+    def = { get_value = def }
+  end
+
+  if type(def) ~= 'table' or type(def.get_value) ~= 'function' then
+    rspamd_logger.errx(cfg, 'lua_extras: bad selector %s: expected function or table with get_value',
+        name)
+    return false
+  end
+
+  return lua_selectors.register_extractor(cfg, name, def)
+end
+
+--[[[
+-- @function lua_extras.register_map(cfg, name, args)
+-- Registers a map. `args` is the table accepted by rspamd_config:add_map().
+-- The created map object is stored as rspamd_maps[name] so it can be looked
+-- up by other lua code.
+-- Returns the map object on success, nil on error.
+--]]
+exports.register_map = function(cfg, name, args)
+  if type(args) ~= 'table' then
+    rspamd_logger.errx(cfg, 'lua_extras: bad map %s: expected table of add_map arguments', name)
+    return nil
+  end
+
+  rspamd_maps = rspamd_maps or {}
+
+  local ok, map_or_err = pcall(function()
+    return cfg:add_map(args)
+  end)
+
+  if not ok or not map_or_err then
+    rspamd_logger.errx(cfg, 'lua_extras: cannot add map %s: %s', name, map_or_err)
+    return nil
+  end
+
+  rspamd_maps[name] = map_or_err
+  return map_or_err
+end
+
+--[[[
+-- @function lua_extras.register_regexp(cfg, symbol, def)
+-- Registers a regexp rule by assigning it into config['regexp'][symbol],
+-- matching the rspamd.local.lua / *.lua pattern documented in
+-- conf/lua.local.d/module.lua.example.
+-- Returns true on success, false on error.
+--]]
+exports.register_regexp = function(cfg, symbol, def)
+  if type(def) ~= 'table' or type(def.re) ~= 'string' then
+    rspamd_logger.errx(cfg, 'lua_extras: bad regexp %s: expected table with `re` string', symbol)
+    return false
+  end
+
+  config = config or {}
+  config['regexp'] = config['regexp'] or {}
+
+  if config['regexp'][symbol] then
+    rspamd_logger.warnx(cfg, 'lua_extras: redefining regexp symbol %s', symbol)
+  end
+
+  config['regexp'][symbol] = def
+  return true
+end
+
+local kind_handlers = {
+  selectors = exports.register_selector,
+  maps = exports.register_map,
+  regexps = exports.register_regexp,
+}
+
+--[[[
+-- @function lua_extras.load_dir(cfg, dir, kind)
+-- Loads every *.lua file in `dir`, expecting each to return a table of
+-- { name = def } pairs. Each pair is dispatched to the helper for `kind`
+-- (one of 'selectors', 'maps', 'regexps'). Errors are logged and skipped.
+--]]
+exports.load_dir = function(cfg, dir, kind)
+  local handler = kind_handlers[kind]
+  if not handler then
+    rspamd_logger.errx(cfg, 'lua_extras: unknown kind %s for dir %s', kind, dir)
+    return
+  end
+
+  local files = rspamd_util.glob(dir .. '/*.lua') or {}
+  -- Stable ordering across platforms
+  table.sort(files)
+
+  for _, path in ipairs(files) do
+    local ok, chunk = pcall(loadfile, path)
+    if not ok or not chunk then
+      rspamd_logger.errx(cfg, 'lua_extras: cannot load %s: %s', path, chunk)
+    else
+      local run_ok, ret = pcall(chunk)
+      if not run_ok then
+        rspamd_logger.errx(cfg, 'lua_extras: error executing %s: %s', path, ret)
+      elseif type(ret) ~= 'table' then
+        rspamd_logger.warnx(cfg,
+            'lua_extras: %s did not return a table (kind=%s), skipped', path, kind)
+      else
+        for name, def in pairs(ret) do
+          if type(name) ~= 'string' then
+            rspamd_logger.errx(cfg,
+                'lua_extras: %s contains non-string key (kind=%s), skipped entry', path, kind)
+          else
+            handler(cfg, name, def)
+          end
+        end
+      end
+    end
+  end
+end
+
+return exports

--- a/rules/rspamd.lua
+++ b/rules/rspamd.lua
@@ -44,12 +44,14 @@ dofile(local_rules .. '/content.lua')
 dofile(local_rules .. '/fuzzy_html_phishing.lua')
 dofile(local_rules .. '/controller/init.lua')
 
--- Structured custom code: lua.local.d/{selectors,maps,regexps}/*.lua are loaded
+-- Structured custom code: lua.local.d/{maps,selectors,regexps}/*.lua are loaded
 -- before rspamd.local.lua so end-user customisation can still override them.
+-- The loader is two-phase: every file is read first, then entries are registered
+-- in maps -> selectors -> regexps order so cross-kind dependencies (e.g. a
+-- selector that captures rspamd_maps[name] or compiles an rspamd_regexp from a
+-- map) work via lua_extras.deferred(factory).
 local lua_extras = require "lua_extras"
-for _, kind in ipairs({ 'selectors', 'maps', 'regexps' }) do
-  lua_extras.load_dir(rspamd_config, local_conf .. '/lua.local.d/' .. kind, kind)
-end
+lua_extras.load_extras(rspamd_config, local_conf .. '/lua.local.d')
 
 if rspamd_util.file_exists(local_conf .. '/rspamd.local.lua') then
   dofile(local_conf .. '/rspamd.local.lua')

--- a/rules/rspamd.lua
+++ b/rules/rspamd.lua
@@ -44,6 +44,13 @@ dofile(local_rules .. '/content.lua')
 dofile(local_rules .. '/fuzzy_html_phishing.lua')
 dofile(local_rules .. '/controller/init.lua')
 
+-- Structured custom code: lua.local.d/{selectors,maps,regexps}/*.lua are loaded
+-- before rspamd.local.lua so end-user customisation can still override them.
+local lua_extras = require "lua_extras"
+for _, kind in ipairs({ 'selectors', 'maps', 'regexps' }) do
+  lua_extras.load_dir(rspamd_config, local_conf .. '/lua.local.d/' .. kind, kind)
+end
+
 if rspamd_util.file_exists(local_conf .. '/rspamd.local.lua') then
   dofile(local_conf .. '/rspamd.local.lua')
 else

--- a/test/functional/cases/001_merged/271_lua_extras.robot
+++ b/test/functional/cases/001_merged/271_lua_extras.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${MSG_IN_MAP}      ${RSPAMD_TESTDIR}/messages/lua_extras_in_map.eml
+${MSG_NOT_IN_MAP}  ${RSPAMD_TESTDIR}/messages/lua_extras_not_in_map.eml
+
+*** Test Cases ***
+Lua_extras deferred selector fires regexp when From in map
+  Scan File  ${MSG_IN_MAP}
+  ...  Settings={symbols_enabled = [TEST_EXTRAS_LOCAL_FROM]}
+  Expect Symbol  TEST_EXTRAS_LOCAL_FROM
+
+Lua_extras deferred selector silent when From not in map
+  Scan File  ${MSG_NOT_IN_MAP}
+  ...  Settings={symbols_enabled = [TEST_EXTRAS_LOCAL_FROM]}
+  Do Not Expect Symbol  TEST_EXTRAS_LOCAL_FROM

--- a/test/functional/configs/merged.conf
+++ b/test/functional/configs/merged.conf
@@ -25,6 +25,9 @@ lua = "{= env.TESTDIR =}/lua/dns.lua"
 # 270_selector
 lua = "{= env.TESTDIR =}/lua/selector_test.lua"
 
+# 271_lua_extras
+lua = "{= env.TESTDIR =}/lua/lua_extras_test.lua"
+
 # 281_fnames
 lua = "{= env.TESTDIR =}/lua/test_fname.lua"
 

--- a/test/functional/lua/lua_extras_test.lua
+++ b/test/functional/lua/lua_extras_test.lua
@@ -1,0 +1,74 @@
+-- Functional test for the structured lua.local.d/{maps,selectors,regexps}
+-- loader (lua_extras). Stages a small tree under TMPDIR and calls
+-- lua_extras.load_extras() to register a map, a deferred selector that
+-- captures rspamd_maps[name] in its factory, and a regexp using that
+-- selector through the regexp DSL. The companion robot test then asserts
+-- the symbol fires only when the From-domain is present in the map.
+
+local lua_extras = require "lua_extras"
+
+local tmpdir = os.getenv('TMPDIR') or '/tmp'
+local base = tmpdir .. '/lua_extras_test'
+
+-- Always start clean
+os.execute('rm -rf "' .. base .. '"')
+os.execute('mkdir -p "' .. base .. '/maps" "' .. base .. '/selectors" "' .. base .. '/regexps"')
+
+local function write_file(path, content)
+  local f = assert(io.open(path, 'w'))
+  f:write(content)
+  f:close()
+end
+
+-- Map data
+local map_list = base .. '/local_domains.list'
+write_file(map_list, 'example.com\nlocal.test\n')
+
+-- Map definition
+write_file(base .. '/maps/test_extras.lua', string.format([[
+return {
+  example_local_domains = {
+    type = 'set',
+    description = 'TEST: local domains',
+    url = '%s',
+  },
+}
+]], map_list))
+
+-- Deferred selector capturing the map ref at registration time. This is the
+-- whole point of the two-phase loader: by the time this factory runs, the
+-- map above has already been registered and rspamd_maps[name] is populated.
+write_file(base .. '/selectors/test_extras.lua', [[
+local lua_extras = require "lua_extras"
+return {
+  test_extras_local_domain = lua_extras.deferred(function()
+    local domains = rspamd_maps.example_local_domains
+    return {
+      description = 'TEST: From-domain when present in example_local_domains map',
+      re_selector = true,
+      get_value = function(task)
+        local from = task:get_from('mime')
+        local dom = from and from[1] and from[1].domain or nil
+        if dom and domains and domains:get_key(dom) then
+          return dom, 'string'
+        end
+        return nil
+      end,
+    }
+  end),
+}
+]])
+
+-- Regexp symbol firing when the deferred selector resolves a non-nil value.
+write_file(base .. '/regexps/test_extras.lua', [[
+return {
+  TEST_EXTRAS_LOCAL_FROM = {
+    re = 'test_extras_local_domain=/.+/{selector}',
+    score = 0.1,
+    description = 'TEST: From present in example_local_domains map',
+  },
+}
+]])
+
+-- Trigger the structured loader on our staged tree.
+lua_extras.load_extras(rspamd_config, base)

--- a/test/functional/messages/lua_extras_in_map.eml
+++ b/test/functional/messages/lua_extras_in_map.eml
@@ -1,0 +1,5 @@
+From: alice@example.com
+To: bob@elsewhere.test
+Subject: in map
+
+body

--- a/test/functional/messages/lua_extras_not_in_map.eml
+++ b/test/functional/messages/lua_extras_not_in_map.eml
@@ -1,0 +1,5 @@
+From: alice@unknown.test
+To: bob@elsewhere.test
+Subject: not in map
+
+body


### PR DESCRIPTION
## Summary

- Add `lualib/lua_extras` with `register_selector` / `register_map` / `register_regexp` helpers and a `load_dir(cfg, dir, kind)` directory loader.
- Wire structured loading into `rules/rspamd.lua`: files in `$LOCAL_CONFDIR/lua.local.d/{selectors,maps,regexps}/*.lua` are loaded before `rspamd.local.lua`. Each file returns a `{ name = def }` table whose entries are dispatched to the matching helper.
- Ship `example.lua.example` files in each new subdirectory documenting the expected contract.

## Why

Today, distributions and add-ons that want to ship custom selectors, maps or regexp rules have no place to put them other than `rspamd.local.lua` or free-form `lua.local.d/*.lua` — both of which end users routinely edit. Selectors specifically had no convenient registration helper at all (`lua_selectors.register_extractor` is callable, but adding maps/regexps required separate boilerplate).

The new tree gives a stable, structured location that vendor code can use without colliding with end-user customization, while keeping the existing free-form behaviour intact.

## Load order

1. `lua.local.d/{selectors,maps,regexps}/*.lua` — structured (NEW)
2. `rspamd.local.lua` (unchanged)
3. `lua.local.d/*.lua` at root (existing free-form)
4. `local.d/rspamd.lua` (unchanged)

End users can still override anything shipped via the structured tree from either `rspamd.local.lua` or a root-level free-form file.

## File contract

Each structured file must `return` a table; the loader iterates it and calls the matching helper:

- `selectors/*.lua` — `{ name = fn }` or `{ name = { get_value = fn, description = ..., type = ... } }`
- `maps/*.lua` — `{ name = add_map_args_table }`; the resulting map is stored in `rspamd_maps[name]`
- `regexps/*.lua` — `{ SYMBOL = { re = ..., score = ..., description = ..., condition = ... } }`

Errors in any single file are logged with the file path via `rspamd_logger.errx` and skipped — they never abort startup.

## Reload

Picked up on `rspamadm reload` / SIGHUP, same as the existing `lua.local.d/*.lua` files.

## Test plan

- [x] `luacheck lualib/lua_extras.lua rules/rspamd.lua` — clean
- [x] `ninja install` — `lua_extras.lua` installed via existing `GLOB_RECURSE` rule, no CMake changes needed
- [x] `test/rspamd-test -p /rspamd/lua` — no new failures (unchanged: 1003/1014, 8 pre-existing errors in `lua_redis.prepare_setup.lua`)
- [x] `rspamadm configtest` with example selector/regexp files dropped into the runtime config dir — symbols register, `configdump` shows them with re/score/description, ends with `syntax OK`
- [ ] Reviewer sanity check on file contract / naming