### PR TITLE
[Rework] mx_check: three-layer cache, finer outcomes, IP-class classification (#6032 Phases A & C)

### DIFF
--- a/conf/modules.d/mx_check.conf
+++ b/conf/modules.d/mx_check.conf
@@ -21,19 +21,53 @@
 # You also need to define redis servers for this module
 
 mx_check {
-  # TCP connection timeout in seconds. The effective symbol timeout is
-  # timeout + dns.timeout (see options.inc), so task_timeout must be set
-  # higher than their sum to avoid forced task termination.
-  timeout = 1.0;
-  # symbol yielded if no MX is connectable
+  # Per-phase TCP timeouts (seconds). The effective symbol budget is
+  # connect_timeout + read_timeout + dns.timeout (see options.inc);
+  # task_timeout must be higher than that sum to avoid forced termination.
+  connect_timeout = 1.0;
+  # read_timeout is only used when verify_greeting = true.
+  read_timeout = 5.0;
+
+  # Legacy `timeout` is still accepted and is mapped to connect_timeout
+  # at module load with a deprecation warning. Don't set both.
+
+  # SMTP greeting validation. When verify_greeting = true the probe reads
+  # the SMTP banner, validates the reply code (220 -> good, 4xx/5xx ->
+  # MX_ERROR, other -> MX_INVALID) and handles multi-line banners
+  # correctly. send_quit, when also true, issues `QUIT` after the final
+  # banner line for a clean shutdown.
+  verify_greeting = false;
+  send_quit = false;
+
+  # Cache TTLs (seconds).
+  expire = 86400;          # successful outcomes
+  expire_novalid = 7200;   # hard failures (refused, invalid, nxdomain, null, broken, error)
+  expire_timeout = 1800;   # transient timeouts (so recovery surfaces quickly)
+
+  # Force-reject behaviour. Defaults are off; flip these only after
+  # auditing your operator scores and DNS reliability.
+  reject_nxdomain = false;
+  reject_null_mx = false;
+
+  # Symbol names (primary surface; today's behaviour preserved).
   symbol_bad_mx = "MX_INVALID";
-  # symbol yielded if no MX is found
   symbol_no_mx = "MX_MISSING";
-  # symbol yielded if MX is connectable
   symbol_good_mx = "MX_GOOD";
-  # lifetime of redis cache - 1 day by default
-  expire = 86400;
-  # prefix used for redis key
+  symbol_white_mx = "MX_WHITE";
+
+  # Finer outcome symbols (Phase A: score 0, informational).
+  symbol_mx_refused = "MX_REFUSED";
+  symbol_mx_timeout_connect = "MX_TIMEOUT_CONNECT";
+  symbol_mx_timeout_read = "MX_TIMEOUT_READ";
+  symbol_mx_error = "MX_ERROR";
+  symbol_mx_nxdomain = "MX_NXDOMAIN";
+  symbol_mx_null = "MX_NULL";
+  symbol_mx_broken = "MX_BROKEN";
+
+  # Redis key prefix. The three cache layers live under <key_prefix>:d:<domain>,
+  # <key_prefix>:m:<mx_host>, and <key_prefix>:i:<ip>. Old single-layer keys
+  # of the form <key_prefix><domain> from previous releases become orphans
+  # and age out under their own TTL.
   key_prefix = "rmx";
 
   # !!! Disabled by default !!!

--- a/conf/modules.d/mx_check.conf
+++ b/conf/modules.d/mx_check.conf
@@ -24,19 +24,25 @@ mx_check {
   # Per-phase TCP timeouts (seconds). The effective symbol budget is
   # connect_timeout + read_timeout + dns.timeout (see options.inc);
   # task_timeout must be higher than that sum to avoid forced termination.
-  connect_timeout = 1.0;
+  #
+  # NOTE: `connect_timeout` and `verify_greeting` are intentionally NOT set
+  # in this shipped file. They carry legacy aliases (`timeout` ->
+  # connect_timeout, `wait_for_greeting` -> verify_greeting) that the module
+  # maps only when the new key is absent from the merged config. Setting them
+  # here would make every config always carry them, so a legacy alias placed
+  # in local.d/mx_check.conf would be silently ignored. Their defaults live
+  # in the module itself; the values below are shown for documentation only.
+  #
+  # connect_timeout = 1.0;   # default; legacy alias: `timeout`
   # read_timeout is only used when verify_greeting = true.
   read_timeout = 5.0;
-
-  # Legacy `timeout` is still accepted and is mapped to connect_timeout
-  # at module load with a deprecation warning. Don't set both.
 
   # SMTP greeting validation. When verify_greeting = true the probe reads
   # the SMTP banner, validates the reply code (220 -> good, 4xx/5xx ->
   # MX_ERROR, other -> MX_INVALID) and handles multi-line banners
   # correctly. send_quit, when also true, issues `QUIT` after the final
   # banner line for a clean shutdown.
-  verify_greeting = false;
+  # verify_greeting = false;   # default; legacy alias: `wait_for_greeting`
   send_quit = false;
 
   # Cache TTLs (seconds).

--- a/conf/modules.d/mx_check.conf
+++ b/conf/modules.d/mx_check.conf
@@ -55,13 +55,39 @@ mx_check {
   reject_nxdomain = false;
   reject_null_mx = false;
 
+  # Run scope. By default mx_check only inspects untrusted inbound mail:
+  # authenticated and local-network senders are skipped as our own traffic.
+  # ESP / outbound deployments can opt into checking that traffic too.
+  check_authorized = false;
+  check_local = false;
+
+  # Per-layer trust/skip maps (optional; no default). Each accepts a file
+  # path, URL, or inline list.
+  #   exclude_domains - sender domains to skip entirely (emit MX_WHITE).
+  #   exclude_mxs     - trusted MX hostnames; a hit short-circuits the whole
+  #                     check with MX_WHITE. Glob map: a bare hostname matches
+  #                     exactly, an explicit `*.foo` matches subdomains.
+  #   exclude_ips     - IP/CIDR ranges dropped from the probe set. If the set
+  #                     empties as a result, MX_SKIP fires.
+  # exclude_domains = "$LOCAL_CONFDIR/local.d/mx_exclude_domains.map";
+  # exclude_mxs = "$LOCAL_CONFDIR/local.d/mx_exclude_mxs.map";
+  # exclude_ips = "$LOCAL_CONFDIR/local.d/mx_exclude_ips.map";
+
+  # MX targets resolving into private (RFC1918/CGNAT/ULA) or non-routable
+  # (loopback/TEST-NET/multicast/...) address space are never probed and are
+  # flagged with MX_LOCAL_* / MX_BOGON_*. These ranges are a fixed correctness
+  # invariant and are not operator-tunable. `test_mode` is FOR TESTING ONLY:
+  # it makes loopback probeable so the probe path can be exercised against a
+  # local listener. Never enable it in production.
+  # test_mode = false;
+
   # Symbol names (primary surface; today's behaviour preserved).
   symbol_bad_mx = "MX_INVALID";
   symbol_no_mx = "MX_MISSING";
   symbol_good_mx = "MX_GOOD";
   symbol_white_mx = "MX_WHITE";
 
-  # Finer outcome symbols (Phase A: score 0, informational).
+  # Finer outcome symbols (Phase A/C: score 0, informational).
   symbol_mx_refused = "MX_REFUSED";
   symbol_mx_timeout_connect = "MX_TIMEOUT_CONNECT";
   symbol_mx_timeout_read = "MX_TIMEOUT_READ";
@@ -69,6 +95,11 @@ mx_check {
   symbol_mx_nxdomain = "MX_NXDOMAIN";
   symbol_mx_null = "MX_NULL";
   symbol_mx_broken = "MX_BROKEN";
+  symbol_mx_local_only = "MX_LOCAL_ONLY";
+  symbol_mx_local_mix = "MX_LOCAL_MIX";
+  symbol_mx_bogon_only = "MX_BOGON_ONLY";
+  symbol_mx_bogon_mix = "MX_BOGON_MIX";
+  symbol_mx_skip = "MX_SKIP";
 
   # Redis key prefix. The three cache layers live under <key_prefix>:d:<domain>,
   # <key_prefix>:m:<mx_host>, and <key_prefix>:i:<ip>. Old single-layer keys

--- a/src/plugins/lua/mx_check.lua
+++ b/src/plugins/lua/mx_check.lua
@@ -12,40 +12,755 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-]]--
+]] --
 
 if confighelp then
   return
 end
 
--- MX check plugin
+-- MX check plugin — Phase A rewrite (issue #6032 step 2)
+--
+-- Three-layer Redis cache (d:/m:/i:) under <key_prefix>:; probe shapes split
+-- via lua_tcp's on_error + phased timeouts (PR #6034); multi-line SMTP banner
+-- parsing under verify_greeting/send_quit (wait_for_greeting deprecated).
+-- Finer outcome symbols (MX_REFUSED, MX_TIMEOUT_*, MX_ERROR, MX_NULL,
+-- MX_BROKEN, MX_NXDOMAIN) emit at score 0 for tuning data; primary symbols
+-- (MX_GOOD/MX_INVALID/MX_MISSING/MX_WHITE) preserve today's behaviour.
+
 local rspamd_logger = require "rspamd_logger"
 local rspamd_tcp = require "rspamd_tcp"
 local rspamd_util = require "rspamd_util"
 local lua_util = require "lua_util"
 local lua_redis = require "lua_redis"
+
 local N = "mx_check"
-local fun = require "fun"
+local CRLF = '\r\n'
+local E = {}
+
+-- librdns strerror strings we care about (see contrib/librdns/dns_private.h)
+local DNS_ERR_NXDOMAIN = 'no records with this name'
+local DNS_ERR_NOREC = 'requested record is not found'
 
 local settings = {
-  timeout = 1.0, -- connect timeout
+  -- timeouts (phased; legacy `timeout` parsed at config load as a fallback)
+  connect_timeout = 1.0,
+  read_timeout = 5.0,
+
+  -- greeting controls
+  verify_greeting = false,
+  send_quit = false,
+
+  -- cache TTLs
+  expire = 86400, -- successful outcomes
+  expire_novalid = 7200, -- hard failures
+  expire_timeout = 1800, -- transient timeouts (so recovery surfaces quickly)
+
+  -- behaviour
+  reject_nxdomain = false,
+  reject_null_mx = false,
+  greylist_invalid = true,
+
+  -- maps / cache
+  key_prefix = 'rmx',
+  max_mx_a_records = 5,
+
+  -- SMTP port (configurable so the module is testable on unprivileged ports;
+  -- production should leave this at 25).
+  port = 25,
+
+  -- primary symbols (today's surface)
   symbol_bad_mx = 'MX_INVALID',
   symbol_no_mx = 'MX_MISSING',
   symbol_good_mx = 'MX_GOOD',
   symbol_white_mx = 'MX_WHITE',
-  expire = 86400, -- 1 day by default
-  expire_novalid = 7200, -- 2 hours by default for no valid mxes
-  greylist_invalid = true, -- Greylist first message with invalid MX (require greylist plugin)
-  key_prefix = 'rmx',
-  max_mx_a_records = 5, -- Maximum number of A records to check per MX request
-  wait_for_greeting = false, -- Wait for SMTP greeting and emit `quit` command
+
+  -- finer symbols (Phase A: score 0, informational)
+  symbol_mx_refused = 'MX_REFUSED',
+  symbol_mx_timeout_connect = 'MX_TIMEOUT_CONNECT',
+  symbol_mx_timeout_read = 'MX_TIMEOUT_READ',
+  symbol_mx_error = 'MX_ERROR',
+  symbol_mx_nxdomain = 'MX_NXDOMAIN',
+  symbol_mx_null = 'MX_NULL',
+  symbol_mx_broken = 'MX_BROKEN',
 }
+
 local redis_params
 local exclude_domains
 
-local E = {}
-local CRLF = '\r\n'
-local mx_miss_cache_prefix = 'mx_miss:'
+-- ---------------------------------------------------------------------------
+-- Cache layer (Redis-backed; falls back gracefully if Redis is unavailable
+-- mid-task — we still complete the probe, we just skip the write).
+-- ---------------------------------------------------------------------------
+
+local function cache_key(layer, value)
+  return string.format('%s:%s:%s', settings.key_prefix, layer, value)
+end
+
+local function cache_get(task, layer, value, cb)
+  local key = cache_key(layer, value)
+  local function on_reply(err, data)
+    cb(err, data, key)
+  end
+  local ok = rspamd_redis_make_request(task, redis_params, key, false,
+      on_reply, 'GET', { key })
+  if not ok then
+    -- Synthesise a miss so the caller proceeds with DNS/probe.
+    cb('redis dispatch failed', nil, key)
+  end
+end
+
+local function cache_set(task, layer, value, payload, ttl)
+  local key = cache_key(layer, value)
+  local function on_reply(err)
+    if err then
+      rspamd_logger.errx(task, 'mx_check cache write %s: %s', key, err)
+    end
+  end
+  local ok = rspamd_redis_make_request(task, redis_params, key, true,
+      on_reply, 'SETEX', { key, tostring(ttl), payload })
+  if not ok then
+    rspamd_logger.errx(task, 'mx_check cache write failed (no redis): %s', key)
+  end
+  lua_util.debugm(N, task, 'cache write %s ttl=%s value=%s', key, ttl, payload)
+end
+
+-- Choose the TTL class for an i-layer verdict.
+local function ttl_for_verdict(verdict)
+  if verdict == 'good' then
+    return settings.expire
+  elseif verdict == 'timeout_connect' or verdict == 'timeout_read' then
+    return settings.expire_timeout
+  else
+    -- refused / invalid / error:<code>
+    return settings.expire_novalid
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- Encoding helpers for d-layer and m-layer values.
+-- d-layer:  "mx:host1:prio1,host2:prio2,..."  | "mx_miss:ip1,ip2,..."  | "nxd" | "null"
+-- m-layer:  "ip1,ip2,..."                     | "nxd"
+-- i-layer:  "good" | "refused" | "timeout_connect" | "timeout_read"
+--           | "invalid" | "error:<code>"
+-- ---------------------------------------------------------------------------
+
+local function encode_mx_list(results)
+  local parts = {}
+  for _, mx in ipairs(results) do
+    parts[#parts + 1] = string.format('%s:%d', mx.name, mx.priority)
+  end
+  return 'mx:' .. table.concat(parts, ',')
+end
+
+local function decode_mx_list(value)
+  -- value already stripped of "mx:" prefix
+  local out = {}
+  for entry in string.gmatch(value, '[^,]+') do
+    local host, prio = string.match(entry, '^(.-):(%-?%d+)$')
+    if host then
+      out[#out + 1] = { name = host, priority = tonumber(prio) }
+    end
+  end
+  return out
+end
+
+local function encode_ip_list(ips)
+  local parts = {}
+  for _, ip in ipairs(ips) do
+    parts[#parts + 1] = (type(ip) == 'string') and ip or ip:to_string()
+  end
+  return table.concat(parts, ',')
+end
+
+local function decode_ip_list(value)
+  return lua_util.str_split(value, ',')
+end
+
+-- Detect RFC 7505 Null MX: a single MX RR with priority 0 and root target.
+local function is_null_mx(results)
+  if #results ~= 1 then
+    return false
+  end
+  local r = results[1]
+  if r.priority ~= 0 then
+    return false
+  end
+  return r.name == '' or r.name == '.'
+end
+
+-- ---------------------------------------------------------------------------
+-- SMTP banner parsing.
+-- Returns {code = "220", sep = ' '|'-', rest = "<text>"} or nil for non-SMTP.
+-- ---------------------------------------------------------------------------
+
+local function parse_greeting_line(data)
+  if type(data) ~= 'string' then
+    data = tostring(data or '')
+  end
+  local code, sep = string.match(data, '^(%d%d%d)([ %-])')
+  if not code then
+    return nil
+  end
+  return { code = code, sep = sep }
+end
+
+-- ---------------------------------------------------------------------------
+-- Probe shapes.
+--
+-- probe_connect_only:  open TCP, success on connect, close.  Distinguishes
+--   connect errors (refused vs timeout) via on_error.
+--
+-- probe_with_greeting: open TCP, read banner line-by-line, validate the
+--   3-digit reply code, optionally send QUIT after the final line of a 220
+--   banner, then close.  Connect-phase errors via on_error; read-phase
+--   outcomes via the read callback.
+--
+-- Both invoke `cb(verdict, extra)` where verdict is one of:
+--   good | refused | timeout_connect | timeout_read | invalid | error:<code>
+-- ---------------------------------------------------------------------------
+
+local function classify_connect_error(err)
+  local e = tostring(err or ''):lower()
+  if e:find('refused', 1, true)
+      or e:find('reset', 1, true)
+      or e:find('econnrefused', 1, true) then
+    return 'refused'
+  end
+  if e:find('timeout', 1, true)
+      or e:find('timed out', 1, true)
+      or e:find('unreachable', 1, true)
+      or e:find('no route', 1, true) then
+    return 'timeout_connect'
+  end
+  return nil -- local-side: EPERM, EADDRNOTAVAIL, etc. — caller logs only.
+end
+
+local function probe_connect_only(task, ip, cb)
+  -- One-shot wrapper: on_error may fire synchronously (refused on localhost)
+  -- before rspamd_tcp.new returns, then the function returns false, then our
+  -- !ok fallback below would fire cb again with a worse verdict.  Guard it.
+  local fired = false
+  local function finish(verdict)
+    if fired then
+      return
+    end
+    fired = true
+    cb(verdict)
+  end
+
+  local function on_connect(conn)
+    conn:close()
+    finish('good')
+  end
+  local function on_error(err)
+    local v = classify_connect_error(err)
+    if not v then
+      rspamd_logger.infox(task, 'mx probe local error for %s: %s', ip, err)
+      v = 'timeout_connect'
+    end
+    finish(v)
+  end
+
+  -- lua_tcp_request requires `callback` even with read=false; it is a no-op
+  -- in the pure connect-only shape because no read handler is queued.
+  local function stub_cb() end
+
+  local ok = rspamd_tcp.new({
+    task = task,
+    callback = stub_cb,
+    host = ip,
+    port = settings.port,
+    read = false,
+    connect_timeout = settings.connect_timeout,
+    on_connect = on_connect,
+    on_error = on_error,
+  })
+
+  if not ok then
+    finish('timeout_connect')
+  end
+end
+
+local function probe_with_greeting(task, ip, cb)
+  local fired = false
+  local function finish(verdict, extra)
+    if fired then
+      return
+    end
+    fired = true
+    cb(verdict, extra)
+  end
+
+  local function on_error(err)
+    -- Connect-phase only (lua_tcp guarantees the gate via LUA_TCP_FLAG_CONNECTED).
+    local v = classify_connect_error(err)
+    if not v then
+      rspamd_logger.infox(task, 'mx probe local error for %s: %s', ip, err)
+      v = 'timeout_connect'
+    end
+    finish(v)
+  end
+
+  -- Forward declaration so the read callback can re-queue itself for
+  -- multi-line banner draining.
+  local read_line
+
+  local function send_quit_and_close(conn)
+    conn:add_write(function(_)
+      conn:close()
+    end, 'QUIT' .. CRLF)
+  end
+
+  read_line = function(io_err, data, conn)
+    if io_err then
+      local e = tostring(io_err or ''):lower()
+      if e:find('timeout', 1, true) then
+        finish('timeout_read')
+      else
+        -- EOF before CRLF, or anything not a timeout, is non-SMTP behaviour.
+        finish('invalid')
+      end
+      if conn then
+        conn:close()
+      end
+      return
+    end
+
+    local parsed = parse_greeting_line(data)
+    if not parsed then
+      finish('invalid')
+      conn:close()
+      return
+    end
+
+    local family = string.sub(parsed.code, 1, 1)
+    if family == '2' then
+      -- 220 (or other 2xx) — successful greeting. If send_quit, drain any
+      -- continuation lines before issuing QUIT so we don't talk mid-banner.
+      if settings.send_quit then
+        if parsed.sep == '-' then
+          -- More banner lines to come; keep reading until the final line.
+          conn:add_read(read_line, CRLF)
+          return
+        end
+        finish('good')
+        send_quit_and_close(conn)
+      else
+        finish('good')
+        conn:close()
+      end
+      return
+    end
+
+    if family == '4' or family == '5' then
+      finish('error:' .. parsed.code)
+      conn:close()
+      return
+    end
+
+    -- 1xx, 3xx, or anything else with the right shape but the wrong class —
+    -- treat as non-SMTP.
+    finish('invalid')
+    conn:close()
+  end
+
+  local ok = rspamd_tcp.new({
+    task = task,
+    host = ip,
+    port = settings.port,
+    callback = read_line,
+    stop_pattern = CRLF,
+    connect_timeout = settings.connect_timeout,
+    read_timeout = settings.read_timeout,
+    on_error = on_error,
+  })
+
+  if not ok then
+    rspamd_logger.errx(task, 'mx_check: failed to dispatch TCP probe to %s', ip)
+    finish('timeout_connect')
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- Outcome → symbol emission.  Phase A: emit existing primary symbols at
+-- today's scores plus finer symbols at score 0 for tuning data.
+-- ---------------------------------------------------------------------------
+
+local function emit_outcome(task, mx_domain, outcome, info)
+  -- info table: { mx_missing = bool, host = string, code = string (for error), key = string (for white) }
+  info = info or {}
+
+  if outcome == 'white' then
+    task:insert_result(settings.symbol_white_mx, 1.0, info.key or mx_domain)
+    return
+  end
+
+  -- A-fallback path: today's module fires MX_MISSING whenever the MX RR is
+  -- absent and we fell back to A, independent of the probe outcome.  Match
+  -- that behaviour: emit MX_MISSING first, then fall through to the regular
+  -- outcome emission below.
+  if info.mx_missing then
+    task:insert_result(settings.symbol_no_mx, 1.0, info.host or mx_domain)
+  end
+
+  if outcome == 'good' then
+    task:insert_result(settings.symbol_good_mx, 1.0, info.host or mx_domain)
+    return
+  end
+
+  -- DNS-level outcomes: emit the finer symbol AND fall through to the
+  -- MX_INVALID emission path below so the primary skip-mail signal still
+  -- fires (matches today's behaviour: anything not connectable = MX_INVALID).
+  local invalid_reason
+  if outcome == 'null' then
+    task:insert_result(settings.symbol_mx_null, 1.0, mx_domain)
+    invalid_reason = 'null mx'
+    if settings.reject_null_mx then
+      invalid_reason = 'null mx: rejected'
+    end
+  elseif outcome == 'nxdomain' then
+    task:insert_result(settings.symbol_mx_nxdomain, 1.0, mx_domain)
+    invalid_reason = 'nxdomain'
+    if settings.reject_nxdomain then
+      invalid_reason = 'nxdomain: rejected'
+    end
+  elseif outcome == 'broken' then
+    task:insert_result(settings.symbol_mx_broken, 1.0, mx_domain)
+    invalid_reason = 'broken mx'
+  end
+
+  if invalid_reason then
+    -- DNS failures: emit MX_INVALID with a descriptive reason.  We bypass
+    -- greylisting here because there is no transient signal — DNS results
+    -- already include their own caching/retry semantics.
+    task:insert_result(settings.symbol_bad_mx, 1.0, invalid_reason)
+    return
+  end
+
+  -- Finer probe outcomes.
+  local finer
+  local code_param
+  if outcome == 'refused' then
+    finer = settings.symbol_mx_refused
+  elseif outcome == 'timeout_connect' then
+    finer = settings.symbol_mx_timeout_connect
+  elseif outcome == 'timeout_read' then
+    finer = settings.symbol_mx_timeout_read
+  elseif outcome == 'invalid' then
+    finer = nil -- MX_INVALID is the primary; no finer symbol
+  else
+    -- "error:<code>"
+    local code = string.match(outcome, '^error:(%d+)$')
+    if code then
+      finer = settings.symbol_mx_error
+      code_param = code
+    end
+  end
+
+  if finer then
+    if code_param then
+      task:insert_result(finer, 1.0, code_param)
+    else
+      task:insert_result(finer, 1.0, info.host or mx_domain)
+    end
+  end
+
+  -- Special case: a 4xx/5xx greeting means the MX is a real SMTP server —
+  -- map to MX_GOOD for the primary symbol (today's behaviour too).
+  if string.find(outcome, '^error:', 1) then
+    if info.mx_missing then
+      task:insert_result(settings.symbol_no_mx, 1.0, info.host or mx_domain)
+    end
+    task:insert_result(settings.symbol_good_mx, 1.0, info.host or mx_domain)
+    return
+  end
+
+  -- All remaining outcomes are MX_INVALID territory.
+  if settings.greylist_invalid then
+    task:get_mempool():set_variable('grey_greylisted_required', '1')
+    lua_util.debugm(N, task, 'advice to greylist a message')
+    task:insert_result(settings.symbol_bad_mx, 1.0, 'greylisted')
+  else
+    task:insert_result(settings.symbol_bad_mx, 1.0)
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- Lookup orchestrator: step1 (d:) → step2 (m:) → step3 (i:).
+-- Stateful via small closure-captured tables; each cache GET is its own
+-- continuation.
+-- ---------------------------------------------------------------------------
+
+local function lookup(task, mx_domain, done)
+  local ctx = { mx_domain = mx_domain, mx_missing = false }
+
+  -- step 3: walk IP list, take first cached verdict, else probe the first one.
+  local function step3(ips)
+    if #ips == 0 then
+      -- Should not happen — defensive.
+      done('invalid', ctx)
+      return
+    end
+
+    local i = 1
+    local function try_next()
+      if i > #ips then
+        -- All uncached; probe the first IP.
+        local ip = ips[1]
+        local function on_probe(verdict, extra)
+          cache_set(task, 'i', ip, verdict, ttl_for_verdict(verdict))
+          ctx.host = ip
+          done(verdict, ctx)
+        end
+        if settings.verify_greeting then
+          probe_with_greeting(task, ip, on_probe)
+        else
+          probe_connect_only(task, ip, on_probe)
+        end
+        return
+      end
+
+      local ip = ips[i]
+      cache_get(task, 'i', ip, function(err, data)
+        if not err and type(data) == 'string' and #data > 0 then
+          ctx.host = ip
+          ctx.from_cache = true
+          done(data, ctx)
+          return
+        end
+        i = i + 1
+        try_next()
+      end)
+    end
+
+    try_next()
+  end
+
+  -- step 2: walk MX list, take first cached IP list; if every entry is broken,
+  -- emit MX_BROKEN.  If none cached, resolve A for the highest-priority MX.
+  local function step2(mx_list)
+    table.sort(mx_list, function(a, b)
+      return a.priority < b.priority -- RFC 5321: lowest preference first
+    end)
+    local limit = math.min(#mx_list, settings.max_mx_a_records)
+    if limit < #mx_list then
+      local trimmed = {}
+      for k = 1, limit do
+        trimmed[k] = mx_list[k]
+      end
+      mx_list = trimmed
+    end
+
+    local i = 1
+    local broken_count = 0
+
+    local function resolve_uncached()
+      -- Find the highest-priority MX without a cache entry; resolve A for it.
+      local target
+      for _, mx in ipairs(mx_list) do
+        if not mx._cache_checked or mx._cache_value == nil then
+          target = mx.name
+          break
+        end
+      end
+      if not target then
+        -- Everything was cache-broken.
+        cache_set(task, 'd', mx_domain, 'nxd', settings.expire_novalid)
+        done('broken', ctx)
+        return
+      end
+
+      local r = task:get_resolver()
+      r:resolve('a', {
+        name = target,
+        task = task,
+        forced = true,
+        callback = function(_, _, results, err)
+          if err and err ~= DNS_ERR_NOREC and err ~= DNS_ERR_NXDOMAIN then
+            -- Soft DNS failure; treat as broken-reference for this host.
+            cache_set(task, 'm', target, 'nxd', settings.expire_novalid)
+            broken_count = broken_count + 1
+            if broken_count >= #mx_list then
+              done('broken', ctx)
+              return
+            end
+            -- Try next uncached MX.
+            for _, mx in ipairs(mx_list) do
+              if mx.name == target then
+                mx._cache_checked = true
+                mx._cache_value = 'nxd'
+              end
+            end
+            resolve_uncached()
+            return
+          end
+
+          if not results or #results == 0 then
+            cache_set(task, 'm', target, 'nxd', settings.expire_novalid)
+            broken_count = broken_count + 1
+            for _, mx in ipairs(mx_list) do
+              if mx.name == target then
+                mx._cache_checked = true
+                mx._cache_value = 'nxd'
+              end
+            end
+            if broken_count >= #mx_list then
+              done('broken', ctx)
+              return
+            end
+            resolve_uncached()
+            return
+          end
+
+          lua_util.shuffle(results) -- match today's per-IP picking behaviour
+          local ip_strs = {}
+          for _, addr in ipairs(results) do
+            ip_strs[#ip_strs + 1] = addr:to_string()
+          end
+          cache_set(task, 'm', target, encode_ip_list(ip_strs), settings.expire)
+          step3(ip_strs)
+        end,
+      })
+    end
+
+    local function step()
+      if i > #mx_list then
+        if broken_count >= #mx_list then
+          -- Every cached entry says the MX target doesn't resolve.
+          done('broken', ctx)
+          return
+        end
+        resolve_uncached()
+        return
+      end
+      local mx = mx_list[i]
+      cache_get(task, 'm', mx.name, function(err, data)
+        i = i + 1
+        if err or type(data) ~= 'string' or #data == 0 then
+          mx._cache_checked = true
+          mx._cache_value = nil
+          step()
+          return
+        end
+        if data == 'nxd' or data == 'none' then
+          mx._cache_checked = true
+          mx._cache_value = 'nxd'
+          broken_count = broken_count + 1
+          step()
+          return
+        end
+        -- Got a cached IP list; go to step 3.
+        local ips = decode_ip_list(data)
+        if #ips == 0 then
+          broken_count = broken_count + 1
+          step()
+          return
+        end
+        step3(ips)
+      end)
+    end
+
+    step()
+  end
+
+  -- step 1.5: A-fallback (no MX RR found at domain).
+  local function fallback_a()
+    ctx.mx_missing = true
+    local r = task:get_resolver()
+    r:resolve('a', {
+      name = mx_domain,
+      task = task,
+      forced = true,
+      callback = function(_, _, results, err)
+        if (err and err ~= DNS_ERR_NOREC) or not results or #results == 0 then
+          if err == DNS_ERR_NXDOMAIN then
+            -- Drop one level deeper: check eTLD via NS.  For Phase A simplicity
+            -- we treat eTLD NXDOMAIN as MX_NXDOMAIN; resolver returning
+            -- NXDOMAIN at this stage already means the domain doesn't exist.
+            cache_set(task, 'd', mx_domain, 'nxd', settings.expire_novalid)
+            done('nxdomain', ctx)
+            return
+          end
+          cache_set(task, 'd', mx_domain, 'nxd', settings.expire_novalid)
+          done('nxdomain', ctx)
+          return
+        end
+        lua_util.shuffle(results)
+        local ip_strs = {}
+        for _, addr in ipairs(results) do
+          ip_strs[#ip_strs + 1] = addr:to_string()
+        end
+        cache_set(task, 'd', mx_domain,
+          'mx_miss:' .. encode_ip_list(ip_strs), settings.expire)
+        step3(ip_strs)
+      end,
+    })
+  end
+
+  -- step 1: d-layer cache, else MX resolution.
+  local function step1_resolve_mx()
+    local r = task:get_resolver()
+    r:resolve('mx', {
+      name = mx_domain,
+      task = task,
+      forced = true,
+      callback = function(_, _, results, err)
+        if results and #results > 0 then
+          if is_null_mx(results) then
+            cache_set(task, 'd', mx_domain, 'null', settings.expire_novalid)
+            done('null', ctx)
+            return
+          end
+          cache_set(task, 'd', mx_domain, encode_mx_list(results), settings.expire)
+          step2(results)
+          return
+        end
+        -- No MX → A-fallback per RFC 5321 §5.1
+        fallback_a()
+      end,
+    })
+  end
+
+  cache_get(task, 'd', mx_domain, function(err, data)
+    if err or type(data) ~= 'string' or #data == 0 then
+      step1_resolve_mx()
+      return
+    end
+    if data == 'nxd' then
+      done('nxdomain', ctx)
+      return
+    end
+    if data == 'null' then
+      done('null', ctx)
+      return
+    end
+    if lua_util.str_startswith(data, 'mx:') then
+      local mx_list = decode_mx_list(string.sub(data, 4))
+      if #mx_list == 0 then
+        step1_resolve_mx()
+        return
+      end
+      step2(mx_list)
+      return
+    end
+    if lua_util.str_startswith(data, 'mx_miss:') then
+      ctx.mx_missing = true
+      local ips = decode_ip_list(string.sub(data, 9))
+      if #ips == 0 then
+        step1_resolve_mx()
+        return
+      end
+      step3(ips)
+      return
+    end
+    -- Unknown value; treat as miss.
+    step1_resolve_mx()
+  end)
+end
+
+-- ---------------------------------------------------------------------------
+-- Module entry.
+-- ---------------------------------------------------------------------------
 
 local function mx_check(task)
   local ip_addr = task:get_ip()
@@ -59,7 +774,6 @@ local function mx_check(task)
     mx_domain = from[1]['domain']
   else
     mx_domain = task:get_helo()
-
     if mx_domain then
       mx_domain = rspamd_util.get_tld(mx_domain)
     end
@@ -72,321 +786,151 @@ local function mx_check(task)
   if exclude_domains then
     if exclude_domains:get_key(mx_domain) then
       rspamd_logger.infox(task, 'skip mx check for %s, excluded', mx_domain)
-      task:insert_result(settings.symbol_white_mx, 1.0, mx_domain)
+      emit_outcome(task, mx_domain, 'white', { key = mx_domain })
       return
     end
   end
 
-  local valid = false
-
-  local function check_results(mxes)
-    if fun.all(function(_, elt)
-      return elt.checked
-    end, mxes) then
-      -- Save cache
-      local key = settings.key_prefix .. mx_domain
-      local function redis_cache_cb(err)
-        if err ~= nil then
-          rspamd_logger.errx(task, 'redis_cache_cb received error: %1', err)
-          return
-        end
-      end
-      if not valid then
-        -- Greylist message
-        if settings.greylist_invalid then
-          task:get_mempool():set_variable("grey_greylisted_required", "1")
-          lua_util.debugm(N, task, "advice to greylist a message")
-          task:insert_result(settings.symbol_bad_mx, 1.0, "greylisted")
-        else
-          task:insert_result(settings.symbol_bad_mx, 1.0)
-        end
-        local ret = rspamd_redis_make_request(task,
-            redis_params, -- connect params
-            key, -- hash key
-            true, -- is write
-            redis_cache_cb, --callback
-            'SETEX', -- command
-            { key, tostring(settings.expire_novalid), '0' } -- arguments
-        )
-        lua_util.debugm(N, task, "set redis cache key: %s; invalid MX", key)
-        if not ret then
-          rspamd_logger.errx(task, 'got error connecting to redis')
-        end
-      else
-        local valid_mx = {}
-        fun.each(function(k)
-          table.insert(valid_mx, k)
-        end, fun.filter(function(_, elt)
-          return elt.working
-        end, mxes))
-        task:insert_result(settings.symbol_good_mx, 1.0, valid_mx)
-        local value = table.concat(valid_mx, ';')
-        if mxes[mx_domain] and type(mxes[mx_domain]) == 'table' and mxes[mx_domain].mx_missing then
-          value = mx_miss_cache_prefix .. value
-        end
-        local ret = rspamd_redis_make_request(task,
-            redis_params, -- connect params
-            key, -- hash key
-            true, -- is write
-            redis_cache_cb, --callback
-            'SETEX', -- command
-            { key, tostring(settings.expire), value } -- arguments
-        )
-        lua_util.debugm(N, task, "set redis cache key: %s; %s", key, value)
-        if not ret then
-          rspamd_logger.errx(task, 'error connecting to redis')
-        end
-      end
-    end
-  end
-
-  local function gen_mx_a_callback(name, mxes)
-    return function(_, _, results, err)
-      lua_util.debugm(N, task, "got DNS results for %s: %s", name, results)
-      mxes[name].ips = results
-
-      local function io_cb(io_err, _, conn)
-        lua_util.debugm(N, task, "TCP IO callback for %s, error: %s", name, io_err)
-        if io_err then
-          mxes[name].checked = true
-          conn:close()
-        else
-          mxes[name].checked = true
-          mxes[name].working = true
-          valid = true
-          if settings.wait_for_greeting then
-            conn:add_write(function(_)
-              conn:close()
-            end, string.format('QUIT%s', CRLF))
-          end
-        end
-        check_results(mxes)
-      end
-      local function on_connect_cb(conn)
-        lua_util.debugm(N, task, "TCP connect callback for %s, error: %s", name, err)
-        if err then
-          mxes[name].checked = true
-          conn:close()
-          check_results(mxes)
-        else
-          mxes[name].checked = true
-          valid = true
-          mxes[name].working = true
-        end
-
-        -- Disconnect without SMTP dialog
-        if not settings.wait_for_greeting then
-          check_results(mxes)
-          conn:close()
-        end
-      end
-
-      if err or not results or #results == 0 then
-        mxes[name].checked = true
-      else
-        -- Try to open TCP connection to port 25 for a random IP address
-        -- see #3839 on GitHub
-        lua_util.shuffle(results)
-        local str_ip = results[1]:to_string()
-        lua_util.debugm(N, task, "trying to connect to IP %s", str_ip)
-        local t_ret = rspamd_tcp.new({
-          task = task,
-          host = str_ip,
-          callback = io_cb,
-          stop_pattern = CRLF,
-          on_connect = on_connect_cb,
-          timeout = settings.timeout,
-          port = 25
-        })
-
-        if not t_ret then
-          mxes[name].checked = true
-        end
-      end
-      check_results(mxes)
-    end
-  end
-
-  local function mx_callback(_, _, results, err)
-    local mxes = {}
-    if err or not results then
-      local r = task:get_resolver()
-      -- XXX: maybe add ipv6?
-      -- fallback to implicit mx
-      if not err and not results then
-        err = 'no MX records found'
-      end
-
-      lua_util.debugm(N, task, "cannot find MX record for %s: %s, use implicit fallback",
-          mx_domain, err)
-      mxes[mx_domain] = { checked = false, working = false, ips = {}, mx_missing = true }
-      r:resolve('a', {
-        name = mx_domain,
-        callback = gen_mx_a_callback(mx_domain, mxes),
-        task = task,
-        forced = true
-      })
-      task:insert_result(settings.symbol_no_mx, 1.0, err)
-    else
-      -- Inverse sort by priority
-      table.sort(results, function(r1, r2)
-        return r1['priority'] > r2['priority']
-      end)
-
-      local max_mx_to_resolve = math.min(#results, settings.max_mx_a_records)
-      lua_util.debugm(N, task, 'check %s MX records (%d actually returned)',
-          max_mx_to_resolve, #results)
-      for i = 1, max_mx_to_resolve do
-        local mx = results[i]
-        mxes[mx.name] = { checked = false, working = false, ips = {} }
-        local r = task:get_resolver()
-        -- XXX: maybe add ipv6?
-        r:resolve('a', {
-          name = mx.name,
-          callback = gen_mx_a_callback(mx.name, mxes),
-          task = task,
-          forced = true
-        })
-      end
-      check_results(mxes)
-    end
-  end
-
-  if not redis_params then
-    local r = task:get_resolver()
-    r:resolve('mx', {
-      name = mx_domain,
-      callback = mx_callback,
-      task = task,
-      forced = true
-    })
-  else
-    local function redis_cache_get_cb(err, data)
-      if err or type(data) ~= 'string' then
-        local r = task:get_resolver()
-        r:resolve('mx', {
-          name = mx_domain,
-          callback = mx_callback,
-          task = task,
-          forced = true
-        })
-      else
-        if data == '0' then
-          task:insert_result(settings.symbol_bad_mx, 1.0, 'cached')
-        else
-          if lua_util.str_startswith(data, mx_miss_cache_prefix) then
-            task:insert_result(settings.symbol_no_mx, 1.0, 'cached')
-            data = string.sub(data, #mx_miss_cache_prefix + 1)
-          end
-          local mxes = lua_util.str_split(data, ';')
-          task:insert_result(settings.symbol_good_mx, 1.0, 'cached: ' .. mxes[1])
-        end
-      end
-    end
-
-    local key = settings.key_prefix .. mx_domain
-    local ret = rspamd_redis_make_request(task,
-        redis_params, -- connect params
-        key, -- hash key
-        false, -- is write
-        redis_cache_get_cb, --callback
-        'GET', -- command
-        { key } -- arguments
-    )
-
-    if not ret then
-      local r = task:get_resolver()
-      r:resolve('mx', {
-        name = mx_domain,
-        callback = mx_callback,
-        task = task,
-        forced = true
-      })
-    end
-  end
+  lookup(task, mx_domain, function(outcome, info)
+    -- `outcome` is one of:
+    --   good | refused | timeout_connect | timeout_read | invalid
+    --   error:<code> | nxdomain | null | broken | white
+    lua_util.debugm(N, task, 'mx_check verdict for %s: %s', mx_domain, outcome)
+    emit_outcome(task, mx_domain, outcome, info)
+  end)
 end
 
--- Module setup
+-- ---------------------------------------------------------------------------
+-- Module setup.
+-- ---------------------------------------------------------------------------
+
 local opts = rspamd_config:get_all_opt('mx_check')
 if not (opts and type(opts) == 'table') then
   rspamd_logger.infox(rspamd_config, 'module is unconfigured')
   return
 end
-if opts then
-  redis_params = lua_redis.parse_redis_server('mx_check')
-  if not redis_params then
-    rspamd_logger.errx(rspamd_config, 'no redis servers are specified, disabling module')
-    lua_util.disable_module(N, "redis")
-    return
+
+redis_params = lua_redis.parse_redis_server('mx_check')
+if not redis_params then
+  rspamd_logger.errx(rspamd_config, 'no redis servers are specified, disabling module')
+  lua_util.disable_module(N, "redis")
+  return
+end
+
+-- Honour deprecated keys: legacy `timeout` and `wait_for_greeting`.
+do
+  local legacy_timeout = opts.timeout
+  local legacy_wfg = opts.wait_for_greeting
+  if legacy_timeout ~= nil and opts.connect_timeout == nil then
+    opts.connect_timeout = legacy_timeout
+    rspamd_logger.warnx(rspamd_config,
+      'mx_check: `timeout` is deprecated; use `connect_timeout` (mapped automatically)')
   end
+  if legacy_wfg ~= nil and opts.verify_greeting == nil then
+    opts.verify_greeting = legacy_wfg
+    rspamd_logger.warnx(rspamd_config,
+      'mx_check: `wait_for_greeting` is deprecated; use `verify_greeting` (mapped automatically). '
+        .. 'Note: the new flag also adds multi-line banner parsing and reply-code validation.')
+  end
+  opts.timeout = nil
+  opts.wait_for_greeting = nil
+end
 
-  settings = lua_util.override_defaults(settings, opts)
-  lua_redis.register_prefix(settings.key_prefix .. '*', N,
-      'MX check cache', {
-        type = 'string',
-      })
+settings = lua_util.override_defaults(settings, opts)
 
-  local id = rspamd_config:register_symbol({
-    name = settings.symbol_bad_mx,
-    type = 'normal',
-    callback = mx_check,
-    flags = 'empty',
-    augmentations = { string.format("timeout=%f", settings.timeout + rspamd_config:get_dns_timeout() or 0.0) },
-  })
-  rspamd_config:register_symbol({
-    name = settings.symbol_no_mx,
-    type = 'virtual',
-    parent = id
-  })
-  rspamd_config:register_symbol({
-    name = settings.symbol_good_mx,
-    type = 'virtual',
-    parent = id
-  })
-  rspamd_config:register_symbol({
-    name = settings.symbol_white_mx,
-    type = 'virtual',
-    parent = id
-  })
+lua_redis.register_prefix(settings.key_prefix .. ':*', N,
+  'MX check cache (three-layer: d:/m:/i:)', { type = 'string' })
 
-  rspamd_config:set_metric_symbol({
-    name = settings.symbol_bad_mx,
-    score = 0.5,
-    description = 'Domain has no working MX',
-    group = 'MX',
-    one_shot = true,
-    one_param = true,
+-- Augmentation budget: worst case is one DNS round + connect + read.
+local dns_to = rspamd_config:get_dns_timeout() or 0.0
+local budget = settings.connect_timeout + settings.read_timeout + dns_to
+
+local id = rspamd_config:register_symbol({
+  name = settings.symbol_bad_mx,
+  type = 'normal',
+  callback = mx_check,
+  flags = 'empty',
+  augmentations = { string.format("timeout=%f", budget) },
+})
+
+local function register_virtual(name)
+  rspamd_config:register_symbol({
+    name = name,
+    type = 'virtual',
+    parent = id,
   })
+end
+
+register_virtual(settings.symbol_no_mx)
+register_virtual(settings.symbol_good_mx)
+register_virtual(settings.symbol_white_mx)
+register_virtual(settings.symbol_mx_refused)
+register_virtual(settings.symbol_mx_timeout_connect)
+register_virtual(settings.symbol_mx_timeout_read)
+register_virtual(settings.symbol_mx_error)
+register_virtual(settings.symbol_mx_nxdomain)
+register_virtual(settings.symbol_mx_null)
+register_virtual(settings.symbol_mx_broken)
+
+-- Primary metric symbols (today's scores).
+rspamd_config:set_metric_symbol({
+  name = settings.symbol_bad_mx,
+  score = 0.5,
+  description = 'Domain has no working MX',
+  group = 'MX',
+  one_shot = true,
+  one_param = true,
+})
+rspamd_config:set_metric_symbol({
+  name = settings.symbol_good_mx,
+  score = -0.01,
+  description = 'Domain has working MX',
+  group = 'MX',
+  one_shot = true,
+  one_param = true,
+})
+rspamd_config:set_metric_symbol({
+  name = settings.symbol_white_mx,
+  score = 0.0,
+  description = 'Domain is whitelisted from MX check',
+  group = 'MX',
+  one_shot = true,
+  one_param = true,
+})
+rspamd_config:set_metric_symbol({
+  name = settings.symbol_no_mx,
+  score = 3.5,
+  description = 'Domain has no resolvable MX',
+  group = 'MX',
+  one_shot = true,
+  one_param = true,
+})
+
+-- Finer symbols: registered at score 0 in Phase A.  Phase B flips them on
+-- with real defaults; operators can override scores today.
+local function set_finer(name, description)
   rspamd_config:set_metric_symbol({
-    name = settings.symbol_good_mx,
-    score = -0.01,
-    description = 'Domain has working MX',
-    group = 'MX',
-    one_shot = true,
-    one_param = true,
-  })
-  rspamd_config:set_metric_symbol({
-    name = settings.symbol_white_mx,
+    name = name,
     score = 0.0,
-    description = 'Domain is whitelisted from MX check',
+    description = description,
     group = 'MX',
     one_shot = true,
     one_param = true,
   })
-  rspamd_config:set_metric_symbol({
-    name = settings.symbol_no_mx,
-    score = 3.5,
-    description = 'Domain has no resolvable MX',
-    group = 'MX',
-    one_shot = true,
-    one_param = true,
-  })
+end
 
-  if settings.exclude_domains then
-    exclude_domains = rspamd_config:add_map {
-      type = 'set',
-      description = 'Exclude specific domains from MX checks',
-      url = settings.exclude_domains,
-    }
-  end
+set_finer(settings.symbol_mx_refused, 'MX target sent TCP RST (port 25 closed)')
+set_finer(settings.symbol_mx_timeout_connect, 'MX target did not respond to connect attempt')
+set_finer(settings.symbol_mx_timeout_read, 'MX target accepted TCP but did not send greeting')
+set_finer(settings.symbol_mx_error, 'MX target greeted with 4xx/5xx (real SMTP, rejected probe)')
+set_finer(settings.symbol_mx_nxdomain, 'Domain itself does not exist (NXDOMAIN)')
+set_finer(settings.symbol_mx_null, 'Domain published RFC 7505 Null MX')
+set_finer(settings.symbol_mx_broken, 'All MX RRs point at hostnames that do not resolve')
+
+if settings.exclude_domains then
+  exclude_domains = rspamd_config:add_map {
+    type = 'set',
+    description = 'Exclude specific domains from MX checks',
+    url = settings.exclude_domains,
+  }
 end

--- a/src/plugins/lua/mx_check.lua
+++ b/src/plugins/lua/mx_check.lua
@@ -32,6 +32,7 @@ local rspamd_tcp = require "rspamd_tcp"
 local rspamd_util = require "rspamd_util"
 local lua_util = require "lua_util"
 local lua_redis = require "lua_redis"
+local lua_maps = require "lua_maps"
 
 local N = "mx_check"
 local CRLF = '\r\n'
@@ -60,6 +61,17 @@ local settings = {
   reject_null_mx = false,
   greylist_invalid = true,
 
+  -- run scope: by default mx_check skips authenticated and local-network
+  -- senders (they are our own traffic). ESP/outbound deployments can flip
+  -- these on to check outgoing mail too.
+  check_authorized = false,
+  check_local = false,
+
+  -- Testing only. When true, loopback (127/8, ::1) is treated as a normal
+  -- probeable address instead of a bogon, so the probe path can be exercised
+  -- against a local listener. NEVER enable this in production.
+  test_mode = false,
+
   -- maps / cache
   key_prefix = 'rmx',
   max_mx_a_records = 5,
@@ -82,10 +94,60 @@ local settings = {
   symbol_mx_nxdomain = 'MX_NXDOMAIN',
   symbol_mx_null = 'MX_NULL',
   symbol_mx_broken = 'MX_BROKEN',
+
+  -- IP-class symbols (Phase C: score 0, informational)
+  symbol_mx_local_only = 'MX_LOCAL_ONLY',
+  symbol_mx_local_mix = 'MX_LOCAL_MIX',
+  symbol_mx_bogon_only = 'MX_BOGON_ONLY',
+  symbol_mx_bogon_mix = 'MX_BOGON_MIX',
+  symbol_mx_skip = 'MX_SKIP',
 }
+
+-- RFC-defined address ranges, classified for MX-target probing. An MX RR
+-- resolving into LOCAL space is unprobeable from our vantage point (we would
+-- reach our own LAN, not the publisher's); one resolving into BOGON space has
+-- no legitimate meaning at all and is a packet-injection footgun. Both sets
+-- are a fixed correctness invariant and are deliberately not operator-tunable.
+local LOCAL_RANGES = {
+  '10.0.0.0/8',      -- RFC 1918 private
+  '172.16.0.0/12',   -- RFC 1918 private
+  '192.168.0.0/16',  -- RFC 1918 private
+  '100.64.0.0/10',   -- RFC 6598 CGNAT
+  'fc00::/7',        -- RFC 4193 IPv6 unique-local
+}
+local BOGON_RANGES = {
+  '0.0.0.0/8',       -- RFC 1122 "this network"
+  '127.0.0.0/8',     -- loopback (dropped from the set under test_mode)
+  '169.254.0.0/16',  -- RFC 3927 link-local (APIPA)
+  '192.0.0.0/24',    -- RFC 6890 IETF protocol assignments
+  '192.0.2.0/24',    -- RFC 5737 TEST-NET-1
+  '192.88.99.0/24',  -- RFC 7526 6to4 relay anycast (deprecated)
+  '198.18.0.0/15',   -- RFC 2544 benchmarking
+  '198.51.100.0/24', -- RFC 5737 TEST-NET-2
+  '203.0.113.0/24',  -- RFC 5737 TEST-NET-3
+  '224.0.0.0/4',     -- RFC 5771 IPv4 multicast
+  '240.0.0.0/4',     -- RFC 1112 reserved (incl. 255.255.255.255 broadcast)
+  '::/128',          -- IPv6 unspecified
+  '::1/128',         -- IPv6 loopback (dropped from the set under test_mode)
+  '64:ff9b::/96',    -- RFC 6052 NAT64
+  -- NB: the IPv4-mapped range ::ffff:0:0/96 is deliberately NOT listed.
+  -- rspamd's radix stores every IPv4 address as its v4-mapped form, so that
+  -- prefix would match all IPv4 traffic. v4-mapped IPv6 MX targets can only
+  -- arise once AAAA probing lands and must be rejected before the radix test.
+  '100::/64',        -- RFC 6666 IPv6 discard-only
+  '2001:db8::/32',   -- RFC 3849 IPv6 documentation
+  'fe80::/10',       -- IPv6 link-local
+  'ff00::/8',        -- IPv6 multicast
+}
+-- Loopback prefixes lifted out of the BOGON set when test_mode is on.
+local LOOPBACK_RANGES = { ['127.0.0.0/8'] = true, ['::1/128'] = true }
 
 local redis_params
 local exclude_domains
+local exclude_mxs
+local exclude_ips
+local local_map
+local bogon_map
 
 -- ---------------------------------------------------------------------------
 -- Cache layer (Redis-backed; falls back gracefully if Redis is unavailable
@@ -186,6 +248,24 @@ local function is_null_mx(results)
     return false
   end
   return r.name == '' or r.name == '.'
+end
+
+-- Classify resolved MX-target IPs into PUBLIC / LOCAL / BOGON buckets.
+-- Membership is mutually exclusive; anything that matches neither map is
+-- PUBLIC.  Range membership depends only on the IP, so it is recomputed per
+-- lookup rather than cached.
+local function partition_ips(ips)
+  local public, locals, bogons = {}, {}, {}
+  for _, ip in ipairs(ips) do
+    if bogon_map and bogon_map:get_key(ip) then
+      bogons[#bogons + 1] = ip
+    elseif local_map and local_map:get_key(ip) then
+      locals[#locals + 1] = ip
+    else
+      public[#public + 1] = ip
+    end
+  end
+  return public, locals, bogons
 end
 
 -- ---------------------------------------------------------------------------
@@ -395,6 +475,13 @@ local function emit_outcome(task, mx_domain, outcome, info)
     return
   end
 
+  if outcome == 'skip' then
+    -- The probe set was emptied by the exclude_ips filter; MX_SKIP has
+    -- already been emitted where the filter ran.  Neutral outcome — no
+    -- MX_INVALID, and no MX_MISSING noise for a deliberately skipped check.
+    return
+  end
+
   -- A-fallback path: today's module fires MX_MISSING whenever the MX RR is
   -- absent and we fell back to A, independent of the probe outcome.  Match
   -- that behaviour: emit MX_MISSING first, then fall through to the regular
@@ -427,6 +514,12 @@ local function emit_outcome(task, mx_domain, outcome, info)
   elseif outcome == 'broken' then
     task:insert_result(settings.symbol_mx_broken, 1.0, mx_domain)
     invalid_reason = 'broken mx'
+  elseif outcome == 'local_only' then
+    -- MX_LOCAL_ONLY was already emitted during IP classification.
+    invalid_reason = 'mx resolves only to private addresses'
+  elseif outcome == 'bogon_only' then
+    -- MX_BOGON_ONLY was already emitted during IP classification.
+    invalid_reason = 'mx resolves only to non-routable addresses'
   end
 
   if invalid_reason then
@@ -544,6 +637,57 @@ local function lookup(task, mx_domain, done)
     done(verdict, ctx)
   end
 
+  -- Classify one MX target's IP set, emit the IP-class symbols, drop the
+  -- operator-excluded IPs, and probe whatever public addresses remain.
+  -- Bogon and private addresses are never probed: probing them is meaningless
+  -- from our vantage point and, for bogons, a packet-injection footgun.
+  local function probe_ip_set(ips, on_result)
+    local public, locals, bogons = partition_ips(ips)
+
+    if #public == 0 then
+      -- Nothing probeable: the MX target resolves only into private and/or
+      -- non-routable space.
+      if #locals > 0 then
+        task:insert_result(settings.symbol_mx_local_only, 1.0, locals[1])
+      end
+      if #bogons > 0 then
+        task:insert_result(settings.symbol_mx_bogon_only, 1.0, bogons[1])
+      end
+      on_result(#bogons > 0 and 'bogon_only' or 'local_only', nil)
+      return
+    end
+
+    -- Mixed set: keep the public addresses, flag the rest as informational.
+    if #locals > 0 then
+      task:insert_result(settings.symbol_mx_local_mix, 1.0, locals[1])
+    end
+    if #bogons > 0 then
+      task:insert_result(settings.symbol_mx_bogon_mix, 1.0, bogons[1])
+    end
+
+    -- Operator skip filter: drop public IPs that match exclude_ips.
+    local probe_list = public
+    if exclude_ips then
+      probe_list = {}
+      local dropped
+      for _, ip in ipairs(public) do
+        if exclude_ips:get_key(ip) then
+          dropped = dropped or ip
+        else
+          probe_list[#probe_list + 1] = ip
+        end
+      end
+      if #probe_list == 0 then
+        -- The filter emptied the probe set — nothing left to check.
+        task:insert_result(settings.symbol_mx_skip, 1.0, dropped)
+        on_result('skip', nil)
+        return
+      end
+    end
+
+    step3(probe_list, on_result)
+  end
+
   -- step 2: walk the MX list in priority order.  For each MX, resolve its IP
   -- set (m: cache, else an A lookup) and probe it via step3.  A non-working
   -- verdict moves on to the next MX so a reachable backup MX still scores the
@@ -607,7 +751,7 @@ local function lookup(task, mx_domain, done)
             ip_strs[#ip_strs + 1] = addr:to_string()
           end
           cache_set(task, 'm', mx.name, encode_ip_list(ip_strs), settings.expire)
-          step3(ip_strs, on_mx_result)
+          probe_ip_set(ip_strs, on_mx_result)
         end,
       })
     end
@@ -629,6 +773,11 @@ local function lookup(task, mx_domain, done)
       end
 
       local mx = mx_list[idx]
+      if exclude_mxs and exclude_mxs:get_key(mx.name) then
+        -- Trusted MX host: short-circuit the whole domain with MX_WHITE.
+        done('white', { key = mx.name })
+        return
+      end
       cache_get(task, 'm', mx.name, function(err, data)
         if not err and type(data) == 'string' and #data > 0 then
           if data == 'nxd' or data == 'none' then
@@ -638,7 +787,7 @@ local function lookup(task, mx_domain, done)
           end
           local ips = decode_ip_list(data)
           if #ips > 0 then
-            step3(ips, on_mx_result)
+            probe_ip_set(ips, on_mx_result)
             return
           end
         end
@@ -683,7 +832,7 @@ local function lookup(task, mx_domain, done)
         end
         cache_set(task, 'd', mx_domain,
           'mx_miss:' .. encode_ip_list(ip_strs), settings.expire)
-        step3(ip_strs, finish_single)
+        probe_ip_set(ip_strs, finish_single)
       end,
     })
   end
@@ -741,7 +890,7 @@ local function lookup(task, mx_domain, done)
         step1_resolve_mx()
         return
       end
-      step3(ips, finish_single)
+      probe_ip_set(ips, finish_single)
       return
     end
     -- Unknown value; treat as miss.
@@ -755,7 +904,15 @@ end
 
 local function mx_check(task)
   local ip_addr = task:get_ip()
-  if task:get_user() or (ip_addr and ip_addr:is_local()) then
+  -- By default we only check inbound mail from untrusted senders. Authenticated
+  -- and local-network senders are our own traffic; ESP/outbound deployments
+  -- can opt into checking them via check_authorized / check_local.
+  if not settings.check_authorized and task:get_user() then
+    lua_util.debugm(N, task, 'skip mx check for an authenticated sender')
+    return
+  end
+  if not settings.check_local and ip_addr and ip_addr:is_local() then
+    lua_util.debugm(N, task, 'skip mx check for a local-network sender')
     return
   end
 
@@ -786,6 +943,7 @@ local function mx_check(task)
     -- `outcome` is one of:
     --   good | refused | timeout_connect | timeout_read | invalid
     --   error:<code> | nxdomain | null | broken | white
+    --   local_only | bogon_only | skip
     lua_util.debugm(N, task, 'mx_check verdict for %s: %s', mx_domain, outcome)
     emit_outcome(task, mx_domain, outcome, info)
   end)
@@ -880,6 +1038,11 @@ register_virtual(settings.symbol_mx_error)
 register_virtual(settings.symbol_mx_nxdomain)
 register_virtual(settings.symbol_mx_null)
 register_virtual(settings.symbol_mx_broken)
+register_virtual(settings.symbol_mx_local_only)
+register_virtual(settings.symbol_mx_local_mix)
+register_virtual(settings.symbol_mx_bogon_only)
+register_virtual(settings.symbol_mx_bogon_mix)
+register_virtual(settings.symbol_mx_skip)
 
 -- Primary metric symbols (today's scores).
 rspamd_config:set_metric_symbol({
@@ -935,6 +1098,11 @@ set_finer(settings.symbol_mx_error, 'MX target greeted with 4xx/5xx (real SMTP, 
 set_finer(settings.symbol_mx_nxdomain, 'Domain itself does not exist (NXDOMAIN)')
 set_finer(settings.symbol_mx_null, 'Domain published RFC 7505 Null MX')
 set_finer(settings.symbol_mx_broken, 'All MX RRs point at hostnames that do not resolve')
+set_finer(settings.symbol_mx_local_only, 'MX resolves only to private (RFC1918/CGNAT/ULA) addresses')
+set_finer(settings.symbol_mx_local_mix, 'MX resolves to a mix of public and private addresses')
+set_finer(settings.symbol_mx_bogon_only, 'MX resolves only to non-routable/reserved addresses')
+set_finer(settings.symbol_mx_bogon_mix, 'MX resolves to a mix of public and non-routable addresses')
+set_finer(settings.symbol_mx_skip, 'MX probe skipped: every candidate IP matched exclude_ips')
 
 if settings.exclude_domains then
   exclude_domains = rspamd_config:add_map {
@@ -942,4 +1110,36 @@ if settings.exclude_domains then
     description = 'Exclude specific domains from MX checks',
     url = settings.exclude_domains,
   }
+end
+
+-- Per-layer trust/skip maps (Phase C). exclude_mxs is a glob map so a bare
+-- hostname matches exactly while an explicit `*.foo` matches subdomains.
+if settings.exclude_mxs then
+  exclude_mxs = lua_maps.map_add_from_ucl(settings.exclude_mxs, 'glob',
+    'mx_check: trusted MX hostnames (bare = exact, *.glob = subdomains)')
+end
+if settings.exclude_ips then
+  exclude_ips = lua_maps.map_add_from_ucl(settings.exclude_ips, 'radix',
+    'mx_check: IP/CIDR ranges to drop from the probe set')
+end
+
+-- Module-private IP-class radix maps. test_mode lifts loopback out of the
+-- bogon set so the probe path stays exercisable against a local listener.
+do
+  local bogon_ranges = BOGON_RANGES
+  if settings.test_mode then
+    rspamd_logger.warnx(rspamd_config,
+      'mx_check: test_mode is ON — loopback is treated as probeable; '
+        .. 'do NOT use this in production')
+    bogon_ranges = {}
+    for _, r in ipairs(BOGON_RANGES) do
+      if not LOOPBACK_RANGES[r] then
+        bogon_ranges[#bogon_ranges + 1] = r
+      end
+    end
+  end
+  local_map = lua_maps.map_add_from_ucl(LOCAL_RANGES, 'radix',
+    'mx_check: private/CGNAT/ULA MX-target ranges')
+  bogon_map = lua_maps.map_add_from_ucl(bogon_ranges, 'radix',
+    'mx_check: non-routable/reserved MX-target ranges')
 end

--- a/src/plugins/lua/mx_check.lua
+++ b/src/plugins/lua/mx_check.lua
@@ -494,11 +494,14 @@ end
 local function lookup(task, mx_domain, done)
   local ctx = { mx_domain = mx_domain, mx_missing = false }
 
-  -- step 3: walk IP list, take first cached verdict, else probe the first one.
-  local function step3(ips)
-    if #ips == 0 then
+  -- step 3: resolve a verdict for one MX's IP set — the first cached i:
+  -- verdict wins, else probe the first IP.  The verdict and the IP that
+  -- produced it are handed to `on_result`; the caller decides whether to stop
+  -- or, for a multi-MX domain, fall through to the next MX host.
+  local function step3(ips, on_result)
+    if not ips or #ips == 0 then
       -- Should not happen — defensive.
-      done('invalid', ctx)
+      on_result('invalid', nil)
       return
     end
 
@@ -507,10 +510,9 @@ local function lookup(task, mx_domain, done)
       if i > #ips then
         -- All uncached; probe the first IP.
         local ip = ips[1]
-        local function on_probe(verdict, extra)
+        local function on_probe(verdict)
           cache_set(task, 'i', ip, verdict, ttl_for_verdict(verdict))
-          ctx.host = ip
-          done(verdict, ctx)
+          on_result(verdict, ip)
         end
         if settings.verify_greeting then
           probe_with_greeting(task, ip, on_probe)
@@ -523,9 +525,8 @@ local function lookup(task, mx_domain, done)
       local ip = ips[i]
       cache_get(task, 'i', ip, function(err, data)
         if not err and type(data) == 'string' and #data > 0 then
-          ctx.host = ip
           ctx.from_cache = true
-          done(data, ctx)
+          on_result(data, ip)
           return
         end
         i = i + 1
@@ -536,8 +537,18 @@ local function lookup(task, mx_domain, done)
     try_next()
   end
 
-  -- step 2: walk MX list, take first cached IP list; if every entry is broken,
-  -- emit MX_BROKEN.  If none cached, resolve A for the highest-priority MX.
+  -- Terminal step3 result handler for the single-IP-set paths (A-fallback and
+  -- the cached mx_miss: shortcut): there is no MX list to fall through to.
+  local function finish_single(verdict, host)
+    ctx.host = host
+    done(verdict, ctx)
+  end
+
+  -- step 2: walk the MX list in priority order.  For each MX, resolve its IP
+  -- set (m: cache, else an A lookup) and probe it via step3.  A non-working
+  -- verdict moves on to the next MX so a reachable backup MX still scores the
+  -- domain as MX_GOOD — only after every selected MX fails do we emit the
+  -- failure.  If no MX target resolves to an address at all, emit MX_BROKEN.
   local function step2(mx_list)
     table.sort(mx_list, function(a, b)
       return a.priority < b.priority -- RFC 5321: lowest preference first
@@ -551,116 +562,92 @@ local function lookup(task, mx_domain, done)
       mx_list = trimmed
     end
 
-    local i = 1
-    local broken_count = 0
+    local idx = 0
+    -- First non-working probe verdict, set once at least one MX was reachable.
+    -- Its absence at exhaustion means no MX target resolved at all (broken).
+    local first_fail
 
-    local function resolve_uncached()
-      -- Find the highest-priority MX without a cache entry; resolve A for it.
-      local target
-      for _, mx in ipairs(mx_list) do
-        if not mx._cache_checked or mx._cache_value == nil then
-          target = mx.name
-          break
-        end
-      end
-      if not target then
-        -- Everything was cache-broken.
-        cache_set(task, 'd', mx_domain, 'nxd', settings.expire_novalid)
-        done('broken', ctx)
+    local process_mx -- forward declaration
+
+    -- step3 result for the MX currently at `idx`.
+    local function on_mx_result(verdict, host)
+      if verdict == 'good' or lua_util.str_startswith(verdict, 'error:') then
+        -- A working MX (real SMTP, including a 4xx/5xx greeting): stop here so
+        -- a reachable backup MX still scores the domain as good.
+        ctx.host = host
+        done(verdict, ctx)
         return
       end
+      -- Non-working MX: remember the first failure, then try the next MX.
+      if not first_fail then
+        first_fail = verdict
+        ctx.host = host
+      end
+      process_mx()
+    end
 
+    -- Resolve A records for `mx`, cache them under m:, then probe via step3.
+    local function resolve_and_probe(mx)
       local r = task:get_resolver()
       r:resolve('a', {
-        name = target,
+        name = mx.name,
         task = task,
         forced = true,
         callback = function(_, _, results, err)
-          if err and err ~= DNS_ERR_NOREC and err ~= DNS_ERR_NXDOMAIN then
-            -- Soft DNS failure; treat as broken-reference for this host.
-            cache_set(task, 'm', target, 'nxd', settings.expire_novalid)
-            broken_count = broken_count + 1
-            if broken_count >= #mx_list then
-              done('broken', ctx)
-              return
-            end
-            -- Try next uncached MX.
-            for _, mx in ipairs(mx_list) do
-              if mx.name == target then
-                mx._cache_checked = true
-                mx._cache_value = 'nxd'
-              end
-            end
-            resolve_uncached()
+          if (err and err ~= DNS_ERR_NOREC and err ~= DNS_ERR_NXDOMAIN)
+              or not results or #results == 0 then
+            -- This MX target resolves to no address: a broken reference.
+            cache_set(task, 'm', mx.name, 'nxd', settings.expire_novalid)
+            process_mx()
             return
           end
-
-          if not results or #results == 0 then
-            cache_set(task, 'm', target, 'nxd', settings.expire_novalid)
-            broken_count = broken_count + 1
-            for _, mx in ipairs(mx_list) do
-              if mx.name == target then
-                mx._cache_checked = true
-                mx._cache_value = 'nxd'
-              end
-            end
-            if broken_count >= #mx_list then
-              done('broken', ctx)
-              return
-            end
-            resolve_uncached()
-            return
-          end
-
           lua_util.shuffle(results) -- match today's per-IP picking behaviour
           local ip_strs = {}
           for _, addr in ipairs(results) do
             ip_strs[#ip_strs + 1] = addr:to_string()
           end
-          cache_set(task, 'm', target, encode_ip_list(ip_strs), settings.expire)
-          step3(ip_strs)
+          cache_set(task, 'm', mx.name, encode_ip_list(ip_strs), settings.expire)
+          step3(ip_strs, on_mx_result)
         end,
       })
     end
 
-    local function step()
-      if i > #mx_list then
-        if broken_count >= #mx_list then
-          -- Every cached entry says the MX target doesn't resolve.
+    process_mx = function()
+      idx = idx + 1
+      if idx > #mx_list then
+        -- Every selected MX has been tried.
+        if first_fail then
+          -- At least one MX was reachable but none accepted the probe.
+          done(first_fail, ctx)
+        else
+          -- No MX target resolved to an address at all.  Not cached under d:
+          -- as 'nxd' on purpose — the domain and its MX RRs do exist, so a
+          -- later lookup must not be told the domain is NXDOMAIN.
           done('broken', ctx)
-          return
         end
-        resolve_uncached()
         return
       end
-      local mx = mx_list[i]
+
+      local mx = mx_list[idx]
       cache_get(task, 'm', mx.name, function(err, data)
-        i = i + 1
-        if err or type(data) ~= 'string' or #data == 0 then
-          mx._cache_checked = true
-          mx._cache_value = nil
-          step()
-          return
+        if not err and type(data) == 'string' and #data > 0 then
+          if data == 'nxd' or data == 'none' then
+            -- Cached: this MX target does not resolve.  Try the next MX.
+            process_mx()
+            return
+          end
+          local ips = decode_ip_list(data)
+          if #ips > 0 then
+            step3(ips, on_mx_result)
+            return
+          end
         end
-        if data == 'nxd' or data == 'none' then
-          mx._cache_checked = true
-          mx._cache_value = 'nxd'
-          broken_count = broken_count + 1
-          step()
-          return
-        end
-        -- Got a cached IP list; go to step 3.
-        local ips = decode_ip_list(data)
-        if #ips == 0 then
-          broken_count = broken_count + 1
-          step()
-          return
-        end
-        step3(ips)
+        -- Cache miss (or an unusable value): resolve A for this MX.
+        resolve_and_probe(mx)
       end)
     end
 
-    step()
+    process_mx()
   end
 
   -- step 1.5: A-fallback (no MX RR found at domain).
@@ -672,17 +659,21 @@ local function lookup(task, mx_domain, done)
       task = task,
       forced = true,
       callback = function(_, _, results, err)
-        if (err and err ~= DNS_ERR_NOREC) or not results or #results == 0 then
-          if err == DNS_ERR_NXDOMAIN then
-            -- Drop one level deeper: check eTLD via NS.  For Phase A simplicity
-            -- we treat eTLD NXDOMAIN as MX_NXDOMAIN; resolver returning
-            -- NXDOMAIN at this stage already means the domain doesn't exist.
-            cache_set(task, 'd', mx_domain, 'nxd', settings.expire_novalid)
-            done('nxdomain', ctx)
-            return
-          end
+        if err == DNS_ERR_NXDOMAIN then
+          -- The domain itself does not exist.
           cache_set(task, 'd', mx_domain, 'nxd', settings.expire_novalid)
           done('nxdomain', ctx)
+          return
+        end
+        if (err and err ~= DNS_ERR_NOREC) or not results or #results == 0 then
+          -- The domain exists but publishes neither MX nor A records (NODATA,
+          -- empty answer, or a soft resolver error): there is no mail
+          -- destination.  This is NOT NXDOMAIN, so we must not poison the
+          -- d-cache with 'nxd' — that would make later lookups emit
+          -- MX_NXDOMAIN for a domain that does exist.  Emit a missing/invalid
+          -- outcome instead; ctx.mx_missing makes emit_outcome fire MX_MISSING
+          -- alongside MX_INVALID, matching today's no-resolvable-MX behaviour.
+          done('invalid', ctx)
           return
         end
         lua_util.shuffle(results)
@@ -692,7 +683,7 @@ local function lookup(task, mx_domain, done)
         end
         cache_set(task, 'd', mx_domain,
           'mx_miss:' .. encode_ip_list(ip_strs), settings.expire)
-        step3(ip_strs)
+        step3(ip_strs, finish_single)
       end,
     })
   end
@@ -750,7 +741,7 @@ local function lookup(task, mx_domain, done)
         step1_resolve_mx()
         return
       end
-      step3(ips)
+      step3(ips, finish_single)
       return
     end
     -- Unknown value; treat as miss.
@@ -818,19 +809,37 @@ if not redis_params then
 end
 
 -- Honour deprecated keys: legacy `timeout` and `wait_for_greeting`.
+--
+-- This relies on the shipped modules.d/mx_check.conf NOT setting
+-- `connect_timeout` / `verify_greeting`: their defaults live in the `settings`
+-- table above, so `opts` carries the new keys only when an operator set them
+-- explicitly. If the shipped config pre-populated them, the merged `opts`
+-- would always carry them and a legacy alias in local.d would be silently
+-- ignored.
 do
   local legacy_timeout = opts.timeout
   local legacy_wfg = opts.wait_for_greeting
-  if legacy_timeout ~= nil and opts.connect_timeout == nil then
-    opts.connect_timeout = legacy_timeout
-    rspamd_logger.warnx(rspamd_config,
-      'mx_check: `timeout` is deprecated; use `connect_timeout` (mapped automatically)')
+  if legacy_timeout ~= nil then
+    if opts.connect_timeout == nil then
+      opts.connect_timeout = legacy_timeout
+      rspamd_logger.warnx(rspamd_config,
+        'mx_check: `timeout` is deprecated; use `connect_timeout` (mapped automatically)')
+    else
+      rspamd_logger.warnx(rspamd_config,
+        'mx_check: both `timeout` (deprecated) and `connect_timeout` are set; ignoring `timeout`')
+    end
   end
-  if legacy_wfg ~= nil and opts.verify_greeting == nil then
-    opts.verify_greeting = legacy_wfg
-    rspamd_logger.warnx(rspamd_config,
-      'mx_check: `wait_for_greeting` is deprecated; use `verify_greeting` (mapped automatically). '
-        .. 'Note: the new flag also adds multi-line banner parsing and reply-code validation.')
+  if legacy_wfg ~= nil then
+    if opts.verify_greeting == nil then
+      opts.verify_greeting = legacy_wfg
+      rspamd_logger.warnx(rspamd_config,
+        'mx_check: `wait_for_greeting` is deprecated; use `verify_greeting` (mapped automatically). '
+          .. 'Note: the new flag also adds multi-line banner parsing and reply-code validation.')
+    else
+      rspamd_logger.warnx(rspamd_config,
+        'mx_check: both `wait_for_greeting` (deprecated) and `verify_greeting` are set; '
+          .. 'ignoring `wait_for_greeting`')
+    end
   end
   opts.timeout = nil
   opts.wait_for_greeting = nil

--- a/test/functional/cases/167_mx_check.robot
+++ b/test/functional/cases/167_mx_check.robot
@@ -47,6 +47,31 @@ Domain with no MX and no A (NODATA) is not treated as NXDOMAIN
   Expect Symbol  MX_INVALID
   Do Not Expect Symbol  MX_NXDOMAIN
 
+MX resolving only to private addresses emits MX_LOCAL_ONLY
+  Scan File  ${MESSAGE}  From=test@localmx.test  Settings=${SETTINGS}
+  Expect Symbol  MX_LOCAL_ONLY
+  Expect Symbol  MX_INVALID
+
+MX resolving only to non-routable addresses emits MX_BOGON_ONLY
+  Scan File  ${MESSAGE}  From=test@bogonmx.test  Settings=${SETTINGS}
+  Expect Symbol  MX_BOGON_ONLY
+  Expect Symbol  MX_INVALID
+
+MX hostname in exclude_mxs short-circuits with MX_WHITE
+  Scan File  ${MESSAGE}  From=test@trustedmx.test  Settings=${SETTINGS}
+  Expect Symbol  MX_WHITE
+  Do Not Expect Symbol  MX_INVALID
+
+MX whose only IP is in exclude_ips emits MX_SKIP
+  Scan File  ${MESSAGE}  From=test@skipmx.test  Settings=${SETTINGS}
+  Expect Symbol  MX_SKIP
+  Do Not Expect Symbol  MX_INVALID
+
+Local-network sender is skipped unless check_local is set
+  Scan File  ${MESSAGE}  From=test@nxdmx.test  IP=127.0.0.1  Settings=${SETTINGS}
+  Do Not Expect Symbol  MX_NXDOMAIN
+  Do Not Expect Symbol  MX_INVALID
+
 *** Keywords ***
 Mx Check Setup
   Rspamd Redis Setup

--- a/test/functional/cases/167_mx_check.robot
+++ b/test/functional/cases/167_mx_check.robot
@@ -1,0 +1,49 @@
+*** Settings ***
+Suite Setup     Mx Check Setup
+Suite Teardown  Mx Check Teardown
+Library         Process
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/mx_check.conf
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/spam_message.eml
+${REDIS_SCOPE}     Suite
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+${SETTINGS}        {symbols_enabled = [MX_INVALID]}
+
+*** Test Cases ***
+Null MX domain emits MX_NULL
+  Scan File  ${MESSAGE}  From=test@nullmx.test  Settings=${SETTINGS}
+  Expect Symbol  MX_NULL
+  # MX_INVALID is the primary skip-mail signal for Null MX domains
+  Expect Symbol  MX_INVALID
+
+NXDOMAIN domain emits MX_NXDOMAIN
+  Scan File  ${MESSAGE}  From=test@nxdmx.test  Settings=${SETTINGS}
+  Expect Symbol  MX_NXDOMAIN
+  Expect Symbol  MX_INVALID
+
+Broken MX target emits MX_BROKEN
+  Scan File  ${MESSAGE}  From=test@brokenmx.test  Settings=${SETTINGS}
+  Expect Symbol  MX_BROKEN
+  Expect Symbol  MX_INVALID
+
+Refused MX target emits MX_REFUSED
+  Scan File  ${MESSAGE}  From=test@refused.test  Settings=${SETTINGS}
+  Expect Symbol  MX_REFUSED
+  Expect Symbol  MX_INVALID
+
+A-fallback (no MX, A points at closed port) emits MX_MISSING and MX_INVALID
+  Scan File  ${MESSAGE}  From=test@amxmiss.test  Settings=${SETTINGS}
+  Expect Symbol  MX_MISSING
+  Expect Symbol  MX_INVALID
+
+*** Keywords ***
+Mx Check Setup
+  Rspamd Redis Setup
+
+Mx Check Teardown
+  Rspamd Redis Teardown

--- a/test/functional/cases/167_mx_check.robot
+++ b/test/functional/cases/167_mx_check.robot
@@ -41,6 +41,12 @@ A-fallback (no MX, A points at closed port) emits MX_MISSING and MX_INVALID
   Expect Symbol  MX_MISSING
   Expect Symbol  MX_INVALID
 
+Domain with no MX and no A (NODATA) is not treated as NXDOMAIN
+  Scan File  ${MESSAGE}  From=test@noaddr.test  Settings=${SETTINGS}
+  Expect Symbol  MX_MISSING
+  Expect Symbol  MX_INVALID
+  Do Not Expect Symbol  MX_NXDOMAIN
+
 *** Keywords ***
 Mx Check Setup
   Rspamd Redis Setup

--- a/test/functional/configs/mx_check-dns.conf
+++ b/test/functional/configs/mx_check-dns.conf
@@ -50,6 +50,17 @@ options {
         name = "amxmiss.test";
         type = "a";
         replies = ["127.0.0.1"];
+      },
+      {
+        # Domain exists (NODATA, not NXDOMAIN) but publishes neither MX nor A.
+        name = "noaddr.test";
+        type = "mx";
+        rcode = 'norec';
+      },
+      {
+        name = "noaddr.test";
+        type = "a";
+        rcode = 'norec';
       }
     ]
   }

--- a/test/functional/configs/mx_check-dns.conf
+++ b/test/functional/configs/mx_check-dns.conf
@@ -1,0 +1,56 @@
+options {
+  dns {
+    fake_records = [
+      {
+        name = "nullmx.test";
+        type = "mx";
+        replies = ["0 ."];
+      },
+      {
+        name = "nullmx.test";
+        type = "a";
+        rcode = 'nxdomain';
+      },
+      {
+        name = "nxdmx.test";
+        type = "mx";
+        rcode = 'nxdomain';
+      },
+      {
+        name = "nxdmx.test";
+        type = "a";
+        rcode = 'nxdomain';
+      },
+      {
+        name = "brokenmx.test";
+        type = "mx";
+        replies = ["10 nope.invalid"];
+      },
+      {
+        name = "nope.invalid";
+        type = "a";
+        rcode = 'nxdomain';
+      },
+      {
+        name = "refused.test";
+        type = "mx";
+        replies = ["10 closedport.refused.test"];
+      },
+      {
+        name = "closedport.refused.test";
+        type = "a";
+        replies = ["127.0.0.1"];
+      },
+      {
+        name = "amxmiss.test";
+        type = "mx";
+        rcode = 'norec';
+      },
+      {
+        name = "amxmiss.test";
+        type = "a";
+        replies = ["127.0.0.1"];
+      }
+    ]
+  }
+}

--- a/test/functional/configs/mx_check-dns.conf
+++ b/test/functional/configs/mx_check-dns.conf
@@ -61,6 +61,46 @@ options {
         name = "noaddr.test";
         type = "a";
         rcode = 'norec';
+      },
+      {
+        # MX target resolves into RFC1918 space -> MX_LOCAL_ONLY.
+        name = "localmx.test";
+        type = "mx";
+        replies = ["10 priv.localmx.test"];
+      },
+      {
+        name = "priv.localmx.test";
+        type = "a";
+        replies = ["10.11.12.13"];
+      },
+      {
+        # MX target resolves into TEST-NET-1 (bogon) space -> MX_BOGON_ONLY.
+        name = "bogonmx.test";
+        type = "mx";
+        replies = ["10 bad.bogonmx.test"];
+      },
+      {
+        name = "bad.bogonmx.test";
+        type = "a";
+        replies = ["192.0.2.10"];
+      },
+      {
+        # MX hostname matches exclude_mxs (*.trusted.test) -> MX_WHITE.
+        # No A record needed: the check short-circuits before resolving.
+        name = "trustedmx.test";
+        type = "mx";
+        replies = ["10 mail.trusted.test"];
+      },
+      {
+        # MX target IP matches exclude_ips -> probe set empties -> MX_SKIP.
+        name = "skipmx.test";
+        type = "mx";
+        replies = ["10 host.skipmx.test"];
+      },
+      {
+        name = "host.skipmx.test";
+        type = "a";
+        replies = ["127.0.0.9"];
       }
     ]
   }

--- a/test/functional/configs/mx_check.conf
+++ b/test/functional/configs/mx_check.conf
@@ -1,0 +1,16 @@
+.include(duplicate=merge,priority=0) "{= env.TESTDIR =}/configs/plugins.conf"
+.include(duplicate=merge,priority=1) "{= env.TESTDIR =}/configs/mx_check-dns.conf"
+
+redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+}
+
+mx_check {
+  enabled = true;
+  # Use port 1 (guaranteed closed everywhere) so connect_refused outcomes
+  # are deterministic and we don't need a privileged port-25 listener.
+  port = 1;
+  connect_timeout = 0.5;
+  read_timeout = 0.5;
+  greylist_invalid = false;
+}

--- a/test/functional/configs/mx_check.conf
+++ b/test/functional/configs/mx_check.conf
@@ -13,4 +13,10 @@ mx_check {
   connect_timeout = 0.5;
   read_timeout = 0.5;
   greylist_invalid = false;
+  # test_mode lifts loopback out of the bogon set so the probe path can be
+  # exercised against 127.0.0.1. Other reserved ranges (RFC1918, TEST-NET)
+  # still classify, so MX_LOCAL_* / MX_BOGON_* stay testable too.
+  test_mode = true;
+  exclude_mxs = ["*.trusted.test"];
+  exclude_ips = ["127.0.0.9/32"];
 }


### PR DESCRIPTION
## Summary

Reworks the `mx_check` core (Phase A) and adds IP-class classification, per-layer trust maps, and run-scope toggles (Phase C) from the plan in #6032. **Operator-visible scoring is unchanged**: the primary symbols (`MX_GOOD`, `MX_INVALID`, `MX_MISSING`, `MX_WHITE`) keep today's defaults and emission rules. Every new symbol is emitted alongside at score 0 so deployments can collect tuning data before Phase B turns on real default scores.

Depends on the `lua_tcp` enabling change in #6034 (already merged) — phased timeouts and the connect-phase `on_error` callback.

Phase B (two-path `MX_*` / `MX_A_*` matrix, per-source `MIME_FROM_*` / `REPLY_TO_*` families, retiring `MX_MISSING`) and IPv6 probing remain out of scope, landing separately per #6032.

## Phase A — core rework

**Three-layer Redis cache** under `<key_prefix>:` (default `rmx:`):

| Key               | Value examples                                             |
|-------------------|------------------------------------------------------------|
| `rmx:d:<domain>`  | `mx:host1:10,host2:5` / `mx_miss:1.2.3.4` / `nxd` / `null` |
| `rmx:m:<mx_host>` | `1.2.3.4,5.6.7.8` / `nxd`                                  |
| `rmx:i:<ip>`      | `good` / `refused` / `timeout_connect` / `timeout_read` / `invalid` / `error:<code>` |

Two domains pointing at a shared MX host reuse the `m:` and `i:` entries — the second hits cache at every step. Old single-layer keys age out under their own TTL; no migration needed.

**Probe-shape split** using #6034's options: `probe_connect_only` (TCP-connectivity check, distinguishes refused / timeout / unreachable via `on_error`) and `probe_with_greeting` (banner parse with RFC 5321 §4.2.1 multi-line support and reply-code validation).

**Greeting controls.** `wait_for_greeting` (conflated "read the banner" with "send QUIT", and emitted `MX_GOOD` on *any* CRLF-terminated line, including mid-banner) is replaced by `verify_greeting` (validate the reply code: 2xx → good, 4xx/5xx → `MX_ERROR`) and a separate `send_quit` flag that waits for the final banner line.

**New outcome symbols** (score 0; primary `MX_INVALID` still fires alongside): `MX_REFUSED`, `MX_TIMEOUT_CONNECT`, `MX_TIMEOUT_READ`, `MX_ERROR` (4xx/5xx, code as parameter), `MX_NXDOMAIN`, `MX_NULL` (RFC 7505 Null MX), `MX_BROKEN` (all MX RRs unresolvable).

**Deprecation aliases**, mapped at config load with a warning: `timeout` → `connect_timeout`, `wait_for_greeting` → `verify_greeting`. The shipped `modules.d/mx_check.conf` deliberately does not pre-set the new keys, so a legacy alias in `local.d` is honoured.

## Phase C — IP-class classification, trust maps, run scope

**IP-class classification.** Resolved MX-target IPs are partitioned PUBLIC / LOCAL / BOGON against fixed RFC range sets. LOCAL (RFC1918 / CGNAT / ULA) is unprobeable from our vantage point — probing it reaches our own LAN, not the publisher's. BOGON (loopback, link-local, TEST-NET, multicast, reserved) has no legitimate meaning as a published MX target and is a packet-injection footgun. Only PUBLIC IPs are probed; the rest emit `MX_LOCAL_ONLY` / `MX_LOCAL_MIX` and `MX_BOGON_ONLY` / `MX_BOGON_MIX`. The range sets are a correctness invariant — not operator-tunable.

**Per-layer trust/skip maps.** `exclude_mxs` (glob map — a bare hostname matches exactly, an explicit `*.foo` matches subdomains) short-circuits the whole check with `MX_WHITE` when a trusted MX host is seen. `exclude_ips` (radix) drops matched IPs from the probe set; if the set empties as a result, `MX_SKIP` fires. These join the existing `exclude_domains`.

**Run-scope toggles.** `check_authorized` and `check_local` (both default `false`) control whether authenticated and local-network senders are checked — useful for ESP / outbound deployments. The default (skip both) preserves today's behaviour.

**`test_mode`** (testing only, default `false`): lifts loopback out of the bogon set so the probe path can be exercised against a local listener. Never enable it in production.

## Caveats

- The IPv4-mapped range `::ffff:0:0/96` is intentionally left out of the bogon set: rspamd's radix stores every IPv4 address as its v4-mapped form, so listing that prefix would classify all IPv4 traffic as bogon. v4-mapped IPv6 MX targets can only arise once AAAA probing lands and must be handled outside the radix test.
- `lua_tcp_request` still validates `callback` even with `read = false`; the connect-only probe passes a no-op stub.
- UCL doesn't merge multiple top-level `options{}` blocks; the functional test config splits its `fake_records` into a separate include with `duplicate=merge`.

## Test plan

- `luacheck src/plugins/lua/mx_check.lua` — clean.
- `cases/167_mx_check.robot` — 11/11 pass: Null MX, NXDOMAIN, broken MX, NODATA-is-not-NXDOMAIN, connect-refused, A-fallback, `MX_LOCAL_ONLY`, `MX_BOGON_ONLY`, `exclude_mxs` → `MX_WHITE`, `exclude_ips` → `MX_SKIP`, local-sender skip.
- `cases/230_tcp.robot` — passes (regression check on `lua_tcp` callers).

Refs #6032.
