### PR TITLE
[Feature] Env-overridable baseline config and fasttext model auto-load

### DIFF
--- a/conf/lang_detection.inc
+++ b/conf/lang_detection.inc
@@ -20,7 +20,9 @@
 # Disable specific languages
 # languages_disable = ["fr", "es"]
 
-# Use the following fasttext model for language detection (if Fasttext support is compiled in)
+# Use the following fasttext model for language detection (if Fasttext support is compiled in).
+# When this is unset, a model shipped at "${SHAREDIR}/languages/fasttext_model.ftz"
+# is auto-loaded if present; set this explicitly to use a different model or a map.
 # fasttext_model = "${SHAREDIR}/languages/fasttext_model.ftz"
 
 # Prefer fasttext over all other methods

--- a/conf/rspamd.conf
+++ b/conf/rspamd.conf
@@ -18,7 +18,9 @@
 .include "$CONFDIR/common.conf"
 
 options {
-    pidfile = "$RUNDIR/rspamd.pid";
+    # An empty RSPAMD_PIDFILE disables writing a pidfile (useful when running
+    # as PID 1); otherwise it overrides the default location.
+    pidfile = "{= env.PIDFILE|default('$RUNDIR/rspamd.pid') =}";
     .include "$CONFDIR/options.inc"
     .include(try=true; priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/options.inc"
     .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/options.inc"

--- a/conf/rspamd.conf
+++ b/conf/rspamd.conf
@@ -31,8 +31,10 @@ lang_detection {
 }
 
 logging {
-    type = "file";
-    filename = "$LOGDIR/rspamd.log";
+    # Defaults to file logging; a deployment can export RSPAMD_LOG_TYPE
+    # (e.g. console or syslog) and RSPAMD_LOG_FILE to override without a patch.
+    type = "{= env.LOG_TYPE|default('file') =}";
+    filename = "{= env.LOG_FILE|default('$LOGDIR/rspamd.log') =}";
     .include "$CONFDIR/logging.inc"
     .include(try=true; priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/logging.inc"
     .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/logging.inc"

--- a/src/libmime/lang_detection_fasttext.cxx
+++ b/src/libmime/lang_detection_fasttext.cxx
@@ -90,6 +90,32 @@ private:
 		}
 	}
 
+	/*
+	 * Fallback used when no fasttext_model is configured: load the model that
+	 * ships in the languages data dir if it exists. Stays silent (debug only)
+	 * when the file is absent so stock installs without the model behave as
+	 * before.
+	 */
+	void try_load_default_model()
+	{
+		auto *cfg = cfg_;
+		static const char default_model_path[] =
+			RSPAMD_SHAREDIR "/languages/fasttext_model.ftz";
+
+		if (access(default_model_path, R_OK) != 0) {
+			msg_debug_config("no default fasttext model at %s: %s",
+							 default_model_path, strerror(errno));
+			return;
+		}
+
+		load_model_direct(default_model_path);
+
+		if (owned_model_) {
+			msg_info_config("loaded default fasttext model from %s",
+							default_model_path);
+		}
+	}
+
 	void load_model_map(const char *model_path)
 	{
 		auto *cfg = cfg_;
@@ -193,20 +219,25 @@ public:
 	{
 		const auto *ucl_obj = cfg->cfg_ucl_obj;
 		const auto *opts_section = ucl_object_find_key(ucl_obj, "lang_detection");
+		const ucl_object_t *model = nullptr;
 
 		if (opts_section) {
-			const auto *model = ucl_object_find_key(opts_section, "fasttext_model");
+			model = ucl_object_find_key(opts_section, "fasttext_model");
+		}
 
-			if (model) {
-				const char *model_path = ucl_object_tostring(model);
+		if (model) {
+			const char *model_path = ucl_object_tostring(model);
 
-				if (rspamd_map_is_map(model_path)) {
-					load_model_map(model_path);
-				}
-				else {
-					load_model_direct(model_path);
-				}
+			if (rspamd_map_is_map(model_path)) {
+				load_model_map(model_path);
 			}
+			else {
+				load_model_direct(model_path);
+			}
+		}
+		else {
+			/* No explicit model configured: try the shipped default */
+			try_load_default_model();
 		}
 	}
 

--- a/src/rspamd.c
+++ b/src/rspamd.c
@@ -223,7 +223,7 @@ rspamd_write_pid(struct rspamd_main *main)
 {
 	pid_t pid;
 
-	if (main->cfg->pid_file == NULL) {
+	if (main->cfg->pid_file == NULL || main->cfg->pid_file[0] == '\0') {
 		return -1;
 	}
 	main->pfh = rspamd_pidfile_open(main->cfg->pid_file, 0644, &pid);
@@ -1621,7 +1621,8 @@ int main(int argc, char **argv, char **env)
 	sigpipe_act.sa_flags = 0;
 	sigaction(SIGPIPE, &sigpipe_act, NULL);
 
-	if (rspamd_main->cfg->pid_file == NULL) {
+	if (rspamd_main->cfg->pid_file == NULL ||
+		rspamd_main->cfg->pid_file[0] == '\0') {
 		msg_info_main("pid file is not specified, skipping writing it");
 		skip_pid = TRUE;
 	}


### PR DESCRIPTION
## Summary

Makes a few baseline deployment knobs overridable via environment variables (handy for containers and PID-1 setups), and auto-loads the shipped fasttext language model when one is present without requiring explicit config.

## Changes

- **Env-overridable logging** (`conf/rspamd.conf`): `logging.type` and `logging.filename` now read from `RSPAMD_LOG_TYPE` / `RSPAMD_LOG_FILE`, defaulting to `file` and `$LOGDIR/rspamd.log`. A deployment can switch to `console`/`syslog` without patching the config.
- **Env-overridable pidfile** (`conf/rspamd.conf`, `src/rspamd.c`): `options.pidfile` reads from `RSPAMD_PIDFILE`. An empty value now disables pidfile writing entirely (useful when running as PID 1 in a container).
- **Auto-load shipped fasttext model** (`src/libmime/lang_detection_fasttext.cxx`, `conf/lang_detection.inc`): when no `fasttext_model` is configured, the model shipped at `${SHAREDIR}/languages/fasttext_model.ftz` is loaded automatically if present. Stock installs without the model behave exactly as before (silent debug log when absent).

## Notes

All defaults are unchanged, so existing deployments are unaffected. The pidfile empty-disables-it change is also guarded in `rspamd_write_pid()`.
