### PR TITLE
[Feature] Dynamic composites: hot-reloadable composites map

### DIFF
--- a/src/libserver/cfg_rcl.cxx
+++ b/src/libserver/cfg_rcl.cxx
@@ -1588,14 +1588,29 @@ rspamd_rcl_composites_handler(rspamd_mempool_t *pool,
 							  struct rspamd_rcl_section *section,
 							  GError **err)
 {
+	auto *cfg = static_cast<rspamd_config *>(ud);
 	auto success = TRUE;
 
 	auto it = ucl_object_iterate_new(obj);
 	const auto *cur = obj;
 
 	while ((cur = ucl_object_iterate_safe(it, true))) {
+		const auto *cur_key = ucl_object_key(cur);
+
+		/* `dynamic` is reserved for hot-reloadable composite map sources.
+		 * Its value is whatever rspamd_map_add_from_ucl accepts: a single
+		 * URL string, an array of URLs, or a full map UCL object. */
+		if (cur_key != nullptr && strcmp(cur_key, "dynamic") == 0) {
+			if (!rspamd_composites_add_dynamic_map(cfg->composites_manager, cur, cfg)) {
+				msg_err_config("failed to register dynamic composites map");
+				success = FALSE;
+				break;
+			}
+			continue;
+		}
+
 		success = rspamd_rcl_composite_handler(pool, cur,
-											   ucl_object_key(cur), ud, section, err);
+											   cur_key, ud, section, err);
 		if (!success) {
 			break;
 		}

--- a/src/libserver/composites/composites.cxx
+++ b/src/libserver/composites/composites.cxx
@@ -87,14 +87,39 @@ struct composites_data {
 								 std::vector<symbol_remove_data>>
 		symbols_to_remove;
 	std::vector<bool> checked;
+	/*
+	 * Pinned snapshot of the composites generation that was current when
+	 * this task started evaluating composites. All evaluation reads happen
+	 * through this pointer, so a concurrent dynamic-map reload cannot
+	 * change the world under our feet mid-task.
+	 *
+	 * Composite ids are globally monotonic across reloads; sizing `checked`
+	 * by gen->all_composites.size() means we have a slot for every
+	 * composite in this snapshot.  Composites not in this generation are
+	 * never evaluated, so their ids never index `checked`.
+	 */
+	std::shared_ptr<composites_generation> gen;
 	bool is_second_pass;      /**< true if we're in COMPOSITES_POST stage */
 	uint64_t matched_count{}; /**< number of matched composites */
 
 	explicit composites_data(struct rspamd_task *task, struct rspamd_scan_result *mres)
-		: task(task), composite(nullptr), metric_res(mres), matched_count(0)
+		: task(task), composite(nullptr), metric_res(mres),
+		  gen(COMPOSITE_MANAGER_FROM_PTR(task->cfg->composites_manager)->snapshot_generation()),
+		  matched_count(0)
 	{
-		checked.resize(rspamd_composites_manager_nelts(task->cfg->composites_manager) * 2,
-					   false);
+		/*
+		 * Size `checked` by the largest composite id this generation could
+		 * possibly produce + 1 (ids are 0-based and monotonic across
+		 * reloads). For an empty generation we allocate a 2-slot dummy
+		 * vector so indexing never overflows even if a stale id sneaks in.
+		 */
+		int max_id = -1;
+		for (const auto &c: gen->all_composites) {
+			if (c->id > max_id) {
+				max_id = c->id;
+			}
+		}
+		checked.resize((max_id + 1) * 2, false);
 		/* Determine if we're in second pass by checking if POST_FILTERS stage has been processed */
 		is_second_pass = (task->processed_stages & RSPAMD_TASK_STAGE_POST_FILTERS) != 0;
 	}
@@ -204,17 +229,9 @@ struct rspamd_composite_option_match {
 	}
 };
 
-enum class rspamd_composite_atom_type {
-	ATOM_UNKNOWN,
-	ATOM_COMPOSITE,
-	ATOM_PLAIN
-};
-
 struct rspamd_composite_atom {
 	std::string symbol;
 	std::string_view norm_symbol;
-	rspamd_composite_atom_type comp_type = rspamd_composite_atom_type::ATOM_UNKNOWN;
-	const struct rspamd_composite *ncomp; /* underlying composite */
 	std::vector<rspamd_composite_option_match> opts;
 };
 
@@ -586,30 +603,28 @@ process_single_symbol(struct composites_data *cd,
 		msg_debug_composites("not found symbol %s in composite %s", sym.data(),
 							 cd->composite->sym.c_str());
 
-		if (G_UNLIKELY(atom->comp_type == rspamd_composite_atom_type::ATOM_UNKNOWN)) {
-			const struct rspamd_composite *ncomp;
+		/*
+		 * Resolve composite references against the task's pinned snapshot
+		 * every time. We do not cache the resolution on the atom because
+		 * the atom struct is shared across tasks that may be using
+		 * different generations — caching would dangle on reload.
+		 * Hashtable lookups are cheap and only happen for symbols that
+		 * aren't already in the scan result.
+		 */
+		const struct rspamd_composite *ncomp = cd->gen->find(sym);
 
-			if ((ncomp = COMPOSITE_MANAGER_FROM_PTR(task->cfg->composites_manager)->find(sym)) != NULL) {
-				atom->comp_type = rspamd_composite_atom_type::ATOM_COMPOSITE;
-				atom->ncomp = ncomp;
-			}
-			else {
-				atom->comp_type = rspamd_composite_atom_type::ATOM_PLAIN;
-			}
-		}
-
-		if (atom->comp_type == rspamd_composite_atom_type::ATOM_COMPOSITE) {
+		if (ncomp != nullptr && !ncomp->disabled) {
 			msg_debug_composites("symbol %s for composite %s is another composite",
 								 sym.data(), cd->composite->sym.c_str());
 
-			if (!cd->checked[atom->ncomp->id * 2]) {
+			if (!cd->checked[ncomp->id * 2]) {
 				msg_debug_composites("composite dependency %s for %s is not checked",
 									 sym.data(), cd->composite->sym.c_str());
 				/* Set checked for this symbol to avoid cyclic references */
 				cd->checked[cd->composite->id * 2] = true;
 				auto *saved = cd->composite; /* Save the current composite */
-				composites_foreach_callback((gpointer) atom->ncomp->sym.c_str(),
-											(gpointer) atom->ncomp, (gpointer) cd);
+				composites_foreach_callback((gpointer) ncomp->sym.c_str(),
+											(gpointer) ncomp, (gpointer) cd);
 				/* Restore state */
 				cd->composite = saved;
 				cd->checked[cd->composite->id * 2] = false;
@@ -621,7 +636,7 @@ process_single_symbol(struct composites_data *cd,
 				/*
 				 * XXX: in case of cyclic references this would return 0
 				 */
-				if (cd->checked[atom->ncomp->id * 2 + 1]) {
+				if (cd->checked[ncomp->id * 2 + 1]) {
 					ms = rspamd_task_find_symbol_result(cd->task, sym.data(),
 														cd->metric_res);
 				}
@@ -1001,15 +1016,24 @@ composites_metric_callback(struct rspamd_task *task)
 	{
 		auto &cd = comp_data_vec.emplace_back(task, mres);
 
+		/*
+		 * All evaluation reads go through cd.gen — the snapshot we pinned
+		 * when this composites_data was constructed. cm->use_inverted_index
+		 * is read off the manager (it is config-time only and never
+		 * changes after init).
+		 */
+		auto *gen = cd.gen.get();
+
 		if (is_second_pass) {
-			/* Second pass: process only second-pass composites directly from manager */
-			msg_debug_composites("processing second-pass composites");
-			for (auto *comp: cm->second_pass_composites) {
+			/* Second pass: process only second-pass composites from the snapshot */
+			msg_debug_composites("processing second-pass composites (gen %L)",
+								 (int64_t) gen->generation_id);
+			for (auto *comp: gen->second_pass_composites) {
 				composites_foreach_callback((gpointer) comp->sym.c_str(),
 											(gpointer) comp,
 											&cd);
 			}
-			composites_checked += cm->second_pass_composites.size();
+			composites_checked += gen->second_pass_composites.size();
 		}
 		else if (use_fast_path) {
 			/* First pass with inverted index: fast lookup */
@@ -1017,17 +1041,17 @@ composites_metric_callback(struct rspamd_task *task)
 
 			/* Callback data for collecting potentially active composites */
 			struct collect_active_cbdata {
-				composites_manager *cm;
+				composites_generation *gen;
 				ankerl::unordered_dense::set<rspamd_composite *> *active;
-			} collect_data{cm, &potentially_active};
+			} collect_data{gen, &potentially_active};
 
 			/* Collect composites that have at least one positive atom present */
 			rspamd_task_symbol_result_foreach(task, mres, [](gpointer key, gpointer value, gpointer ud) {
 												  auto *cbd = reinterpret_cast<collect_active_cbdata *>(ud);
 												  std::string_view sym_name{reinterpret_cast<const char *>(key)};
 
-												  auto it = cbd->cm->symbol_to_composites.find(sym_name);
-												  if (it != cbd->cm->symbol_to_composites.end()) {
+												  auto it = cbd->gen->symbol_to_composites.find(sym_name);
+												  if (it != cbd->gen->symbol_to_composites.end()) {
 													  for (auto *comp: it->second) {
 														  /* Only add first-pass composites */
 														  if (!comp->second_pass) {
@@ -1037,15 +1061,16 @@ composites_metric_callback(struct rspamd_task *task)
 												  } }, &collect_data);
 
 			/* Always add NOT-only composites (they have no positive atoms) */
-			for (auto *comp: cm->not_only_composites) {
+			for (auto *comp: gen->not_only_composites) {
 				if (!comp->second_pass) {
 					potentially_active.insert(comp);
 				}
 			}
 
-			msg_debug_composites("processing %d potentially active composites (from %d first-pass)",
+			msg_debug_composites("processing %d potentially active composites (from %d first-pass, gen %L)",
 								 (int) potentially_active.size(),
-								 (int) cm->first_pass_composites.size());
+								 (int) gen->first_pass_composites.size(),
+								 (int64_t) gen->generation_id);
 
 			/* Process only potentially active composites */
 			for (auto *comp: potentially_active) {
@@ -1057,14 +1082,15 @@ composites_metric_callback(struct rspamd_task *task)
 		}
 		else {
 			/* Slow path: check all first-pass composites */
-			msg_debug_composites("processing all %d first-pass composites (slow path)",
-								 (int) cm->first_pass_composites.size());
-			for (auto *comp: cm->first_pass_composites) {
+			msg_debug_composites("processing all %d first-pass composites (slow path, gen %L)",
+								 (int) gen->first_pass_composites.size(),
+								 (int64_t) gen->generation_id);
+			for (auto *comp: gen->first_pass_composites) {
 				composites_foreach_callback((gpointer) comp->sym.c_str(),
 											(gpointer) comp,
 											&cd);
 			}
-			composites_checked += cm->first_pass_composites.size();
+			composites_checked += gen->first_pass_composites.size();
 		}
 	}
 
@@ -1100,43 +1126,6 @@ composites_metric_callback(struct rspamd_task *task)
 		for (const auto &srd_it: cd.symbols_to_remove) {
 			remove_symbols(cd, srd_it.second);
 		}
-	}
-}
-
-void rspamd_composites_resolve_atom_types(composites_manager *cm)
-{
-	auto resolve_callback = [](GNode *, rspamd_expression_atom_t *atom, gpointer ud) {
-		auto *manager = reinterpret_cast<composites_manager *>(ud);
-		auto *comp_atom = reinterpret_cast<rspamd_composite_atom *>(atom->data);
-
-		if (comp_atom == nullptr) {
-			return;
-		}
-
-		if (comp_atom->comp_type != rspamd_composite_atom_type::ATOM_UNKNOWN) {
-			/* Already resolved */
-			return;
-		}
-
-		const auto *ncomp = manager->find(comp_atom->symbol);
-		if (ncomp != nullptr) {
-			comp_atom->comp_type = rspamd_composite_atom_type::ATOM_COMPOSITE;
-			comp_atom->ncomp = ncomp;
-		}
-		else {
-			comp_atom->comp_type = rspamd_composite_atom_type::ATOM_PLAIN;
-			comp_atom->ncomp = nullptr;
-		}
-	};
-
-	/* Process all first-pass composites */
-	for (auto *comp: cm->first_pass_composites) {
-		rspamd_expression_atom_foreach_ex(comp->expr, resolve_callback, cm);
-	}
-
-	/* Process all second-pass composites */
-	for (auto *comp: cm->second_pass_composites) {
-		rspamd_expression_atom_foreach_ex(comp->expr, resolve_callback, cm);
 	}
 }
 

--- a/src/libserver/composites/composites.h
+++ b/src/libserver/composites/composites.h
@@ -105,10 +105,40 @@ void rspamd_composites_get_stats(void *cm_ptr, struct rspamd_composites_stats_ex
  * Mark symbols used in whitelist composites (negative score) with SYMBOL_TYPE_FINE
  * so they won't be skipped when reject threshold is reached. This ensures
  * whitelist composites can still evaluate correctly.
+ *
+ * Also performs the last step of static composites load — pinning the
+ * static-config generation as the base and recording its names — so that
+ * subsequent dynamic-map publishes can clone from a stable base. Safe to
+ * call multiple times.
+ *
  * @param cm_ptr composites manager pointer
  * @param cfg config structure
  */
 void rspamd_composites_mark_whitelist_deps(void *cm_ptr, struct rspamd_config *cfg);
+
+/**
+ * Register a dynamic composites map. The map is read as a UCL object
+ * mapping composite name → { expression, score, group, policy, description,
+ * groups, enabled }. On every reload the manager builds a fresh staging
+ * generation off the static base, layers the map's composites, materialises
+ * disabled stubs for names this map previously published but no longer
+ * mentions, and atomically swaps it in. In-flight tasks keep their
+ * pinned snapshot and continue with the previous generation.
+ *
+ * @param cm_ptr composites manager pointer
+ * @param obj UCL object describing the map (string URL, array of URLs,
+ *            or full map UCL with backends/signature/etc.)
+ * @param cfg config structure
+ * @return true if the map was registered with the watcher
+ */
+bool rspamd_composites_add_dynamic_map(void *cm_ptr, const ucl_object_t *obj,
+									   struct rspamd_config *cfg);
+
+/**
+ * Returns the current composites generation id (monotonically increasing
+ * across publishes). 0 if the manager has not published anything yet.
+ */
+uint64_t rspamd_composites_current_generation(void *cm_ptr);
 
 #ifdef __cplusplus
 }

--- a/src/libserver/composites/composites_internal.hxx
+++ b/src/libserver/composites/composites_internal.hxx
@@ -191,12 +191,31 @@ public:
 	/* Statistics (updated probabilistically for performance) */
 	composites_stats stats{};
 
-	/* Analyze composite dependencies and split into first/second pass vectors */
-	void process_dependencies();
-	/* Build inverted index for fast composite lookup */
-	void build_inverted_index();
-	/* Mark symbols used in whitelist composites (negative score) as FINE */
-	void mark_whitelist_dependencies();
+	/* Analyze composite dependencies and split a generation into first/second
+	 * pass vectors. The no-arg form operates on current_gen for compatibility
+	 * with config-load wiring. */
+	void process_dependencies(composites_generation &gen);
+	void process_dependencies()
+	{
+		process_dependencies(*current_gen);
+	}
+
+	/* Build inverted index for fast composite lookup in the given generation. */
+	void build_inverted_index(composites_generation &gen);
+	void build_inverted_index()
+	{
+		build_inverted_index(*current_gen);
+	}
+
+	/* Mark symbols used in whitelist composites (negative score) as FINE.
+	 * Always operates against the manager's cfg symcache; the generation
+	 * argument selects which whitelist composites contribute to the
+	 * FINE-symbol set. */
+	void mark_whitelist_dependencies(composites_generation &gen);
+	void mark_whitelist_dependencies()
+	{
+		mark_whitelist_dependencies(*current_gen);
+	}
 };
 
 }// namespace rspamd::composites

--- a/src/libserver/composites/composites_internal.hxx
+++ b/src/libserver/composites/composites_internal.hxx
@@ -154,6 +154,89 @@ public:
 		return current_gen.get();
 	}
 
+	/**
+	 * Snapshot current_gen as base_gen — every future staging generation
+	 * starts from a clone of base_gen. Called once after static config has
+	 * been loaded and the first round of process_dependencies /
+	 * build_inverted_index / mark_whitelist_dependencies has completed.
+	 */
+	auto pin_base_generation() -> void
+	{
+		base_gen = current_gen;
+	}
+
+	auto get_base_generation() const -> std::shared_ptr<composites_generation>
+	{
+		return base_gen;
+	}
+
+	/**
+	 * Build a fresh staging generation off the pinned base. Composites from
+	 * base_gen are cloned (new shared_ptr, fresh id, flags reset) so the
+	 * staging can run process_dependencies / build_inverted_index without
+	 * mutating composites that in-flight tasks may still be observing.
+	 *
+	 * Callers (the dynamic-map fin callback) layer the map's composites on
+	 * top, then call publish_generation().
+	 */
+	auto build_staging() -> std::shared_ptr<composites_generation>;
+
+	/**
+	 * Apply a single UCL composite definition to a staging generation.
+	 * Parses the expression, creates a fresh composite struct, replaces any
+	 * existing entry under this name, and updates cfg->symbols so scoring
+	 * and FINE-flag propagation see the dynamic composite. Returns the new
+	 * composite or nullptr on parse/validation failure.
+	 */
+	auto add_composite_to_staging(composites_generation &staging,
+								  std::string_view name,
+								  const ucl_object_t *obj) -> rspamd_composite *;
+
+	/**
+	 * Replace the composite under `name` in `staging` with a disabled stub
+	 * (or insert one if the name was unknown). Returns true if a stub was
+	 * (re)created.
+	 */
+	auto disable_in_staging(composites_generation &staging,
+							const std::string &name) -> bool;
+
+	/**
+	 * Publish a staging generation as current:
+	 *  - register new composite names with the symcache + cfg->symbols
+	 *  - update ever_seen_names
+	 *  - bump the resort generation on the symcache
+	 *  - run process_dependencies / build_inverted_index / mark_whitelist
+	 *  - atomically swap current_gen
+	 *
+	 * Single-threaded libev makes the swap a plain assignment; in-flight
+	 * tasks keep their snapshot alive via shared_ptr.
+	 */
+	auto publish_generation(std::shared_ptr<composites_generation> staging) -> void;
+
+	/**
+	 * Capture current_gen as the static-config base. Subsequent
+	 * build_staging() calls clone from this snapshot. Populates
+	 * ever_seen_names from the static composites so they aren't
+	 * re-registered with the symcache on first dynamic publish. Idempotent
+	 * — calling more than once is a no-op.
+	 */
+	auto seal_static_load() -> void;
+
+	/**
+	 * Returns the set of composite names this manager has ever published.
+	 * Map handlers consult this to materialise disabled stubs for names
+	 * that previously existed and have now been removed.
+	 */
+	auto ever_seen() const -> const ankerl::unordered_dense::set<std::string> &
+	{
+		return ever_seen_names;
+	}
+
+	auto allocate_generation_id() -> uint64_t
+	{
+		return ++next_gen_id;
+	}
+
 private:
 	~composites_manager() = default;
 	static void composites_manager_dtor(void *ptr)
@@ -180,9 +263,28 @@ private:
 
 	struct rspamd_config *cfg;
 	int next_composite_id = 0;
+	uint64_t next_gen_id = 0;
 
 	/* The live generation. Replaced on dynamic-map reload via publish_generation(). */
 	std::shared_ptr<composites_generation> current_gen;
+
+	/* Snapshot of the static-config generation, taken after config-load.
+	 * Every staging generation is cloned from this. */
+	std::shared_ptr<composites_generation> base_gen;
+
+	/* Names this manager has ever published (static or dynamic). Monotonic.
+	 * Used to (a) gate one-time symcache + cfg->symbols registration and
+	 * (b) help map handlers materialise disabled stubs for vanished names. */
+	ankerl::unordered_dense::set<std::string> ever_seen_names;
+
+	/* The composite shared_ptr each name was first registered with in the
+	 * symcache. The symcache stores raw cbdata; pinning the shared_ptr here
+	 * guarantees it never dangles even when later generations replace the
+	 * composite under the same name. Static composites are already pinned
+	 * via base_gen → all_composites so this map only fills in for
+	 * dynamic-only names. */
+	ankerl::unordered_dense::map<std::string, std::shared_ptr<rspamd_composite>>
+		symcache_pinned;
 
 public:
 	/* Configuration flags */

--- a/src/libserver/composites/composites_internal.hxx
+++ b/src/libserver/composites/composites_internal.hxx
@@ -18,7 +18,10 @@
 #define RSPAMD_COMPOSITES_INTERNAL_HXX
 #pragma once
 
+#include <memory>
 #include <string>
+#include <vector>
+#include "contrib/ankerl/unordered_dense.h"
 #include "libutil/expression.h"
 #include "libutil/util.h"
 #include "libutil/cxx/hash_util.hxx"
@@ -50,6 +53,43 @@ struct rspamd_composite {
 	rspamd_composite_policy policy;
 	bool second_pass;        /**< true if this composite needs second pass evaluation */
 	bool has_positive_atoms; /**< true if composite has at least one non-negated atom */
+	bool disabled;           /**< true if composite is a placeholder stub (evaluates to false) */
+};
+
+/**
+ * A composites generation: an immutable-once-published snapshot of all
+ * composites and their precomputed evaluation indices.
+ *
+ * The manager holds one current generation. On dynamic map reloads a new
+ * generation is built off-line and atomically swapped in; in-flight tasks
+ * keep using their snapshot (held via shared_ptr in composites_data).
+ */
+struct composites_generation {
+	ankerl::unordered_dense::map<std::string,
+								 std::shared_ptr<rspamd_composite>,
+								 rspamd::smart_str_hash, rspamd::smart_str_equal>
+		composites;
+	/* Ownership of every composite belongs here (including duplicates) */
+	std::vector<std::shared_ptr<rspamd_composite>> all_composites;
+
+	/* Two-phase evaluation buckets */
+	std::vector<rspamd_composite *> first_pass_composites;
+	std::vector<rspamd_composite *> second_pass_composites;
+
+	/* Inverted index: symbol -> composites that contain this symbol as positive atom */
+	ankerl::unordered_dense::map<std::string, std::vector<rspamd_composite *>,
+								 rspamd::smart_str_hash, rspamd::smart_str_equal>
+		symbol_to_composites;
+	/* Composites that have only negated atoms or group matchers (must always be checked) */
+	std::vector<rspamd_composite *> not_only_composites;
+
+	uint64_t generation_id = 0;
+
+	auto find(std::string_view name) const -> const rspamd_composite *
+	{
+		auto found = composites.find(std::string(name));
+		return found != composites.end() ? found->second.get() : nullptr;
+	}
 };
 
 #define COMPOSITE_MANAGER_FROM_PTR(ptr) (reinterpret_cast<rspamd::composites::composites_manager *>(ptr))
@@ -68,29 +108,51 @@ struct composites_stats {
 class composites_manager {
 public:
 	composites_manager(struct rspamd_config *_cfg)
-		: cfg(_cfg), use_inverted_index(true)
+		: cfg(_cfg),
+		  current_gen(std::make_shared<composites_generation>()),
+		  use_inverted_index(true)
 	{
 		rspamd_mempool_add_destructor(_cfg->cfg_pool, composites_manager_dtor, this);
 	}
 
 	auto size(void) const -> std::size_t
 	{
-		return all_composites.size();
+		return current_gen->all_composites.size();
 	}
 
 	auto find(std::string_view name) const -> const rspamd_composite *
 	{
-		auto found = composites.find(std::string(name));
+		return current_gen->find(name);
+	}
 
-		if (found != composites.end()) {
-			return found->second.get();
-		}
-
-		return nullptr;
+	/**
+	 * Snapshot the current generation. Callers (tasks) keep this shared_ptr
+	 * alive for the duration of evaluation so a concurrent reload cannot
+	 * pull the rug out from under them.
+	 */
+	auto snapshot_generation() const -> std::shared_ptr<composites_generation>
+	{
+		return current_gen;
 	}
 
 	auto add_composite(std::string_view, const ucl_object_t *, bool silent_duplicate) -> rspamd_composite *;
 	auto add_composite(std::string_view name, std::string_view expression, bool silent_duplicate, double score = NAN) -> rspamd_composite *;
+
+	/* Allocate a fresh monotonic composite id (stable across generations) */
+	auto next_id() -> int
+	{
+		return next_composite_id++;
+	}
+
+	auto get_cfg() const -> struct rspamd_config *
+	{
+		return cfg;
+	}
+
+	auto current() const -> composites_generation *
+	{
+		return current_gen.get();
+	}
 
 private:
 	~composites_manager() = default;
@@ -102,38 +164,27 @@ private:
 	auto new_composite(std::string_view composite_name, rspamd_expression *expr,
 					   std::string_view composite_expression) -> auto
 	{
-		auto &composite = all_composites.emplace_back(std::make_shared<rspamd_composite>());
+		auto &gen = *current_gen;
+		auto &composite = gen.all_composites.emplace_back(std::make_shared<rspamd_composite>());
 		composite->expr = expr;
-		composite->id = all_composites.size() - 1;
+		composite->id = next_id();
 		composite->str_expr = composite_expression;
 		composite->sym = composite_name;
 		composite->second_pass = false; /* Initially all composites are first pass */
+		composite->disabled = false;
 
-		composites[composite->sym] = composite;
+		gen.composites[composite->sym] = composite;
 
 		return composite;
 	}
 
-	ankerl::unordered_dense::map<std::string,
-								 std::shared_ptr<rspamd_composite>, rspamd::smart_str_hash, rspamd::smart_str_equal>
-		composites;
-	/* Store all composites here, even if we have duplicates */
-	std::vector<std::shared_ptr<rspamd_composite>> all_composites;
-
 	struct rspamd_config *cfg;
+	int next_composite_id = 0;
+
+	/* The live generation. Replaced on dynamic-map reload via publish_generation(). */
+	std::shared_ptr<composites_generation> current_gen;
 
 public:
-	/* Two-phase evaluation: composites are split into first and second pass */
-	std::vector<rspamd_composite *> first_pass_composites;  /* Evaluated during COMPOSITES stage */
-	std::vector<rspamd_composite *> second_pass_composites; /* Evaluated during COMPOSITES_POST stage */
-
-	/* Inverted index: symbol -> composites that contain this symbol as positive atom */
-	ankerl::unordered_dense::map<std::string, std::vector<rspamd_composite *>,
-								 rspamd::smart_str_hash, rspamd::smart_str_equal>
-		symbol_to_composites;
-	/* Composites that have only negated atoms (must always be checked) */
-	std::vector<rspamd_composite *> not_only_composites;
-
 	/* Configuration flags */
 	bool use_inverted_index; /**< Use inverted index for fast composite lookup (default: true) */
 
@@ -147,13 +198,6 @@ public:
 	/* Mark symbols used in whitelist composites (negative score) as FINE */
 	void mark_whitelist_dependencies();
 };
-
-/**
- * Precompute atom types (ATOM_COMPOSITE vs ATOM_PLAIN) for all composites.
- * This eliminates lazy lookups during expression evaluation.
- * Should be called after all composites are registered.
- */
-void rspamd_composites_resolve_atom_types(composites_manager *cm);
 
 }// namespace rspamd::composites
 

--- a/src/libserver/composites/composites_manager.cxx
+++ b/src/libserver/composites/composites_manager.cxx
@@ -362,7 +362,7 @@ symbol_needs_second_pass(struct rspamd_config *cfg, const char *symbol_name)
 struct composite_dep_cbdata {
 	struct rspamd_config *cfg;
 	bool needs_second_pass;
-	composites_manager *cm;
+	composites_generation *gen;
 };
 
 static void
@@ -385,8 +385,9 @@ composite_dep_callback(const rspamd_ftok_t *atom, gpointer ud)
 		return;
 	}
 
-	/* Check if this is a reference to another composite */
-	if (auto *dep_comp = cbd->cm->find(atom_str); dep_comp != nullptr) {
+	/* Check if this is a reference to another composite within the
+	 * generation being built */
+	if (auto *dep_comp = cbd->gen->find(atom_str); dep_comp != nullptr) {
 		/* Dependency on another composite - will be handled in transitive pass */
 		return;
 	}
@@ -401,11 +402,10 @@ composite_dep_callback(const rspamd_ftok_t *atom, gpointer ud)
 	}
 }
 
-void composites_manager::process_dependencies()
+void composites_manager::process_dependencies(composites_generation &gen)
 {
 	ankerl::unordered_dense::set<rspamd_composite *> second_pass_set;
 	bool changed;
-	auto &gen = *current_gen;
 
 	msg_debug_config("analyzing composite dependencies for two-phase evaluation (gen %L)",
 					 (int64_t) gen.generation_id);
@@ -426,7 +426,7 @@ void composites_manager::process_dependencies()
 
 	/* First pass: mark composites that directly depend on postfilters/stats */
 	for (auto *comp: gen.first_pass_composites) {
-		composite_dep_cbdata cbd{cfg, false, this};
+		composite_dep_cbdata cbd{cfg, false, &gen};
 
 		rspamd_expression_atom_foreach(comp->expr,
 									   composite_dep_callback,
@@ -451,15 +451,15 @@ void composites_manager::process_dependencies()
 
 			/* Helper struct for lambda capture */
 			struct trans_check_data {
-				composites_manager *cm;
+				composites_generation *gen;
 				ankerl::unordered_dense::set<rspamd_composite *> *second_pass_set;
 				bool *has_dep;
-			} trans_data{this, &second_pass_set, &has_second_pass_dep};
+			} trans_data{&gen, &second_pass_set, &has_second_pass_dep};
 
 			rspamd_expression_atom_foreach(comp->expr, [](const rspamd_ftok_t *atom, gpointer ud) {
 											   auto *data = reinterpret_cast<trans_check_data *>(ud);
 											   std::string_view atom_str(atom->begin, atom->len);
-											   if (auto *dep_comp = data->cm->find(atom_str); dep_comp != nullptr) {
+											   if (auto *dep_comp = data->gen->find(atom_str); dep_comp != nullptr) {
 												   /* Cast away const since we know this points to a modifiable composite */
 												   if (data->second_pass_set->contains(const_cast<rspamd_composite *>(dep_comp))) {
 													   *data->has_dep = true;
@@ -561,7 +561,7 @@ extract_atom_symbol_name(const rspamd_expression_atom_t *atom)
  * for a composite. Handles transitive composite references with cycle detection.
  */
 static void
-collect_leaf_atoms(composites_manager *cm, const rspamd_composite *comp,
+collect_leaf_atoms(composites_generation &gen, const rspamd_composite *comp,
 				   ankerl::unordered_dense::set<std::string> &leaf_atoms,
 				   ankerl::unordered_dense::set<int> &visited)
 {
@@ -571,10 +571,10 @@ collect_leaf_atoms(composites_manager *cm, const rspamd_composite *comp,
 	visited.insert(comp->id);
 
 	struct walk_data {
-		composites_manager *cm;
+		composites_generation *gen;
 		ankerl::unordered_dense::set<std::string> *leaves;
 		ankerl::unordered_dense::set<int> *visited;
-	} wd{cm, &leaf_atoms, &visited};
+	} wd{&gen, &leaf_atoms, &visited};
 
 	rspamd_expression_atom_foreach_ex(comp->expr, [](GNode *node, rspamd_expression_atom_t *atom, gpointer ud) {
 			auto *wd = reinterpret_cast<walk_data *>(ud);
@@ -588,10 +588,10 @@ collect_leaf_atoms(composites_manager *cm, const rspamd_composite *comp,
 				return;
 			}
 
-			auto *ref = wd->cm->find(sym);
+			auto *ref = wd->gen->find(sym);
 			if (ref != nullptr) {
 				/* Atom is a composite reference - recurse into it */
-				collect_leaf_atoms(wd->cm, ref, *wd->leaves, *wd->visited);
+				collect_leaf_atoms(*wd->gen, ref, *wd->leaves, *wd->visited);
 			}
 			else {
 				wd->leaves->insert(std::move(sym));
@@ -600,7 +600,7 @@ collect_leaf_atoms(composites_manager *cm, const rspamd_composite *comp,
 
 /* Context for building inverted index */
 struct inverted_index_cbdata {
-	composites_manager *cm;
+	composites_generation *gen;
 	rspamd_composite *comp;
 	bool has_positive;
 	bool has_group_atom; /* Composite uses group matcher (g:, g+:, g-:) */
@@ -645,15 +645,12 @@ inverted_index_atom_callback(GNode *atom_node, rspamd_expression_atom_t *atom, g
 	/* Mark that we have at least one positive atom */
 	cbd->has_positive = true;
 
-	/* Add to inverted index (always the manager's *current* generation, which
-	 * is what build_inverted_index operates on) */
-	cbd->cm->current()->symbol_to_composites[symbol_name].push_back(cbd->comp);
+	/* Add to inverted index in the generation being built */
+	cbd->gen->symbol_to_composites[symbol_name].push_back(cbd->comp);
 }
 
-void composites_manager::build_inverted_index()
+void composites_manager::build_inverted_index(composites_generation &gen)
 {
-	auto &gen = *current_gen;
-
 	msg_debug_config("building inverted index for %d composites (gen %L)",
 					 (int) gen.all_composites.size(), (int64_t) gen.generation_id);
 
@@ -667,7 +664,7 @@ void composites_manager::build_inverted_index()
 			continue;
 		}
 
-		inverted_index_cbdata cbd{this, comp.get(), false, false};
+		inverted_index_cbdata cbd{&gen, comp.get(), false, false};
 
 		rspamd_expression_atom_foreach_ex(comp->expr, inverted_index_atom_callback, &cbd);
 
@@ -705,7 +702,7 @@ void composites_manager::build_inverted_index()
 	 */
 	ankerl::unordered_dense::set<std::string> composite_keys;
 	for (const auto &[sym, _]: gen.symbol_to_composites) {
-		if (find(sym) != nullptr) {
+		if (gen.find(sym) != nullptr) {
 			composite_keys.insert(sym);
 		}
 	}
@@ -721,12 +718,12 @@ void composites_manager::build_inverted_index()
 			}
 
 			auto dependents = it->second; /* Copy before modifying the map */
-			auto *ref_comp = find(comp_key);
+			auto *ref_comp = gen.find(comp_key);
 
 			/* Collect all leaf (non-composite) atoms reachable from this composite */
 			ankerl::unordered_dense::set<std::string> leaf_atoms;
 			ankerl::unordered_dense::set<int> visited;
-			collect_leaf_atoms(this, ref_comp, leaf_atoms, visited);
+			collect_leaf_atoms(gen, ref_comp, leaf_atoms, visited);
 
 			/* Propagate dependents to each leaf atom's index entry */
 			for (const auto &leaf: leaf_atoms) {
@@ -824,10 +821,9 @@ whitelist_atom_callback(const rspamd_ftok_t *atom, gpointer ud)
 	}
 }
 
-void composites_manager::mark_whitelist_dependencies()
+void composites_manager::mark_whitelist_dependencies(composites_generation &gen)
 {
 	ankerl::unordered_dense::set<std::string> fine_symbols;
-	auto &gen = *current_gen;
 
 	msg_debug_config("analyzing whitelist composites for FINE symbol marking (gen %L)",
 					 (int64_t) gen.generation_id);

--- a/src/libserver/composites/composites_manager.cxx
+++ b/src/libserver/composites/composites_manager.cxx
@@ -198,10 +198,16 @@ auto composites_manager::add_composite(std::string_view composite_name,
 	return new_composite(composite_name, expr, composite_expression).get();
 }
 
+/*
+ * Per-map state. Lives in cfg->cfg_pool and survives across reloads of the
+ * same map. `last_names` tracks which composite names this map last
+ * published so that on reload we can stub-out names that the map dropped.
+ */
 struct map_cbdata {
 	composites_manager *cm;
 	struct rspamd_config *cfg;
 	std::string buf;
+	ankerl::unordered_dense::set<std::string> last_names;
 
 	explicit map_cbdata(struct rspamd_config *cfg)
 		: cfg(cfg)
@@ -213,14 +219,12 @@ struct map_cbdata {
 						  struct map_cb_data *data,
 						  gboolean _final)
 	{
-
 		if (data->cur_data == nullptr) {
 			data->cur_data = data->prev_data;
 			reinterpret_cast<map_cbdata *>(data->cur_data)->buf.clear();
 		}
 
 		auto *cbd = reinterpret_cast<map_cbdata *>(data->cur_data);
-
 		cbd->buf.append(chunk, len);
 		return nullptr;
 	}
@@ -234,46 +238,102 @@ struct map_cbdata {
 			if (cbd) {
 				cbd->buf.clear();
 			}
+			return;
 		}
-		else if (cbd != nullptr) {
-			if (target) {
-				*target = data->cur_data;
+
+		if (cbd == nullptr) {
+			msg_err("no data read for composites map");
+			return;
+		}
+
+		if (target) {
+			*target = data->cur_data;
+		}
+
+		auto *cfg = cbd->cfg;
+		auto *cm = cbd->cm;
+
+		/* Parse the buffered bytes as UCL. */
+		auto *parser = ucl_parser_new(UCL_PARSER_NO_FILEVARS);
+		if (!ucl_parser_add_chunk(parser,
+								  reinterpret_cast<const unsigned char *>(cbd->buf.data()),
+								  cbd->buf.size())) {
+			msg_err_config("cannot parse composites map as UCL: %s",
+						   ucl_parser_get_error(parser));
+			ucl_parser_free(parser);
+			cbd->buf.clear();
+			return;
+		}
+
+		ucl_object_t *top = ucl_parser_get_object(parser);
+		ucl_parser_free(parser);
+
+		if (top == nullptr) {
+			msg_err_config("composites map UCL is empty");
+			cbd->buf.clear();
+			return;
+		}
+
+		if (ucl_object_type(top) != UCL_OBJECT) {
+			msg_err_config("composites map must be a UCL object, got %s",
+						   ucl_object_type_to_string(ucl_object_type(top)));
+			ucl_object_unref(top);
+			cbd->buf.clear();
+			return;
+		}
+
+		/* Build a staging generation cloned from the base. */
+		auto staging = cm->build_staging();
+		ankerl::unordered_dense::set<std::string> seen_in_map;
+		unsigned int added = 0, updated = 0, failed = 0;
+
+		const ucl_object_t *cur;
+		auto *it = ucl_object_iterate_new(top);
+		while ((cur = ucl_object_iterate_safe(it, true)) != nullptr) {
+			const char *key = ucl_object_key(cur);
+			if (key == nullptr) {
+				continue;
+			}
+			std::string name{key};
+
+			bool replacing = staging->composites.contains(name);
+			auto *comp = cm->add_composite_to_staging(*staging, name, cur);
+			if (comp == nullptr) {
+				failed++;
+				continue;
 			}
 
-			rspamd::string_foreach_line(cbd->buf, [&](std::string_view line) {
-				auto [name_and_score, expr] = rspamd::string_split_on(line, ' ');
-				auto [name, score] = rspamd::string_split_on(name_and_score, ':');
-
-				if (!score.empty()) {
-					/* I wish it was supported properly */
-					//auto conv_res = std::from_chars(value->data(), value->size(), num);
-					char numbuf[128], *endptr = nullptr;
-					size_t n = std::min(score.size(), sizeof(numbuf) - 1);
-					memcpy(numbuf, score.data(), n);
-					numbuf[n] = '\0';
-					auto num = g_ascii_strtod(numbuf, &endptr);
-
-					if (fabs(num) >= G_MAXFLOAT || std::isnan(num)) {
-						msg_err("invalid score for %*s", (int) name_and_score.size(), name_and_score.data());
-						return;
-					}
-
-					auto ret = cbd->cm->add_composite(name, expr, true, num);
-
-					if (ret == nullptr) {
-						msg_err("cannot add composite %*s", (int) name_and_score.size(), name_and_score.data());
-						return;
-					}
-				}
-				else {
-					msg_err("missing score for %*s", (int) name_and_score.size(), name_and_score.data());
-					return;
-				}
-			});
+			seen_in_map.insert(name);
+			if (replacing) {
+				updated++;
+			}
+			else {
+				added++;
+			}
 		}
-		else {
-			msg_err("no data read for composites map");
+		ucl_object_iterate_free(it);
+		ucl_object_unref(top);
+
+		/* Names this map previously owned but no longer mentions become
+		 * disabled stubs in the staging. */
+		unsigned int stubbed = 0;
+		for (const auto &name: cbd->last_names) {
+			if (seen_in_map.contains(name)) {
+				continue;
+			}
+			if (cm->disable_in_staging(*staging, name)) {
+				stubbed++;
+			}
 		}
+
+		cm->publish_generation(staging);
+		cbd->last_names = std::move(seen_in_map);
+		cbd->buf.clear();
+
+		msg_info_config("dynamic composites map reloaded (gen %L): "
+						"%ud added, %ud updated, %ud stubbed, %ud failed",
+						(int64_t) cm->current()->generation_id,
+						added, updated, stubbed, failed);
 	}
 
 	static void
@@ -879,6 +939,257 @@ void composites_manager::mark_whitelist_dependencies(composites_generation &gen)
 					marked_count);
 }
 
+auto composites_manager::build_staging() -> std::shared_ptr<composites_generation>
+{
+	auto staging = std::make_shared<composites_generation>();
+	staging->generation_id = allocate_generation_id();
+
+	if (!base_gen) {
+		/* Should not happen — pin_base_generation must be called once
+		 * after static load. Fall back to current_gen so the caller still
+		 * gets a workable staging. */
+		msg_warn_config("composites: build_staging() called before base "
+						"generation was pinned, cloning current_gen instead");
+	}
+
+	const auto &source = base_gen ? *base_gen : *current_gen;
+
+	for (const auto &orig: source.all_composites) {
+		/*
+		 * Deep-copy the composite struct (shared expression pointer is
+		 * fine, it lives in cfg_pool). Re-derive per-generation flags
+		 * via the analysis pipeline.
+		 */
+		auto cloned = std::make_shared<rspamd_composite>(*orig);
+		cloned->id = next_id();
+		cloned->second_pass = false;
+		cloned->has_positive_atoms = false;
+		staging->all_composites.push_back(cloned);
+		staging->composites[cloned->sym] = cloned;
+	}
+
+	msg_debug_config("composites: built staging gen %L with %d cloned composites",
+					 (int64_t) staging->generation_id,
+					 (int) staging->all_composites.size());
+
+	return staging;
+}
+
+auto composites_manager::add_composite_to_staging(composites_generation &staging,
+												  std::string_view name,
+												  const ucl_object_t *obj) -> rspamd_composite *
+{
+	const auto *val = ucl_object_lookup(obj, "enabled");
+	if (val != nullptr && !ucl_object_toboolean(val)) {
+		/* Operator wants the name present but inactive — disabled stub */
+		disable_in_staging(staging, std::string(name));
+		return staging.find(name) ? const_cast<rspamd_composite *>(staging.find(name)) : nullptr;
+	}
+
+	const char *composite_expression = nullptr;
+	val = ucl_object_lookup(obj, "expression");
+
+	if (val == nullptr || !ucl_object_tostring_safe(val, &composite_expression)) {
+		msg_err_config("dynamic composite %*s has no expression",
+					   (int) name.size(), name.data());
+		return nullptr;
+	}
+
+	/* Copy the expression into cfg_pool — parser keeps pointers into it. */
+	auto expr_len = strlen(composite_expression);
+	char *expr_copy = rspamd_mempool_alloc_buffer(cfg->cfg_pool, expr_len + 1);
+	memcpy(expr_copy, composite_expression, expr_len);
+	expr_copy[expr_len] = '\0';
+
+	GError *err = nullptr;
+	rspamd_expression *expr = nullptr;
+
+	if (!rspamd_parse_expression(expr_copy, expr_len, &composite_expr_subr,
+								 nullptr, cfg->cfg_pool, &err, &expr)) {
+		msg_err_config("cannot parse expression for dynamic composite %*s: %e",
+					   (int) name.size(), name.data(), err);
+		if (err) {
+			g_error_free(err);
+		}
+		return nullptr;
+	}
+
+	auto composite = std::make_shared<rspamd_composite>();
+	composite->id = next_id();
+	composite->expr = expr;
+	composite->str_expr = composite_expression;
+	composite->sym = std::string(name);
+	composite->second_pass = false;
+	composite->has_positive_atoms = false;
+	composite->disabled = false;
+	composite->policy = rspamd_composite_policy::RSPAMD_COMPOSITE_POLICY_REMOVE_ALL;
+
+	val = ucl_object_lookup(obj, "policy");
+	if (val) {
+		auto p = composite_policy_from_str(ucl_object_tostring(val));
+		if (p == rspamd_composite_policy::RSPAMD_COMPOSITE_POLICY_UNKNOWN) {
+			msg_err_config("dynamic composite %*s has unknown policy '%s'",
+						   (int) name.size(), name.data(), ucl_object_tostring(val));
+			return nullptr;
+		}
+		composite->policy = p;
+	}
+
+	/* Replace any existing entry under this name (came from base_gen
+	 * clone or from an earlier entry in this same map). */
+	auto sym_key = composite->sym;
+	auto it = staging.composites.find(sym_key);
+	if (it != staging.composites.end()) {
+		/* Find and replace in all_composites */
+		for (auto &slot: staging.all_composites) {
+			if (slot.get() == it->second.get()) {
+				slot = composite;
+				break;
+			}
+		}
+		it->second = composite;
+	}
+	else {
+		staging.all_composites.push_back(composite);
+		staging.composites[sym_key] = composite;
+	}
+
+	/* Reflect the composite in cfg->symbols so scoring and FINE-flag
+	 * propagation work for both static and dynamic composites. Safe to
+	 * mutate the GHashTable here because we're on the libev thread with
+	 * no scan in progress. */
+	auto score = std::isnan(cfg->unknown_weight) ? 0.0 : cfg->unknown_weight;
+	val = ucl_object_lookup(obj, "score");
+	if (val != nullptr) {
+		ucl_object_todouble_safe(val, &score);
+	}
+
+	const char *group = "composite";
+	val = ucl_object_lookup(obj, "group");
+	if (val != nullptr) {
+		group = ucl_object_tostring(val);
+	}
+
+	const char *description = composite_expression;
+	val = ucl_object_lookup(obj, "description");
+	if (val != nullptr) {
+		description = ucl_object_tostring(val);
+	}
+
+	rspamd_config_add_symbol(cfg, composite->sym.c_str(), score,
+							 description, group,
+							 0, ucl_object_get_priority(obj),
+							 1);
+
+	const auto *groups = ucl_object_lookup(obj, "groups");
+	if (groups && ucl_object_type(groups) == UCL_ARRAY) {
+		const ucl_object_t *cur_gr;
+		auto *gr_it = ucl_object_iterate_new(groups);
+
+		while ((cur_gr = ucl_object_iterate_safe(gr_it, true)) != nullptr) {
+			rspamd_config_add_symbol_group(cfg, composite->sym.c_str(),
+										   ucl_object_tostring(cur_gr));
+		}
+
+		ucl_object_iterate_free(gr_it);
+	}
+
+	return composite.get();
+}
+
+auto composites_manager::disable_in_staging(composites_generation &staging,
+											const std::string &name) -> bool
+{
+	auto it = staging.composites.find(name);
+	if (it == staging.composites.end()) {
+		/* Name never existed — create an inert stub so find() works */
+		auto stub = std::make_shared<rspamd_composite>();
+		stub->id = next_id();
+		stub->expr = nullptr;
+		stub->sym = name;
+		stub->second_pass = false;
+		stub->has_positive_atoms = false;
+		stub->disabled = true;
+		stub->policy = rspamd_composite_policy::RSPAMD_COMPOSITE_POLICY_LEAVE;
+		staging.all_composites.push_back(stub);
+		staging.composites[name] = stub;
+		return true;
+	}
+
+	auto stub = std::make_shared<rspamd_composite>(*it->second);
+	stub->id = next_id();
+	stub->expr = nullptr;
+	stub->second_pass = false;
+	stub->has_positive_atoms = false;
+	stub->disabled = true;
+	for (auto &slot: staging.all_composites) {
+		if (slot.get() == it->second.get()) {
+			slot = stub;
+			break;
+		}
+	}
+	it->second = stub;
+	return true;
+}
+
+auto composites_manager::publish_generation(std::shared_ptr<composites_generation> staging) -> void
+{
+	if (!staging) {
+		return;
+	}
+
+	/* Register newly-introduced composite names with the symcache. cfg->symbols
+	 * was already updated by add_composite_to_staging(). ever_seen_names gates
+	 * the one-time symcache add. */
+	bool symcache_changed = false;
+	for (const auto &[name, comp]: staging->composites) {
+		if (comp->disabled) {
+			continue;
+		}
+		if (ever_seen_names.contains(name)) {
+			continue;
+		}
+		if (cfg->cache) {
+			rspamd_symcache_add_symbol(cfg->cache, name.c_str(), 0,
+									   nullptr, comp.get(),
+									   SYMBOL_TYPE_COMPOSITE, -1);
+			symcache_changed = true;
+		}
+		/* Pin the shared_ptr so the symcache's ud never dangles even if
+		 * the composite is replaced in a later generation. */
+		symcache_pinned[name] = comp;
+		ever_seen_names.insert(name);
+	}
+
+	if (symcache_changed && cfg->cache) {
+		rspamd_symcache_promote_resort(cfg->cache);
+	}
+
+	/* Run the analysis pipeline on the staging gen. */
+	process_dependencies(*staging);
+	build_inverted_index(*staging);
+	mark_whitelist_dependencies(*staging);
+
+	/* Atomic swap (single-threaded libev: assignment is the swap). */
+	current_gen = std::move(staging);
+}
+
+auto composites_manager::seal_static_load() -> void
+{
+	if (base_gen) {
+		return; /* Already sealed */
+	}
+	base_gen = current_gen;
+	for (const auto &[name, comp]: current_gen->composites) {
+		ever_seen_names.insert(name);
+		/* Static composites are pinned via base_gen → all_composites, no
+		 * extra pinning required for the symcache ud. */
+	}
+	msg_debug_config("composites: sealed static load (gen %L, %d composites)",
+					 (int64_t) current_gen->generation_id,
+					 (int) current_gen->all_composites.size());
+}
+
 }// namespace rspamd::composites
 
 void rspamd_composites_process_deps(void *cm_ptr, struct rspamd_config *cfg)
@@ -921,4 +1232,22 @@ void rspamd_composites_mark_whitelist_deps(void *cm_ptr, struct rspamd_config *c
 {
 	auto *cm = COMPOSITE_MANAGER_FROM_PTR(cm_ptr);
 	cm->mark_whitelist_dependencies();
+	/* Last step of static load: snapshot base generation and ever-seen
+	 * names so dynamic map publishes can clone from a stable base. */
+	cm->seal_static_load();
+}
+
+bool rspamd_composites_add_dynamic_map(void *cm_ptr, const ucl_object_t *obj,
+									   struct rspamd_config *cfg)
+{
+	auto *cm = COMPOSITE_MANAGER_FROM_PTR(cm_ptr);
+	(void) cm;
+	return rspamd_composites_add_map_handlers(obj, cfg);
+}
+
+uint64_t rspamd_composites_current_generation(void *cm_ptr)
+{
+	auto *cm = COMPOSITE_MANAGER_FROM_PTR(cm_ptr);
+	auto *gen = cm->current();
+	return gen ? gen->generation_id : 0;
 }

--- a/src/libserver/composites/composites_manager.cxx
+++ b/src/libserver/composites/composites_manager.cxx
@@ -61,7 +61,7 @@ auto composites_manager::add_composite(std::string_view composite_name, const uc
 		return nullptr;
 	}
 
-	if (composites.contains(composite_name)) {
+	if (current_gen->composites.contains(composite_name)) {
 		if (silent_duplicate) {
 			msg_debug_config("composite %s is redefined", composite_name.data());
 			return nullptr;
@@ -156,7 +156,7 @@ auto composites_manager::add_composite(std::string_view composite_name,
 	GError *err = nullptr;
 	rspamd_expression *expr = nullptr;
 
-	if (composites.contains(composite_name)) {
+	if (current_gen->composites.contains(composite_name)) {
 		/* Duplicate composite - refuse to add */
 		if (silent_duplicate) {
 			msg_debug_config("composite %s is redefined", composite_name.data());
@@ -405,16 +405,27 @@ void composites_manager::process_dependencies()
 {
 	ankerl::unordered_dense::set<rspamd_composite *> second_pass_set;
 	bool changed;
+	auto &gen = *current_gen;
 
-	msg_debug_config("analyzing composite dependencies for two-phase evaluation");
+	msg_debug_config("analyzing composite dependencies for two-phase evaluation (gen %L)",
+					 (int64_t) gen.generation_id);
 
-	/* Initially, all composites start in first pass */
-	for (const auto &comp: all_composites) {
-		first_pass_composites.push_back(comp.get());
+	/* Reset pass buckets in case process_dependencies() is called repeatedly */
+	gen.first_pass_composites.clear();
+	gen.second_pass_composites.clear();
+
+	/* Skip disabled stubs entirely — they will not be evaluated */
+	for (const auto &comp: gen.all_composites) {
+		if (!comp->disabled) {
+			gen.first_pass_composites.push_back(comp.get());
+		}
+		else {
+			comp->second_pass = false;
+		}
 	}
 
 	/* First pass: mark composites that directly depend on postfilters/stats */
-	for (auto *comp: first_pass_composites) {
+	for (auto *comp: gen.first_pass_composites) {
 		composite_dep_cbdata cbd{cfg, false, this};
 
 		rspamd_expression_atom_foreach(comp->expr,
@@ -431,7 +442,7 @@ void composites_manager::process_dependencies()
 	/* Second pass: handle transitive dependencies */
 	do {
 		changed = false;
-		for (auto *comp: first_pass_composites) {
+		for (auto *comp: gen.first_pass_composites) {
 			if (second_pass_set.contains(comp)) {
 				continue;
 			}
@@ -465,20 +476,21 @@ void composites_manager::process_dependencies()
 	} while (changed);
 
 	/* Move second-pass composites from first_pass to second_pass vector and mark them */
-	auto it = first_pass_composites.begin();
-	while (it != first_pass_composites.end()) {
+	auto it = gen.first_pass_composites.begin();
+	while (it != gen.first_pass_composites.end()) {
 		if (second_pass_set.contains(*it)) {
 			(*it)->second_pass = true;
-			second_pass_composites.push_back(*it);
-			it = first_pass_composites.erase(it);
+			gen.second_pass_composites.push_back(*it);
+			it = gen.first_pass_composites.erase(it);
 		}
 		else {
+			(*it)->second_pass = false;
 			++it;
 		}
 	}
 
 	msg_debug_config("composite dependency analysis complete: %d first-pass, %d second-pass composites",
-					 (int) first_pass_composites.size(), (int) second_pass_composites.size());
+					 (int) gen.first_pass_composites.size(), (int) gen.second_pass_composites.size());
 }
 
 /*
@@ -633,15 +645,28 @@ inverted_index_atom_callback(GNode *atom_node, rspamd_expression_atom_t *atom, g
 	/* Mark that we have at least one positive atom */
 	cbd->has_positive = true;
 
-	/* Add to inverted index */
-	cbd->cm->symbol_to_composites[symbol_name].push_back(cbd->comp);
+	/* Add to inverted index (always the manager's *current* generation, which
+	 * is what build_inverted_index operates on) */
+	cbd->cm->current()->symbol_to_composites[symbol_name].push_back(cbd->comp);
 }
 
 void composites_manager::build_inverted_index()
 {
-	msg_debug_config("building inverted index for %d composites", (int) all_composites.size());
+	auto &gen = *current_gen;
 
-	for (auto &comp: all_composites) {
+	msg_debug_config("building inverted index for %d composites (gen %L)",
+					 (int) gen.all_composites.size(), (int64_t) gen.generation_id);
+
+	gen.symbol_to_composites.clear();
+	gen.not_only_composites.clear();
+
+	for (auto &comp: gen.all_composites) {
+		if (comp->disabled) {
+			/* Stub: contributes neither to the index nor to "always check" */
+			comp->has_positive_atoms = false;
+			continue;
+		}
+
 		inverted_index_cbdata cbd{this, comp.get(), false, false};
 
 		rspamd_expression_atom_foreach_ex(comp->expr, inverted_index_atom_callback, &cbd);
@@ -654,7 +679,7 @@ void composites_manager::build_inverted_index()
 			 * - It has only negated atoms (no positive symbols to match)
 			 * - It uses group matchers (we don't know which symbols will match)
 			 */
-			not_only_composites.push_back(comp.get());
+			gen.not_only_composites.push_back(comp.get());
 			if (cbd.has_group_atom) {
 				msg_debug_config("composite '%s' uses group matcher, will always be checked",
 								 comp->sym.c_str());
@@ -679,7 +704,7 @@ void composites_manager::build_inverted_index()
 	 * entries. Then remove the composite-name keys.
 	 */
 	ankerl::unordered_dense::set<std::string> composite_keys;
-	for (const auto &[sym, _]: symbol_to_composites) {
+	for (const auto &[sym, _]: gen.symbol_to_composites) {
 		if (find(sym) != nullptr) {
 			composite_keys.insert(sym);
 		}
@@ -690,8 +715,8 @@ void composites_manager::build_inverted_index()
 						 (int) composite_keys.size());
 
 		for (const auto &comp_key: composite_keys) {
-			auto it = symbol_to_composites.find(comp_key);
-			if (it == symbol_to_composites.end()) {
+			auto it = gen.symbol_to_composites.find(comp_key);
+			if (it == gen.symbol_to_composites.end()) {
 				continue;
 			}
 
@@ -705,7 +730,7 @@ void composites_manager::build_inverted_index()
 
 			/* Propagate dependents to each leaf atom's index entry */
 			for (const auto &leaf: leaf_atoms) {
-				auto &entry = symbol_to_composites[leaf];
+				auto &entry = gen.symbol_to_composites[leaf];
 				for (auto *dep: dependents) {
 					if (std::find(entry.begin(), entry.end(), dep) == entry.end()) {
 						entry.push_back(dep);
@@ -720,9 +745,9 @@ void composites_manager::build_inverted_index()
 			 */
 			if (leaf_atoms.empty()) {
 				for (auto *dep: dependents) {
-					if (std::find(not_only_composites.begin(),
-								  not_only_composites.end(), dep) == not_only_composites.end()) {
-						not_only_composites.push_back(dep);
+					if (std::find(gen.not_only_composites.begin(),
+								  gen.not_only_composites.end(), dep) == gen.not_only_composites.end()) {
+						gen.not_only_composites.push_back(dep);
 						msg_debug_config("composite '%s' depends on composite '%s' "
 										 "with no leaf atoms, will always be checked",
 										 dep->sym.c_str(), comp_key.c_str());
@@ -731,7 +756,7 @@ void composites_manager::build_inverted_index()
 			}
 
 			/* Remove the composite-name key from the index */
-			symbol_to_composites.erase(comp_key);
+			gen.symbol_to_composites.erase(comp_key);
 
 			msg_debug_config("resolved composite reference '%s': "
 							 "propagated %d dependents to %d leaf atoms",
@@ -741,7 +766,7 @@ void composites_manager::build_inverted_index()
 	}
 
 	msg_debug_config("inverted index built: %d unique symbols, %d not-only composites",
-					 (int) symbol_to_composites.size(), (int) not_only_composites.size());
+					 (int) gen.symbol_to_composites.size(), (int) gen.not_only_composites.size());
 }
 
 /* Callback data for collecting atoms from whitelist composites */
@@ -802,11 +827,16 @@ whitelist_atom_callback(const rspamd_ftok_t *atom, gpointer ud)
 void composites_manager::mark_whitelist_dependencies()
 {
 	ankerl::unordered_dense::set<std::string> fine_symbols;
+	auto &gen = *current_gen;
 
-	msg_debug_config("analyzing whitelist composites for FINE symbol marking");
+	msg_debug_config("analyzing whitelist composites for FINE symbol marking (gen %L)",
+					 (int64_t) gen.generation_id);
 
 	/* Step 1: Find composites with negative score and collect their atoms */
-	for (const auto &comp: all_composites) {
+	for (const auto &comp: gen.all_composites) {
+		if (comp->disabled) {
+			continue;
+		}
 		auto *sym_def = static_cast<struct rspamd_symbol *>(
 			g_hash_table_lookup(cfg->symbols, comp->sym.c_str()));
 
@@ -824,7 +854,10 @@ void composites_manager::mark_whitelist_dependencies()
 	bool changed;
 	do {
 		changed = false;
-		for (const auto &comp: all_composites) {
+		for (const auto &comp: gen.all_composites) {
+			if (comp->disabled) {
+				continue;
+			}
 			if (fine_symbols.contains(comp->sym)) {
 				size_t before = fine_symbols.size();
 				whitelist_atom_cbdata cbd{&fine_symbols};
@@ -856,7 +889,6 @@ void rspamd_composites_process_deps(void *cm_ptr, struct rspamd_config *cfg)
 {
 	auto *cm = COMPOSITE_MANAGER_FROM_PTR(cm_ptr);
 	cm->process_dependencies();
-	rspamd_composites_resolve_atom_types(cm);
 	cm->build_inverted_index();
 }
 

--- a/test/functional/cases/119_dynamic_composites.robot
+++ b/test/functional/cases/119_dynamic_composites.robot
@@ -1,0 +1,54 @@
+*** Settings ***
+Suite Setup     Dynamic Composites Setup
+Suite Teardown  Dynamic Composites Teardown
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}                  ${RSPAMD_TESTDIR}/configs/dynamic_composites.conf
+${RSPAMD_MAP_WATCH_INTERVAL}  0.5s
+${MESSAGE}                 ${RSPAMD_TESTDIR}/messages/spam_message.eml
+${RSPAMD_LUA_SCRIPT}       ${RSPAMD_TESTDIR}/lua/dynamic_composites.lua
+${RSPAMD_SCOPE}            Suite
+${RSPAMD_URL_TLD}          ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+INITIAL MAP - DYN_ONE FIRES
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  DYN_ONE  2.5
+  Expect Symbol With Score  DYN_TWO  3.5
+  Expect Symbol With Score  STATIC_COMP  1.0
+  Do Not Expect Symbol  DYN_THREE
+
+RELOAD - UPDATED SCORES AND NEW NAME
+  ${TMP_FILE} =  Make Temporary File
+  Copy File  ${RSPAMD_TESTDIR}/configs/maps/dynamic_composites.map.2  ${TMP_FILE}
+  Move File  ${TMP_FILE}  ${RSPAMD_DYN_COMP_MAP}
+  Sleep  2s  Wait for map reload
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  DYN_ONE  7.0
+  Expect Symbol With Score  DYN_THREE  4.0
+  Expect Symbol With Score  STATIC_COMP  1.0
+  Do Not Expect Symbol  DYN_TWO
+
+RELOAD - REMOVED COMPOSITE BECOMES STUB
+  ${TMP_FILE} =  Make Temporary File
+  Copy File  ${RSPAMD_TESTDIR}/configs/maps/dynamic_composites.map.1  ${TMP_FILE}
+  Move File  ${TMP_FILE}  ${RSPAMD_DYN_COMP_MAP}
+  Sleep  2s  Wait for map reload
+  Scan File  ${MESSAGE}
+  Expect Symbol With Score  DYN_ONE  2.5
+  Expect Symbol With Score  DYN_TWO  3.5
+  Do Not Expect Symbol  DYN_THREE
+
+*** Keywords ***
+Dynamic Composites Setup
+  ${RSPAMD_DYN_COMP_MAP} =  Make Temporary File
+  Set Suite Variable  ${RSPAMD_DYN_COMP_MAP}
+  Copy File  ${RSPAMD_TESTDIR}/configs/maps/dynamic_composites.map.1  ${RSPAMD_DYN_COMP_MAP}
+  Rspamd Setup
+
+Dynamic Composites Teardown
+  Remove File  ${RSPAMD_DYN_COMP_MAP}
+  Rspamd Teardown

--- a/test/functional/configs/dynamic_composites.conf
+++ b/test/functional/configs/dynamic_composites.conf
@@ -1,0 +1,42 @@
+options = {
+	filters = []
+	url_tld = "{= env.URL_TLD =}"
+	pidfile = "{= env.TMPDIR =}/rspamd.pid"
+	map_watch_interval = {= env.MAP_WATCH_INTERVAL =};
+}
+logging = {
+	type = "file",
+	level = "debug"
+	filename = "{= env.TMPDIR =}/rspamd.log"
+}
+metric = {
+	name = "default",
+	actions = {
+		reject = 100500,
+	}
+	unknown_weight = 1
+}
+
+worker {
+	type = normal
+	bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_NORMAL =}"
+	count = 1
+	task_timeout = 10s;
+}
+worker {
+	type = controller
+	bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_CONTROLLER =}"
+	count = 1
+	secure_ip = ["127.0.0.1", "::1"];
+	stats_path = "{= env.TMPDIR =}/stats.ucl"
+}
+lua = "{= env.TESTDIR =}/lua/test_coverage.lua";
+lua = "{= env.LUA_SCRIPT =}";
+
+composites {
+	STATIC_COMP {
+		expression = "DYN_BASE_A";
+		score = 1.0;
+	}
+	dynamic = "{= env.DYN_COMP_MAP =}";
+}

--- a/test/functional/configs/maps/dynamic_composites.map.1
+++ b/test/functional/configs/maps/dynamic_composites.map.1
@@ -1,0 +1,8 @@
+DYN_ONE {
+	expression = "DYN_BASE_A";
+	score = 2.5;
+}
+DYN_TWO {
+	expression = "DYN_BASE_B";
+	score = 3.5;
+}

--- a/test/functional/configs/maps/dynamic_composites.map.2
+++ b/test/functional/configs/maps/dynamic_composites.map.2
@@ -1,0 +1,8 @@
+DYN_ONE {
+	expression = "DYN_BASE_A";
+	score = 7.0;
+}
+DYN_THREE {
+	expression = "DYN_BASE_C";
+	score = 4.0;
+}

--- a/test/functional/lua/dynamic_composites.lua
+++ b/test/functional/lua/dynamic_composites.lua
@@ -1,0 +1,11 @@
+-- Always-firing atomic symbols used as inputs for dynamic composites.
+local atoms = { 'DYN_BASE_A', 'DYN_BASE_B', 'DYN_BASE_C' }
+for _, name in ipairs(atoms) do
+  rspamd_config:register_symbol({
+    name = name,
+    score = 0.1,
+    callback = function()
+      return true, 'fires always'
+    end
+  })
+end


### PR DESCRIPTION
## Summary

Adds hot-reloadable composites: a `composites { dynamic = "..."; }` map source can introduce, update, score-adjust, and remove composites at runtime. The map is fetched and parsed by the standard rspamd map watcher, so file://, http(s)://, signed maps, etc. all work as-is.

Each map reload builds a fresh **generation** off the static-config base, layers the map's composites on top, materialises **disabled stubs** for names this map previously published but no longer mentions, and atomically swaps it in as the live generation. In-flight tasks keep using their pinned snapshot via `shared_ptr<composites_generation>` and finish on whatever was current when they started.

## Configuration

```ucl
composites {
    # static composites (unchanged)
    MY_STATIC { expression = "FOO & BAR"; score = 1.0; }

    # hot-reloadable map(s) — value accepts anything rspamd_map_add_from_ucl does
    dynamic = "/etc/rspamd/composites.map";
    # or dynamic = ["http://a/x.ucl", "file:///y.ucl"];
    # or dynamic = { url = "..."; signature = "..."; }
}
```

Map content is UCL: `{ COMPOSITE_NAME = { expression, score, group, policy, description, groups, enabled }, ... }` — same vocabulary as the static `composites { }` block.

## Design

Documented in commits, summary:

| | |
|---|---|
| Snapshotting | `composites_data` pins `shared_ptr<composites_generation>` at task creation; all reads go through it. |
| ID space | Monotonic across reloads; `checked` vector sized by max id in the snapshot. |
| Atom resolution | No caching on atom — lookup against the task's snapshot every eval (avoids cross-generation dangling). |
| Removed names | Become **disabled** stubs (`comp->disabled = true`, expr = nullptr, eval skips). Symcache entry stays alive forever. |
| New names | Registered with `rspamd_symcache_add_symbol` + `rspamd_symcache_promote_resort` on first publish; gated by `ever_seen_names`. |
| Concurrency | Single-threaded libev → swap is plain `shared_ptr` assignment; pinning the originally-registered composite via `symcache_pinned` keeps the symcache cbdata pointer non-dangling. |
| Lifecycle | Expressions live in `cfg->cfg_pool` (accepted leak — periodic worker restart resets); FINE flag remains sticky (documented over-approximation). |

## What's where

- `src/libserver/composites/composites_internal.hxx` — `composites_generation` struct, manager API.
- `src/libserver/composites/composites_manager.cxx` — `build_staging`, `add_composite_to_staging`, `disable_in_staging`, `publish_generation`, `seal_static_load`, UCL-parsing `map_cbdata`.
- `src/libserver/composites/composites.cxx` — runtime path reads through snapshot; dropped `ATOM_COMPOSITE`/`ATOM_PLAIN` cache.
- `src/libserver/composites/composites.h` — `rspamd_composites_add_dynamic_map`, `rspamd_composites_current_generation`.
- `src/libserver/cfg_rcl.cxx` — intercepts the `dynamic` key in `composites { }`.

## Testing

- **C++ unit tests** (`rspamd-test-cxx`): 209/209 pass.
- **Static composites** (`109 Composites`): 7/7 pass — refactor preserves behaviour.
- **Settings merge** (`109 Settings Merge`): 10/10 pass.
- **New functional suite** (`119 Dynamic Composites`, `test/functional/cases/119_dynamic_composites.robot`): 3/3 pass — covers initial load, reload-with-update (changed score + new name + dropped name), reload-with-removed (stub turns previously-published name inert).

## Commits

```
[Refactor] composites: extract per-task generation snapshot
[Refactor] composites: parameterise build helpers by generation
[Feature] composites: dynamic UCL map handler
[Conf]    composites: route composites.dynamic to map handler
[Test]    composites: functional test for dynamic UCL composites map
```

Each refactor commit is no-behaviour-change for static configurations; the feature commit is opt-in via the new `dynamic` key.

## Known caveats

- Stub composites and `symcache_pinned` entries accumulate monotonically across reloads. Memory grows by O(unique-names-ever-seen). Periodic worker restart resets — intentional per design discussion.
- The composites section handler runs per `composites { }` block across `.include`s. Each fire is idempotent (generation rebuild is deterministic) so multiple dynamic-map registrations of the same URL just produce extra `gen N` publishes. Pre-existing cfg_rcl behaviour.
- FINE-flag for whitelist composites can only ever expand, never shrink — atoms that were once part of a negative-score composite stay FINE even if the composite is removed. Safe over-approximation.
