### PR TITLE
[Feature] upstream: per-target SRV upstreams

### DIFF
--- a/contrib/libev/Changes
+++ b/contrib/libev/Changes
@@ -1,5 +1,18 @@
 Revision history for libev, a high-performance and full-featured event loop.
 
+Rspamd local extensions (not present in upstream libev):
+        - ev_active_cnt: returns the loop's activecnt counter.
+        - ev_now_update_if_cheap: cheap variant of ev_now_update for paths
+          that need a fresh cached time but cannot afford a realtime read.
+        - ev_now_resync: force-resync the loop's cached realtime/monotonic
+          state from the current time sources, discarding interpolation.
+          Use after installing/removing a fake clock.
+        - ev_set_fake_time_cb / ev_get_fake_time_cb: process-global fake
+          clock hook for unit tests; when set, replaces both ev_time() and
+          the internal monotonic clock so timers and ev_now() advance under
+          test control. NULL by default; cost in production is one
+          predicted-false branch.
+
 4.25 Fri Dec 21 07:49:20 CET 2018
         - INCOMPATIBLE CHANGE: EV_THROW was renamed to EV_NOEXCEPT
           (EV_THROW sitll provided) and now uses noexcept on C++11 or newer.

--- a/contrib/libev/ev.c
+++ b/contrib/libev/ev.c
@@ -2075,6 +2075,26 @@ ev_set_allocator (void *(*cb)(void *ptr, long size) EV_NOEXCEPT) EV_NOEXCEPT
   alloc = cb;
 }
 
+/* RSPAMD LOCAL EXTENSION: process-global fake-clock hook for unit tests.
+ * When non-NULL, both ev_time() and get_clock() return the callback's value
+ * instead of reading the system clocks. See ev.h for the public API.
+ */
+static ev_fake_time_cb fake_time_cb = 0;
+
+ecb_cold
+void
+ev_set_fake_time_cb (ev_fake_time_cb cb) EV_NOEXCEPT
+{
+  fake_time_cb = cb;
+}
+
+ecb_cold
+ev_fake_time_cb
+ev_get_fake_time_cb (void) EV_NOEXCEPT
+{
+  return fake_time_cb;
+}
+
 inline_speed void *
 ev_realloc (void *ptr, long size)
 {
@@ -2202,6 +2222,10 @@ typedef struct
 ev_tstamp
 ev_time (void) EV_NOEXCEPT
 {
+  /* RSPAMD LOCAL EXTENSION: fake clock hook for unit tests. */
+  if (ecb_expect_false (fake_time_cb != 0))
+    return fake_time_cb ();
+
 #if EV_USE_REALTIME
   if (ecb_expect_true (have_realtime))
     {
@@ -2222,6 +2246,10 @@ ev_time (void) EV_NOEXCEPT
 inline_size ev_tstamp
 get_clock (void)
 {
+  /* RSPAMD LOCAL EXTENSION: fake clock hook for unit tests. */
+  if (ecb_expect_false (fake_time_cb != 0))
+    return fake_time_cb ();
+
 #if EV_USE_MONOTONIC
   if (ecb_expect_true (have_monotonic))
     {
@@ -5687,6 +5715,16 @@ void
 ev_now_update_if_cheap (EV_P) EV_NOEXCEPT
 {
 	if (have_cheap_timer) time_update (EV_A_ 1e100);
+}
+
+/* RSPAMD LOCAL EXTENSION: see ev.h. */
+void
+ev_now_resync (EV_P) EV_NOEXCEPT
+{
+	ev_rt_now = ev_time ();
+	mn_now    = get_clock ();
+	now_floor = mn_now;
+	rtmn_diff = ev_rt_now - mn_now;
 }
 
 int

--- a/contrib/libev/ev.h
+++ b/contrib/libev/ev.h
@@ -553,6 +553,17 @@ EV_API_DECL void ev_set_allocator (void *(*cb)(void *ptr, long size) EV_NOEXCEPT
  */
 EV_API_DECL void ev_set_syserr_cb (void (*cb)(const char *msg) EV_NOEXCEPT) EV_NOEXCEPT;
 
+/* RSPAMD LOCAL EXTENSION:
+ * Install a process-global fake clock callback used by ev_time() and the
+ * internal monotonic clock read. When set, the callback's return value
+ * replaces both the realtime and monotonic clock sources, so timers and
+ * ev_now()/ev_now_update() advance under test control. Pass NULL to
+ * restore the system clocks. Intended for unit tests only.
+ */
+typedef ev_tstamp (*ev_fake_time_cb)(void);
+EV_API_DECL void ev_set_fake_time_cb (ev_fake_time_cb cb) EV_NOEXCEPT;
+EV_API_DECL ev_fake_time_cb ev_get_fake_time_cb (void) EV_NOEXCEPT;
+
 #if EV_MULTIPLICITY
 
 /* the default loop is the only one that handles signals and child watchers */
@@ -602,6 +613,13 @@ EV_API_DECL void ev_now_update (EV_P) EV_NOEXCEPT; /* update event loop time */
  * are used in system.
  */
 EV_API_DECL void ev_now_update_if_cheap (EV_P) EV_NOEXCEPT;
+/* RSPAMD LOCAL EXTENSION:
+ * Force-resync the loop's cached realtime/monotonic state from the current
+ * time sources, discarding any interpolation state. Use after installing
+ * or removing a fake clock via ev_set_fake_time_cb(), or after any other
+ * large discontinuity in the clock source.
+ */
+EV_API_DECL void ev_now_resync (EV_P) EV_NOEXCEPT;
 
 #if EV_WALK_ENABLE
 /* walk (almost) all watchers in the loop of a given type, invoking the */

--- a/src/libutil/upstream.c
+++ b/src/libutil/upstream.c
@@ -15,6 +15,7 @@
  */
 #include "config.h"
 #include "upstream.h"
+#include "upstream_internal.h"
 #include "ottery.h"
 #include "ref.h"
 #include "cfg_file.h"
@@ -120,6 +121,36 @@ struct upstream {
 	gsize available_tokens; /* Current available tokens */
 	gsize inflight_tokens;  /* Tokens reserved by in-flight requests */
 	double last_refill_at;  /* Last lazy-refill timestamp (ev_now/ticks); 0 = uninit */
+
+	/*
+	 * SRV-derived member fields. Set on members (FLAG_SRV_MEMBER); zero
+	 * on non-SRV upstreams and on SRV parents. srv_priority and srv_weight
+	 * mirror RFC 2782 fields from the originating SRV reply entry; they
+	 * survive re-resolves until the corresponding target disappears.
+	 * srv_parent is a weak back-pointer used to remove the member from the
+	 * parent's hash table during drain. It does not hold a ref on the
+	 * parent.
+	 */
+	struct upstream *srv_parent;
+	unsigned int srv_priority;
+	unsigned int srv_weight;
+
+	/*
+	 * Owned by SRV parents (FLAG_SRV_RESOLVE). Hash table from "fqdn:port"
+	 * to struct upstream * (the member). Used by the re-resolve diff path
+	 * to identify add/remove/update of members. NULL on members and on
+	 * non-SRV upstreams.
+	 */
+	GHashTable *srv_members;
+
+	/*
+	 * Tombstone for graceful drain. Set when a member is removed from the
+	 * parent's set (target disappeared from a re-resolve). Once true, the
+	 * revive timer must not re-activate the upstream — it should silently
+	 * release the timer ref and leave the upstream waiting for inflight
+	 * selectors to release their refs, after which the dtor runs.
+	 */
+	gboolean is_draining;
 #ifdef UPSTREAMS_THREAD_SAFE
 	rspamd_mutex_t *lock;
 #endif
@@ -277,6 +308,12 @@ static const struct upstream_limits default_limits = {
 };
 
 static void rspamd_upstream_lazy_resolve_cb(struct ev_loop *, ev_timer *, int);
+static void rspamd_upstream_revive_cb(struct ev_loop *loop, ev_timer *w, int revents);
+static void rspamd_upstream_dtor(struct upstream *up);
+static void rspamd_upstream_resolve_addrs(const struct upstream_list *ls,
+										  struct upstream *upstream);
+static void rspamd_upstream_set_inactive(struct upstream_list *ls,
+										 struct upstream *upstream);
 
 void rspamd_upstreams_library_config(struct rspamd_config *cfg,
 									 struct upstream_ctx *ctx,
@@ -449,9 +486,20 @@ rspamd_upstream_addr_sort_func(gconstpointer a, gconstpointer b)
 static void
 rspamd_upstream_set_active(struct upstream_list *ls, struct upstream *upstream)
 {
-	gboolean is_pending;
+	gboolean is_pending = FALSE;
 
 	RSPAMD_UPSTREAM_LOCK(ls);
+
+	/*
+	 * SRV parents are placeholders that own member upstreams; they must
+	 * never become selectable. Skip the alive-list bookkeeping but keep
+	 * the lazy-resolve timer setup below — that timer is what drives the
+	 * periodic SRV re-resolution.
+	 */
+	if (upstream->flags & RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE) {
+		upstream->active_idx = -1;
+		goto schedule_resolve;
+	}
 
 	is_pending = (upstream->flags & RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE) != 0;
 
@@ -473,6 +521,7 @@ rspamd_upstream_set_active(struct upstream_list *ls, struct upstream *upstream)
 		upstream->active_idx = -1;
 	}
 
+schedule_resolve:
 	if (upstream->ctx && upstream->ctx->configured &&
 		!((upstream->flags & RSPAMD_UPSTREAM_FLAG_NORESOLVE) ||
 		  (upstream->flags & RSPAMD_UPSTREAM_FLAG_DNS))) {
@@ -662,7 +711,7 @@ rspamd_upstream_promote_pending(struct upstream *upstream)
 	struct upstream_list *ls = upstream->ls;
 	struct upstream_list_watcher *w;
 
-	if (ls == NULL) {
+	if (ls == NULL || upstream->is_draining) {
 		return;
 	}
 
@@ -739,124 +788,442 @@ rspamd_upstream_dns_cb(struct rdns_reply *reply, void *arg)
 	REF_RELEASE(up);
 }
 
-struct rspamd_upstream_srv_dns_cb {
-	struct upstream *up;
-	unsigned int priority;
-	unsigned int port;
-	unsigned int requests_inflight;
-};
-
-/* Used when we have resolved SRV record and resolved addrs */
-static void
-rspamd_upstream_dns_srv_phase2_cb(struct rdns_reply *reply, void *arg)
+/*
+ * Build a stable "fqdn:port" key for indexing SRV members on the parent.
+ * Allocated with g_malloc; the parent's hash table owns the string and
+ * frees it via the value-destroy callback registered at hash creation.
+ */
+static char *
+rspamd_upstream_srv_member_key(const char *target, uint16_t port)
 {
-	struct rspamd_upstream_srv_dns_cb *cbdata =
-		(struct rspamd_upstream_srv_dns_cb *) arg;
-	struct upstream *up;
-	struct rdns_reply_entry *entry;
-	struct upstream_inet_addr_entry *up_ent;
-
-	up = cbdata->up;
-
-	if (reply->code == RDNS_RC_NOERROR) {
-		entry = reply->entries;
-
-		RSPAMD_UPSTREAM_LOCK(up);
-		while (entry) {
-
-			if (entry->type == RDNS_REQUEST_A) {
-				up_ent = g_malloc0(sizeof(*up_ent));
-				up_ent->addr = rspamd_inet_address_new(AF_INET,
-													   &entry->content.a.addr);
-				up_ent->priority = cbdata->priority;
-				rspamd_inet_address_set_port(up_ent->addr, cbdata->port);
-				LL_PREPEND(up->new_addrs, up_ent);
-			}
-			else if (entry->type == RDNS_REQUEST_AAAA) {
-				up_ent = g_malloc0(sizeof(*up_ent));
-				up_ent->addr = rspamd_inet_address_new(AF_INET6,
-													   &entry->content.aaa.addr);
-				up_ent->priority = cbdata->priority;
-				rspamd_inet_address_set_port(up_ent->addr, cbdata->port);
-				LL_PREPEND(up->new_addrs, up_ent);
-			}
-			entry = entry->next;
-		}
-
-		RSPAMD_UPSTREAM_UNLOCK(up);
-	}
-
-	up->dns_requests--;
-	cbdata->requests_inflight--;
-
-	if (cbdata->requests_inflight == 0) {
-		g_free(cbdata);
-	}
-
-	if (up->dns_requests == 0) {
-		rspamd_upstream_update_addrs(up);
-	}
-
-	REF_RELEASE(up);
+	return g_strdup_printf("%s:%u", target, (unsigned int) port);
 }
 
+/*
+ * Create a brand-new SRV member upstream, register it with the parent,
+ * push it into the upstream list and ctx queue, and kick off A/AAAA
+ * resolution. The member starts in PENDING_RESOLVE state and becomes
+ * selectable only after rspamd_upstream_promote_pending fires from
+ * rspamd_upstream_update_addrs once a non-empty A/AAAA reply arrives.
+ *
+ * Caller holds parent's lock. ls and ctx must be non-NULL (i.e. parent
+ * is still attached to a live list).
+ */
+static struct upstream *
+rspamd_upstream_srv_create_member(struct upstream *parent,
+								  const char *target,
+								  uint16_t port,
+								  uint16_t srv_weight,
+								  uint16_t srv_priority)
+{
+	struct upstream_list *ls = parent->ls;
+	struct upstream_ctx *ctx = parent->ctx;
+	struct upstream *member;
+	rspamd_mempool_t *pool = ctx ? ctx->pool : NULL;
+	unsigned int h;
+	char *key;
+
+	g_assert(ls != NULL);
+	g_assert(ctx != NULL);
+
+	member = g_malloc0(sizeof(*member));
+	member->name = pool ? rspamd_mempool_strdup(pool, target) : g_strdup(target);
+	member->srv_parent = parent;
+	member->srv_priority = srv_priority;
+	member->srv_weight = srv_weight;
+	/*
+	 * RFC 2782 weight 0 means "rarely used but selectable". We clamp to >=1
+	 * so the existing weighted-RR path doesn't treat the member as
+	 * effectively disabled. True weight-0 semantics are a follow-up.
+	 */
+	member->weight = MAX((unsigned int) srv_weight, 1u);
+	member->cur_weight = member->weight;
+	member->deferred_port = port;
+	member->active_idx = -1;
+	/*
+	 * Members inherit the list-level flags applied to the parent at
+	 * creation time but never carry the SRV_RESOLVE marker themselves —
+	 * that flag is the parent placeholder's identifying mark.
+	 */
+	member->flags = (parent->flags & ~RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE) |
+					RSPAMD_UPSTREAM_FLAG_SRV_MEMBER |
+					RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE;
+
+	g_ptr_array_add(ls->ups, member);
+	member->ud = parent->ud;
+	member->ls = ls;
+	REF_INIT_RETAIN(member, rspamd_upstream_dtor);
+#ifdef UPSTREAMS_THREAD_SAFE
+	member->lock = rspamd_mutex_new();
+#endif
+	member->ctx = ctx;
+	REF_RETAIN(ctx);
+	g_queue_push_tail(ctx->upstreams, member);
+	member->ctx_pos = g_queue_peek_tail_link(ctx->upstreams);
+
+	h = rspamd_cryptobox_fast_hash(member->name, strlen(member->name), 0);
+	memset(member->uid, 0, sizeof(member->uid));
+	rspamd_encode_base32_buf((const unsigned char *) &h, sizeof(h),
+							 member->uid, sizeof(member->uid) - 1,
+							 RSPAMD_BASE32_DEFAULT);
+
+	key = rspamd_upstream_srv_member_key(target, port);
+	g_hash_table_insert(parent->srv_members, key, member);
+
+	{
+		struct upstream *upstream = member;
+		msg_info_upstream("created SRV member %s for %s "
+						  "(target=%s port=%ud weight=%ud priority=%ud)",
+						  member->uid, parent->name, target,
+						  (unsigned int) port,
+						  (unsigned int) srv_weight,
+						  (unsigned int) srv_priority);
+	}
+
+	/*
+	 * set_active arms the lazy-resolve timer; for PENDING_RESOLVE members
+	 * it leaves them out of `alive`. The first successful A/AAAA reply
+	 * promotes the member via rspamd_upstream_promote_pending.
+	 */
+	rspamd_upstream_set_active(ls, member);
+	/*
+	 * Issue the A/AAAA query immediately rather than waiting for the lazy
+	 * timer; users expect new SRV targets to start serving traffic
+	 * promptly after a re-resolve.
+	 */
+	rspamd_upstream_resolve_addrs(ls, member);
+
+	return member;
+}
+
+/*
+ * Graceful drain: remove a member from selection, unlink it from the
+ * parent's hash, drop its presence in `ls->ups`. The set_inactive call
+ * keeps the upstream pinned in memory until its revive timer fires —
+ * by that point any in-flight selectors will have called fail/ok/release
+ * and the dtor can run safely.
+ *
+ * The is_draining flag tells revive_cb to skip set_active when the
+ * timer fires, so the drained member stays out of selection forever.
+ */
+static void
+rspamd_upstream_srv_drain_member(struct upstream *member)
+{
+	struct upstream *parent = member->srv_parent;
+	struct upstream_list *ls = member->ls;
+	struct upstream *upstream = member; /* for the logging macro */
+
+	if (!(member->flags & RSPAMD_UPSTREAM_FLAG_SRV_MEMBER)) {
+		return;
+	}
+
+	msg_info_upstream("drain SRV member %s (%s)",
+					  member->uid, member->name);
+
+	member->is_draining = TRUE;
+
+	/* Stop any timer that might re-activate the member. */
+	if (member->ctx && member->ctx->event_loop && ev_can_stop(&member->ev)) {
+		ev_timer_stop(member->ctx->event_loop, &member->ev);
+	}
+
+	/* Unlink from the parent's index. */
+	if (parent && parent->srv_members) {
+		GHashTableIter it;
+		gpointer k, v;
+
+		g_hash_table_iter_init(&it, parent->srv_members);
+		while (g_hash_table_iter_next(&it, &k, &v)) {
+			if (v == member) {
+				g_hash_table_iter_remove(&it);
+				break;
+			}
+		}
+	}
+
+	/*
+	 * Pull from the alive list directly, mirroring the relevant subset
+	 * of set_inactive. We deliberately do NOT go through set_inactive
+	 * itself: it pins the upstream with REF_RETAIN+revive timer
+	 * expecting the timer to release later, but for a drained member
+	 * there is no "later" — we want the dtor to run as soon as inflight
+	 * selectors release their refs.
+	 */
+	if (ls != NULL && member->active_idx != -1) {
+		struct upstream_list_watcher *w;
+
+		RSPAMD_UPSTREAM_LOCK(ls);
+		g_ptr_array_remove_index(ls->alive, member->active_idx);
+		member->active_idx = -1;
+		ls->ring_dirty = TRUE;
+
+		if (ls->rot_alg == RSPAMD_UPSTREAM_TOKEN_BUCKET &&
+			member->inflight_tokens > 0) {
+			member->available_tokens += member->inflight_tokens;
+			if (member->available_tokens > member->max_tokens) {
+				member->available_tokens = member->max_tokens;
+			}
+			member->inflight_tokens = 0;
+		}
+
+		/* Reindex */
+		for (unsigned int i = 0; i < ls->alive->len; i++) {
+			struct upstream *cur = g_ptr_array_index(ls->alive, i);
+			cur->active_idx = i;
+		}
+
+		DL_FOREACH(ls->watchers, w)
+		{
+			if (w->events_mask & RSPAMD_UPSTREAM_WATCH_OFFLINE) {
+				w->func(member, RSPAMD_UPSTREAM_WATCH_OFFLINE,
+						member->errors, w->ud);
+			}
+		}
+
+		RSPAMD_UPSTREAM_UNLOCK(ls);
+	}
+
+	/* Remove from ls->ups so traversal/probe paths stop seeing it. */
+	if (ls != NULL) {
+		for (unsigned int i = 0; i < ls->ups->len; i++) {
+			if (g_ptr_array_index(ls->ups, i) == member) {
+				g_ptr_array_remove_index(ls->ups, i);
+				break;
+			}
+		}
+	}
+
+	/* Sever the parent link so the dtor doesn't re-touch parent state. */
+	member->srv_parent = NULL;
+
+	/*
+	 * Production grace window: a caller may have just received this
+	 * member from rspamd_upstream_get_* and not yet called fail/ok.
+	 * Arm a one-shot timer (reusing revive_cb, which checks is_draining
+	 * and bails to REF_RELEASE on fire) to keep the upstream alive long
+	 * enough for inflight selectors to drain naturally. We use
+	 * revive_time as the grace period — same TTL the rest of the system
+	 * already assumes for inactive upstreams.
+	 *
+	 * Without an event loop (tests, early startup), no inflight is
+	 * possible; we skip the timer and let REF_RELEASE below run the
+	 * dtor synchronously.
+	 */
+	if (member->ctx && member->ctx->event_loop && ls != NULL) {
+		double ntim = rspamd_time_jitter(ls->limits->revive_time,
+										 ls->limits->revive_time *
+											 ls->limits->revive_jitter);
+		REF_RETAIN(member);
+		ev_timer_init(&member->ev, rspamd_upstream_revive_cb, ntim, 0);
+		member->ev.data = member;
+		if (member->ctx->configured) {
+			ev_timer_start(member->ctx->event_loop, &member->ev);
+		}
+	}
+
+	/* Release the original creation ref. */
+	REF_RELEASE(member);
+}
+
+/*
+ * Apply a snapshot of SRV targets to a parent. Public-internal entry
+ * point: takes a plain-data array decoupled from the DNS client struct
+ * layout, so tests can drive expansion without DNS.
+ *
+ * Caller must ensure parent has srv_members allocated (true for any
+ * upstream created via "service=..."). Acquires/releases the parent
+ * lock internally.
+ */
+void rspamd_upstream_srv_apply(struct upstream *parent,
+							   const struct rspamd_upstream_srv_entry *entries,
+							   size_t n)
+{
+	GHashTable *seen;
+	GList *to_drain = NULL, *cur;
+	GHashTableIter iter;
+	gpointer k, v;
+	size_t i;
+	struct upstream *upstream = parent; /* for the logging macro */
+
+	if (parent == NULL || parent->srv_members == NULL) {
+		return;
+	}
+
+	RSPAMD_UPSTREAM_LOCK(parent);
+
+	seen = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+
+	for (i = 0; i < n; i++) {
+		const struct rspamd_upstream_srv_entry *e = &entries[i];
+		struct upstream *existing;
+		char *key;
+
+		msg_debug_upstream("apply SRV target for %s: %s "
+						   "(weight=%ud priority=%ud port=%ud)",
+						   parent->name, e->target,
+						   (unsigned int) e->weight,
+						   (unsigned int) e->priority,
+						   (unsigned int) e->port);
+
+		key = rspamd_upstream_srv_member_key(e->target, e->port);
+		existing = g_hash_table_lookup(parent->srv_members, key);
+
+		if (existing != NULL) {
+			gboolean topology_changed = FALSE;
+
+			if (existing->srv_weight != e->weight) {
+				existing->srv_weight = e->weight;
+				existing->weight = MAX((unsigned int) e->weight, 1u);
+				if (existing->cur_weight == 0) {
+					existing->cur_weight = existing->weight;
+				}
+				topology_changed = TRUE;
+			}
+			if (existing->srv_priority != e->priority) {
+				existing->srv_priority = e->priority;
+				topology_changed = TRUE;
+			}
+			if (topology_changed && parent->ls != NULL) {
+				parent->ls->ring_dirty = TRUE;
+			}
+			/* Refresh A/AAAA so address changes propagate. */
+			if (parent->ls != NULL) {
+				rspamd_upstream_resolve_addrs(parent->ls, existing);
+			}
+		}
+		else {
+			rspamd_upstream_srv_create_member(parent, e->target, e->port,
+											  e->weight, e->priority);
+		}
+
+		g_hash_table_insert(seen, key, NULL);
+	}
+
+	/* Anything in srv_members not in `seen` is gone — drain it. */
+	g_hash_table_iter_init(&iter, parent->srv_members);
+	while (g_hash_table_iter_next(&iter, &k, &v)) {
+		if (!g_hash_table_contains(seen, k)) {
+			to_drain = g_list_prepend(to_drain, v);
+		}
+	}
+
+	for (cur = to_drain; cur != NULL; cur = cur->next) {
+		rspamd_upstream_srv_drain_member((struct upstream *) cur->data);
+	}
+	g_list_free(to_drain);
+	g_hash_table_unref(seen);
+
+	RSPAMD_UPSTREAM_UNLOCK(parent);
+}
+
+struct upstream *
+rspamd_upstream_srv_test_get_parent(struct upstream_list *ups)
+{
+	unsigned int i;
+
+	if (ups == NULL) {
+		return NULL;
+	}
+
+	for (i = 0; i < ups->ups->len; i++) {
+		struct upstream *up = g_ptr_array_index(ups->ups, i);
+		if (up->flags & RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE) {
+			return up;
+		}
+	}
+
+	return NULL;
+}
+
+void rspamd_upstream_member_force_alive_for_test(struct upstream *member,
+												 const char *ip_str)
+{
+	rspamd_inet_addr_t *addr = NULL;
+
+	g_assert(member != NULL);
+	g_assert(member->flags & RSPAMD_UPSTREAM_FLAG_SRV_MEMBER);
+
+	if (!rspamd_parse_inet_address(&addr, ip_str, strlen(ip_str),
+								   RSPAMD_INET_ADDRESS_PARSE_DEFAULT)) {
+		g_assert_not_reached();
+	}
+
+	rspamd_inet_address_set_port(addr, member->deferred_port);
+	rspamd_upstream_add_addr(member, addr);
+
+	/*
+	 * Drop the PENDING_RESOLVE flag and place the member into the alive
+	 * list directly. set_active would re-arm the lazy-resolve timer; in
+	 * tests the runtime has no event loop, so we do the bookkeeping by
+	 * hand to keep the test deterministic.
+	 */
+	RSPAMD_UPSTREAM_LOCK(member->ls);
+	member->flags &= ~RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE;
+	g_ptr_array_add(member->ls->alive, member);
+	member->active_idx = member->ls->alive->len - 1;
+	member->ls->ring_dirty = TRUE;
+	RSPAMD_UPSTREAM_UNLOCK(member->ls);
+}
+
+/*
+ * SRV reply handler: convert the rdns reply into the plain-data entry
+ * vector and hand it to rspamd_upstream_srv_apply. Each SRV target lives
+ * as its own struct upstream — own error budget, latency EWMA,
+ * addresses, and full first-class participation in every selection
+ * algorithm.
+ *
+ * On reply errors (NXDOMAIN, timeout) we deliberately do nothing: the
+ * existing member set remains in place and the next re-resolve gets to
+ * try again. Otherwise one bad query would tear down the whole cluster.
+ */
 static void
 rspamd_upstream_dns_srv_cb(struct rdns_reply *reply, void *arg)
 {
-	struct upstream *upstream = (struct upstream *) arg;
+	struct upstream *parent = (struct upstream *) arg;
+	struct upstream *upstream = parent; /* for the logging macro */
 	struct rdns_reply_entry *entry;
-	struct rspamd_upstream_srv_dns_cb *ncbdata;
 
-	if (reply->code == RDNS_RC_NOERROR) {
-		entry = reply->entries;
-
-		RSPAMD_UPSTREAM_LOCK(upstream);
-		while (entry) {
-			/* XXX: we ignore weight as it contradicts with upstreams logic */
-			if (entry->type == RDNS_REQUEST_SRV) {
-				msg_debug_upstream("got srv reply for %s: %s "
-								   "(weight=%d, priority=%d, port=%d)",
-								   upstream->name, entry->content.srv.target,
-								   entry->content.srv.weight, entry->content.srv.priority,
-								   entry->content.srv.port);
-				ncbdata = g_malloc0(sizeof(*ncbdata));
-				ncbdata->priority = entry->content.srv.weight;
-				ncbdata->port = entry->content.srv.port;
-				/* XXX: for all entries? */
-				upstream->ttl = entry->ttl;
-
-				if (rdns_make_request_full(upstream->ctx->res,
-										   rspamd_upstream_dns_srv_phase2_cb, ncbdata,
-										   upstream->ls->limits->dns_timeout,
-										   upstream->ls->limits->dns_retransmits,
-										   1, entry->content.srv.target, RDNS_REQUEST_A) != NULL) {
-					upstream->dns_requests++;
-					REF_RETAIN(upstream);
-					ncbdata->requests_inflight++;
-				}
-
-				if (rdns_make_request_full(upstream->ctx->res,
-										   rspamd_upstream_dns_srv_phase2_cb, ncbdata,
-										   upstream->ls->limits->dns_timeout,
-										   upstream->ls->limits->dns_retransmits,
-										   1, entry->content.srv.target, RDNS_REQUEST_AAAA) != NULL) {
-					upstream->dns_requests++;
-					REF_RETAIN(upstream);
-					ncbdata->requests_inflight++;
-				}
-
-				if (ncbdata->requests_inflight == 0) {
-					g_free(ncbdata);
-				}
-			}
-			entry = entry->next;
-		}
-
-		RSPAMD_UPSTREAM_UNLOCK(upstream);
+	if (parent->ls == NULL || parent->is_draining) {
+		/* Parent destroyed or drained mid-flight; just release the ref. */
+		parent->dns_requests--;
+		REF_RELEASE(parent);
+		return;
 	}
 
-	upstream->dns_requests--;
-	REF_RELEASE(upstream);
+	if (reply->code == RDNS_RC_NOERROR) {
+		GArray *flat = g_array_new(FALSE, FALSE,
+								   sizeof(struct rspamd_upstream_srv_entry));
+
+		for (entry = reply->entries; entry != NULL; entry = entry->next) {
+			if (entry->type != RDNS_REQUEST_SRV) {
+				continue;
+			}
+
+			parent->ttl = entry->ttl;
+
+			struct rspamd_upstream_srv_entry e = {
+				.target = entry->content.srv.target,
+				.port = entry->content.srv.port,
+				.weight = entry->content.srv.weight,
+				.priority = entry->content.srv.priority,
+			};
+			g_array_append_val(flat, e);
+		}
+
+		rspamd_upstream_srv_apply(parent,
+								  (const struct rspamd_upstream_srv_entry *) flat->data,
+								  flat->len);
+		g_array_free(flat, TRUE);
+	}
+	else {
+		msg_info_upstream("SRV resolution for %s returned %s; keeping "
+						  "existing %ud member(s)",
+						  parent->name, rdns_strerror(reply->code),
+						  parent->srv_members ? (unsigned int) g_hash_table_size(parent->srv_members) : 0u);
+	}
+
+	parent->dns_requests--;
+	REF_RELEASE(parent);
 }
 
 static void
@@ -866,6 +1233,20 @@ rspamd_upstream_revive_cb(struct ev_loop *loop, ev_timer *w, int revents)
 
 	RSPAMD_UPSTREAM_LOCK(upstream);
 	ev_timer_stop(loop, w);
+
+	/*
+	 * Drained SRV members must not re-enter the alive list. The drain
+	 * helper unlinks them from `ls->ups` and `srv_members` and flips this
+	 * flag; the only thing left is to release the timer ref so the dtor
+	 * runs once inflight selectors release theirs.
+	 */
+	if (upstream->is_draining) {
+		msg_debug_upstream("skip revive for drained upstream %s",
+						   upstream->name);
+		RSPAMD_UPSTREAM_UNLOCK(upstream);
+		REF_RELEASE(upstream);
+		return;
+	}
 
 	msg_debug_upstream("revive upstream %s", upstream->name);
 
@@ -884,6 +1265,15 @@ static void
 rspamd_upstream_resolve_addrs(const struct upstream_list *ls,
 							  struct upstream *upstream)
 {
+	/*
+	 * Drained SRV members and SRV parents must never resolve. Parents
+	 * resolve SRV through the dedicated path below; the early bail here
+	 * matters when set_inactive is invoked on a draining member: it would
+	 * otherwise re-issue A/AAAA and pollute the just-released state.
+	 */
+	if (upstream->is_draining) {
+		return;
+	}
 
 	if ((upstream->flags & RSPAMD_UPSTREAM_FLAG_DNS)) {
 		/* For DNS upstreams: resolve synchronously using getaddrinfo if name */
@@ -1398,7 +1788,26 @@ rspamd_upstreams_create(struct upstream_ctx *ctx)
 
 gsize rspamd_upstreams_count(struct upstream_list *ups)
 {
-	return ups != NULL ? ups->ups->len : 0;
+	gsize n = 0;
+	unsigned int i;
+	struct upstream *up;
+
+	if (ups == NULL) {
+		return 0;
+	}
+
+	/*
+	 * SRV parents are placeholders, not selectable upstreams. Count only
+	 * first-class entries so callers see the real cluster size.
+	 */
+	for (i = 0; i < ups->ups->len; i++) {
+		up = g_ptr_array_index(ups->ups, i);
+		if (!(up->flags & RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE)) {
+			n++;
+		}
+	}
+
+	return n;
 }
 
 gsize rspamd_upstreams_alive(struct upstream_list *ups)
@@ -1422,6 +1831,18 @@ rspamd_upstream_dtor(struct upstream *up)
 
 	if (up->addrs.addr) {
 		g_ptr_array_free(up->addrs.addr, TRUE);
+	}
+
+	/*
+	 * SRV parents own a hash table of "fqdn:port" → member upstream. The
+	 * members themselves carry their own refs and are freed independently
+	 * once their drain ref counts reach zero, so we only release the hash
+	 * itself here. Drain on rspamd_upstreams_destroy already cleared the
+	 * entries by the time the parent's dtor runs.
+	 */
+	if (up->srv_members != NULL) {
+		g_hash_table_unref(up->srv_members);
+		up->srv_members = NULL;
 	}
 
 #ifdef UPSTREAMS_THREAD_SAFE
@@ -1650,6 +2071,15 @@ rspamd_upstreams_add_upstream(struct upstream_list *ups, const char *str,
 								(int) (plus_pos - service_pos), service_pos,
 								(int) (semicolon_pos - (plus_pos + 1)), plus_pos + 1);
 				upstream->flags |= RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE;
+				/*
+				 * Pre-allocate the member index. The hash owns the keys
+				 * (g_free destructor) and not the values; member upstreams
+				 * are released through their own ref counts during drain
+				 * or list teardown.
+				 */
+				upstream->srv_members = g_hash_table_new_full(g_str_hash,
+															  g_str_equal,
+															  g_free, NULL);
 				ret = RSPAMD_PARSE_ADDR_RESOLVED;
 
 				if (ups->ctx) {
@@ -2498,6 +2928,13 @@ rspamd_upstream_get_common(struct upstream_list *ups,
 				continue;
 			}
 			/*
+			 * SRV parents never enter selection; they only own member
+			 * upstreams. Skip them so probe mode considers real backends.
+			 */
+			if (cur->flags & RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE) {
+				continue;
+			}
+			/*
 			 * Pending-resolve upstreams have no addresses yet — they can't
 			 * be probed. The lazy resolver will move them into `alive` once
 			 * DNS comes back.
@@ -2662,12 +3099,22 @@ void rspamd_upstreams_foreach(struct upstream_list *ups,
 							  rspamd_upstream_traverse_func cb, void *ud)
 {
 	struct upstream *up;
-	unsigned int i;
+	unsigned int i, idx = 0;
 
 	for (i = 0; i < ups->ups->len; i++) {
 		up = g_ptr_array_index(ups->ups, i);
 
-		cb(up, i, ud);
+		/*
+		 * Skip SRV parent placeholders — they aren't selectable
+		 * upstreams and exposing them to consumers (foreach is the
+		 * public iteration API) would surprise callers that expect
+		 * to enumerate real backends.
+		 */
+		if (up->flags & RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE) {
+			continue;
+		}
+
+		cb(up, idx++, ud);
 	}
 }
 

--- a/src/libutil/upstream.c
+++ b/src/libutil/upstream.c
@@ -598,6 +598,22 @@ rspamd_upstream_update_addrs(struct upstream *upstream)
 	struct upstream_addr_elt *addr_elt, *naddr;
 
 	/*
+	 * Drained members exit early — drain has unlinked them from the
+	 * list; rebuilding addresses now would just leak the address array
+	 * once the member's dtor runs.
+	 */
+	if (upstream->is_draining) {
+		struct upstream_inet_addr_entry *cur_pending, *tmp_pending;
+		LL_FOREACH_SAFE(upstream->new_addrs, cur_pending, tmp_pending)
+		{
+			rspamd_inet_address_free(cur_pending->addr);
+			g_free(cur_pending);
+		}
+		upstream->new_addrs = NULL;
+		return;
+	}
+
+	/*
 	 * We need first of all get the saved port, since DNS gives us no
 	 * idea about what port has been used previously. For PENDING_RESOLVE
 	 * upstreams there is no prior address: use the port stashed at parse
@@ -754,6 +770,19 @@ rspamd_upstream_dns_cb(struct rdns_reply *reply, void *arg)
 	struct upstream *up = (struct upstream *) arg;
 	struct rdns_reply_entry *entry;
 	struct upstream_inet_addr_entry *up_ent;
+
+	/*
+	 * Drained SRV members may still receive their last A/AAAA reply
+	 * after drain. Don't accumulate addresses or call update_addrs —
+	 * the member is on its way out and any address mutation is wasted
+	 * work (and risks a UAF on the addrs array if drain races with the
+	 * callback).
+	 */
+	if (up->is_draining) {
+		up->dns_requests--;
+		REF_RELEASE(up);
+		return;
+	}
 
 	if (reply->code == RDNS_RC_NOERROR) {
 		entry = reply->entries;
@@ -922,6 +951,16 @@ rspamd_upstream_srv_drain_member(struct upstream *member)
 
 	member->is_draining = TRUE;
 
+	/*
+	 * If the member was mid-probe at drain time, clearing
+	 * half_open_inflight prevents the eventual fail/ok callback from
+	 * the inflight selector from advancing the probe state machine
+	 * (and the is_draining check in rspamd_upstream_ok blocks
+	 * re-activation as a belt-and-braces measure).
+	 */
+	member->half_open_inflight = 0;
+	member->next_probe_at = 0;
+
 	/* Stop any timer that might re-activate the member. */
 	if (member->ctx && member->ctx->event_loop && ev_can_stop(&member->ev)) {
 		ev_timer_stop(member->ctx->event_loop, &member->ev);
@@ -1005,21 +1044,31 @@ rspamd_upstream_srv_drain_member(struct upstream *member)
 	 * revive_time as the grace period — same TTL the rest of the system
 	 * already assumes for inactive upstreams.
 	 *
-	 * Without an event loop (tests, early startup), no inflight is
-	 * possible; we skip the timer and let REF_RELEASE below run the
-	 * dtor synchronously.
+	 * Without a configured event loop (tests, early startup, ctx mid-
+	 * teardown), no inflight is possible; we skip the timer and let
+	 * REF_RELEASE below run the dtor synchronously. The two conditions
+	 * — `event_loop` and `configured` — are checked together so we
+	 * never REF_RETAIN without guaranteeing the timer that releases
+	 * that ref will actually run.
 	 */
-	if (member->ctx && member->ctx->event_loop && ls != NULL) {
+	if (member->ctx && member->ctx->event_loop && member->ctx->configured &&
+		ls != NULL) {
 		double ntim = rspamd_time_jitter(ls->limits->revive_time,
 										 ls->limits->revive_time *
 											 ls->limits->revive_jitter);
 		REF_RETAIN(member);
 		ev_timer_init(&member->ev, rspamd_upstream_revive_cb, ntim, 0);
 		member->ev.data = member;
-		if (member->ctx->configured) {
-			ev_timer_start(member->ctx->event_loop, &member->ev);
-		}
+		ev_timer_start(member->ctx->event_loop, &member->ev);
 	}
+
+	/*
+	 * Now that the alive bookkeeping and grace timer are set up using
+	 * the local `ls`, sever the back-pointer so any callback that fires
+	 * later on this drained member sees a NULL ls and bails (revive_cb,
+	 * record_latency, return_tokens already guard on this).
+	 */
+	member->ls = NULL;
 
 	/* Release the original creation ref. */
 	REF_RELEASE(member);
@@ -1049,7 +1098,15 @@ void rspamd_upstream_srv_apply(struct upstream *parent,
 		return;
 	}
 
-	RSPAMD_UPSTREAM_LOCK(parent);
+	/*
+	 * No parent lock here on purpose. Both `srv_create_member` and
+	 * `srv_drain_member` take the list lock further down — locking the
+	 * parent first would invert the ls -> upstream order used everywhere
+	 * else (set_inactive, return_tokens, …) and deadlock thread-safe
+	 * builds. Mutations to `srv_members` are serialized by the event
+	 * loop (DNS replies don't run concurrently with each other on the
+	 * same parent), and tests are single-threaded.
+	 */
 
 	seen = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 
@@ -1112,8 +1169,6 @@ void rspamd_upstream_srv_apply(struct upstream *parent,
 	}
 	g_list_free(to_drain);
 	g_hash_table_unref(seen);
-
-	RSPAMD_UPSTREAM_UNLOCK(parent);
 }
 
 struct upstream *
@@ -1698,8 +1753,14 @@ void rspamd_upstream_ok(struct upstream *upstream)
 	if (upstream->inflight > 0) {
 		upstream->inflight--;
 	}
-	/* Success handling */
-	if (upstream->half_open_inflight > 0) {
+	/*
+	 * Success handling. Drained SRV members must not slip back into the
+	 * alive list through the half-open probe path: a member could have
+	 * been mid-probe at drain time, with an inflight selector still
+	 * holding its pointer; that selector's eventual ok() must not
+	 * undo the drain.
+	 */
+	if (upstream->half_open_inflight > 0 && !upstream->is_draining) {
 		/* Successful probe: mark alive and reset backoff */
 		upstream->half_open_inflight = 0;
 		upstream->probe_backoff = upstream->ls ? upstream->ls->limits->revive_time : default_revive_time;
@@ -1834,11 +1895,13 @@ rspamd_upstream_dtor(struct upstream *up)
 	}
 
 	/*
-	 * SRV parents own a hash table of "fqdn:port" → member upstream. The
-	 * members themselves carry their own refs and are freed independently
-	 * once their drain ref counts reach zero, so we only release the hash
-	 * itself here. Drain on rspamd_upstreams_destroy already cleared the
-	 * entries by the time the parent's dtor runs.
+	 * SRV parents own a hash table of "fqdn:port" → member upstream.
+	 * The hash's value-destroy is NULL by design: members are released
+	 * independently through `ls->ups` iteration in
+	 * `rspamd_upstreams_destroy` (or via the grace-timer ref drop after
+	 * a drain). Only the keys are freed by the hash unref. Calling
+	 * unref on a hash that still holds live entries is safe — only
+	 * the keys leak, not the upstream pointers.
 	 */
 	if (up->srv_members != NULL) {
 		g_hash_table_unref(up->srv_members);

--- a/src/libutil/upstream.c
+++ b/src/libutil/upstream.c
@@ -315,6 +315,39 @@ static void rspamd_upstream_resolve_addrs(const struct upstream_list *ls,
 static void rspamd_upstream_set_inactive(struct upstream_list *ls,
 										 struct upstream *upstream);
 
+/*
+ * Time helpers. We use ev_now() — the loop's cached time — wherever an event
+ * loop is available, so all decisions in a single loop iteration agree on
+ * "now" and tests can drive time deterministically via the libev fake-clock
+ * hook. The rspamd_get_ticks() fallback covers paths that may run before the
+ * event loop is wired up (early init, unit tests of pure helpers).
+ */
+static inline double
+rspamd_upstream_now(const struct upstream *up)
+{
+	if (up->ctx && up->ctx->event_loop) {
+		return ev_now(up->ctx->event_loop);
+	}
+	return rspamd_get_ticks(FALSE);
+}
+
+/*
+ * Same as rspamd_upstream_now() but first refreshes the loop's cached
+ * monotonic time. Use on rare paths (e.g. fail handling) where multiple
+ * timestamps may be sampled in a single loop iteration and we want each
+ * sample to reflect actual elapsed time. The "_if_cheap" variant only
+ * touches the monotonic clock; no realtime read.
+ */
+static inline double
+rspamd_upstream_now_fresh(const struct upstream *up)
+{
+	if (up->ctx && up->ctx->event_loop) {
+		ev_now_update_if_cheap(up->ctx->event_loop);
+		return ev_now(up->ctx->event_loop);
+	}
+	return rspamd_get_ticks(FALSE);
+}
+
 void rspamd_upstreams_library_config(struct rspamd_config *cfg,
 									 struct upstream_ctx *ctx,
 									 struct ev_loop *event_loop,
@@ -1190,6 +1223,13 @@ rspamd_upstream_srv_test_get_parent(struct upstream_list *ups)
 	return NULL;
 }
 
+void rspamd_upstream_ctx_set_event_loop_for_test(struct upstream_ctx *ctx,
+												 struct ev_loop *event_loop)
+{
+	g_assert(ctx != NULL);
+	ctx->event_loop = event_loop;
+}
+
 void rspamd_upstream_member_force_alive_for_test(struct upstream *member,
 												 const char *ip_str)
 {
@@ -1627,7 +1667,7 @@ void rspamd_upstream_fail(struct upstream *upstream,
 	}
 
 	if (upstream->ctx && upstream->active_idx != -1 && upstream->ls) {
-		sec_cur = rspamd_get_ticks(FALSE);
+		sec_cur = rspamd_upstream_now_fresh(upstream);
 
 		RSPAMD_UPSTREAM_LOCK(upstream);
 		if (upstream->errors == 0) {
@@ -3456,15 +3496,6 @@ rspamd_upstream_refill_tokens(struct upstream *up,
 		}
 	}
 	up->last_refill_at = now;
-}
-
-static inline double
-rspamd_upstream_now(const struct upstream *up)
-{
-	if (up->ctx && up->ctx->event_loop) {
-		return ev_now(up->ctx->event_loop);
-	}
-	return rspamd_get_ticks(FALSE);
 }
 
 struct upstream *

--- a/src/libutil/upstream.h
+++ b/src/libutil/upstream.h
@@ -48,6 +48,12 @@ enum rspamd_upstream_rotation {
 
 enum rspamd_upstream_flag {
 	RSPAMD_UPSTREAM_FLAG_NORESOLVE = (1 << 0),
+	/*
+	 * Upstream is an SRV "parent": a placeholder that owns SRV-derived
+	 * member upstreams. Never put into the alive list, never selected
+	 * directly; its only job is to host the lazy SRV re-resolve timer
+	 * and a hash table of members keyed by "fqdn:port".
+	 */
 	RSPAMD_UPSTREAM_FLAG_SRV_RESOLVE = (1 << 1),
 	RSPAMD_UPSTREAM_FLAG_DNS = (1 << 2),
 	/*
@@ -57,6 +63,16 @@ enum rspamd_upstream_flag {
 	 * and the upstream becomes selectable.
 	 */
 	RSPAMD_UPSTREAM_FLAG_PENDING_RESOLVE = (1 << 3),
+	/*
+	 * SRV-derived member: a first-class upstream created by expanding a
+	 * single SRV target into its own struct upstream. Holds its own error
+	 * budget, latency EWMA, weight, addresses, and is selectable via the
+	 * normal rotation algorithms. Lifetime is bound to the parent's SRV
+	 * member table; on graceful drain (target gone from re-resolve), the
+	 * member is removed from selection and released after its inflight
+	 * refs drop.
+	 */
+	RSPAMD_UPSTREAM_FLAG_SRV_MEMBER = (1 << 4),
 };
 
 struct rspamd_config;

--- a/src/libutil/upstream_internal.h
+++ b/src/libutil/upstream_internal.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Internal hooks into the upstream subsystem. NOT a public API — the
+ * stability story is "tests and same-tree consumers only". The public
+ * surface lives in upstream.h.
+ */
+#ifndef RSPAMD_UPSTREAM_INTERNAL_H
+#define RSPAMD_UPSTREAM_INTERNAL_H
+
+#include "config.h"
+#include "upstream.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Plain-data view of one SRV target. Used both by the real DNS callback
+ * (built from rdns_reply_entry) and the test entry point — keeping the
+ * diff logic agnostic of the DNS client struct layout.
+ */
+struct rspamd_upstream_srv_entry {
+	const char *target;
+	uint16_t port;
+	uint16_t weight;
+	uint16_t priority;
+};
+
+/*
+ * Apply a snapshot of SRV targets to a parent upstream:
+ *   - new keys → create member upstream
+ *   - existing keys → refresh weight/priority and re-resolve A/AAAA
+ *   - keys present on parent but missing in `entries` → graceful drain
+ *
+ * Caller must own `parent` (refcount keeps it alive); the parent must
+ * have been created with the SRV_RESOLVE flag (e.g. via
+ * `rspamd_upstreams_add_upstream` with a "service=..." string).
+ *
+ * Tests use this to drive SRV expansion deterministically without DNS.
+ */
+void rspamd_upstream_srv_apply(struct upstream *parent,
+							   const struct rspamd_upstream_srv_entry *entries,
+							   size_t n);
+
+/*
+ * Force a freshly-created SRV member out of PENDING_RESOLVE into the
+ * alive list with a single synthetic loopback address. Test-only:
+ * production code never bypasses DNS like this. `ip_str` must be a
+ * numeric IPv4 / IPv6 literal (parsed by rspamd_parse_inet_address).
+ */
+void rspamd_upstream_member_force_alive_for_test(struct upstream *member,
+												 const char *ip_str);
+
+/*
+ * Return the first SRV parent placeholder in the list, or NULL if none.
+ * Test-only: SRV parents are deliberately invisible to the public
+ * iteration APIs (foreach, count) since they aren't selectable
+ * upstreams. Tests need a way to reach the parent for srv_apply.
+ */
+struct upstream *rspamd_upstream_srv_test_get_parent(struct upstream_list *ups);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RSPAMD_UPSTREAM_INTERNAL_H */

--- a/src/libutil/upstream_internal.h
+++ b/src/libutil/upstream_internal.h
@@ -74,6 +74,15 @@ void rspamd_upstream_member_force_alive_for_test(struct upstream *member,
  */
 struct upstream *rspamd_upstream_srv_test_get_parent(struct upstream_list *ups);
 
+/*
+ * Install an event loop on the context without going through
+ * rspamd_upstreams_library_config (which requires a full rspamd_config).
+ * Test-only: lets unit tests drive ev_now() and timer firing through the
+ * libev fake-clock hook (see ev.h: ev_set_fake_time_cb).
+ */
+void rspamd_upstream_ctx_set_event_loop_for_test(struct upstream_ctx *ctx,
+												 struct ev_loop *event_loop);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -34,6 +34,7 @@
 #include "rspamd_cxx_unit_upstream_p2c.hxx"
 #include "rspamd_cxx_unit_upstream_slow_start.hxx"
 #include "rspamd_cxx_unit_upstream_latency.hxx"
+#include "rspamd_cxx_unit_upstream_srv.hxx"
 #include "rspamd_cxx_unit_multipart.hxx"
 #include "rspamd_cxx_unit_settings_merge.hxx"
 

--- a/test/rspamd_cxx_unit_upstream_srv.hxx
+++ b/test/rspamd_cxx_unit_upstream_srv.hxx
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Unit tests for the SRV-as-multiple-upstreams refactor: each SRV target
+ * expands into its own struct upstream with first-class participation in
+ * every selection algorithm.
+ */
+
+#ifndef RSPAMD_CXX_UNIT_UPSTREAM_SRV_HXX
+#define RSPAMD_CXX_UNIT_UPSTREAM_SRV_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+#include "libutil/upstream.h"
+#include "libutil/upstream_internal.h"
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace upstream_srv_test {
+
+struct ctx_holder {
+	struct upstream_ctx *ctx;
+	struct upstream_list *ups;
+	struct upstream *parent;
+
+	ctx_holder()
+	{
+		ctx = rspamd_upstreams_library_init();
+		ups = rspamd_upstreams_create(ctx);
+		rspamd_upstreams_set_rotation(ups, RSPAMD_UPSTREAM_ROUND_ROBIN);
+
+		auto ok = rspamd_upstreams_add_upstream(ups,
+												"service=fuzzy+example.com",
+												11335,
+												RSPAMD_UPSTREAM_PARSE_DEFAULT,
+												nullptr);
+		REQUIRE(ok);
+		parent = rspamd_upstream_srv_test_get_parent(ups);
+		REQUIRE(parent != nullptr);
+	}
+
+	~ctx_holder()
+	{
+		rspamd_upstreams_destroy(ups);
+		rspamd_upstreams_library_unref(ctx);
+	}
+
+	ctx_holder(const ctx_holder &) = delete;
+	ctx_holder &operator=(const ctx_holder &) = delete;
+
+	/* Snapshot the current member set as name → upstream*. */
+	std::map<std::string, struct upstream *> members()
+	{
+		std::map<std::string, struct upstream *> out;
+		rspamd_upstreams_foreach(ups, [](struct upstream *up, unsigned int, void *ud) {
+			auto *m = static_cast<std::map<std::string, struct upstream *> *>(ud);
+			(*m)[rspamd_upstream_name(up)] = up; }, &out);
+		return out;
+	}
+
+	/* Apply an SRV snapshot. New members come back with PENDING_RESOLVE
+	 * set; activate() puts each one into the alive list with a synthetic
+	 * loopback IP so it's selectable. */
+	void apply(std::initializer_list<rspamd_upstream_srv_entry> entries)
+	{
+		std::vector<rspamd_upstream_srv_entry> v(entries);
+		rspamd_upstream_srv_apply(parent, v.data(), v.size());
+	}
+
+	void activate(const std::string &target, const std::string &ip)
+	{
+		auto m = members();
+		auto it = m.find(target);
+		REQUIRE(it != m.end());
+		rspamd_upstream_member_force_alive_for_test(it->second, ip.c_str());
+	}
+};
+
+}// namespace upstream_srv_test
+
+TEST_SUITE("upstream_srv")
+{
+	using upstream_srv_test::ctx_holder;
+
+	TEST_CASE("single-target SRV expansion creates one selectable member")
+	{
+		ctx_holder t;
+		t.apply({{"a.example.com", 11335, 100, 10}});
+		t.activate("a.example.com", "127.0.0.1");
+
+		CHECK(rspamd_upstreams_alive(t.ups) == 1);
+		CHECK(rspamd_upstreams_count(t.ups) == 1);
+
+		auto *up = rspamd_upstream_get(t.ups, RSPAMD_UPSTREAM_ROUND_ROBIN,
+									   nullptr, 0);
+		REQUIRE(up != nullptr);
+		CHECK(std::string(rspamd_upstream_name(up)) == "a.example.com");
+	}
+
+	TEST_CASE("3 equal-weight targets distribute uniformly under RR")
+	{
+		ctx_holder t;
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"b.example.com", 11335, 1, 10},
+			{"c.example.com", 11335, 1, 10},
+		});
+		t.activate("a.example.com", "127.0.0.1");
+		t.activate("b.example.com", "127.0.0.2");
+		t.activate("c.example.com", "127.0.0.3");
+
+		REQUIRE(rspamd_upstreams_alive(t.ups) == 3);
+
+		std::map<std::string, int> counts;
+		for (int i = 0; i < 3000; i++) {
+			auto *up = rspamd_upstream_get(t.ups, RSPAMD_UPSTREAM_ROUND_ROBIN,
+										   nullptr, 0);
+			REQUIRE(up != nullptr);
+			counts[rspamd_upstream_name(up)]++;
+		}
+
+		CHECK(counts.size() == 3);
+		for (const auto &[name, c]: counts) {
+			CHECK(c >= 900);
+			CHECK(c <= 1100);
+		}
+	}
+
+	TEST_CASE("SRV weight is honoured by weighted round-robin")
+	{
+		ctx_holder t;
+		t.apply({
+			{"heavy-a.example.com", 11335, 100, 10},
+			{"heavy-b.example.com", 11335, 100, 10},
+			{"light.example.com", 11335, 1, 10},
+		});
+		t.activate("heavy-a.example.com", "127.0.0.1");
+		t.activate("heavy-b.example.com", "127.0.0.2");
+		t.activate("light.example.com", "127.0.0.3");
+
+		REQUIRE(rspamd_upstreams_alive(t.ups) == 3);
+
+		std::map<std::string, int> counts;
+		const int total = 2010; /* 10 cycles of 201 = 100 + 100 + 1 */
+		for (int i = 0; i < total; i++) {
+			auto *up = rspamd_upstream_get(t.ups, RSPAMD_UPSTREAM_ROUND_ROBIN,
+										   nullptr, 0);
+			REQUIRE(up != nullptr);
+			counts[rspamd_upstream_name(up)]++;
+		}
+
+		CHECK(counts["heavy-a.example.com"] >= 900);
+		CHECK(counts["heavy-a.example.com"] <= 1100);
+		CHECK(counts["heavy-b.example.com"] >= 900);
+		CHECK(counts["heavy-b.example.com"] <= 1100);
+		CHECK(counts["light.example.com"] >= 5);
+		CHECK(counts["light.example.com"] <= 25);
+	}
+
+	TEST_CASE("re-resolve add: new target appears, identity preserved")
+	{
+		ctx_holder t;
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"b.example.com", 11335, 1, 10},
+		});
+		t.activate("a.example.com", "127.0.0.1");
+		t.activate("b.example.com", "127.0.0.2");
+
+		auto before = t.members();
+		REQUIRE(before.size() == 2);
+		struct upstream *m_a = before["a.example.com"];
+		struct upstream *m_b = before["b.example.com"];
+
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"b.example.com", 11335, 1, 10},
+			{"c.example.com", 11335, 1, 10},
+		});
+		t.activate("c.example.com", "127.0.0.3");
+
+		auto after = t.members();
+		CHECK(after.size() == 3);
+		CHECK(after["a.example.com"] == m_a);
+		CHECK(after["b.example.com"] == m_b);
+	}
+
+	TEST_CASE("re-resolve remove: dropped target is drained from selection")
+	{
+		ctx_holder t;
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"b.example.com", 11335, 1, 10},
+			{"c.example.com", 11335, 1, 10},
+		});
+		t.activate("a.example.com", "127.0.0.1");
+		t.activate("b.example.com", "127.0.0.2");
+		t.activate("c.example.com", "127.0.0.3");
+
+		REQUIRE(rspamd_upstreams_alive(t.ups) == 3);
+
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"c.example.com", 11335, 1, 10},
+		});
+
+		CHECK(rspamd_upstreams_alive(t.ups) == 2);
+
+		auto m = t.members();
+		CHECK(m.count("a.example.com") == 1);
+		CHECK(m.count("c.example.com") == 1);
+		CHECK(m.count("b.example.com") == 0);
+
+		/* Subsequent selection only returns the survivors. */
+		std::set<std::string> seen;
+		for (int i = 0; i < 100; i++) {
+			auto *up = rspamd_upstream_get(t.ups,
+										   RSPAMD_UPSTREAM_ROUND_ROBIN,
+										   nullptr, 0);
+			REQUIRE(up != nullptr);
+			seen.insert(rspamd_upstream_name(up));
+		}
+		CHECK(seen.count("a.example.com") == 1);
+		CHECK(seen.count("c.example.com") == 1);
+		CHECK(seen.count("b.example.com") == 0);
+	}
+
+	TEST_CASE("re-resolve weight change shifts the distribution")
+	{
+		ctx_holder t;
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"b.example.com", 11335, 1, 10},
+			{"c.example.com", 11335, 1, 10},
+		});
+		t.activate("a.example.com", "127.0.0.1");
+		t.activate("b.example.com", "127.0.0.2");
+		t.activate("c.example.com", "127.0.0.3");
+
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"b.example.com", 11335, 1, 10},
+			{"c.example.com", 11335, 100, 10},
+		});
+
+		std::map<std::string, int> counts;
+		const int total = 5100; /* 50 cycles of 102 */
+		for (int i = 0; i < total; i++) {
+			auto *up = rspamd_upstream_get(t.ups,
+										   RSPAMD_UPSTREAM_ROUND_ROBIN,
+										   nullptr, 0);
+			REQUIRE(up != nullptr);
+			counts[rspamd_upstream_name(up)]++;
+		}
+
+		CHECK(counts["c.example.com"] >= 4500);
+		CHECK(counts["c.example.com"] <= 5500);
+		CHECK(counts["a.example.com"] >= 30);
+		CHECK(counts["a.example.com"] <= 80);
+		CHECK(counts["b.example.com"] >= 30);
+		CHECK(counts["b.example.com"] <= 80);
+	}
+
+	TEST_CASE("error budget is per member, not shared across SRV cluster")
+	{
+		ctx_holder t;
+		/*
+		 * Squeeze the error window so a few fails over a few tens of
+		 * ms cross the rate threshold. Defaults (4 errors / 10s) would
+		 * require multi-second sleeps to trigger in unit tests.
+		 */
+		/*
+		 * Rate-based inactive transition fires when:
+		 *   (sec_cur - last_fail) >= error_time  AND
+		 *   errors / elapsed > max_errors / error_time
+		 *
+		 * Pick aggressive limits so we comfortably exceed the threshold
+		 * even with macOS scheduler jitter on g_usleep.
+		 */
+		rspamd_upstreams_set_limits(t.ups,
+									/* revive_time */ 60.0,
+									/* revive_jitter */ 0.4,
+									/* error_time */ 0.002,
+									/* dns_timeout */ 1.0,
+									/* max_errors */ 1,
+									/* dns_retransmits */ 2);
+
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"b.example.com", 11335, 1, 10},
+			{"c.example.com", 11335, 1, 10},
+		});
+		t.activate("a.example.com", "127.0.0.1");
+		t.activate("b.example.com", "127.0.0.2");
+		t.activate("c.example.com", "127.0.0.3");
+
+		auto before = t.members();
+		REQUIRE(before.size() == 3);
+		struct upstream *bad = before["a.example.com"];
+
+		/*
+		 * Pre-refactor, the three SRV targets shared one error budget;
+		 * a burst here would have killed every target. With per-member
+		 * budgets, only `bad` crosses the rate threshold and exits the
+		 * alive list.
+		 */
+		for (int i = 0; i < 12; i++) {
+			rspamd_upstream_fail(bad, TRUE, "test");
+			g_usleep(1000); /* 1 ms — gives ample margin over error_time=2ms */
+		}
+
+		/*
+		 * `bad` is now out of the alive list but still in ls->ups (the
+		 * revive timer holds a ref + position). The other two members
+		 * must still be selectable; verify by sampling.
+		 */
+		CHECK(rspamd_upstreams_alive(t.ups) == 2);
+
+		std::set<std::string> seen_names;
+		for (int i = 0; i < 100; i++) {
+			auto *up = rspamd_upstream_get(t.ups,
+										   RSPAMD_UPSTREAM_ROUND_ROBIN,
+										   nullptr, 0);
+			REQUIRE(up != nullptr);
+			seen_names.insert(rspamd_upstream_name(up));
+		}
+		CHECK(seen_names.count("a.example.com") == 0);
+		CHECK(seen_names.count("b.example.com") == 1);
+		CHECK(seen_names.count("c.example.com") == 1);
+	}
+
+	TEST_CASE("per-member latency EWMA records distinct values")
+	{
+		ctx_holder t;
+		t.apply({
+			{"a.example.com", 11335, 1, 10},
+			{"b.example.com", 11335, 1, 10},
+		});
+		t.activate("a.example.com", "127.0.0.1");
+		t.activate("b.example.com", "127.0.0.2");
+
+		auto m = t.members();
+		REQUIRE(m.size() == 2);
+
+		rspamd_upstream_record_latency(m["a.example.com"], 0.005);
+		rspamd_upstream_record_latency(m["b.example.com"], 0.250);
+
+		double la = rspamd_upstream_get_latency(m["a.example.com"]);
+		double lb = rspamd_upstream_get_latency(m["b.example.com"]);
+
+		CHECK(la > 0.0);
+		CHECK(lb > 0.0);
+		CHECK(lb > la * 5.0);
+	}
+
+	TEST_CASE("parent is invisible to public iteration / count APIs")
+	{
+		ctx_holder t;
+		/* Even before any apply, a parent exists in ls->ups but neither
+		 * count nor foreach exposes it. */
+		CHECK(rspamd_upstreams_count(t.ups) == 0);
+		CHECK(t.members().empty());
+
+		t.apply({{"a.example.com", 11335, 1, 10}});
+		t.activate("a.example.com", "127.0.0.1");
+
+		CHECK(rspamd_upstreams_count(t.ups) == 1);
+		CHECK(t.members().size() == 1);
+	}
+}
+
+#endif /* RSPAMD_CXX_UNIT_UPSTREAM_SRV_HXX */

--- a/test/rspamd_cxx_unit_upstream_srv.hxx
+++ b/test/rspamd_cxx_unit_upstream_srv.hxx
@@ -28,6 +28,8 @@
 
 #include "libutil/upstream.h"
 #include "libutil/upstream_internal.h"
+#include "rspamd_test_fake_time.hxx"
+#include "contrib/libev/ev.h"
 
 #include <map>
 #include <set>
@@ -40,10 +42,20 @@ struct ctx_holder {
 	struct upstream_ctx *ctx;
 	struct upstream_list *ups;
 	struct upstream *parent;
+	struct ev_loop *loop;
 
 	ctx_holder()
 	{
+		/*
+		 * Use a non-default loop so installing a fake clock in one test
+		 * can't bleed into anything that touches the default loop. The
+		 * loop never runs ev_run() in these tests; we only need it for
+		 * ev_now() to read through to our fake-clock hook.
+		 */
+		loop = ev_loop_new(EVFLAG_AUTO);
+		REQUIRE(loop != nullptr);
 		ctx = rspamd_upstreams_library_init();
+		rspamd_upstream_ctx_set_event_loop_for_test(ctx, loop);
 		ups = rspamd_upstreams_create(ctx);
 		rspamd_upstreams_set_rotation(ups, RSPAMD_UPSTREAM_ROUND_ROBIN);
 
@@ -61,6 +73,7 @@ struct ctx_holder {
 	{
 		rspamd_upstreams_destroy(ups);
 		rspamd_upstreams_library_unref(ctx);
+		ev_loop_destroy(loop);
 	}
 
 	ctx_holder(const ctx_holder &) = delete;
@@ -283,25 +296,20 @@ TEST_SUITE("upstream_srv")
 	{
 		ctx_holder t;
 		/*
-		 * Squeeze the error window so a few fails over a few tens of
-		 * ms cross the rate threshold. Defaults (4 errors / 10s) would
-		 * require multi-second sleeps to trigger in unit tests.
-		 */
-		/*
-		 * Rate-based inactive transition fires when:
-		 *   (sec_cur - last_fail) >= error_time  AND
-		 *   errors / elapsed > max_errors / error_time
-		 *
-		 * Pick aggressive limits so we comfortably exceed the threshold
-		 * even with macOS scheduler jitter on g_usleep.
+		 * Realistic defaults — the rate-window math is the same whether we
+		 * run in real or fake time, so there's no need to squeeze error_time
+		 * down to milliseconds. Five errors over a one-second budget with
+		 * max_errors=4 puts us comfortably past the rate threshold.
 		 */
 		rspamd_upstreams_set_limits(t.ups,
 									/* revive_time */ 60.0,
 									/* revive_jitter */ 0.4,
-									/* error_time */ 0.002,
+									/* error_time */ 1.0,
 									/* dns_timeout */ 1.0,
-									/* max_errors */ 1,
+									/* max_errors */ 4,
 									/* dns_retransmits */ 2);
+
+		rspamd_test::fake_clock clk(1000.0, t.loop);
 
 		t.apply({
 			{"a.example.com", 11335, 1, 10},
@@ -320,11 +328,12 @@ TEST_SUITE("upstream_srv")
 		 * Pre-refactor, the three SRV targets shared one error budget;
 		 * a burst here would have killed every target. With per-member
 		 * budgets, only `bad` crosses the rate threshold and exits the
-		 * alive list.
+		 * alive list. Each fail() advances virtual time by 100 ms so the
+		 * rate-window arithmetic sees real elapsed time without sleeping.
 		 */
 		for (int i = 0; i < 12; i++) {
 			rspamd_upstream_fail(bad, TRUE, "test");
-			g_usleep(1000); /* 1 ms — gives ample margin over error_time=2ms */
+			clk.advance(0.1);
 		}
 
 		/*

--- a/test/rspamd_test_fake_time.hxx
+++ b/test/rspamd_test_fake_time.hxx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test-only fake-clock helper. Drives ev_now() and timer firing in our
+ * bundled libev (see ev.h: ev_set_fake_time_cb / ev_now_resync) so unit
+ * tests can advance virtual time deterministically instead of sleeping.
+ *
+ * Process-global by design — the libev hook is process-wide. Use one
+ * fake_clock per scope, and don't run two in parallel within the same
+ * process.
+ */
+
+#ifndef RSPAMD_TEST_FAKE_TIME_HXX
+#define RSPAMD_TEST_FAKE_TIME_HXX
+
+#include "contrib/libev/ev.h"
+
+namespace rspamd_test {
+
+class fake_clock {
+public:
+	/* Install the fake clock at `start` seconds. The optional `loop` is
+	 * resynced so its cached realtime/monotonic state matches the new
+	 * source — required when the loop was created before the hook was
+	 * installed (otherwise ev_now() returns garbage from interpolation).
+	 */
+	explicit fake_clock(double start = 1000.0, struct ev_loop *loop = nullptr)
+		: now_(start), loop_(loop)
+	{
+		instance_ = this;
+		ev_set_fake_time_cb(&fake_clock::read);
+		if (loop_) {
+			ev_now_resync(loop_);
+		}
+	}
+
+	~fake_clock()
+	{
+		ev_set_fake_time_cb(nullptr);
+		instance_ = nullptr;
+		if (loop_) {
+			ev_now_resync(loop_);
+		}
+	}
+
+	fake_clock(const fake_clock &) = delete;
+	fake_clock &operator=(const fake_clock &) = delete;
+
+	/* Move time forward by `seconds`. Negative values intentionally
+	 * unsupported: backward jumps would defeat libev's monotonic
+	 * assumption and produce garbage timer behaviour.
+	 */
+	void advance(double seconds)
+	{
+		if (seconds < 0.0) {
+			seconds = 0.0;
+		}
+		now_ += seconds;
+	}
+
+	void set(double t)
+	{
+		now_ = t;
+	}
+
+	double now() const
+	{
+		return now_;
+	}
+
+private:
+	static double read()
+	{
+		return instance_ ? instance_->now_ : 0.0;
+	}
+
+	double now_;
+	struct ev_loop *loop_;
+
+	static inline fake_clock *instance_ = nullptr;
+};
+
+}// namespace rspamd_test
+
+#endif /* RSPAMD_TEST_FAKE_TIME_HXX */


### PR DESCRIPTION
## Summary

Refactor the SRV resolution path so each `_service._tcp.domain` target becomes its own first-class `struct upstream`, rather than collapsing every target's A/AAAA records into a single upstream.

The old path had three concrete consequences:
- SRV weight was dropped on the floor (see the long-standing *"contradicts with upstreams logic"* comment).
- The 4-errors-in-10s budget was shared across the whole cluster — one bad backend could kill the service.
- Modern selection algorithms (P2C, token bucket, ring hash, slow start, latency EWMA) operate at the upstream level. With one upstream they had nothing to choose from; only primitive `addr_next` rotation worked.

This aligns rspamd with how every modern balancer treats SRV — HAProxy `server-template`, Envoy `STRICT_DNS`, NGINX Plus `resolve`, gRPC subchannels, Consul/Linkerd: one SRV target = one backend member.

The user-facing `service=name+domain` config syntax is unchanged.

## How it works

- **Parse-time.** SRV-flagged parent gets a pre-allocated `GHashTable` keyed by `"fqdn:port"`. The parent is invisible to `rspamd_upstreams_count`, `rspamd_upstreams_foreach`, and the probe-mode iterator — it only owns the lazy SRV re-resolve timer.
- **DNS callback.** Reply entries are flattened into a `rspamd_upstream_srv_entry[]` and handed to the new common `rspamd_upstream_srv_apply`, which diffs the snapshot against the parent's member set.
  - **New target** → create member in `PENDING_RESOLVE`, kick off A/AAAA; existing `promote_pending` machinery moves it into `alive` once addresses arrive.
  - **Existing target** → refresh weight/priority, re-resolve A/AAAA. Identity preserved.
  - **Dropped target** → graceful drain: pull from `alive`, fire `OFFLINE` watcher, restore token-bucket inflight, remove from `ls->ups`, then arm a `revive_time` grace timer (reusing `revive_cb`'s `is_draining` short-circuit) for inflight selectors. With no event loop the drain is synchronous.

Selection paths (`get_round_robin`, `get_random`, `get_p2c`, `get_hashed`, `get_token_bucket`) need no changes — members are first-class entries in `ls->alive`.

## Out of scope (follow-ups)

- RFC 2782 priority-tier failover (only-use-low-priority-when-high-priority-dead). `srv_priority` is recorded on each member but not used as a selection filter.
- Adapting `addr_next`-on-failure callers like `fuzzy_check` to retry across members via `rspamd_upstream_get_except`. The new model makes per-member `addr_next` a no-op rotation, which degrades cleanly but isn't optimal for retries.

## Test plan

- [x] All 9 new SRV doctest cases pass (`rspamd-test-cxx --test-suite=upstream_srv`)
  - single-target expansion
  - 3 equal-weight targets distribute uniformly
  - SRV weight honoured (100/100/1 ratio)
  - diff add — identity preserved
  - diff remove — drained out of selection
  - diff weight change — distribution shifts
  - error budget per-member (one bad target leaves others alive)
  - per-member latency EWMA records distinct values
  - parent invisible to count/foreach
- [x] All existing upstream test suites pass (56 cases, 61k+ assertions across `upstream_round_robin`, `upstream_token_bucket`, `upstream_ring_hash`, `upstream_p2c`, `upstream_slow_start`, `upstream_latency`)
- [x] Full cxx test suite green (209 cases, 73k+ assertions)
- [x] Lua tests green (1012/1015, 3 unassertive unrelated)
- [x] `clang-format --dry-run --Werror` clean on touched files
- [ ] Manual smoke against a real DNS server with SRV records (post-merge)
- [ ] Confirm new debug logs are sane in a live deployment with `service=` config