### PR TITLE
[Feature] url_redirector: switch redirector_hosts_map from set to glob

### DIFF
--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -950,7 +950,7 @@ if opts then
     else
       local lua_maps = require "lua_maps"
       settings.redirector_hosts_map = lua_maps.map_add_from_ucl(settings.redirector_hosts_map,
-          'set', 'Redirectors definitions')
+          'glob', 'Redirectors definitions (glob: bare names match exactly, *.foo matches subs)')
 
       if settings.redirector_get_urls_map then
         settings.redirector_get_urls_map = lua_maps.map_add_from_ucl(


### PR DESCRIPTION
Allow operators to use glob patterns (e.g. *.bit.ly, *.t.co) in the redirector hosts list. Bare hostnames continue to match exactly, so no operational change for existing maps; only the option to use wildcards is new.