### PR TITLE
[Fix] neural: preserve trained ANN across symcache-driven profile rotation

### DIFF
--- a/lualib/plugins/neural.lua
+++ b/lualib/plugins/neural.lua
@@ -717,6 +717,59 @@ local function pending_train_key(rule, set)
     settings.prefix, rule.prefix, set.name)
 end
 
+-- Check whether a candidate profile (loaded from the zset) is compatible with
+-- the running rule/set configuration for the purposes of loading the trained
+-- ANN.  Compatibility is governed by the vector schema fingerprint:
+--
+--   * has_providers + disable_symbols_input: symbols never enter the input
+--     vector, so providers_digest alone is authoritative. Symbol-list drift
+--     is ignored (dist = 0 when providers_digest matches).
+--   * has_providers (hybrid mode): providers_digest must match (otherwise the
+--     fused vector dimensions differ); symbol drift is tolerated and surfaced
+--     as the returned dist for the caller's tie-breaking.
+--   * pure symbols (no providers): legacy Levenshtein-tolerance — accept when
+--     dist < 30% of |set.symbols|.
+--
+-- Profiles trained with providers are rejected for pure-symbol rules (mixed
+-- vector schemas) and vice versa.
+--
+-- Returns (compatible_bool, dist_number).  `dist` is math.huge on rejection.
+local function is_profile_compatible(rule, set, profile_elt, current_providers_digest)
+  if not profile_elt then return false, math.huge end
+  local has_providers = rule.providers and #rule.providers > 0
+
+  if has_providers then
+    if not current_providers_digest or not profile_elt.providers_digest then
+      return false, math.huge
+    end
+    if profile_elt.providers_digest ~= current_providers_digest then
+      return false, math.huge
+    end
+    if rule.disable_symbols_input then
+      return true, 0
+    end
+    local dist = 0
+    if profile_elt.symbols and set.symbols then
+      dist = lua_util.distance_sorted(profile_elt.symbols, set.symbols)
+    end
+    return true, dist
+  end
+
+  -- Pure symbols mode: reject profiles trained with providers (vector schemas
+  -- would be incompatible).
+  if profile_elt.providers_digest then
+    return false, math.huge
+  end
+  if not profile_elt.symbols or not set.symbols then
+    return false, math.huge
+  end
+  local dist = lua_util.distance_sorted(profile_elt.symbols, set.symbols)
+  if dist >= #set.symbols * 0.3 then
+    return false, dist
+  end
+  return true, dist
+end
+
 -- Compute a stable digest for providers configuration
 local function providers_config_digest(providers_cfg, rule)
   if not providers_cfg then return nil end
@@ -1495,6 +1548,7 @@ return {
   gen_unlock_cb = gen_unlock_cb,
   get_provider = get_provider,
   get_rule_settings = get_rule_settings,
+  is_profile_compatible = is_profile_compatible,
   load_scripts = load_scripts,
   module_config = module_config,
   new_ann_key = new_ann_key,

--- a/src/plugins/lua/neural.lua
+++ b/src/plugins/lua/neural.lua
@@ -57,9 +57,14 @@ end
 local has_blas = rspamd_tensor.has_blas()
 local text_cookie = rspamd_text.cookie
 
+-- Forward declarations
+local maybe_carryover_ann
+local load_ann_profile
+
 -- Creates and stores ANN profile in Redis
 local function new_ann_profile(task, rule, set, version)
   local ann_key = neural_common.new_ann_key(rule, set, version, settings)
+  local providers_digest = neural_common.providers_config_digest(rule.providers, rule)
 
   local profile = {
     symbols = set.symbols,
@@ -67,7 +72,7 @@ local function new_ann_profile(task, rule, set, version)
     version = version,
     digest = set.digest,
     distance = 0, -- Since we are using our own profile
-    providers_digest = neural_common.providers_config_digest(rule.providers, rule),
+    providers_digest = providers_digest,
   }
 
   local ucl = require "ucl"
@@ -80,6 +85,14 @@ local function new_ann_profile(task, rule, set, version)
     else
       rspamd_logger.infox(task, 'created new ANN profile for %s:%s, data stored at prefix %s',
         rule.prefix, set.name, profile.redis_key)
+      -- If a prior profile with the same providers_digest holds trained
+      -- weights, carry them over into the fresh profile key.  This prevents
+      -- a symcache-driven profile rotation from abandoning a still-valid
+      -- ANN whenever the input vector schema is decided by providers
+      -- (rather than the symbol list).
+      if providers_digest then
+        maybe_carryover_ann(task, rule, set, ann_key, providers_digest)
+      end
     end
   end
 
@@ -925,22 +938,25 @@ end
 -- the existing ones.
 -- Use this function to load ANNs as `callback` parameter for `check_anns` function
 local function process_existing_ann(_, ev_base, rule, set, profiles)
-  local my_symbols = set.symbols
+  local has_providers = rule.providers and #rule.providers > 0
+  local current_providers_digest = has_providers and
+      neural_common.providers_config_digest(rule.providers, rule) or nil
   local min_diff = math.huge
   local sel_elt
-  lua_util.debugm(N, rspamd_config, 'process_existing_ann: have %s profiles for %s:%s',
-    type(profiles) == 'table' and #profiles or -1, rule.prefix, set.name)
+  lua_util.debugm(N, rspamd_config,
+    'process_existing_ann: have %s profiles for %s:%s (providers_digest=%s)',
+    type(profiles) == 'table' and #profiles or -1, rule.prefix, set.name,
+    current_providers_digest or 'none')
 
   for _, elt in fun.iter(profiles) do
-    if elt and elt.symbols then
-      local dist = lua_util.distance_sorted(elt.symbols, my_symbols)
-      -- Check distance
-      if dist < #my_symbols * .3 then
-        -- Prefer profiles with smaller distance, or higher version when distance is equal
-        if dist < min_diff or (dist == min_diff and sel_elt and elt.version > sel_elt.version) then
-          min_diff = dist
-          sel_elt = elt
-        end
+    local compatible, dist = neural_common.is_profile_compatible(
+      rule, set, elt, current_providers_digest)
+    if compatible then
+      -- Prefer smaller distance; tie-break on higher version
+      if dist < min_diff
+          or (dist == min_diff and sel_elt and (elt.version or 0) > (sel_elt.version or 0)) then
+        min_diff = dist
+        sel_elt = elt
       end
     end
   end
@@ -961,11 +977,18 @@ local function process_existing_ann(_, ev_base, rule, set, profiles)
     }
     -- We can load element from ANN
     if set.ann then
-      -- We have an existing ANN, probably the same...
+      -- Providers schema acts as the dominant identity when configured: even
+      -- if the symbol-digest portion drifted (symcache shift), a matching
+      -- providers_digest means the vector shape (and therefore the trained
+      -- weights) are still valid.  Reload purely on version freshness in
+      -- that case.
+      local providers_compatible = has_providers and current_providers_digest
+          and set.ann.providers_digest == current_providers_digest
+          and sel_elt.providers_digest == current_providers_digest
+
       if set.ann.digest == sel_elt.digest then
         -- Same ANN, check version
-        if set.ann.version < sel_elt.version then
-          -- Load new ann
+        if (set.ann.version or 0) < (sel_elt.version or 0) then
           rspamd_logger.infox(rspamd_config, 'ann %s is changed, ' ..
             'our version = %s, remote version = %s',
             rule.prefix .. ':' .. set.name,
@@ -979,10 +1002,22 @@ local function process_existing_ann(_, ev_base, rule, set, profiles)
             set.ann.version,
             sel_elt.version)
         end
+      elseif providers_compatible then
+        if (sel_elt.version or 0) > (set.ann.version or 0) then
+          rspamd_logger.infox(rspamd_config,
+            'providers schema matches for %s; reload newer version %s (ours = %s)',
+            rule.prefix .. ':' .. set.name,
+            sel_elt.version, set.ann.version)
+          load_new_ann(rule, ev_base, set, sel_elt, min_diff)
+        else
+          lua_util.debugm(N, rspamd_config,
+            'providers schema matches for %s; our version %s >= remote %s, no reload',
+            rule.prefix .. ':' .. set.name,
+            set.ann.version, sel_elt.version)
+        end
       else
         -- We have some different ANN, so we need to compare distance
-        if set.ann.distance > min_diff then
-          -- Load more specific ANN
+        if (set.ann.distance or math.huge) > min_diff then
           rspamd_logger.infox(rspamd_config, 'more specific ann is available for %s, ' ..
             'our distance = %s, remote distance = %s',
             rule.prefix .. ':' .. set.name,
@@ -1015,7 +1050,9 @@ end
 -- ANN. By our we mean that it has exactly the same symbols in profile.
 -- Use this function to train ANN as `callback` parameter for `check_anns` function
 local function maybe_train_existing_ann(worker, ev_base, rule, set, profiles)
-  local my_symbols = set.symbols
+  local has_providers = rule.providers and #rule.providers > 0
+  local current_providers_digest = has_providers and
+      neural_common.providers_config_digest(rule.providers, rule) or nil
   local sel_elt
   local lens = {
     spam = 0,
@@ -1024,14 +1061,16 @@ local function maybe_train_existing_ann(worker, ev_base, rule, set, profiles)
   lua_util.debugm(N, rspamd_config, 'maybe_train_existing_ann: %s profiles for %s:%s',
     type(profiles) == 'table' and #profiles or -1, rule.prefix, set.name)
 
+  -- Strict match: training data accumulated against an existing profile
+  -- must come from a compatible vector schema.  is_profile_compatible
+  -- returns dist=0 when symbols are irrelevant (disable_symbols_input) or
+  -- when symbol-lists actually match.
   for _, elt in fun.iter(profiles) do
-    if elt and elt.symbols then
-      local dist = lua_util.distance_sorted(elt.symbols, my_symbols)
-      -- Check distance
-      if dist == 0 then
-        sel_elt = elt
-        break
-      end
+    local compatible, dist = neural_common.is_profile_compatible(
+      rule, set, elt, current_providers_digest)
+    if compatible and dist == 0 then
+      sel_elt = elt
+      break
     end
   end
 
@@ -1175,7 +1214,7 @@ local function maybe_train_existing_ann(worker, ev_base, rule, set, profiles)
 end
 
 -- Used to deserialise ANN element from a list
-local function load_ann_profile(element)
+load_ann_profile = function(element)
   local ucl = require "ucl"
 
   local parser = ucl.parser()
@@ -1194,6 +1233,127 @@ local function load_ann_profile(element)
     end
     return checked
   end
+end
+
+-- Async carryover: look up the most recent zset entry with the same
+-- providers_digest and a trained ANN blob, then copy its
+-- ann/roc_thresholds/pca/providers_meta/norm_stats fields into the freshly
+-- created profile's redis_key.  Only runs when the new key has no ANN yet,
+-- so this never overwrites a freshly-trained model.
+maybe_carryover_ann = function(task, rule, set, new_key, target_providers_digest)
+  local function zrange_cb(err, data)
+    if err or type(data) ~= 'table' then
+      lua_util.debugm(N, task, 'carryover: cannot read zset %s: %s',
+        set.prefix, err)
+      return
+    end
+
+    local source_key
+    for _, raw in ipairs(data) do
+      local profile = load_ann_profile(raw)
+      if profile
+          and profile.providers_digest == target_providers_digest
+          and profile.redis_key ~= new_key then
+        source_key = profile.redis_key
+        break
+      end
+    end
+
+    if not source_key then
+      lua_util.debugm(N, task,
+        'carryover: no prior profile with matching providers_digest for %s:%s',
+        rule.prefix, set.name)
+      return
+    end
+
+    local function hmset_cb(hmset_err)
+      if hmset_err then
+        rspamd_logger.errx(task,
+          'carryover: cannot copy ANN from %s to %s: %s',
+          source_key, new_key, hmset_err)
+      else
+        rspamd_logger.infox(task,
+          'carryover: copied ANN weights from %s into fresh profile %s ' ..
+          '(providers_digest unchanged)',
+          source_key, new_key)
+      end
+    end
+
+    local function hmget_cb(hmget_err, hmget_data)
+      if hmget_err or type(hmget_data) ~= 'table' then
+        lua_util.debugm(N, task,
+          'carryover: HMGET error for %s: %s', source_key, hmget_err)
+        return
+      end
+      if not (type(hmget_data[1]) == 'userdata' and hmget_data[1].cookie == text_cookie) then
+        lua_util.debugm(N, task,
+          'carryover: source key %s has no ANN blob', source_key)
+        return
+      end
+
+      local fields = { 'ann', 'roc_thresholds', 'pca', 'providers_meta', 'norm_stats' }
+      local args = { new_key }
+      for i, fname in ipairs(fields) do
+        local v = hmget_data[i]
+        if type(v) == 'userdata' and v.cookie == text_cookie then
+          args[#args + 1] = fname
+          args[#args + 1] = v
+        end
+      end
+
+      if #args <= 1 then
+        lua_util.debugm(N, task,
+          'carryover: nothing to copy from %s', source_key)
+        return
+      end
+
+      lua_redis.redis_make_request(task,
+        rule.redis,
+        nil,
+        true,
+        hmset_cb,
+        'HMSET',
+        args)
+    end
+
+    local function exists_cb(hex_err, hex_data)
+      if hex_err then
+        lua_util.debugm(N, task,
+          'carryover: HEXISTS error for %s: %s', new_key, hex_err)
+        return
+      end
+      if tonumber(hex_data) == 1 then
+        lua_util.debugm(N, task,
+          'carryover: %s already has an ANN, skipping copy', new_key)
+        return
+      end
+
+      lua_redis.redis_make_request(task,
+        rule.redis,
+        nil,
+        false,
+        hmget_cb,
+        'HMGET',
+        { source_key, 'ann', 'roc_thresholds', 'pca', 'providers_meta', 'norm_stats' },
+        { opaque_data = true })
+    end
+
+    lua_redis.redis_make_request(task,
+      rule.redis,
+      nil,
+      false,
+      exists_cb,
+      'HEXISTS',
+      { new_key, 'ann' })
+  end
+
+  lua_redis.redis_make_request(task,
+    rule.redis,
+    nil,
+    false,
+    zrange_cb,
+    'ZREVRANGE',
+    { set.prefix, '0', tostring(settings.max_profiles) })
 end
 
 -- Function to check or load ANNs from Redis

--- a/test/functional/cases/330_neural/003_carryover.robot
+++ b/test/functional/cases/330_neural/003_carryover.robot
@@ -1,0 +1,49 @@
+*** Settings ***
+Suite Setup      Rspamd Redis Setup
+Suite Teardown   Rspamd Redis Teardown
+Library         Process
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/neural_rotation.conf
+${SPAM_MSG}        ${RSPAMD_TESTDIR}/messages/spam.eml
+${HAM_MSG}         ${RSPAMD_TESTDIR}/messages/ham.eml
+${REDIS_SCOPE}     Suite
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+Train providers-driven ANN
+  # max_trains=1 means a single spam + single ham scan triggers training.
+  # Metatokens-only vector + disable_symbols_input=true makes the input
+  # vector independent of which symbols fire — providers_digest is the
+  # only schema fingerprint.
+  Sleep  2s  Wait for redis and initial check_anns
+  Scan File  ${SPAM_MSG}  Settings={symbols_enabled = ["SPAM_SYMBOL1", "SPAM_SYMBOL2", "SPAM_SYMBOL3"]}
+  Expect Symbol  SPAM_SYMBOL1
+  Scan File  ${HAM_MSG}   Settings={symbols_enabled = ["HAM_SYMBOL1", "HAM_SYMBOL2", "HAM_SYMBOL3"]}
+  Expect Symbol  HAM_SYMBOL1
+
+Inference fires before rotation
+  Sleep  5s  Wait for training to complete and ANN to be reloaded
+  Scan File  ${SPAM_MSG}  Settings={symbols_enabled = ["SPAM_SYMBOL1","SPAM_SYMBOL2","SPAM_SYMBOL3"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_SPAM_SHORT
+  Scan File  ${HAM_MSG}   Settings={symbols_enabled = ["HAM_SYMBOL1","HAM_SYMBOL2","HAM_SYMBOL3"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_HAM_SHORT
+
+Force symcache-style rotation
+  # Mutate set.symbols/set.digest in the scanner worker so the next
+  # check_anns poll re-runs profile selection.  With the fix, the
+  # providers_digest-based match preserves the trained ANN; pre-fix
+  # the symbol-digest shift would orphan it.
+  Scan File  ${SPAM_MSG}  Settings={symbols_enabled = ["FORCE_ROTATE_NEURAL"];symbols_disabled = ["NEURAL_LEARN","NEURAL_CHECK"]}
+  Expect Symbol  FORCE_ROTATE_NEURAL
+  Sleep  3s  Wait for check_anns periodic to reload after rotation
+
+Inference still fires after rotation
+  Scan File  ${SPAM_MSG}  Settings={symbols_enabled = ["SPAM_SYMBOL1","SPAM_SYMBOL2","SPAM_SYMBOL3"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_SPAM_SHORT
+  Scan File  ${HAM_MSG}   Settings={symbols_enabled = ["HAM_SYMBOL1","HAM_SYMBOL2","HAM_SYMBOL3"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_HAM_SHORT

--- a/test/functional/configs/neural_rotation.conf
+++ b/test/functional/configs/neural_rotation.conf
@@ -1,0 +1,82 @@
+options = {
+  url_tld = "{= env.URL_TLD =}"
+  pidfile = "{= env.TMPDIR =}/rspamd.pid"
+  lua_path = "{= env.INSTALLROOT =}/share/rspamd/lib/?.lua"
+  filters = [];
+  explicit_modules = ["settings"];
+}
+
+logging = {
+  type = "file",
+  level = "debug"
+  filename = "{= env.TMPDIR =}/rspamd.log"
+  log_usec = true;
+}
+metric = {
+  name = "default",
+  actions = {
+    reject = 100500,
+    add_header = 50500,
+  }
+  unknown_weight = 1
+}
+worker {
+  type = normal
+  bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_NORMAL =}"
+  count = 1
+  task_timeout = 10s;
+}
+worker {
+  type = controller
+  bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_CONTROLLER =}"
+  count = 1
+  secure_ip = ["127.0.0.1", "::1"];
+  stats_path = "{= env.TMPDIR =}/stats.ucl"
+}
+
+modules {
+  path = "{= env.TESTDIR =}/../../src/plugins/lua/"
+}
+
+lua = "{= env.TESTDIR =}/lua/test_coverage.lua";
+
+neural {
+  rules {
+      SHORT {
+          train {
+              learning_rate = 0.001;
+              max_usages = 2;
+              spam_score = 1;
+              ham_score = -1;
+              # metatokens-only vectors deduplicate per message in Redis SADD,
+              # so a single sample per class is enough — keep max_trains at 1
+              # so balanced-mode training fires after one spam + one ham scan.
+              max_trains = 1;
+              max_iterations = 250;
+              classes_bias = 0.0;
+          }
+          symbol_spam = "NEURAL_SPAM_SHORT";
+          symbol_ham = "NEURAL_HAM_SHORT";
+          ann_expire = 86400;
+          watch_interval = 0.5;
+          # Providers-driven input vector; symbol set is decoupled from the ANN.
+          # Rotating set.symbols/set.digest mid-life must not invalidate the
+          # trained model so long as providers_digest stays constant.
+          providers = [
+            { type = "metatokens"; }
+          ];
+          disable_symbols_input = true;
+          fusion {
+            include_meta = false;
+            normalization = "none";
+          }
+      }
+  }
+  allow_local = true;
+}
+redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+  expand_keys = true;
+}
+
+lua = "{= env.TESTDIR =}/lua/neural_rotation.lua";

--- a/test/functional/lua/neural_rotation.lua
+++ b/test/functional/lua/neural_rotation.lua
@@ -1,0 +1,73 @@
+-- Test helper for the providers-digest rotation scenario.
+--
+-- Mirrors the SPAM_SYMBOL{i}/HAM_SYMBOL{i} setup from neural.lua (so a Robot
+-- suite can drive autolearn via verdict scoring) and adds a callback symbol
+-- that forces a symcache-style rotation: mutates the loaded neural rule's
+-- settings to flip set.symbols and set.digest in place, then clears
+-- set.ann/set.training_profile so the next check_anns poll re-runs profile
+-- selection.
+--
+-- With providers configured + disable_symbols_input=true, the rotation must
+-- not invalidate the trained ANN: providers_digest stays constant, so the
+-- old profile is still compatible and must be reloaded.
+
+local lua_util = require "lua_util"
+local neural_common = require "plugins/neural"
+
+for i = 1, 14 do
+  rspamd_config:register_symbol({
+    name = 'SPAM_SYMBOL' .. tostring(i),
+    score = 5.0,
+    callback = function()
+      return true, 'Fires always'
+    end
+  })
+  rspamd_config:register_symbol({
+    name = 'HAM_SYMBOL' .. tostring(i),
+    score = -3.0,
+    callback = function()
+      return true, 'Fires always'
+    end
+  })
+end
+
+-- Force an in-place "symcache shift" on the loaded neural rule(s).
+-- Appends a unique symbol to set.symbols, recomputes set.digest, and clears
+-- the loaded ANN reference so the next check_anns poll re-selects a profile
+-- from Redis.
+--
+-- IMPORTANT: registered WITHOUT explicit_disable so it stays subject to the
+-- symbols_enabled allowlist — otherwise it would fire on every training scan
+-- and trample set.can_store_vectors before training data can accumulate.
+-- Replace set.symbols with a wholly fresh list so the Levenshtein distance
+-- against the stored profile exceeds the legacy 30% tolerance — pre-fix this
+-- would orphan the trained ANN; with providers_digest matching it is still
+-- recognised as compatible.
+local rotation_counter = 0
+rspamd_config.FORCE_ROTATE_NEURAL = {
+  callback = function(task)
+    rotation_counter = rotation_counter + 1
+    for _, rule in pairs(neural_common.settings.rules or {}) do
+      for _, set in pairs(rule.settings or {}) do
+        if type(set) == 'table' and type(set.symbols) == 'table' then
+          local fresh = {}
+          for i = 1, math.max(#set.symbols * 2, 32) do
+            fresh[#fresh + 1] = string.format('ROTATED_SYM_%d_%d',
+              rotation_counter, i)
+          end
+          table.sort(fresh)
+          set.symbols = fresh
+          set.digest = lua_util.table_digest(fresh)
+          set.ann = nil
+          set.training_profile = nil
+          -- Leave set.can_store_vectors alone: check_anns has already
+          -- populated profile state for this set, the next poll will
+          -- reselect from Redis.
+        end
+      end
+    end
+    return true, 1.0, string.format('rotated_%d', rotation_counter)
+  end
+}
+
+dofile(rspamd_env.INSTALLROOT .. "/share/rspamd/rules/controller/init.lua")


### PR DESCRIPTION
## Summary

- When the per-rule symbol digest shifts (any symcache change — added or removed symbol, even unrelated to the neural rule), the plugin historically picked a brand-new profile and abandoned the previously-trained ANN at the old `redis_key`. For deployments where the input vector is built from providers (e.g. `fasttext_embed` conv1d) with `disable_symbols_input = true`, the symbol list is irrelevant to the vector schema, so the rotation needlessly reset inference until enough new training data accumulated.
- This PR makes `providers_digest` the authoritative schema fingerprint when `providers` are configured. `is_profile_compatible` (new helper in `lualib/plugins/neural.lua`) ignores symbol-list drift entirely when `disable_symbols_input = true`, and tolerates unbounded drift in hybrid (providers + symbols) rules where symbols are only a minor slice of the fused vector. Pure-symbols rules keep the legacy 30% Levenshtein tolerance and now also reject profiles trained with providers (vector schemas differ).
- As a belt-and-suspenders, `new_ann_profile` triggers an async carryover after the `ZADD`: `ZREVRANGE` the zset, find the most recent prior profile with a matching `providers_digest`, and `HMSET` its `ann` / `roc_thresholds` / `pca` / `providers_meta` / `norm_stats` into the new key. Gated on `HEXISTS new_key ann == 0` so a freshly-trained model is never overwritten.

## Test plan

Functional regression test added at `test/functional/cases/330_neural/003_carryover.robot` (with `neural_rotation.conf` + `neural_rotation.lua`). It drives a live rspamd + Redis through train → assert inference → mutate `set.symbols`/`set.digest` in the scanner worker (simulates a symcache shift past the legacy 30% tolerance) → assert inference still fires after `check_anns` reloads.

- [x] All three 330 Neural suites pass with the fix: `001_autotrain`, `002_manualtrain`, `003_carryover`.
- [x] Confirmed the new test is load-bearing: reverting just the plugin changes (keeping the test) reproduces the regression — `Inference still fires after rotation` FAILS on master, PASSES on this branch.
- [x] Full Lua unit suite (`test/rspamd-test -p /rspamd/lua`) — 1025 tests, 0 failures.
- [x] `luacheck` clean on `src/plugins/lua/neural.lua` and `lualib/plugins/neural.lua`.