### PR TITLE
[Fix] Properly populate timeout read in tcp_lua.c

### DIFF
--- a/src/lua/lua_tcp.c
+++ b/src/lua/lua_tcp.c
@@ -2025,24 +2025,34 @@ lua_tcp_request(lua_State *L)
 	}
 
 	/*
-	 * Two shapes need an explicit LUA_WANT_CONNECT marker so that EV_WRITE
-	 * is armed for the dial and LUA_TCP_FLAG_CONNECTED is set in the proper
-	 * connect-phase path:
+	 * Always seat an explicit LUA_WANT_CONNECT marker at the queue head so
+	 * the dial gets its own EV_WRITE arming under `connect_timeout`, and
+	 * LUA_TCP_FLAG_CONNECTED is set in the proper connect-phase path. Three
+	 * shapes need this:
 	 *
 	 *   1. Pure probe (empty queue, only on_connect/on_error registered):
-	 *      without the marker plan_handler_event would tear the session down
-	 *      before the dial completes.
+	 *      without the marker plan_handler_event would tear the session
+	 *      down before the dial completes.
 	 *
-	 *   2. Read-without-prior-write (queue head is LUA_WANT_READ): without
+	 *   2. Read-without-prior-write (queue head LUA_WANT_READ): without
 	 *      the marker plan_handler_event arms EV_READ with read_timeout
 	 *      straight away, the socket-writable connect signal is never
 	 *      consumed, LUA_TCP_FLAG_CONNECTED stays unset, and any pre-byte
 	 *      error/timeout misroutes to on_error (looking like a connect
 	 *      failure) -- plus FINISHED|CONNECTED gates on conn:close() leak
-	 *      refcounts. The natural connect detection that LUA_WANT_WRITE
-	 *      gets for free (writes require socket-writable) is missing here.
+	 *      refcounts.
 	 *
-	 * In both shapes the marker is shifted in lua_tcp_connect_helper once
+	 *   3. Write-first (queue head LUA_WANT_WRITE): EV_WRITE is naturally
+	 *      armed (writes require socket-writable), so connect-error
+	 *      *routing* already worked. But the timer was armed with
+	 *      `write_timeout`, not `connect_timeout` -- so a black-holed SYN
+	 *      sat under the write budget and the caller's `connect_timeout`
+	 *      setting was silently ignored. The marker re-arms the timer
+	 *      under `connect_timeout`; after the dial resolves,
+	 *      plan_handler_event re-arms EV_WRITE under `write_timeout` for
+	 *      the actual write.
+	 *
+	 * In every shape the marker is shifted in lua_tcp_connect_helper once
 	 * the connect resolves.
 	 */
 	if (g_queue_get_length(cbd->handlers) == 0) {
@@ -2053,12 +2063,9 @@ lua_tcp_request(lua_State *L)
 		}
 	}
 	else {
-		struct lua_tcp_handler *first = g_queue_peek_head(cbd->handlers);
-		if (first != NULL && first->type == LUA_WANT_READ) {
-			struct lua_tcp_handler *ch = g_malloc0(sizeof(*ch));
-			ch->type = LUA_WANT_CONNECT;
-			g_queue_push_head(cbd->handlers, ch);
-		}
+		struct lua_tcp_handler *ch = g_malloc0(sizeof(*ch));
+		ch->type = LUA_WANT_CONNECT;
+		g_queue_push_head(cbd->handlers, ch);
 	}
 
 	cbd->connect_cb = conn_cbref;

--- a/src/lua/lua_tcp.c
+++ b/src/lua/lua_tcp.c
@@ -846,16 +846,18 @@ lua_tcp_connect_helper(struct lua_tcp_cbdata *cbd)
 
 	if (cbd->thread == NULL) {
 		/*
-		 * Async pure-connect probe: the LUA_WANT_CONNECT marker was queued only
-		 * to keep plan_handler_event from finishing the session before the
-		 * socket completes the dial. The on_connect callback (if any) was
-		 * already fired in lua_tcp_handler when LUA_TCP_FLAG_CONNECTED got
-		 * set; shift the marker and re-plan so the now-empty queue triggers
-		 * the FINISHED tear-down.
+		 * Async path: the LUA_WANT_CONNECT marker was queued either as a
+		 * pure-connect probe (queue empty after shift -> FINISHED tear-down)
+		 * or ahead of a LUA_WANT_READ for connect-phase detection on a
+		 * read-without-write request (queue head is now the read handler).
+		 * The on_connect callback (if any) was already fired in
+		 * lua_tcp_handler when LUA_TCP_FLAG_CONNECTED got set; shift the
+		 * marker and re-plan with can_read/can_write enabled so any remaining
+		 * handler gets armed correctly.
 		 */
 		msg_debug_tcp("tcp connected (async probe)");
 		lua_tcp_shift_handler(cbd);
-		lua_tcp_plan_handler_event(cbd, FALSE, FALSE);
+		lua_tcp_plan_handler_event(cbd, TRUE, TRUE);
 		return;
 	}
 
@@ -2023,19 +2025,40 @@ lua_tcp_request(lua_State *L)
 	}
 
 	/*
-	 * Pure-probe shape: caller wants to verify TCP connectivity (and/or be
-	 * notified of connect-phase errors via on_error) without queueing any
-	 * read or write. Push a LUA_WANT_CONNECT marker so plan_handler_event
-	 * arms the EV_WRITE watcher; the marker is shifted in
-	 * lua_tcp_connect_helper once the connect resolves. Without this,
-	 * plan_handler_event would see an empty queue and tear the session down
-	 * before the dial ever completes.
+	 * Two shapes need an explicit LUA_WANT_CONNECT marker so that EV_WRITE
+	 * is armed for the dial and LUA_TCP_FLAG_CONNECTED is set in the proper
+	 * connect-phase path:
+	 *
+	 *   1. Pure probe (empty queue, only on_connect/on_error registered):
+	 *      without the marker plan_handler_event would tear the session down
+	 *      before the dial completes.
+	 *
+	 *   2. Read-without-prior-write (queue head is LUA_WANT_READ): without
+	 *      the marker plan_handler_event arms EV_READ with read_timeout
+	 *      straight away, the socket-writable connect signal is never
+	 *      consumed, LUA_TCP_FLAG_CONNECTED stays unset, and any pre-byte
+	 *      error/timeout misroutes to on_error (looking like a connect
+	 *      failure) -- plus FINISHED|CONNECTED gates on conn:close() leak
+	 *      refcounts. The natural connect detection that LUA_WANT_WRITE
+	 *      gets for free (writes require socket-writable) is missing here.
+	 *
+	 * In both shapes the marker is shifted in lua_tcp_connect_helper once
+	 * the connect resolves.
 	 */
-	if (g_queue_get_length(cbd->handlers) == 0 &&
-		(conn_cbref != -1 || error_cbref != -1)) {
-		struct lua_tcp_handler *ch = g_malloc0(sizeof(*ch));
-		ch->type = LUA_WANT_CONNECT;
-		g_queue_push_tail(cbd->handlers, ch);
+	if (g_queue_get_length(cbd->handlers) == 0) {
+		if (conn_cbref != -1 || error_cbref != -1) {
+			struct lua_tcp_handler *ch = g_malloc0(sizeof(*ch));
+			ch->type = LUA_WANT_CONNECT;
+			g_queue_push_tail(cbd->handlers, ch);
+		}
+	}
+	else {
+		struct lua_tcp_handler *first = g_queue_peek_head(cbd->handlers);
+		if (first != NULL && first->type == LUA_WANT_READ) {
+			struct lua_tcp_handler *ch = g_malloc0(sizeof(*ch));
+			ch->type = LUA_WANT_CONNECT;
+			g_queue_push_head(cbd->handlers, ch);
+		}
 	}
 
 	cbd->connect_cb = conn_cbref;


### PR DESCRIPTION
In `mx_check.lua` (`probe_with_greeting` shape), a slow-bannering SMTP server
caused a verdict of `tc` (timeout connect) after exactly `read_timeout` seconds,
even though `connect_timeout` was lower and TCP connect itself completed
quickly.

### Reproduction

Target: Exim with intentionally slow ~20s banner

Python socket measurement:

```text
connect:     0.181s
first CRLF: 21.629s
total:      21.810s
banner: '220-server.example.com ESMTP Exim 4.99.2 ...
         220-We do not authorize the use of this system to transport unsolicited,
         220 and/or bulk e-mail.'
```

`mx_check.conf` (relevant fields):

```
connect_timeout = 3s
read_timeout    = 8s
verify_greeting = true
```

Observed rspamd log:

```text
01:10:59.39167  mx_check.lua:338: probe lock rmx:i:<ipv4>: claimed (ttl=12s)
01:11:07.39532  mx_check.lua:315: cache write rmx:i:<ipv4> ttl=7200 value=tc
01:11:07.39538  mx_check.lua:1336: verdict for <mx> (from): tc
```

Elapsed: **8.00s** — matches `read_timeout`, not `connect_timeout`. Yet the
verdict was cached as `tc` (connect-phase) rather than `tr` (read-phase).

Cross-check: with `verify_greeting = false` (probe-connect-only shape), the
same target completes the probe in **0.182s** with verdict `gd` — confirming
the TCP dial itself is healthy and the 8s was spent waiting for the SMTP
banner.

## Root cause

`lua_tcp_request` builds the handler queue in this order:
1. If write data is present → `g_queue_push_tail(LUA_WANT_WRITE)`
2. If `do_read` is true → `g_queue_push_tail(LUA_WANT_READ)`
3. Pre-fix: if the queue is **empty** AND a conn/error callback is registered →
   `g_queue_push_tail(LUA_WANT_CONNECT)` (pure-probe shape)

`probe_with_greeting` sets `callback`+`stop_pattern`+`on_error` (no
`on_connect`, no data). That produces queue `[LUA_WANT_READ]` — non-empty, so
no `LUA_WANT_CONNECT` marker is added.

`lua_tcp_plan_handler_event` then arms `EV_READ` with `read_timeout` directly.
`LUA_TCP_FLAG_CONNECTED` is only ever set inside the `EV_WRITE` branch of
`lua_tcp_handler` (line 1222). Because `EV_WRITE` is never armed for this
shape, the flag stays unset.

When the read times out, `lua_tcp_push_error(cbd, TRUE, "IO timeout")` (line
1278) routes through the connect-phase gate:

```c
if (cbd->error_cbref != -1 && !(cbd->flags & LUA_TCP_FLAG_CONNECTED)) {
    /* call on_error */
}
```

`LUA_TCP_FLAG_CONNECTED` is unset → `on_error` is invoked with `"IO timeout"`.
The Lua side (`classify_connect_error`) sees `"timeout"` and classifies it as
`tc`. The same flag stuck unset also causes the `FINISHED|CONNECTED` gates on
`conn:close()` to leak refcounts (the issue that the prior leak patch
addressed by setting CONNECTED when `r > 0` arrives — which only helps when
bytes actually arrive, not on a pure read timeout).

## Fix

Landed in two commits to keep each reviewable on its own.

**Commit 1 — read-without-write routing.**

Push a `LUA_WANT_CONNECT` marker when the queue head is `LUA_WANT_READ`, so
`EV_WRITE`-based connect detection happens before the read arms `EV_READ`.
This is the same mechanism `LUA_WANT_WRITE` gets implicitly (writes require
socket-writable, which exposes the connect signal). Also flip
`lua_tcp_connect_helper`'s async branch from
`plan_handler_event(cbd, FALSE, FALSE)` to `TRUE, TRUE`: previously the
branch assumed the queue was empty after shifting the marker (pure-probe
semantics); with a `LUA_WANT_READ` left behind, `FALSE, FALSE` would trip
`"EOF, cannot read more data"` at line 1327. `TRUE, TRUE` is correct for both
shapes:

- Empty queue: `plan_handler_event` enters the `hdl == NULL` branch →
  FINISHED teardown. `can_read`/`can_write` ignored. ✓
- Queue with remaining `LUA_WANT_READ`: arms `EV_READ` with `read_timeout`. ✓

**Commit 2 — bound the dial under `connect_timeout` for every shape.**

Drop the `head == LUA_WANT_READ` gate and seat the `LUA_WANT_CONNECT` marker
at the head of **every** non-empty queue. A `LUA_WANT_WRITE`-headed request
was already routing connect errors correctly (`EV_WRITE` naturally armed by
the write handler, SO_ERROR check fires before CONNECTED), but the timer was
armed under `write_timeout` rather than `connect_timeout` — a black-holed SYN
sat under the write budget and the caller's `connect_timeout` was silently
ignored. After commit 2 the prepended marker re-arms `EV_WRITE` under
`connect_timeout` for the dial; once CONNECTED is set, `plan_handler_event`
re-arms `EV_WRITE` under `write_timeout` for the actual write.

**Legacy single-budget compatibility.** Callers that set only `timeout` (not
the phased fields) run in `use_deduction = TRUE` mode. `plan_handler_event`
gates every per-phase `ev.timeout = ...` assignment on `if (!cbd->use_deduction)`,
so legacy callers' single budget is set once at init (line 1980) and rides
through all phases — `lua_tcp_handler` deducts elapsed time at every watcher
fire (line 1189–1193). The extra `LUA_WANT_CONNECT` phase costs one
additional event-loop trip; the total budget is preserved.

## Shape matrix

`lua_tcp_request` can produce queues `[]`, `[WRITE]`, `[WRITE, READ]`, or
`[READ]` (writes are always pushed before reads in the queue building).

| Shape | Args | Queue before fix | Queue after fix | Behavior change |
|---|---|---|---|---|
| **A.** Pure probe + on_connect/on_error | `read=false`, no data, cb set | `[CONNECT]` (pushed by existing empty-queue path) | `[CONNECT]` (same path) | None |
| **B.** Pure probe, no callbacks | `read=false`, no data, no cb | `[]` (no marker, no cbs) | `[]` (same: empty + no cbs → skip) | None |
| **C.** Write-only | data, `read=false` | `[WRITE]` → arms EV_WRITE/`write_timeout` for both the dial and the write; `connect_timeout` silently ignored | `[CONNECT, WRITE]` → EV_WRITE/`connect_timeout` for the dial → CONNECTED set → EV_WRITE/`write_timeout` re-armed for the write | **Commit 2: dial now bounded by `connect_timeout`** |
| **D.** Write then read | data, callback | `[WRITE, READ]` → same `connect_timeout`-ignored dial as C | `[CONNECT, WRITE, READ]` → staged: `connect_timeout` → `write_timeout` → `read_timeout` | **Commit 2: dial now bounded by `connect_timeout`** |
| **E.** Read-only with on_error (`probe_with_greeting`) | callback, stop_pattern, on_error, phased timeouts | `[READ]` → arms EV_READ, CONNECTED never set → **BUG**: read timeout misroutes to on_error as `tc` | `[CONNECT, READ]` → EV_WRITE/`connect_timeout` → CONNECTED set → EV_READ/`read_timeout` → read cb receives `"IO timeout"` → correctly classified as `tr` | **Commit 1: fixes primary bug** |
| **F.** Read-only, no on_error | callback only | `[READ]` → same hidden state issue | `[CONNECT, READ]` → connect failures surface via SO_ERROR with `"Socket error detected: ..."`; read timeouts surface via read cb with `"IO timeout"` | **Commit 1: cleaner error messages** |
| **G.** Read + on_connect (no data) | callback + on_connect | `[READ]` → EV_WRITE never armed → **on_connect never fires** (latent bug) | `[CONNECT, READ]` → EV_WRITE → CONNECTED set at line 1222 → on_connect fires (line 1224) → connect_helper → EV_READ armed | **Commit 1: fixes latent on_connect bug** |
| **H.** SSL + write + read (typical HTTPS) | data, callback, ssl | `[WRITE, READ]` → SSL handshake under initial `ev.timeout = connect_timeout` (set at init, line 1980); post-handshake EV_WRITE re-arms under `write_timeout` | `[CONNECT, WRITE, READ]` → same staged transitions; marker is consumed by `connect_helper` after the SSL library calls back into `lua_tcp_handler` post-handshake | **Commit 2: explicit phase split (no behavior regression)** |
| **I.** Sync mode (`tcp.connect_sync`) | n/a | Uses `lua_tcp_connect_sync` (separate function, line 2255) | Untouched | None |
| **J.** `add_write`/`add_read` post-connect | n/a | Operates on already-CONNECTED socket | Unaffected by request-time queue setup | None |

## Dispatch safety

The `EV_WRITE` branch of `lua_tcp_handler` (line 1261–1268) only handles
`event_type == LUA_WANT_WRITE` or `LUA_WANT_CONNECT`, otherwise
`g_assert_not_reached()`. After both commits the queue head when `EV_WRITE`
fires is always `LUA_WANT_CONNECT` (on the dial) or `LUA_WANT_WRITE` (post-
dial, while a write is pending) — never `LUA_WANT_READ`. The assertion stays
unreachable.

## Implication for prior leak fix

The earlier `[Fix] Avoid TCP leak on read without write` patch (set CONNECTED
when `r > 0`) was a workaround for the same root cause: CONNECTED never
getting set in the read-without-write path. With this fix, CONNECTED is set
via the proper `EV_WRITE` → line 1222 path *before* any `read()` is attempted,
so the leak patch becomes unnecessary. Recommend dropping it in favor of a
single source of truth for the flag.