### PR TITLE
[Fix] Handle DKIM permfail in Authentication-Results header

### DIFF
--- a/lualib/lua_auth_results.lua
+++ b/lualib/lua_auth_results.lua
@@ -118,7 +118,7 @@ local function gen_auth_results(task, settings)
       ar_string = 'fail' -- imply failure, not neutral
     elseif dres.result == 'allow' then
       ar_string = 'pass'
-    elseif dres.result == 'bad record' or dres.result == 'permerror' then
+    elseif dres.result == 'bad record' or dres.result == 'permerror' or dres.result == 'permfail' then
       ar_string = 'permerror'
     elseif dres.result == 'tempfail' then
       ar_string = 'temperror'


### PR DESCRIPTION
When a DKIM signature has an invalid record, task:get_dkim_results() returns 'permfail' which should map to dkim=permerror in the Authentication-Results header. Previously this result fell through to dkim=none, which is incorrect when a DKIM signature is present.

Fixes #5957