### PR TITLE
[Minor] Add backend none for Prometheus

### DIFF
--- a/src/plugins/lua/metric_exporter.lua
+++ b/src/plugins/lua/metric_exporter.lua
@@ -142,10 +142,33 @@ local function graphite_push(kwargs)
   })
 end
 
+local function none_config()
+  load_defaults({
+    host = 'localhost',
+    port = 0,
+    metric_prefix = 'rspamd'
+  })
+  return validate_metrics(settings['metrics'])
+end
+
+local function none_push(kwargs)
+  local stamp
+  if kwargs['time'] then
+    stamp = math.floor(kwargs['time'])
+  else
+    stamp = math.floor(util.get_time())
+  end
+  pool:set_variable(VAR_NAME, stamp)
+end
+
 local backends = {
   graphite = {
     configure = graphite_config,
     push = graphite_push,
+  },
+  none = {
+    configure = none_config,
+    push = none_push,
   },
 }
 


### PR DESCRIPTION
The metric_exporter plugin provides an endpoint for Prometheus. If there is no graphite present on the system metric_exporter logs this message every time Prometheus scrapes the metrics:
```
May  8 00:11:50 vultr rspamd[57711]: <>; lua; metric_exporter.lua:137: Push failed: Socket error detected: Connection refused
```
I add the backend `none` which only sets the timestamp of the last export. With this backend I can use Prometheus to scrape metrics without filling the logs with the message above.