### PR TITLE
[Feature] url_redirector: stealth-mode browser fingerprint profiles

### DIFF
--- a/src/libserver/http/http_connection.c
+++ b/src/libserver/http/http_connection.c
@@ -1565,6 +1565,7 @@ rspamd_http_connection_copy_msg(struct rspamd_http_message *msg, GError **err)
 	new_msg->port = msg->port;
 	new_msg->date = msg->date;
 	new_msg->last_modified = msg->last_modified;
+	new_msg->header_cnt = msg->header_cnt;
 
 	kh_foreach_value(msg->headers, hdr, {
 		nhdrs = NULL;
@@ -1581,6 +1582,7 @@ rspamd_http_connection_copy_msg(struct rspamd_http_message *msg, GError **err)
 			nhdr->value.begin = nhdr->combined->str +
 								(hcur->value.begin - hcur->combined->str);
 			nhdr->value.len = hcur->value.len;
+			nhdr->order = hcur->order;
 			DL_APPEND(nhdrs, nhdr);
 		}
 
@@ -1692,6 +1694,28 @@ void rspamd_http_connection_read_message_shared(struct rspamd_http_connection *c
 											   RSPAMD_HTTP_FLAG_SHMEM);
 }
 
+/*
+ * Comparator for sorting header nodes by their insertion order. Used when
+ * RSPAMD_HTTP_FLAG_ORDERED_HEADERS is set so headers leave on the wire in the
+ * exact order the caller added them, instead of hash bucket order. Each header
+ * gets a unique `order` value, so qsort's instability never bites here.
+ */
+static int
+rspamd_http_header_cmp_order(const void *a, const void *b)
+{
+	const struct rspamd_http_header *ha = *(struct rspamd_http_header *const *) a;
+	const struct rspamd_http_header *hb = *(struct rspamd_http_header *const *) b;
+
+	if (ha->order < hb->order) {
+		return -1;
+	}
+	else if (ha->order > hb->order) {
+		return 1;
+	}
+
+	return 0;
+}
+
 static void
 rspamd_http_connection_encrypt_message(
 	struct rspamd_http_connection *conn,
@@ -1746,12 +1770,37 @@ rspamd_http_connection_encrypt_message(
 	}
 
 
-	kh_foreach_value (msg->headers, hdr, {
-		DL_FOREACH (hdr, hcur) {
-			segments[i].data = hcur->combined->str;
-			segments[i++].len = hcur->combined->len;
+	if (msg->flags & RSPAMD_HTTP_FLAG_ORDERED_HEADERS) {
+		struct rspamd_http_header **hdrs_sorted;
+		unsigned int nhdrs = 0;
+
+		hdrs_sorted = g_malloc(sizeof(*hdrs_sorted) * (hdrcount + 1));
+
+		kh_foreach_value (msg->headers, hdr, {
+			DL_FOREACH (hdr, hcur) {
+				hdrs_sorted[nhdrs++] = hcur;
+	}
+});
+
+qsort(hdrs_sorted, nhdrs, sizeof(*hdrs_sorted),
+	  rspamd_http_header_cmp_order);
+
+for (unsigned int j = 0; j < nhdrs; j++) {
+	segments[i].data = hdrs_sorted[j]->combined->str;
+	segments[i++].len = hdrs_sorted[j]->combined->len;
+}
+
+g_free(hdrs_sorted);
+}
+else
+{
+		kh_foreach_value (msg->headers, hdr, {
+			DL_FOREACH (hdr, hcur) {
+				segments[i].data = hcur->combined->str;
+				segments[i++].len = hcur->combined->len;
 }
 });
+}
 
 /* crlfp should point now at the second crlf */
 segments[i].data = crlfp;
@@ -2282,6 +2331,7 @@ rspamd_http_connection_write_message_common(struct rspamd_http_connection *conn,
 			hdr->name.len = srch.len;
 			hdr->value.begin = hdr->combined->str + srch.len + 2;
 			hdr->value.len = vlen;
+			hdr->order = msg->header_cnt++;
 			hdr->prev = hdr; /* for utlists */
 
 			kh_value(msg->headers, k) = hdr;
@@ -2502,12 +2552,37 @@ if (encrypted) {
 else {
 	i = 1;
 	if (msg->method < HTTP_SYMBOLS) {
+		if (msg->flags & RSPAMD_HTTP_FLAG_ORDERED_HEADERS) {
+			struct rspamd_http_header **hdrs_sorted;
+			unsigned int nhdrs = 0;
+
+			hdrs_sorted = g_malloc(sizeof(*hdrs_sorted) * (hdrcount + 1));
+
+			kh_foreach_value (msg->headers, hdr, {
+				DL_FOREACH (hdr, hcur) {
+					hdrs_sorted[nhdrs++] = hcur;
+		}
+	});
+
+	qsort(hdrs_sorted, nhdrs, sizeof(*hdrs_sorted),
+		  rspamd_http_header_cmp_order);
+
+	for (unsigned int j = 0; j < nhdrs; j++) {
+		priv->out[i].iov_base = hdrs_sorted[j]->combined->str;
+		priv->out[i++].iov_len = hdrs_sorted[j]->combined->len;
+	}
+
+	g_free(hdrs_sorted);
+}
+else
+{
 			kh_foreach_value (msg->headers, hdr, {
 				DL_FOREACH (hdr, hcur) {
 					priv->out[i].iov_base = hcur->combined->str;
 					priv->out[i++].iov_len = hcur->combined->len;
-	}
+}
 });
+}
 
 priv->out[i].iov_base = "\r\n";
 priv->out[i++].iov_len = 2;

--- a/src/libserver/http/http_connection.h
+++ b/src/libserver/http/http_connection.h
@@ -88,6 +88,10 @@ struct rspamd_storage_shmem {
  */
 #define RSPAMD_HTTP_FLAG_WANT_SSL (1 << 9)
 /**
+ * Emit headers on the wire in insertion order instead of hash order
+ */
+#define RSPAMD_HTTP_FLAG_ORDERED_HEADERS (1 << 10)
+/**
  * Options for HTTP connection
  */
 enum rspamd_http_options {

--- a/src/libserver/http/http_message.c
+++ b/src/libserver/http/http_message.c
@@ -572,6 +572,7 @@ void rspamd_http_message_add_header_len(struct rspamd_http_message *msg,
 		hdr->name.len = nlen;
 		hdr->value.begin = hdr->combined->str + nlen + 2;
 		hdr->value.len = vlen;
+		hdr->order = msg->header_cnt++;
 
 		k = kh_put(rspamd_http_headers_hash, msg->headers, &hdr->name,
 				   &r);
@@ -616,6 +617,7 @@ void rspamd_http_message_add_header_fstr(struct rspamd_http_message *msg,
 		hdr->name.len = nlen;
 		hdr->value.begin = hdr->combined->str + nlen + 2;
 		hdr->value.len = vlen;
+		hdr->order = msg->header_cnt++;
 
 		k = kh_put(rspamd_http_headers_hash, msg->headers, &hdr->name,
 				   &r);

--- a/src/libserver/http/http_private.h
+++ b/src/libserver/http/http_private.h
@@ -36,6 +36,9 @@ struct rspamd_http_header {
 	rspamd_fstring_t *combined;
 	rspamd_ftok_t name;
 	rspamd_ftok_t value;
+	/* Insertion order, used to emit headers deterministically when
+	 * RSPAMD_HTTP_FLAG_ORDERED_HEADERS is set on the message */
+	unsigned int order;
 	struct rspamd_http_header *prev, *next;
 };
 
@@ -86,6 +89,8 @@ struct rspamd_http_message {
 	int code;
 	enum http_method method;
 	int flags;
+	/* Monotonic counter stamped onto each header as it is added */
+	unsigned int header_cnt;
 	ref_entry_t ref;
 };
 

--- a/src/lua/lua_http.c
+++ b/src/lua/lua_http.c
@@ -686,30 +686,90 @@ lua_http_push_headers(lua_State *L, struct rspamd_http_message *msg)
 {
 	const char *name, *value;
 	int i, sz;
+	int tbl = lua_gettop(L);
 
-	lua_pushnil(L);
-	while (lua_next(L, -2) != 0) {
+	/*
+	 * Two accepted shapes for the headers table:
+	 *  - map:  { ['Name'] = 'value', ['Name'] = {'v1', 'v2'} }  -- order undefined
+	 *  - list: { {'Name', 'value'}, {'Name', {'v1', 'v2'}} }    -- order preserved
+	 * The list shape sets RSPAMD_HTTP_FLAG_ORDERED_HEADERS so the HTTP client
+	 * emits headers on the wire in exactly the order they are listed (used to
+	 * mimic a real browser's header order). It is detected by a non-nil
+	 * integer key 1 whose value is itself a table.
+	 */
+	lua_rawgeti(L, tbl, 1);
+	if (lua_type(L, -1) == LUA_TTABLE) {
+		lua_pop(L, 1);
 
-		lua_pushvalue(L, -2);
-		name = lua_tostring(L, -1);
-		sz = rspamd_lua_table_size(L, -2);
-		if (sz != 0 && name != NULL) {
-			for (i = 1; i <= sz; i++) {
-				lua_rawgeti(L, -2, i);
-				value = lua_tostring(L, -1);
-				if (value != NULL) {
+		msg->flags |= RSPAMD_HTTP_FLAG_ORDERED_HEADERS;
+		sz = rspamd_lua_table_size(L, tbl);
+
+		for (i = 1; i <= sz; i++) {
+			lua_rawgeti(L, tbl, i); /* pair { name, value } */
+
+			if (lua_type(L, -1) == LUA_TTABLE) {
+				int pair = lua_gettop(L);
+				int vsz, j;
+
+				lua_rawgeti(L, pair, 1);
+				name = lua_tostring(L, -1);
+				lua_pop(L, 1);
+
+				lua_rawgeti(L, pair, 2);
+				vsz = rspamd_lua_table_size(L, -1);
+
+				if (name != NULL) {
+					if (vsz != 0) {
+						/* Duplicated header: value is a list of strings */
+						for (j = 1; j <= vsz; j++) {
+							lua_rawgeti(L, -1, j);
+							value = lua_tostring(L, -1);
+							if (value != NULL) {
+								rspamd_http_message_add_header(msg, name, value);
+							}
+							lua_pop(L, 1);
+						}
+					}
+					else {
+						value = lua_tostring(L, -1);
+						if (value != NULL) {
+							rspamd_http_message_add_header(msg, name, value);
+						}
+					}
+				}
+				lua_pop(L, 1); /* value */
+			}
+
+			lua_pop(L, 1); /* pair */
+		}
+	}
+	else {
+		lua_pop(L, 1);
+
+		lua_pushnil(L);
+		while (lua_next(L, tbl) != 0) {
+
+			lua_pushvalue(L, -2);
+			name = lua_tostring(L, -1);
+			sz = rspamd_lua_table_size(L, -2);
+			if (sz != 0 && name != NULL) {
+				for (i = 1; i <= sz; i++) {
+					lua_rawgeti(L, -2, i);
+					value = lua_tostring(L, -1);
+					if (value != NULL) {
+						rspamd_http_message_add_header(msg, name, value);
+					}
+					lua_pop(L, 1);
+				}
+			}
+			else {
+				value = lua_tostring(L, -2);
+				if (name != NULL && value != NULL) {
 					rspamd_http_message_add_header(msg, name, value);
 				}
-				lua_pop(L, 1);
 			}
+			lua_pop(L, 2);
 		}
-		else {
-			value = lua_tostring(L, -2);
-			if (name != NULL && value != NULL) {
-				rspamd_http_message_add_header(msg, name, value);
-			}
-		}
-		lua_pop(L, 2);
 	}
 }
 
@@ -729,7 +789,7 @@ lua_http_push_headers(lua_State *L, struct rspamd_http_message *msg)
  * @param {string} url specifies URL for a request in the standard URI form (e.g. 'http://example.com/path')
  * @param {function} callback specifies callback function in format  `function (err_message, code, body, headers)` that is called on HTTP request completion. if this parameter is missing, the function performs "pseudo-synchronous" call (see [Synchronous and Asynchronous API overview](/doc/developers/sync_async.html#API-example-http-module)
  * @param {task} task if called from symbol handler it is generally a good idea to use the common task objects: event base, DNS resolver and events session
- * @param {table} headers optional headers in form `[name='value']` or `[name=['value1', 'value2']]` to duplicate a header with multiple values
+ * @param {table} headers optional headers in form `[name='value']` or `[name=['value1', 'value2']]` to duplicate a header with multiple values. A list form `{{'name', 'value'}, {'name', {'value1', 'value2'}}}` is also accepted and preserves the header order on the wire
  * @param {string} mime_type MIME type of the HTTP content (for example, `text/html`)
  * @param {string/text} body full body content, can be opaque `rspamd{text}` to avoid data copying
  * @param {number} timeout floating point request timeout value in seconds (default is 5.0 seconds)

--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -26,34 +26,118 @@ local lua_util = require "lua_util"
 local lua_redis = require "lua_redis"
 local N = "url_redirector"
 
--- Some popular UA
-local default_ua = {
-  -- Search-engine and link crawlers
-  'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)',
-  'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
-  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-  'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
-  'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)',
-  -- Modern desktop browsers
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0',
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0',
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:150.0) Gecko/20100101 Firefox/150.0',
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15',
-  -- Modern mobile browsers
-  'Mozilla/5.0 (Linux; Android 14; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36',
-  'Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1',
-  -- CLI fetchers / link checkers
-  'Wget/1.25.0',
-  'curl/8.20.0',
-  'W3C-checklink/4.81 [4.176] libwww-perl/6.83',
-  'Lynx/2.9.2 libwww-FM/2.14 SSL-MM/1.4.1 OpenSSL/3.0.20',
-  -- HTTP client libraries (PHP / Go / Python)
-  'GuzzleHttp/7.10.0 curl/8.20.0 PHP/8.3.31',
-  'Go-http-client/2.0',
-  'python-requests/2.34.2',
-  'Python-urllib/3.14',
+-- Coherent browser fingerprint profiles.
+--
+-- The url_redirector resolves shortened/redirector URLs by issuing HTTP
+-- requests. Sites that cloak (serve different content to bots) commonly
+-- key on a missing or inconsistent header set, so a lone User-Agent
+-- string is the weakest possible disguise. Each profile instead bundles
+-- a User-Agent with the exact header set, values and order that the
+-- matching real browser sends, keeping the request internally consistent
+-- (e.g. Chrome carries `sec-ch-ua` client hints; Firefox and Safari do
+-- not).
+--
+-- `headers` is an ordered list of {name, value} pairs. rspamd_http keeps
+-- this order on the wire (RSPAMD_HTTP_FLAG_ORDERED_HEADERS); the Host
+-- header and request line are emitted by the HTTP client itself. One
+-- profile is picked per task so every hop of every chain shares a single
+-- identity, the way a real browser would.
+
+-- The Accept header all Chromium-based browsers send on a navigation.
+local chromium_accept = 'text/html,application/xhtml+xml,' ..
+    'application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,' ..
+    'application/signed-exchange;v=b3;q=0.7'
+
+local default_profiles = {
+  {
+    name = 'chrome_win',
+    headers = {
+      { 'Connection', 'keep-alive' },
+      { 'sec-ch-ua', '"Not)A;Brand";v="8", "Chromium";v="148", "Google Chrome";v="148"' },
+      { 'sec-ch-ua-mobile', '?0' },
+      { 'sec-ch-ua-platform', '"Windows"' },
+      { 'Upgrade-Insecure-Requests', '1' },
+      { 'User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36' },
+      { 'Accept', chromium_accept },
+      { 'Sec-Fetch-Site', 'none' },
+      { 'Sec-Fetch-Mode', 'navigate' },
+      { 'Sec-Fetch-User', '?1' },
+      { 'Sec-Fetch-Dest', 'document' },
+      { 'Accept-Encoding', 'gzip, deflate, br, zstd' },
+      { 'Accept-Language', 'en-US,en;q=0.9' },
+    },
+  },
+  {
+    name = 'chrome_mac',
+    headers = {
+      { 'Connection', 'keep-alive' },
+      { 'sec-ch-ua', '"Not)A;Brand";v="8", "Chromium";v="148", "Google Chrome";v="148"' },
+      { 'sec-ch-ua-mobile', '?0' },
+      { 'sec-ch-ua-platform', '"macOS"' },
+      { 'Upgrade-Insecure-Requests', '1' },
+      { 'User-Agent',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36' },
+      { 'Accept', chromium_accept },
+      { 'Sec-Fetch-Site', 'none' },
+      { 'Sec-Fetch-Mode', 'navigate' },
+      { 'Sec-Fetch-User', '?1' },
+      { 'Sec-Fetch-Dest', 'document' },
+      { 'Accept-Encoding', 'gzip, deflate, br, zstd' },
+      { 'Accept-Language', 'en-US,en;q=0.9' },
+    },
+  },
+  {
+    name = 'edge_win',
+    headers = {
+      { 'Connection', 'keep-alive' },
+      { 'sec-ch-ua', '"Not)A;Brand";v="8", "Chromium";v="148", "Microsoft Edge";v="148"' },
+      { 'sec-ch-ua-mobile', '?0' },
+      { 'sec-ch-ua-platform', '"Windows"' },
+      { 'Upgrade-Insecure-Requests', '1' },
+      { 'User-Agent',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0' },
+      { 'Accept', chromium_accept },
+      { 'Sec-Fetch-Site', 'none' },
+      { 'Sec-Fetch-Mode', 'navigate' },
+      { 'Sec-Fetch-User', '?1' },
+      { 'Sec-Fetch-Dest', 'document' },
+      { 'Accept-Encoding', 'gzip, deflate, br, zstd' },
+      { 'Accept-Language', 'en-US,en;q=0.9' },
+    },
+  },
+  {
+    -- Firefox sends no sec-ch-ua client hints and uses a different
+    -- header order and Accept set than Chromium.
+    name = 'firefox_win',
+    headers = {
+      { 'User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0' },
+      { 'Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' },
+      { 'Accept-Language', 'en-US,en;q=0.5' },
+      { 'Accept-Encoding', 'gzip, deflate, br, zstd' },
+      { 'Connection', 'keep-alive' },
+      { 'Upgrade-Insecure-Requests', '1' },
+      { 'Sec-Fetch-Dest', 'document' },
+      { 'Sec-Fetch-Mode', 'navigate' },
+      { 'Sec-Fetch-Site', 'none' },
+      { 'Sec-Fetch-User', '?1' },
+      { 'Priority', 'u=0, i' },
+    },
+  },
+  {
+    -- Safari also omits sec-ch-ua and sends a leaner header set.
+    name = 'safari_mac',
+    headers = {
+      { 'Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' },
+      { 'Accept-Encoding', 'gzip, deflate, br' },
+      { 'Connection', 'keep-alive' },
+      { 'User-Agent',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15' },
+      { 'Accept-Language', 'en-US,en;q=0.9' },
+      { 'Sec-Fetch-Site', 'none' },
+      { 'Sec-Fetch-Mode', 'navigate' },
+      { 'Sec-Fetch-Dest', 'document' },
+    },
+  },
 }
 
 local redis_params
@@ -72,7 +156,13 @@ local settings = {
   check_ssl = false, -- check ssl certificates
   max_urls = 5, -- how many urls to check (CTA checked in first place)
   max_size = 10 * 1024, -- maximum body to process
-  user_agent = default_ua,
+  -- Optional operator override. When set (a string, or a list of
+  -- strings picked at random) the module sends a single User-Agent
+  -- header and skips fingerprint profiles entirely. Leave unset to use
+  -- the coherent browser profiles below.
+  user_agent = nil,
+  -- Browser fingerprint profiles used when user_agent is not set.
+  fingerprint_profiles = default_profiles,
   redirector_symbol = nil, -- insert symbol if redirected url has been found
   redirector_symbol_nested = "URL_REDIRECTOR_NESTED", -- insert symbol if nested limit has been reached
   redirector_symbol_non_http = "URL_REDIRECTOR_NON_HTTP", -- HTTP -> non-HTTP(S) redirect detected
@@ -623,23 +713,13 @@ http_walk = function(task, orig_url, url, ntries, chain, seen)
     finalize_chain(task, chain, nil)
   end
 
-  local ua
-  if type(settings.user_agent) == 'string' then
-    ua = settings.user_agent
-  else
-    ua = settings.user_agent[math.random(#settings.user_agent)]
-  end
-
   local method = 'head'
   if settings.redirector_get_urls_map
       and settings.redirector_get_urls_map:get_key(url_str) then
     method = 'get'
   end
-  lua_util.debugm(N, task, 'query %s %s with user agent %s',
-      method, url_str, ua)
 
   local http_params = {
-    headers = { ['User-Agent'] = ua },
     url = url_str,
     task = task,
     method = method,
@@ -648,6 +728,37 @@ http_walk = function(task, orig_url, url, ntries, chain, seen)
     no_ssl_verify = not settings.check_ssl,
     callback = http_callback,
   }
+
+  if settings.user_agent then
+    -- Operator override: a single User-Agent header, no fingerprint.
+    local ua = settings.user_agent
+    if type(ua) ~= 'string' then
+      ua = ua[math.random(#ua)]
+    end
+    http_params.headers = { ['User-Agent'] = ua }
+    lua_util.debugm(N, task, 'query %s %s with user agent %s',
+        method, url_str, ua)
+  else
+    -- Stealth: one coherent browser fingerprint per task, reused by
+    -- every hop of every chain so the identity stays consistent.
+    local profile = task:cache_get('url_redirector_profile')
+    if not profile then
+      local profiles = settings.fingerprint_profiles
+      if profiles and #profiles > 0 then
+        profile = profiles[math.random(#profiles)]
+        task:cache_set('url_redirector_profile', profile)
+      end
+    end
+    if profile then
+      http_params.headers = profile.headers
+      lua_util.debugm(N, task, 'query %s %s with %s fingerprint',
+          method, url_str, profile.name)
+    else
+      lua_util.debugm(N, task, 'query %s %s (no fingerprint profile)',
+          method, url_str)
+    end
+  end
+
   apply_http_timeout(http_params)
   rspamd_http.request(http_params)
 end

--- a/test/functional/cases/162_url_redirector.robot
+++ b/test/functional/cases/162_url_redirector.robot
@@ -24,6 +24,15 @@ RESOLVE URLS CACHED
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   Expect Extended URL  http://127.0.0.1:18080/hello
 
+STEALTH FINGERPRINT HEADERS
+  # The live HEAD requests issued by RESOLVE URLS are logged by the dummy
+  # HTTP server together with their request headers. Verify the redirector
+  # sends a coherent browser fingerprint (not just a bare User-Agent) and
+  # that the header order chosen by the profile is preserved on the wire.
+  ${log} =  Get File  /tmp/dummy_http.log
+  Should Contain  ${log}  Sec-Fetch-Mode
+  Should Match Regexp  ${log}  HEAD [^\n]*headers: [^\n]*Accept[^\n]*Sec-Fetch-Mode
+
 *** Keywords ***
 Urlredirector Setup
   Run Dummy Http

--- a/test/functional/util/dummy_http.py
+++ b/test/functional/util/dummy_http.py
@@ -89,6 +89,11 @@ class MainHandler(tornado.web.RequestHandler):
             raise tornado.web.HTTPError(404)
 
     def head(self, path):
+        # Log the request headers in the exact order they arrived on the
+        # wire so functional tests can assert on header presence and order
+        # (used by the url_redirector stealth fingerprint test).
+        hdrs = ", ".join(f"{k}={v}" for k, v in self.request.headers.get_all())
+        print(f"dummy_http.py: HEAD {path} headers: {hdrs}", file=sys.stderr)
         self.set_header("Content-Type", "text/plain")
         if path == "/redirect1":
             # Send an HTTP redirect to the bind address of the server


### PR DESCRIPTION
## Summary

The `url_redirector` plugin resolves shortened/redirector URLs by issuing HTTP requests. Cloaking and anti-bot pages commonly detect these requests not from the User-Agent string itself but from a **missing or inconsistent header set** — a request carrying only a `User-Agent` and nothing else is an obvious bot tell. This PR makes the redirector mimic a real browser instead.

It does so in two parts.

### 1. Optional insertion-ordered header emission (HTTP client)

The HTTP client stores headers in a khash and emits them in bucket order, so the on-the-wire header order is unpredictable. A new opt-in flag `RSPAMD_HTTP_FLAG_ORDERED_HEADERS` makes the client emit headers in insertion order:

- each `rspamd_http_header` is stamped with a monotonic `order` at insertion time;
- when the flag is set, headers are serialised sorted by `order` instead of hash order;
- `lua_http` accepts a list form for the headers table — `{{'name', 'value'}, ...}` — which preserves order and sets the flag.

The existing map form and **every other HTTP caller in rspamd remain byte-identical** — the ordered path is only taken when the flag is explicitly set.

### 2. Coherent browser fingerprint profiles (`url_redirector`)

The flat `default_ua` list is replaced by `default_profiles`: five coherent browser profiles (Chrome on Windows/macOS, Edge, Firefox, Safari). Each profile bundles a `User-Agent` with the exact header set, values and order that browser actually sends — Chromium profiles carry `sec-ch-ua` client hints; Firefox and Safari correctly omit them.

- One profile is picked **per task** and reused for every hop of every chain, so the identity stays consistent the way a real browser would.
- Headers are sent as an ordered list, so the profile's header order is preserved on the wire.
- `settings.user_agent` becomes an optional operator override (legacy single-header behaviour) and is unset by default; `settings.fingerprint_profiles` holds the profile list.

HEAD requests are retained — the module never reads response bodies.

## Testing

- C++ test suite: 209 cases, 73270 assertions, 0 failed.
- All `url_redirector` functional suites (162–167): 34/34 pass.
- New `STEALTH FINGERPRINT HEADERS` functional test: `dummy_http.py` logs received request headers in order, and the test asserts the redirector emits a coherent fingerprint with preserved header order.

## Known limits

- TLS (JA3/JA4) and HTTP/2 fingerprints are unchanged — rspamd's HTTP client is OpenSSL + HTTP/1.1 only. This defeats naive cloakers, not CDN-tier bot detection; `redirectors_only` + `redirector_hosts_map` already keep the module off CDN-fronted landing pages.
- rspamd still emits `Content-Length: 0` on HEAD requests (in the request prelude, not the ordered header block) — a minor tell, left out of scope.