### PR TITLE
[Test] functional: fix dummy-helper start/scan race and parallel port collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,19 @@ on:
     branches:
       - '**'
 
+# A commit pushed to a branch that also has an open PR fires two runs at
+# once: one for `push` (ref refs/heads/<branch>) and one for `pull_request`
+# (ref refs/pull/<n>/merge). They duplicate each other's work and, sharing
+# the hosted runners, double CPU load -- which is enough to push the heavy
+# 001_merged rspamd's controller startup past the functional suites' fixed
+# readiness timeouts and flake (e.g. 440_ssl_server). The only identifier
+# the two events share is the head commit SHA (their refs differ), so key
+# the concurrency group on it: both events for one commit collapse to a
+# single run, and cancel-in-progress reaps the loser instead of racing it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   linters:
     uses: ./.github/workflows/ci_linters.yml

--- a/test/functional/cases/001_merged/160_antivirus.robot
+++ b/test/functional/cases/001_merged/160_antivirus.robot
@@ -106,32 +106,23 @@ Double FProt Teardown
   Terminate Process  ${process1}
   Terminate Process  ${process2}
 
-Run Dummy
-  [Arguments]  @{varargs}
-  ${process} =  Start Process  @{varargs}
-  ${pid} =  Get From List  ${varargs}  -1
-  ${pass} =  Run Keyword And Return Status  Wait Until Created  ${pid}
-  IF  ${pass}
-    Return From Keyword
-  END
-  Wait For Process  ${process}
-  ${res} =  Get Process Result  ${process}
-  Log To Console  ${res.stdout}
-  Log To Console  ${res.stderr}
-  Fail  Dummy server failed to start
-  RETURN    ${process}
-
 Run Dummy Clam
   [Arguments]  ${port}  ${found}=  ${pid}=${RSPAMD_TMP_PREFIX}/dummy_clamav-${port}.pid
-  ${process} =  Run Dummy  ${RSPAMD_TESTDIR}/util/dummy_clam.py  ${port}  ${found}  ${pid}
+  ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_clamav-${port}.log
+  ${process} =  Start Dummy Service  dummy_clam.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_clam.py  ${port}  ${found}  ${pid}
   RETURN    ${process}
 
 Run Dummy Fprot
   [Arguments]  ${port}  ${found}=  ${pid}=${RSPAMD_TMP_PREFIX}/dummy_fprot-${port}.pid
-  ${process} =  Run Dummy  ${RSPAMD_TESTDIR}/util/dummy_fprot.py  ${port}  ${found}  ${pid}
+  ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_fprot-${port}.log
+  ${process} =  Start Dummy Service  dummy_fprot.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_fprot.py  ${port}  ${found}  ${pid}
   RETURN    ${process}
 
 Run Dummy Avast
   [Arguments]  ${port}  ${found}=  ${pid}=${RSPAMD_TMP_PREFIX}/dummy_avast-${port}.pid
-  ${process} =  Run Dummy  ${RSPAMD_TESTDIR}/util/dummy_avast.py  ${port}  ${found}  ${pid}
+  ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_avast-${port}.log
+  ${process} =  Start Dummy Service  dummy_avast.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_avast.py  ${port}  ${found}  ${pid}
   RETURN    ${process}

--- a/test/functional/cases/001_merged/310_udp.robot
+++ b/test/functional/cases/001_merged/310_udp.robot
@@ -37,6 +37,7 @@ UDP Teardown
 Run Dummy UDP
   [Arguments]
   ${pid} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_udp-${RSPAMD_PORT_DUMMY_UDP}.pid
-  ${result} =  Start Process  ${RSPAMD_TESTDIR}/util/dummy_udp.py  ${RSPAMD_PORT_DUMMY_UDP}  ${pid}
-  Wait Until Created  ${pid}
+  ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_udp-${RSPAMD_PORT_DUMMY_UDP}.log
+  ${result} =  Start Dummy Service  dummy_udp.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_udp.py  ${RSPAMD_PORT_DUMMY_UDP}  ${pid}
   Set Suite Variable  ${DUMMY_UDP_PROC}  ${result}

--- a/test/functional/cases/161_p0f.robot
+++ b/test/functional/cases/161_p0f.robot
@@ -88,15 +88,15 @@ p0f Teardown
   Terminate All Processes    kill=True
 
 Shutdown p0f
-  # dummy_p0f derives its pidfile from the socket basename; mirror that here.
-  ${sockname} =  Evaluate  os.path.basename($RSPAMD_P0F_SOCKET)  modules=os
-  ${pidfile} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_p0f-${sockname}.pid
+  ${pidfile} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_p0f.pid
   ${p0f_pid} =  Get File if exists  ${pidfile}
   Run Keyword if  ${p0f_pid}  Shutdown Process With Children  ${p0f_pid}
 
 Run Dummy p0f
   [Arguments]  ${socket}=${RSPAMD_P0F_SOCKET}  ${os}=linux  ${status}=ok
-  ${sockname} =  Evaluate  os.path.basename($socket)  modules=os
-  ${pidfile} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_p0f-${sockname}.pid
-  ${result} =  Start Process  ${RSPAMD_TESTDIR}/util/dummy_p0f.py  ${socket}  ${os}  ${status}
-  Wait Until Created  ${pidfile}
+  # Pass an explicit pid path so the helper writes exactly where we wait,
+  # and route through Start Dummy Service for the stale-pid-safe barrier.
+  ${pidfile} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_p0f.pid
+  ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_p0f.log
+  Start Dummy Service  dummy_p0f.py  ${pidfile}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_p0f.py  ${socket}  ${os}  ${status}  ${pidfile}

--- a/test/functional/cases/162_url_redirector.robot
+++ b/test/functional/cases/162_url_redirector.robot
@@ -19,11 +19,11 @@ ${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
 *** Test Cases ***
 RESOLVE URLS
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 RESOLVE URLS CACHED
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 STEALTH FINGERPRINT HEADERS
   # The live HEAD requests issued by RESOLVE URLS are logged by the dummy
@@ -38,6 +38,13 @@ STEALTH FINGERPRINT HEADERS
 Urlredirector Setup
   Run Dummy Http
   Rspamd Redis Setup
+  # .eml fixtures carry the dummy_http port as a ${RSPAMD_PORT_DUMMY_HTTP}
+  # placeholder; render them now that RSPAMD_TMPDIR exists so the per-worker
+  # offset is baked into the message the scanner reads.
+  ${MESSAGE} =  Render Message Template  ${MESSAGE}
+  Set Suite Variable  ${MESSAGE}
+  ${CHAIN_MESSAGE} =  Render Message Template  ${CHAIN_MESSAGE}
+  Set Suite Variable  ${CHAIN_MESSAGE}
 
 Urlredirector Teardown
   Rspamd Redis Teardown

--- a/test/functional/cases/163_url_redirector_chain.robot
+++ b/test/functional/cases/163_url_redirector_chain.robot
@@ -19,39 +19,41 @@ ${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
 BASIC CHAIN RESOLUTION AND CACHING
   [Documentation]  Test chain resolution with intermediate hops and caching
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 NESTED LIMIT MARKER
   [Documentation]  Test ^nested: markers for limit exceeded
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 CHAIN AWARE CACHE
   [Documentation]  Test per-hop Redis cache with markers
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 TIMEOUT SETTINGS
   [Documentation]  Test timeout, http_timeout, redis_timeout configuration
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 SAVE INTERMEDIATE REDIRECTS
   [Documentation]  Test save_intermediate_redirs configuration
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 REDIRECTOR SYMBOL
   [Documentation]  Test redirector_symbol with host path output
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 *** Keywords ***
 Urlredirector Chain Setup
   Run Dummy Http
   Rspamd Redis Setup
+  ${MESSAGE} =  Render Message Template  ${MESSAGE}
+  Set Suite Variable  ${MESSAGE}
 
 Urlredirector Chain Teardown
   Rspamd Redis Teardown

--- a/test/functional/cases/164_url_redirector_pr6014.robot
+++ b/test/functional/cases/164_url_redirector_pr6014.robot
@@ -22,19 +22,19 @@ CHAIN REDIRECT RESOLUTION
   [Documentation]  Test PR 6014 feature: resolve redirect chains with intermediate hops
   ...              Tests /redirect2 -> /redirect1 -> /hello chain
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 CHAIN REDIRECT WITH SYMBOL
   [Documentation]  Test that redirector_symbol shows the full redirect path (host1->host2->...->hostN)
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 CHAIN REDIRECT CACHED RESOLUTION
   [Documentation]  Test that cached chain resolution works correctly on second scan
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 REDIRECT CYCLE DETECTION
   [Documentation]  Test cycle detection with /redirect3 <-> /redirect4 cycle
@@ -43,27 +43,33 @@ REDIRECT CYCLE DETECTION
 NESTED LIMIT HANDLING
   [Documentation]  Test ^nested: marker behavior when nested_limit is exceeded
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 TIMEOUT CONFIGURATION
   [Documentation]  Test that timeout, http_timeout, and redis_timeout are correctly applied
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 SAVE INTERMEDIATE REDIRS
   [Documentation]  Test save_intermediate_redirs = {redirectors=false, non_redirectors=true}
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 BASIC URL RESOLUTION
   [Documentation]  Test basic URL resolution without redirects
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 *** Keywords ***
 Urlredirector PR6014 Setup
   Run Dummy Http
   Rspamd Redis Setup
+  ${MESSAGE} =  Render Message Template  ${MESSAGE}
+  Set Suite Variable  ${MESSAGE}
+  ${CHAIN_MESSAGE} =  Render Message Template  ${CHAIN_MESSAGE}
+  Set Suite Variable  ${CHAIN_MESSAGE}
+  ${MULTIPART_MESSAGE} =  Render Message Template  ${MULTIPART_MESSAGE}
+  Set Suite Variable  ${MULTIPART_MESSAGE}
 
 Urlredirector PR6014 Teardown
   Rspamd Redis Teardown

--- a/test/functional/cases/165_url_redirector_cache.robot
+++ b/test/functional/cases/165_url_redirector_cache.robot
@@ -22,24 +22,24 @@ CACHE HOP MARKERS
   ...              - ^nested: for limit exceeded
   ...              - no marker for terminal URLs
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 PER-ADJACENT-PAIR CACHE LAYOUT
   [Documentation]  Test PR 6014 cache layout: one Redis entry per adjacent URL pair
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 CACHE WALK WITH MARKERS
   [Documentation]  Test cache walk behavior: reader follows markers until terminal
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 SELF-HEALING CACHE
   [Documentation]  Test self-healing: ^nested: marker upgrade on extension
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 CYCLE DETECTION
   [Documentation]  Test cycle protection with per-walk seen-set
@@ -48,22 +48,24 @@ CYCLE DETECTION
 REDIS TIMEOUT APPLIED
   [Documentation]  Test that redis_timeout setting is applied to Redis calls
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 TOP_URLS TRACKING
   [Documentation]  Test that ZINCRBY on top_urls uses canonical URL string
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 RESERVATION LOCK
   [Documentation]  Test that reservation lock has correct TTL = settings.timeout
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 *** Keywords ***
 Urlredirector Cache Setup
   Run Dummy Http
   Rspamd Redis Setup
+  ${MESSAGE} =  Render Message Template  ${MESSAGE}
+  Set Suite Variable  ${MESSAGE}
 
 Urlredirector Cache Teardown
   Rspamd Redis Teardown

--- a/test/functional/cases/166_url_redirector_config.robot
+++ b/test/functional/cases/166_url_redirector_config.robot
@@ -19,37 +19,39 @@ ${SETTINGS}        {symbols_enabled=[URL_REDIRECTOR_CHECK]}
 SAVE_INTERMEDIATE_REDIRECTORS_ONLY
   [Documentation]  Test save_intermediate_redirs={redirectors=true, non_redirectors=false}
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 SAVE_INTERMEDIATE_DISABLED
   [Documentation]  Test save_intermediate_redirs with both options disabled
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 DEFAULT_TIMEOUT_VALUE
   [Documentation]  Test default timeout value (8s) from settings
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 CUSTOM_HTTP_TIMEOUT
   [Documentation]  Test custom http_timeout setting overrides default
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 CUSTOM_REDIS_TIMEOUT
   [Documentation]  Test custom redis_timeout setting
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 REDIRECTOR_SYMBOL_DISABLED
   [Documentation]  Test behavior when redirector_symbol is not configured
   Scan File  ${MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/hello
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/hello
 
 *** Keywords ***
 Urlredirector Config Setup
   Run Dummy Http
   Rspamd Redis Setup
+  ${MESSAGE} =  Render Message Template  ${MESSAGE}
+  Set Suite Variable  ${MESSAGE}
 
 Urlredirector Config Teardown
   Rspamd Redis Teardown

--- a/test/functional/cases/167_url_redirector_non_http_scheme.robot
+++ b/test/functional/cases/167_url_redirector_non_http_scheme.robot
@@ -25,7 +25,7 @@ SKIP NON-HTTP SCHEME REDIRECT
   # but then stop when it encounters the tel: scheme and not attempt HTTP request
   Scan File  ${TEL_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
   # The original URL should be processed
-  Expect Extended URL  http://127.0.0.1:18080/tel_redirect
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/tel_redirect
   Expect Symbol With Exact Options  URL_REDIRECTOR_NON_HTTP  telephone=127.0.0.1->tel:88006007775
   Do Not Expect Added URL  tel:88006007775
 
@@ -35,7 +35,7 @@ SKIP NON-HTTP SCHEME REDIRECT WITH INTERMEDIATE HOPS
   # Intermediate redirector hops are not saved to chain by default (redirectors=false),
   # so the chain string only shows the original redirector host and the tel: target.
   Scan File  ${CHAIN_TEL_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/chain_intermediate_1
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/chain_intermediate_1
   Expect Symbol With Exact Options  URL_REDIRECTOR_NON_HTTP  telephone=127.0.0.1->tel:88006007776
   Do Not Expect Added URL  tel:88006007776
 
@@ -45,8 +45,8 @@ MULTIPLE NON-HTTP REDIRECT TARGETS
   # tel_redirect -> tel:88006007775 (rspamd scheme: telephone)
   # mailto_redirect -> mailto:user@example.net (rspamd scheme: mailto)
   Scan File  ${MULTI_NON_HTTP_MESSAGE}  Flags=ext_urls  Settings=${SETTINGS}
-  Expect Extended URL  http://127.0.0.1:18080/tel_redirect
-  Expect Extended URL  http://127.0.0.1:18080/mailto_redirect
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/tel_redirect
+  Expect Extended URL  http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/mailto_redirect
   Expect Symbol With Exact Options  URL_REDIRECTOR_NON_HTTP
   ...  telephone=127.0.0.1->tel:88006007775
   ...  mailto=127.0.0.1->mailto:user@example.net
@@ -57,6 +57,12 @@ MULTIPLE NON-HTTP REDIRECT TARGETS
 Urlredirector Setup
   Run Dummy Http
   Rspamd Redis Setup
+  ${TEL_MESSAGE} =  Render Message Template  ${TEL_MESSAGE}
+  Set Suite Variable  ${TEL_MESSAGE}
+  ${CHAIN_TEL_MESSAGE} =  Render Message Template  ${CHAIN_TEL_MESSAGE}
+  Set Suite Variable  ${CHAIN_TEL_MESSAGE}
+  ${MULTI_NON_HTTP_MESSAGE} =  Render Message Template  ${MULTI_NON_HTTP_MESSAGE}
+  Set Suite Variable  ${MULTI_NON_HTTP_MESSAGE}
 
 Urlredirector Teardown
   Rspamd Redis Teardown

--- a/test/functional/cases/168_mx_check_greeting.robot
+++ b/test/functional/cases/168_mx_check_greeting.robot
@@ -14,7 +14,7 @@ ${REDIS_SCOPE}        Suite
 ${RSPAMD_SCOPE}       Suite
 ${RSPAMD_URL_TLD}     ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
 ${SETTINGS}           {symbols_enabled = [MX_INVALID]}
-${SINGLE_STATUS}      /tmp/dummy_smtp_greeting_single.status
+${SINGLE_STATUS}      ${RSPAMD_TMP_PREFIX}/dummy_smtp_greeting_single.status
 
 *** Test Cases ***
 Silent SMTP listener triggers MX_TIMEOUT_READ
@@ -44,20 +44,13 @@ Non-SMTP line triggers MX_INVALID
 *** Keywords ***
 Start Plain Dummy
   [Arguments]  ${mode}  ${host}
-  Start Process  ${RSPAMD_TESTDIR}/util/dummy_smtp.py
-  ...  --port  11125  --mode  ${mode}  --host  ${host}
-  ...  stderr=/tmp/dummy_smtp_${mode}.log
-  ...  stdout=/tmp/dummy_smtp_${mode}.log
-  Wait Until Created  /tmp/dummy_smtp_${mode}.pid  timeout=2 second
+  Start Dummy Smtp  11125  ${mode}  ${host}
+  ...  ${RSPAMD_TMP_PREFIX}/dummy_smtp_${mode}.pid
 
 Mx Greeting Setup
   Start Plain Dummy  silent  127.0.0.1
-  Start Process  ${RSPAMD_TESTDIR}/util/dummy_smtp.py
-  ...  --port  11125  --mode  greeting_single  --host  127.0.0.2
-  ...  --status-file  ${SINGLE_STATUS}
-  ...  stderr=/tmp/dummy_smtp_greeting_single.log
-  ...  stdout=/tmp/dummy_smtp_greeting_single.log
-  Wait Until Created  /tmp/dummy_smtp_greeting_single.pid  timeout=2 second
+  Start Dummy Smtp  11125  greeting_single  127.0.0.2
+  ...  ${RSPAMD_TMP_PREFIX}/dummy_smtp_greeting_single.pid  --status-file  ${SINGLE_STATUS}
   Start Plain Dummy  error   127.0.0.3
   Start Plain Dummy  messy   127.0.0.4
   Rspamd Redis Setup

--- a/test/functional/cases/168_url_redirector_phishing.robot
+++ b/test/functional/cases/168_url_redirector_phishing.robot
@@ -28,6 +28,8 @@ PHISHING NO FP WHEN DISPLAY TEXT EQUALS REDIRECT DEST
 Urlredirector Setup
   Run Dummy Http
   Rspamd Redis Setup
+  ${MESSAGE} =  Render Message Template  ${MESSAGE}
+  Set Suite Variable  ${MESSAGE}
 
 Urlredirector Teardown
   Rspamd Redis Teardown

--- a/test/functional/cases/169_mx_check_greeting_quit.robot
+++ b/test/functional/cases/169_mx_check_greeting_quit.robot
@@ -14,8 +14,8 @@ ${REDIS_SCOPE}        Suite
 ${RSPAMD_SCOPE}       Suite
 ${RSPAMD_URL_TLD}     ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
 ${SETTINGS}           {symbols_enabled = [MX_INVALID]}
-${PROPER_STATUS}      /tmp/dummy_smtp_greeting_proper.status
-${SLOW_STATUS}        /tmp/dummy_smtp_greeting_slow.status
+${PROPER_STATUS}      ${RSPAMD_TMP_PREFIX}/dummy_smtp_greeting_proper.status
+${SLOW_STATUS}        ${RSPAMD_TMP_PREFIX}/dummy_smtp_greeting_slow.status
 
 *** Test Cases ***
 Multi-line greeting with send_quit=true emits MX_GOOD with QUIT after final line
@@ -32,16 +32,9 @@ Slow second banner line triggers MX_TIMEOUT_READ
 *** Keywords ***
 Start Greeting Dummy
   [Arguments]  ${host}  ${between_wait}  ${status_file}  ${pid_suffix}
-  Start Process  ${RSPAMD_TESTDIR}/util/dummy_smtp.py
-  ...  --port  11125
-  ...  --mode  greeting_multi
-  ...  --host  ${host}
-  ...  --between-wait  ${between_wait}
-  ...  --status-file  ${status_file}
-  ...  --pid-file  /tmp/dummy_smtp_${pid_suffix}.pid
-  ...  stderr=/tmp/dummy_smtp_${pid_suffix}.log
-  ...  stdout=/tmp/dummy_smtp_${pid_suffix}.log
-  Wait Until Created  /tmp/dummy_smtp_${pid_suffix}.pid  timeout=2 second
+  Start Dummy Smtp  11125  greeting_multi  ${host}
+  ...  ${RSPAMD_TMP_PREFIX}/dummy_smtp_${pid_suffix}.pid
+  ...  --between-wait  ${between_wait}  --status-file  ${status_file}
 
 Mx Quit Setup
   Start Greeting Dummy  127.0.0.6  0.2  ${PROPER_STATUS}  greeting_proper

--- a/test/functional/cases/169_url_redirector_query_target.robot
+++ b/test/functional/cases/169_url_redirector_query_target.robot
@@ -33,6 +33,8 @@ RESOLVE ENCODED QUERY TARGET THROUGH PATH-LESS WRAPPER
 Urlredirector Setup
   Run Dummy Http
   Rspamd Redis Setup
+  ${MESSAGE} =  Render Message Template  ${MESSAGE}
+  Set Suite Variable  ${MESSAGE}
 
 Urlredirector Teardown
   Rspamd Redis Teardown

--- a/test/functional/cases/230_tcp.robot
+++ b/test/functional/cases/230_tcp.robot
@@ -82,9 +82,11 @@ Servers Teardown
 Run Dummy Ssl
   [Arguments]
   ${pid} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_ssl-${RSPAMD_PORT_DUMMY_SSL}.pid
+  ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_ssl-${RSPAMD_PORT_DUMMY_SSL}.log
   Set Suite Variable  ${DUMMY_SSL_PID_FILE}  ${pid}
-  ${result} =  Start Process  ${RSPAMD_TESTDIR}/util/dummy_ssl.py  ${RSPAMD_TESTDIR}/util/server.pem  ${RSPAMD_PORT_DUMMY_SSL}  ${pid}
-  Wait Until Created  ${pid}  timeout=2 second
+  Start Dummy Service  dummy_ssl.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_ssl.py  ${RSPAMD_TESTDIR}/util/server.pem  ${RSPAMD_PORT_DUMMY_SSL}  ${pid}
+  Wait Until Dummy Listening  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_DUMMY_SSL}
 
 Teardown Dummy Ssl
   ${ssl_pid} =  Get File  ${DUMMY_SSL_PID_FILE}

--- a/test/functional/configs/neural_llm.conf
+++ b/test/functional/configs/neural_llm.conf
@@ -52,7 +52,7 @@ neural {
       symbol_ham = "NEURAL_HAM";
       ann_expire = 86400;
       watch_interval = 0.5;
-      providers = [{ type = "llm"; model = "dummy-embed"; url = "http://127.0.0.1:18080"; weight = 1.0;
+      providers = [{ type = "llm"; model = "dummy-embed"; url = "http://127.0.0.1:{= env.PORT_DUMMY_HTTP|default('18080') =}"; weight = 1.0;
         #reply_trim_mode = "replies"; # always|none|replies
       }];
       fusion { normalization = "none"; }

--- a/test/functional/lib/rspamd.py
+++ b/test/functional/lib/rspamd.py
@@ -553,7 +553,7 @@ def port_is_free(addr, port):
     Keyword Succeeds retries; connection refused means the port is free.
 
     Example:
-    | Wait Until Keyword Succeeds | 10s | 0.2s | Port Is Free | 127.0.0.1 | 56790 |
+    | Wait Until Keyword Succeeds | 10s | 0.2s | Port Is Free | 127.0.0.1 | 25790 |
     """
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.settimeout(0.5)

--- a/test/functional/lib/rspamd.py
+++ b/test/functional/lib/rspamd.py
@@ -539,6 +539,33 @@ def TCP_Connect(addr, port):
     s.close()
 
 
+def port_is_free(addr, port):
+    """Assert that nothing is listening on addr:port.
+
+    Used by teardown to confirm a just-terminated rspamd has actually
+    released its listening sockets before the next suite on this pabot
+    worker reuses the same port range. `Wait For Process` only reaps the
+    main rspamd; the listening sockets are shared with forked workers and
+    can linger briefly after main exits. rspamd sets SO_REUSEADDR, so this
+    is NOT about TIME_WAIT -- a still-LISTENing socket from a not-yet-gone
+    worker genuinely fails the next bind() with EADDRINUSE. Connecting and
+    succeeding means someone is still listening -> raise so Wait Until
+    Keyword Succeeds retries; connection refused means the port is free.
+
+    Example:
+    | Wait Until Keyword Succeeds | 10s | 0.2s | Port Is Free | 127.0.0.1 | 56790 |
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(0.5)
+    try:
+        s.connect((addr, int(port)))
+    except (ConnectionRefusedError, socket.timeout, OSError):
+        return True
+    finally:
+        s.close()
+    raise AssertionError("port %s:%s is still in use" % (addr, port))
+
+
 def try_reap_zombies():
     try:
         os.waitpid(-1, os.WNOHANG)

--- a/test/functional/lib/rspamd.robot
+++ b/test/functional/lib/rspamd.robot
@@ -314,6 +314,14 @@ Rspamd Teardown
   END
   Terminate Process  ${RSPAMD_PROCESS}
   Wait For Process  ${RSPAMD_PROCESS}
+  # Wait For Process only reaps the main rspamd; its listening sockets are
+  # shared with forked workers and can linger a beat after main exits.
+  # Under pabot each worker runs many suites sequentially on the SAME port
+  # range, so if we release this suite before the kernel has closed the
+  # normal+controller sockets, the next suite's rspamd races them and dies
+  # with EADDRINUSE (rspamd sets SO_REUSEADDR, so this is a live socket,
+  # not TIME_WAIT). Block until the ports are actually free.
+  Wait For Rspamd Ports Released
   Save Run Results  ${RSPAMD_TMPDIR}  configdump.stdout configdump.stderr rspamd.stderr rspamd.stdout rspamd.conf rspamd.log redis.log clickhouse-config.xml
   Log does not contain segfault record
   Collect Lua Coverage
@@ -322,6 +330,22 @@ Rspamd Teardown
 Rspamd Redis Teardown
   Rspamd Teardown
   Redis Teardown
+
+Wait For Rspamd Ports Released
+  [Documentation]  Block until this suite's rspamd listening ports are
+  ...  free, so the next suite on the same pabot worker can rebind them.
+  ...  Checks the always-present normal + controller ports; each is given
+  ...  up to ~6s (matches a slow worker shutdown under CPU contention) and
+  ...  failure to free is a warning, not a hard error -- we don't want a
+  ...  stuck port to mask the real test result, just to close the common
+  ...  handoff race. See port_is_free in rspamd.py for why SO_REUSEADDR
+  ...  does not cover this.
+  Run Keyword And Warn On Failure
+  ...  Wait Until Keyword Succeeds  30x  0.2s
+  ...  Port Is Free  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_NORMAL}
+  Run Keyword And Warn On Failure
+  ...  Wait Until Keyword Succeeds  30x  0.2s
+  ...  Port Is Free  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_CONTROLLER}
 
 Run Redis
   ${RSPAMD_TMPDIR} =  Make Temporary Directory

--- a/test/functional/lib/rspamd.robot
+++ b/test/functional/lib/rspamd.robot
@@ -534,6 +534,22 @@ Run Rspamc
   Log  ${result.stdout}
   RETURN    ${result}
 
+Render Message Template
+  [Documentation]  Read an .eml fixture that contains Robot ${VARIABLE}
+  ...  placeholders (e.g. ${RSPAMD_PORT_DUMMY_HTTP}), expand them, write
+  ...  the result into the suite tmpdir and return the rendered path.
+  ...  .eml files are fed raw to the scanner and are NOT processed by the
+  ...  config-time Jinja engine, so per-pabot-worker values (dummy ports)
+  ...  must be substituted here at runtime. Requires ${RSPAMD_TMPDIR}
+  ...  (set by Rspamd Setup) -- call after the rspamd setup keyword.
+  [Arguments]  ${template_path}
+  ${template} =  Get File  ${template_path}
+  ${rendered} =  Replace Variables  ${template}
+  ${name} =  Evaluate  os.path.basename($template_path)  modules=os
+  ${out} =  Set Variable  ${RSPAMD_TMPDIR}/${name}
+  Create File  ${out}  ${rendered}
+  RETURN  ${out}
+
 Scan File By Reference
   [Arguments]  ${filename}  &{headers}
   Set To Dictionary  ${headers}  File=${filename}

--- a/test/functional/lib/rspamd.robot
+++ b/test/functional/lib/rspamd.robot
@@ -334,18 +334,26 @@ Rspamd Redis Teardown
 Wait For Rspamd Ports Released
   [Documentation]  Block until this suite's rspamd listening ports are
   ...  free, so the next suite on the same pabot worker can rebind them.
-  ...  Checks the always-present normal + controller ports; each is given
-  ...  up to ~6s (matches a slow worker shutdown under CPU contention) and
-  ...  failure to free is a warning, not a hard error -- we don't want a
-  ...  stuck port to mask the real test result, just to close the common
-  ...  handoff race. See port_is_free in rspamd.py for why SO_REUSEADDR
-  ...  does not cover this.
-  Run Keyword And Warn On Failure
-  ...  Wait Until Keyword Succeeds  30x  0.2s
-  ...  Port Is Free  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_NORMAL}
-  Run Keyword And Warn On Failure
-  ...  Wait Until Keyword Succeeds  30x  0.2s
-  ...  Port Is Free  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_CONTROLLER}
+  ...  Covers every port a test rspamd may bind: normal, controller,
+  ...  proxy, and the two TLS listeners (controller + normal SSL). All
+  ...  five RSPAMD_PORT_* vars are always defined in vars.py; a port the
+  ...  current config never bound just refuses connection immediately, so
+  ...  Port Is Free passes at once -- waiting on it is a cheap no-op. The
+  ...  SSL listeners matter specifically: the 440_ssl_server flake was a
+  ...  previous suite's controller-SSL socket lingering on its port, so
+  ...  the next rspamd silently came up WITHOUT its SSL listener (it logs
+  ...  bind 98 for the SSL port, then forks the controller with only the
+  ...  plain socket) and every HTTPS test got connection-refused.
+  ...  Each port gets up to ~6s; failure to free is a warning, not a hard
+  ...  error, so a stuck port can't mask the real test result. See
+  ...  port_is_free in rspamd.py for why SO_REUSEADDR does not cover this.
+  FOR  ${port}  IN
+  ...  ${RSPAMD_PORT_NORMAL}  ${RSPAMD_PORT_CONTROLLER}  ${RSPAMD_PORT_PROXY}
+  ...  ${RSPAMD_PORT_CONTROLLER_SSL}  ${RSPAMD_PORT_NORMAL_SSL}
+    Run Keyword And Warn On Failure
+    ...  Wait Until Keyword Succeeds  30x  0.2s
+    ...  Port Is Free  ${RSPAMD_LOCAL_ADDR}  ${port}
+  END
 
 Run Redis
   ${RSPAMD_TMPDIR} =  Make Temporary Directory

--- a/test/functional/lib/rspamd.robot
+++ b/test/functional/lib/rspamd.robot
@@ -576,57 +576,74 @@ Run Control Command JSON
   Log  ${result.stderr}
   RETURN    ${result}
 
+Start Dummy Service
+  [Documentation]  Start a dummy_* helper and block until it is ready,
+  ...  then return its process handle. Readiness is the PID file: every
+  ...  dummy_* helper calls dummy_killer.write_pid() only AFTER it has
+  ...  bound and activated its listening socket (see server_bind /
+  ...  server_activate / server.start in util/dummy_*.py), so the moment
+  ...  the PID file appears the kernel is already accepting connections.
+  ...  This keyword is the ONE place that barrier lives -- start every
+  ...  dummy through here (or a Run Dummy * / Start Dummy * wrapper),
+  ...  never via a bare Start Process followed straight by a scan, or you
+  ...  reintroduce the start/scan race that flakes under parallel pabot.
+  [Arguments]  ${name}  ${pidfile}  ${logfile}  @{command}
+  # Drop any stale PID file from a previous instance on this same path.
+  # One-shot helpers (clam/fprot/avast/p0f) exit after a single request
+  # and leave their PID file behind; without this a same-port restart
+  # would satisfy Wait Until Created instantly and race the new bind.
+  Remove File  ${pidfile}
+  ${result} =  Start Process  @{command}  stdout=${logfile}  stderr=${logfile}
+  ${status}  ${error} =  Run Keyword And Ignore Error
+  ...  Wait Until Created  ${pidfile}  timeout=5 second
+  IF  '${status}' == 'FAIL'
+    ${logstatus}  ${out} =  Run Keyword And Ignore Error  Get File  ${logfile}
+    IF  '${logstatus}' == 'PASS'
+      Log  ${name} failed to start. Log output:\n${out}  level=ERROR
+    ELSE
+      Log  ${name} failed to start. No log file found at ${logfile}  level=ERROR
+    END
+    Fail  ${name} did not create PID file in 5 seconds
+  END
+  RETURN  ${result}
+
+Wait Until Dummy Listening
+  [Documentation]  Belt-and-suspenders readiness probe on top of the PID
+  ...  barrier: block until a TCP connect to host:port actually succeeds.
+  ...  Self-contained (BuiltIn Evaluate, no library dependency). Use ONLY
+  ...  for helpers that loop and accept many connections (http/https/ssl).
+  ...  Do NOT probe one-shot helpers (clam/fprot/avast/p0f) or the
+  ...  single-threaded smtp helper -- a probe connection would consume or
+  ...  block the very session the scan needs; for those the PID barrier in
+  ...  Start Dummy Service is the correct and sufficient readiness signal.
+  [Arguments]  ${host}  ${port}
+  Wait Until Keyword Succeeds  15x  0.2s
+  ...  Evaluate  __import__('socket').create_connection(("${host}", ${port}), 1).close()
+
 Run Dummy Http
   ${pid} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_http-${RSPAMD_PORT_DUMMY_HTTP}.pid
   ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_http-${RSPAMD_PORT_DUMMY_HTTP}.log
-  ${result} =  Start Process  ${RSPAMD_TESTDIR}/util/dummy_http.py  -pf  ${pid}  -p  ${RSPAMD_PORT_DUMMY_HTTP}
-  ...  stderr=${log}  stdout=${log}
-  ${status}  ${error} =  Run Keyword And Ignore Error  Wait Until Created  ${pid}  timeout=2 second
-  IF  '${status}' == 'FAIL'
-    ${logstatus}  ${out} =  Run Keyword And Ignore Error  Get File  ${log}
-    IF  '${logstatus}' == 'PASS'
-      Log  dummy_http.py failed to start. Log output:\n${out}  level=ERROR
-    ELSE
-      Log  dummy_http.py failed to start. No log file found at ${log}  level=ERROR
-    END
-    Fail  dummy_http.py did not create PID file in 2 seconds
-  END
+  ${result} =  Start Dummy Service  dummy_http.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_http.py  -pf  ${pid}  -p  ${RSPAMD_PORT_DUMMY_HTTP}
+  Wait Until Dummy Listening  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_DUMMY_HTTP}
   Export Scoped Variables  ${RSPAMD_SCOPE}  DUMMY_HTTP_PROC=${result}  DUMMY_HTTP_LOG=${log}
 
 Run Dummy Https
   ${pid} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_https-${RSPAMD_PORT_DUMMY_HTTPS}.pid
   ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_https-${RSPAMD_PORT_DUMMY_HTTPS}.log
-  ${result} =  Start Process  ${RSPAMD_TESTDIR}/util/dummy_http.py
+  ${result} =  Start Dummy Service  dummy_https.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_http.py
   ...  -c  ${RSPAMD_TESTDIR}/util/server.pem  -k  ${RSPAMD_TESTDIR}/util/server.pem
   ...  -pf  ${pid}  -p  ${RSPAMD_PORT_DUMMY_HTTPS}
-  ...  stderr=${log}  stdout=${log}
-  ${status}  ${error} =  Run Keyword And Ignore Error  Wait Until Created  ${pid}  timeout=2 second
-  IF  '${status}' == 'FAIL'
-    ${logstatus}  ${out} =  Run Keyword And Ignore Error  Get File  ${log}
-    IF  '${logstatus}' == 'PASS'
-      Log  dummy_https.py failed to start. Log output:\n${out}  level=ERROR
-    ELSE
-      Log  dummy_https.py failed to start. No log file found at ${log}  level=ERROR
-    END
-    Fail  dummy_https.py did not create PID file in 2 seconds
-  END
+  Wait Until Dummy Listening  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_DUMMY_HTTPS}
   Export Scoped Variables  ${RSPAMD_SCOPE}  DUMMY_HTTPS_PROC=${result}
 
 Run Dummy Llm
   ${pid} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_llm-${RSPAMD_PORT_DUMMY_HTTP}.pid
   ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_llm-${RSPAMD_PORT_DUMMY_HTTP}.log
-  ${result} =  Start Process  ${RSPAMD_TESTDIR}/util/dummy_llm.py  ${RSPAMD_PORT_DUMMY_HTTP}  ${pid}
-  ...  stderr=${log}  stdout=${log}
-  ${status}  ${error} =  Run Keyword And Ignore Error  Wait Until Created  ${pid}  timeout=2 second
-  IF  '${status}' == 'FAIL'
-    ${logstatus}  ${out} =  Run Keyword And Ignore Error  Get File  ${log}
-    IF  '${logstatus}' == 'PASS'
-      Log  dummy_llm.py failed to start. Log output:\n${out}  level=ERROR
-    ELSE
-      Log  dummy_llm.py failed to start. No log file found at ${log}  level=ERROR
-    END
-    Fail  dummy_llm.py did not create PID file in 2 seconds
-  END
+  ${result} =  Start Dummy Service  dummy_llm.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_llm.py  ${RSPAMD_PORT_DUMMY_HTTP}  ${pid}
+  Wait Until Dummy Listening  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_DUMMY_HTTP}
   Export Scoped Variables  ${RSPAMD_SCOPE}  DUMMY_LLM_PROC=${result}
 
 Dummy Llm Teardown
@@ -644,20 +661,26 @@ Dummy Https Teardown
 Run Dummy Http Early Response
   ${pid} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_http_early-${RSPAMD_PORT_DUMMY_HTTP_EARLY}.pid
   ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_http_early-${RSPAMD_PORT_DUMMY_HTTP_EARLY}.log
-  ${result} =  Start Process  ${RSPAMD_TESTDIR}/util/dummy_http_early_response.py  -pf  ${pid}  -p  ${RSPAMD_PORT_DUMMY_HTTP_EARLY}
-  ...  stderr=${log}  stdout=${log}
-  ${status}  ${error} =  Run Keyword And Ignore Error  Wait Until Created  ${pid}  timeout=2 second
-  IF  '${status}' == 'FAIL'
-    ${logstatus}  ${out} =  Run Keyword And Ignore Error  Get File  ${log}
-    IF  '${logstatus}' == 'PASS'
-      Log  dummy_http_early_response.py failed to start. Log output:\n${out}  level=ERROR
-    ELSE
-      Log  dummy_http_early_response.py failed to start. No log file found at ${log}  level=ERROR
-    END
-    Fail  dummy_http_early_response.py did not create PID file in 2 seconds
-  END
+  ${result} =  Start Dummy Service  dummy_http_early_response.py  ${pid}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_http_early_response.py  -pf  ${pid}  -p  ${RSPAMD_PORT_DUMMY_HTTP_EARLY}
+  Wait Until Dummy Listening  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_DUMMY_HTTP_EARLY}
   Export Scoped Variables  ${RSPAMD_SCOPE}  DUMMY_HTTP_EARLY_PROC=${result}
 
 Dummy Http Early Teardown
   Terminate Process  ${DUMMY_HTTP_EARLY_PROC}
   Wait For Process  ${DUMMY_HTTP_EARLY_PROC}
+
+Start Dummy Smtp
+  [Documentation]  Start dummy_smtp.py and block until it is listening,
+  ...  then return the process handle for teardown. No connect probe here:
+  ...  the smtp helper runs single-threaded and its modes hold the handler
+  ...  (silent sleeps 30s; greeting modes drive a state machine and write a
+  ...  status file), so a probe connection would borrow the very session
+  ...  the scan needs -- the PID barrier in Start Dummy Service is correct.
+  ...  @{extra} carries optional flags such as --status-file / --between-wait.
+  [Arguments]  ${port}  ${mode}  ${host}  ${pidfile}  @{extra}
+  ${log} =  Set Variable  ${RSPAMD_TMP_PREFIX}/dummy_smtp-${mode}-${host}.log
+  ${result} =  Start Dummy Service  dummy_smtp.py  ${pidfile}  ${log}
+  ...  ${RSPAMD_TESTDIR}/util/dummy_smtp.py  --port  ${port}  --mode  ${mode}
+  ...  --host  ${host}  --pid-file  ${pidfile}  @{extra}
+  RETURN  ${result}

--- a/test/functional/lib/vars.py
+++ b/test/functional/lib/vars.py
@@ -93,7 +93,7 @@ def _release_slot(slot, owner_pid):
 _WORKER_INDEX = _worker_index()
 # 100 ports per worker. We currently use ~14 distinct ports; 100 leaves
 # headroom for future services and keeps each worker's ports humanly
-# distinguishable in logs (worker 3 -> 56789 + 300 = 57089).
+# distinguishable in logs (worker 3 -> 25789 + 300 = 26089).
 _PORT_OFFSET = _WORKER_INDEX * 100
 
 # Per-worker prefix for unix sockets and pid files that have historically
@@ -119,15 +119,30 @@ RSPAMD_KEY_PUB2 = 'mbggdnw3tdx7r3ruakjecpf5hcqr4cb4nmdp1fxynx3drbyujb3y'
 RSPAMD_KEY_PUB3 = 'zhypei8sartqrtow84dddgp5exh3gsr65kbw88wj7ppot1bwmuiy'
 RSPAMD_LOCAL_ADDR = '127.0.0.1'
 RSPAMD_MAP_WATCH_INTERVAL = '1min'
-RSPAMD_PORT_CONTROLLER = 56790 + _PORT_OFFSET
-RSPAMD_PORT_CONTROLLER_SLAVE = 56793 + _PORT_OFFSET
-RSPAMD_PORT_FUZZY = 56791 + _PORT_OFFSET
-RSPAMD_PORT_FUZZY_SLAVE = 56792 + _PORT_OFFSET
-RSPAMD_PORT_NORMAL = 56789 + _PORT_OFFSET
-RSPAMD_PORT_NORMAL_SLAVE = 56794 + _PORT_OFFSET
-RSPAMD_PORT_PROXY = 56795 + _PORT_OFFSET
-RSPAMD_PORT_CONTROLLER_SSL = 56796 + _PORT_OFFSET
-RSPAMD_PORT_NORMAL_SSL = 56797 + _PORT_OFFSET
+# All listening ports below MUST stay under Linux's default ephemeral
+# range (net.ipv4.ip_local_port_range = 32768..60999). The historical
+# bases sat at 56379/56380/567xx, squarely inside it, so an outbound
+# client socket (redis, monitored DNS, an upstream, a dummy-helper
+# connection) could transiently occupy a server port as its source port;
+# rspamd's later bind() of a listener on that port then failed with
+# EADDRINUSE (98). Because the controller's SSL socket is the LAST of its
+# five ports to bind -- after the controller has already opened many
+# client sockets -- it lost this race most often, surfacing as the flaky
+# 440_ssl_server "SSL controller never came up". Moving the whole
+# rspamd/redis/nginx block down by 31000 keeps it below the ephemeral
+# floor while preserving every relative offset (so the carefully spaced,
+# collision-free per-worker layout is unchanged). Layout across 64 worker
+# slots (100 ports each): dummy_* helpers occupy <= 24383, this block
+# 25379..32097, ephemeral 32768+. Do NOT move these back above 32768.
+RSPAMD_PORT_CONTROLLER = 25790 + _PORT_OFFSET
+RSPAMD_PORT_CONTROLLER_SLAVE = 25793 + _PORT_OFFSET
+RSPAMD_PORT_FUZZY = 25791 + _PORT_OFFSET
+RSPAMD_PORT_FUZZY_SLAVE = 25792 + _PORT_OFFSET
+RSPAMD_PORT_NORMAL = 25789 + _PORT_OFFSET
+RSPAMD_PORT_NORMAL_SLAVE = 25794 + _PORT_OFFSET
+RSPAMD_PORT_PROXY = 25795 + _PORT_OFFSET
+RSPAMD_PORT_CONTROLLER_SSL = 25796 + _PORT_OFFSET
+RSPAMD_PORT_NORMAL_SSL = 25797 + _PORT_OFFSET
 RSPAMD_PORT_CLAM = 2100 + _PORT_OFFSET
 RSPAMD_PORT_FPROT = 2101 + _PORT_OFFSET
 RSPAMD_PORT_FPROT2_DUPLICATE = 2102 + _PORT_OFFSET
@@ -139,9 +154,9 @@ RSPAMD_PORT_DUMMY_UDP = 5005 + _PORT_OFFSET
 RSPAMD_PORT_DUMMY_SSL = 14433 + _PORT_OFFSET
 RSPAMD_P0F_SOCKET = '{}/p0f.sock'.format(RSPAMD_TMP_PREFIX)
 RSPAMD_REDIS_ADDR = '127.0.0.1'
-RSPAMD_REDIS_PORT = 56379 + _PORT_OFFSET
+RSPAMD_REDIS_PORT = 25379 + _PORT_OFFSET
 RSPAMD_NGINX_ADDR = '127.0.0.1'
-RSPAMD_NGINX_PORT = 56380 + _PORT_OFFSET
+RSPAMD_NGINX_PORT = 25380 + _PORT_OFFSET
 RSPAMD_GROUP = 'nogroup'
 RSPAMD_USER = 'nobody'
 SOCK_DGRAM = socket.SOCK_DGRAM

--- a/test/functional/lua/http.lua
+++ b/test/functional/lua/http.lua
@@ -1,6 +1,12 @@
 local rspamd_http = require "rspamd_http"
 local rspamd_logger = require "rspamd_logger"
 
+-- dummy_http / dummy_https ports come from the test harness; rspamd_env
+-- strips the RSPAMD_ prefix so PORT_DUMMY_HTTP/HTTPS carry the per-pabot
+-- worker slot value. Default to the historical literals for ad-hoc runs.
+local http_port = tonumber(rspamd_env and rspamd_env.PORT_DUMMY_HTTP) or 18080
+local https_port = tonumber(rspamd_env and rspamd_env.PORT_DUMMY_HTTPS) or 18081
+
 local function http_symbol(task)
 
   local url = tostring(task:get_request_header('url'))
@@ -27,7 +33,7 @@ local function http_symbol(task)
 
   rspamd_logger.errx(task, 'do http request with callback')
   rspamd_http.request({
-    url = 'http://127.0.0.1:18080' .. url,
+    url = string.format('http://127.0.0.1:%d%s', http_port, url),
     task = task,
     method = method,
     callback = http_callback,
@@ -37,7 +43,7 @@ local function http_symbol(task)
   --[[ request to this address involved DNS resolver subsystem ]]
   rspamd_logger.errx(task, 'do http request with callback + dns resolving')
   rspamd_http.request({
-    url = 'http://site.resolveme:18080' .. url,
+    url = string.format('http://site.resolveme:%d%s', http_port, url),
     task = task,
     method = method,
     callback = http_dns_callback,
@@ -47,7 +53,7 @@ local function http_symbol(task)
   rspamd_logger.errx(task, 'rspamd_http.request[before]')
 
   local err, response = rspamd_http.request({
-    url = 'http://127.0.0.1:18080' .. url,
+    url = string.format('http://127.0.0.1:%d%s', http_port, url),
     task = task,
     method = method,
     timeout = 1,
@@ -62,7 +68,7 @@ local function http_symbol(task)
 
   rspamd_logger.errx(task, 'do http request after coroutine finished')
   err, response = rspamd_http.request({
-    url = 'http://site.resolveme:18080' .. url,
+    url = string.format('http://site.resolveme:%d%s', http_port, url),
     task = task,
     method = method,
     timeout = 1,
@@ -79,7 +85,7 @@ end
 local function finish(task)
   rspamd_logger.errx('function finish')
   local err, response = rspamd_http.request({
-    url = 'http://site.resolveme:18080/timeout',
+    url = string.format('http://site.resolveme:%d/timeout', http_port),
     task = task,
     method = 'get',
     timeout = 1,
@@ -93,7 +99,7 @@ end
 
 local function periodic(cfg, ev_base)
   local err, response = rspamd_http.request({
-    url = 'http://site.resolveme:18080/request/periodic',
+    url = string.format('http://site.resolveme:%d/request/periodic', http_port),
     config = cfg,
   })
   if err then
@@ -134,7 +140,7 @@ local function http_large_symbol(task)
       end
     end
     rspamd_http.request({
-      url = 'https://127.0.0.1:18081/',
+      url = string.format('https://127.0.0.1:%d/', https_port),
       task = task,
       method = 'post',
       callback = http_callback,
@@ -156,7 +162,7 @@ rspamd_config:register_finish_script(finish)
 
 rspamd_config:add_on_load(function(cfg, ev_base, worker)
   local err, response = rspamd_http.request({
-    url = 'http://site.resolveme:18080/request/add_on_load',
+    url = string.format('http://site.resolveme:%d/request/add_on_load', http_port),
     config = cfg,
   })
   if err then

--- a/test/functional/lua/http_early_response.lua
+++ b/test/functional/lua/http_early_response.lua
@@ -4,11 +4,18 @@ Test HTTP client behavior when server sends early responses.
 This tests edge cases where a server responds before the client has finished
 sending the request body (which is allowed by HTTP/1.1 spec).
 
-The test server (dummy_http_early_response.py) runs on port 18083.
+The test server (dummy_http_early_response.py) runs on port 18083
+(per-pabot-worker offset applied via rspamd_env.PORT_DUMMY_HTTP_EARLY).
 ]]
 
 local rspamd_http = require "rspamd_http"
 local rspamd_logger = require "rspamd_logger"
+
+-- dummy_http_early_response port comes from the test harness; rspamd_env
+-- strips the RSPAMD_ prefix so PORT_DUMMY_HTTP_EARLY carries the per-pabot
+-- worker slot value. Default to the historical literal for ad-hoc runs.
+local early_port = tonumber(rspamd_env and rspamd_env.PORT_DUMMY_HTTP_EARLY) or 18083
+local base_url = string.format('http://127.0.0.1:%d', early_port)
 
 -- Register all possible result symbols upfront
 -- These are the symbols that will be inserted based on HTTP response codes
@@ -94,7 +101,7 @@ local function test_early_reply(task)
   end
 
   rspamd_http.request({
-    url = 'http://127.0.0.1:18083/early-reply',
+    url = base_url .. '/early-reply',
     task = task,
     method = 'post',
     body = large_body,
@@ -125,7 +132,7 @@ local function test_early_error_413(task)
   end
 
   rspamd_http.request({
-    url = 'http://127.0.0.1:18083/early-error-413',
+    url = base_url .. '/early-error-413',
     task = task,
     method = 'post',
     body = large_body,
@@ -151,7 +158,7 @@ local function test_keepalive_early(task)
   end
 
   rspamd_http.request({
-    url = 'http://127.0.0.1:18083/keepalive-early',
+    url = base_url .. '/keepalive-early',
     task = task,
     method = 'post',
     body = body,
@@ -172,7 +179,7 @@ local function test_early_reply_coro(task)
   local body = table.concat(body_parts)
 
   local err, response = rspamd_http.request({
-    url = 'http://127.0.0.1:18083/early-reply',
+    url = base_url .. '/early-reply',
     task = task,
     method = 'post',
     body = body,
@@ -203,7 +210,7 @@ local function test_normal_request(task)
   end
 
   rspamd_http.request({
-    url = 'http://127.0.0.1:18083/request',
+    url = base_url .. '/request',
     task = task,
     method = 'post',
     body = 'normal test body',
@@ -258,7 +265,7 @@ local function test_keepalive_sequential(task)
   -- Make 3 sequential requests using keepalive
   for i = 1, 3 do
     local err, response = rspamd_http.request({
-      url = 'http://127.0.0.1:18083/keepalive-normal',
+      url = base_url .. '/keepalive-normal',
       task = task,
       method = 'post',
       body = string.format('request %d body', i),
@@ -312,7 +319,7 @@ local function test_early_keepalive_stress(task)
     end
 
     local err, response = rspamd_http.request({
-      url = 'http://127.0.0.1:18083' .. endpoint,
+      url = base_url .. endpoint,
       task = task,
       method = 'post',
       body = table.concat(body_parts),
@@ -365,7 +372,7 @@ local function test_immediate_close_large(task)
   end
 
   rspamd_http.request({
-    url = 'http://127.0.0.1:18083/immediate-close-413',
+    url = base_url .. '/immediate-close-413',
     task = task,
     method = 'post',
     body = large_body,
@@ -393,7 +400,7 @@ local function test_slow_response_large(task)
   local body = table.concat(body_parts)
 
   local err, response = rspamd_http.request({
-    url = 'http://127.0.0.1:18083/slow-response-no-drain',
+    url = base_url .. '/slow-response-no-drain',
     task = task,
     method = 'post',
     body = body,
@@ -427,7 +434,7 @@ local function test_rapid_close_requests(task)
 
   for i = 1, 5 do
     local err, response = rspamd_http.request({
-      url = 'http://127.0.0.1:18083/immediate-close-413',
+      url = base_url .. '/immediate-close-413',
       task = task,
       method = 'post',
       body = body,
@@ -481,7 +488,7 @@ local function test_block_and_reply(task)
   end
 
   rspamd_http.request({
-    url = 'http://127.0.0.1:18083/block-and-reply',
+    url = base_url .. '/block-and-reply',
     task = task,
     method = 'post',
     body = huge_body,
@@ -506,7 +513,7 @@ local function test_block_and_reply_coro(task)
   local huge_body = string.rep("Y", 512 * 1024)
 
   local err, response = rspamd_http.request({
-    url = 'http://127.0.0.1:18083/block-and-reply',
+    url = base_url .. '/block-and-reply',
     task = task,
     method = 'post',
     body = huge_body,
@@ -538,7 +545,7 @@ local function test_block_slow(task)
   local huge_body = string.rep("Z", 1024 * 1024)
 
   local err, response = rspamd_http.request({
-    url = 'http://127.0.0.1:18083/block-and-reply-slow',
+    url = base_url .. '/block-and-reply-slow',
     task = task,
     method = 'post',
     body = huge_body,
@@ -571,7 +578,7 @@ local function test_instant_reply(task)
   local huge_body = string.rep("Z", 512 * 1024)
 
   local err, response = rspamd_http.request({
-    url = 'http://127.0.0.1:18083/instant-reply',
+    url = base_url .. '/instant-reply',
     task = task,
     method = 'post',
     body = huge_body,

--- a/test/functional/lua/rspamadm/test_redis_client.lua
+++ b/test/functional/lua/rspamadm/test_redis_client.lua
@@ -7,7 +7,7 @@ local upstream_list = require "rspamd_upstream_list"
 -- (unlike rspamd) does NOT populate the rspamd_env global, so read
 -- the RSPAMD_ env var directly. Fall back to the historical literal
 -- for standalone invocations.
-local redis_port = tonumber(os.getenv("RSPAMD_REDIS_PORT")) or 56379
+local redis_port = tonumber(os.getenv("RSPAMD_REDIS_PORT")) or 25379
 local upstreams_write = upstream_list.create('127.0.0.1', redis_port)
 local upstreams_read = upstream_list.create('127.0.0.1', redis_port)
 

--- a/test/functional/lua/rspamadm/test_tcp_client.lua
+++ b/test/functional/lua/rspamadm/test_tcp_client.lua
@@ -1,13 +1,20 @@
 local logger = require "rspamd_logger"
 local tcp_sync = require "lua_tcp_sync"
 
+-- dummy_http port comes from the test harness. This script runs under
+-- `rspamadm lua` (not the rspamd config loader), so prefer the exported
+-- RSPAMD_PORT_DUMMY_HTTP env var, then rspamd_env, then the historical
+-- literal for ad-hoc runs.
+local http_port = tonumber(os.getenv('RSPAMD_PORT_DUMMY_HTTP'))
+  or tonumber(rspamd_env and rspamd_env.PORT_DUMMY_HTTP) or 18080
+
 local is_ok, connection = tcp_sync.connect {
   config = rspamd_config,
   ev_base = rspamadm_ev_base,
   session = rspamadm_session,
   host = '127.0.0.1',
   timeout = 20,
-  port = 18080,
+  port = http_port,
 }
 if not is_ok then
   logger.errx(rspamd_config, 'connect error: %1', connection)

--- a/test/functional/lua/tcp.lua
+++ b/test/functional/lua/tcp.lua
@@ -6,6 +6,12 @@ local rspamd_tcp = require "rspamd_tcp"
 local logger = require "rspamd_logger"
 local tcp_sync = require "lua_tcp_sync"
 
+-- dummy_http / dummy_https ports come from the test harness; rspamd_env
+-- strips the RSPAMD_ prefix so PORT_DUMMY_HTTP/HTTPS carry the per-pabot
+-- worker slot value. Default to the historical literals for ad-hoc runs.
+local http_port = tonumber(rspamd_env and rspamd_env.PORT_DUMMY_HTTP) or 18080
+local https_port = tonumber(rspamd_env and rspamd_env.PORT_DUMMY_HTTPS) or 18081
+
 -- [[ old fashioned callback api ]]
 local function http_simple_tcp_async_symbol(task)
   logger.errx(task, 'http_tcp_symbol: begin')
@@ -19,16 +25,16 @@ local function http_simple_tcp_async_symbol(task)
   end
   local function http_read_cb(err, data, conn)
     logger.errx(task, 'http_read_cb: got reply: %s, error: %s, conn: %s', data, err, conn)
-    conn:add_write(http_read_post_cb, "POST /request2 HTTP/1.1\r\nHost: 127.0.0.1:18080\r\n\r\n")
+    conn:add_write(http_read_post_cb, string.format("POST /request2 HTTP/1.1\r\nHost: 127.0.0.1:%d\r\n\r\n", http_port))
     task:insert_result('HTTP_ASYNC_RESPONSE', 1.0, data or err)
   end
   rspamd_tcp:request({
     task = task,
     callback = http_read_cb,
     host = '127.0.0.1',
-    data = {'GET /request HTTP/1.1\r\nHost: 127.0.0.1:18080\r\nConnection: keep-alive\r\n\r\n'},
+    data = {string.format('GET /request HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nConnection: keep-alive\r\n\r\n', http_port)},
     read = true,
-    port = 18080,
+    port = http_port,
   })
 end
 
@@ -55,7 +61,7 @@ local function http_simple_tcp_ssl_symbol(task)
     read = true,
     ssl = true,
     ssl_noverify = true,
-    port = 18081,
+    port = https_port,
   })
 end
 
@@ -96,7 +102,7 @@ local function http_large_tcp_ssl_symbol(task)
       ssl = true,
       stop_pattern = '\n',
       ssl_noverify = true,
-      port = 18081,
+      port = https_port,
       timeout = 20,
     })
   else
@@ -112,7 +118,7 @@ local function http_simple_tcp_symbol(task)
     task = task,
     host = '127.0.0.1',
     timeout = 20,
-    port = 18080,
+    port = http_port,
   }
 
   if not is_ok then
@@ -122,7 +128,7 @@ local function http_simple_tcp_symbol(task)
 
   logger.errx(task, 'connect_sync %1, %2', is_ok, tostring(connection))
 
-  is_ok, err = connection:write('GET /request HTTP/1.1\r\nHost: 127.0.0.1:18080\r\nConnection: keep-alive\r\n\r\n')
+  is_ok, err = connection:write(string.format('GET /request HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nConnection: keep-alive\r\n\r\n', http_port))
 
   logger.errx(task, 'write %1, %2', is_ok, err)
   if not is_ok then
@@ -149,7 +155,7 @@ local function http_simple_tcp_symbol(task)
 
   task:insert_result('HTTP_SYNC_RESPONSE', 1.0, got_content)
 
-  is_ok, err = connection:write("POST /request HTTP/1.1\r\nHost: 127.0.0.1:18080\r\n\r\n")
+  is_ok, err = connection:write(string.format("POST /request HTTP/1.1\r\nHost: 127.0.0.1:%d\r\n\r\n", http_port))
   logger.errx(task, 'write[2] %1, %2', is_ok, err)
 
   got_content = ''
@@ -185,7 +191,7 @@ local function http_tcp_symbol(task)
     task = task,
     host = '127.0.0.1',
     timeout = 20,
-    port = 18080,
+    port = http_port,
   }
 
   logger.errx(task, 'connect_sync %1, %2', is_ok, tostring(connection))
@@ -194,7 +200,7 @@ local function http_tcp_symbol(task)
     return
   end
 
-  is_ok, err = connection:write(string.format('%s %s HTTP/1.1\r\nHost: 127.0.0.1:18080\r\nConnection: close\r\n\r\n', method:upper(), url))
+  is_ok, err = connection:write(string.format('%s %s HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nConnection: close\r\n\r\n', method:upper(), url, http_port))
 
   logger.errx(task, 'write %1, %2', is_ok, err)
   if not is_ok then
@@ -292,9 +298,9 @@ local function phased_timeout_symbol(task)
     task = task,
     callback = read_cb,
     host = '127.0.0.1',
-    data = {'GET /request HTTP/1.1\r\nHost: 127.0.0.1:18080\r\nConnection: close\r\n\r\n'},
+    data = {string.format('GET /request HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nConnection: close\r\n\r\n', http_port)},
     read = true,
-    port = 18080,
+    port = http_port,
     connect_timeout = 2.0,
     read_timeout = 2.0,
     write_timeout = 2.0,
@@ -343,10 +349,10 @@ local function on_error_post_connect_symbol(task)
     callback = read_cb,
     on_error = err_cb,
     host = '127.0.0.1',
-    port = 18080,
+    port = http_port,
     -- /timeout sleeps 4s before responding. read_timeout=0.5 forces the read
     -- side to time out after the connect succeeds.
-    data = {'GET /timeout HTTP/1.1\r\nHost: 127.0.0.1:18080\r\nConnection: close\r\n\r\n'},
+    data = {string.format('GET /timeout HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nConnection: close\r\n\r\n', http_port)},
     read = true,
     stop_pattern = '\r\n\r\n',
     connect_timeout = 2.0,

--- a/test/functional/messages/chain_multipart.eml
+++ b/test/functional/messages/chain_multipart.eml
@@ -5,7 +5,7 @@ Content-Transfer-Encoding: quoted-printable
 <html>
 <body>
 <p>Test message with redirect chains</p>
-<a href="http://127.0.0.1:18080/chain1">Chain 1</a>
-<a href="http://127.0.0.1:18080/redirect2">Redirect 2</a>
+<a href="http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/chain1">Chain 1</a>
+<a href="http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/redirect2">Redirect 2</a>
 </body>
 </html>

--- a/test/functional/messages/chain_redirect.eml
+++ b/test/functional/messages/chain_redirect.eml
@@ -4,6 +4,6 @@ Content-Transfer-Encoding: quoted-printable
 
 <html>
 <body>
-<a href="http://127.0.0.1:18080/chain1">chain link</a>
+<a href="http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/chain1">chain link</a>
 </body>
 </html>

--- a/test/functional/messages/redir.eml
+++ b/test/functional/messages/redir.eml
@@ -1,6 +1,6 @@
 Content-type: text/plain
 
-bla http://127.0.0.1:18080/redirect2
+bla http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/redirect2
 
-lol http://127.0.0.1:18080/redirect3
+lol http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/redirect3
 

--- a/test/functional/messages/redir_chain_tel_url.eml
+++ b/test/functional/messages/redir_chain_tel_url.eml
@@ -2,6 +2,6 @@ Content-type: text/html
 
 <html>
 <body>
-<a href="http://127.0.0.1:18080/chain_intermediate_1">Call us via chain</a>
+<a href="http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/chain_intermediate_1">Call us via chain</a>
 </body>
 </html>

--- a/test/functional/messages/redir_multi_non_http.eml
+++ b/test/functional/messages/redir_multi_non_http.eml
@@ -2,7 +2,7 @@ Content-type: text/html
 
 <html>
 <body>
-<a href="http://127.0.0.1:18080/tel_redirect">Call us</a>
-<a href="http://127.0.0.1:18080/mailto_redirect">Email us</a>
+<a href="http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/tel_redirect">Call us</a>
+<a href="http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/mailto_redirect">Email us</a>
 </body>
 </html>

--- a/test/functional/messages/redir_phishing_safe.eml
+++ b/test/functional/messages/redir_phishing_safe.eml
@@ -1,3 +1,3 @@
 Content-type: text/html
 
-<a href="http://redir.example.net:18080/redir_to_example">http://www.example.com/</a>
+<a href="http://redir.example.net:${RSPAMD_PORT_DUMMY_HTTP}/redir_to_example">http://www.example.com/</a>

--- a/test/functional/messages/redir_query_target.eml
+++ b/test/functional/messages/redir_query_target.eml
@@ -1,3 +1,3 @@
 Content-type: text/plain
 
-click http://127.0.0.1:18080/combo_entry
+click http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/combo_entry

--- a/test/functional/messages/redir_tel_url.eml
+++ b/test/functional/messages/redir_tel_url.eml
@@ -2,6 +2,6 @@ Content-type: text/html
 
 <html>
 <body>
-<a href="http://127.0.0.1:18080/tel_redirect">Call us</a>
+<a href="http://127.0.0.1:${RSPAMD_PORT_DUMMY_HTTP}/tel_redirect">Call us</a>
 </body>
 </html>

--- a/test/functional/run-parallel.sh
+++ b/test/functional/run-parallel.sh
@@ -41,6 +41,11 @@ if ! command -v pabot >/dev/null 2>&1; then
     exit 1
 fi
 
+# Preflight: every dummy_* helper must be started through the centralized
+# Start Dummy Service barrier (lib/rspamd.robot), never a bare Start Process,
+# or the start/scan race that flakes under parallel execution comes back.
+python3 "$SCRIPT_DIR/util/check_no_bare_dummy_start.py" || exit 1
+
 # Suites that still bake dummy_http/llm/udp/http_early port numbers into
 # Lua test scripts or configs. Track in task #5 follow-up; tag and exclude
 # until those are templated.

--- a/test/functional/util/check_no_bare_dummy_start.py
+++ b/test/functional/util/check_no_bare_dummy_start.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Guard against reintroducing the dummy-helper start/scan race.
+
+Every dummy_* helper must be started through the centralized
+``Start Dummy Service`` keyword (or one of the ``Run Dummy *`` /
+``Start Dummy *`` wrappers) defined in ``test/functional/lib/rspamd.robot``.
+Those wrappers block until the helper's PID file appears -- which each
+helper writes only after it has bound and is listening -- so the rspamd
+worker (or the test) never races a not-yet-listening helper.
+
+A bare ``Start Process  .../dummy_<x>.py`` inside a suite bypasses that
+barrier and reintroduces the flakiness this guard exists to prevent.
+This script exits non-zero if it finds one.
+
+Usage:
+    python3 test/functional/util/check_no_bare_dummy_start.py
+"""
+
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CASES = os.path.normpath(os.path.join(HERE, '..', 'cases'))
+REPO = os.path.normpath(os.path.join(HERE, '..', '..', '..'))
+
+# A line that starts a dummy helper directly via Robot's Process library.
+BARE = re.compile(r'Start Process\b.*dummy_[A-Za-z0-9_]*\.py')
+
+
+def main():
+    offenders = []
+    for root, _dirs, files in os.walk(CASES):
+        for name in sorted(files):
+            if not name.endswith('.robot'):
+                continue
+            path = os.path.join(root, name)
+            with open(path, encoding='utf-8') as fh:
+                for lineno, line in enumerate(fh, 1):
+                    if line.lstrip().startswith('#'):
+                        continue
+                    if BARE.search(line):
+                        offenders.append((path, lineno, line.strip()))
+
+    if offenders:
+        sys.stderr.write(
+            "ERROR: bare 'Start Process ... dummy_*.py' found in functional "
+            "suites.\n"
+            "Start dummy helpers through the 'Start Dummy Service' keyword (or "
+            "a\n"
+            "Run Dummy * / Start Dummy * wrapper) in lib/rspamd.robot so they "
+            "block\n"
+            "until the helper is listening. Offending lines:\n\n")
+        for path, lineno, text in offenders:
+            sys.stderr.write(
+                "  {}:{}: {}\n".format(os.path.relpath(path, REPO), lineno, text))
+        return 1
+
+    print("OK: no bare dummy_*.py 'Start Process' in {}".format(
+        os.path.relpath(CASES, REPO)))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/functional/util/dummy_p0f.py
+++ b/test/functional/util/dummy_p0f.py
@@ -86,9 +86,14 @@ if __name__ == "__main__":
     server.server_activate()
 
     dummy_killer.setup_killer(server)
-    # Derive PID path from socket basename so multiple workers/instances
-    # never collide on the historical /tmp/dummy_p0f.pid.
-    pid_path = dummy_pidfile.pid_path('p0f', os.path.basename(SOCK))
+    # PID path: explicit 4th arg if the harness passed one (so it can wait
+    # on exactly this path), else derive from the socket basename so
+    # multiple workers/instances never collide on the historical
+    # /tmp/dummy_p0f.pid.
+    if alen > 4:
+        pid_path = sys.argv[4]
+    else:
+        pid_path = dummy_pidfile.pid_path('p0f', os.path.basename(SOCK))
     dummy_killer.write_pid(pid_path)
 
     try:


### PR DESCRIPTION
Makes the functional suite reliable under parallel pabot. Several commits, reviewable independently.

## 1. Centralize the dummy-helper readiness barrier
`dummy_*` mock services were connected to before they were listening. Routed all startup through one barrier in `lib/rspamd.robot` (`Start Dummy Service` + `Wait Until Dummy Listening` probe for loop servers), with a `run-parallel.sh` preflight guard (`util/check_no_bare_dummy_start.py`).

## 2. Template dummy ports for parallel safety
Consumers hardcoded the worker-0 dummy-port literals. Routed each through the per-worker value: Lua via `rspamd_env.PORT_DUMMY_*`, `neural_llm.conf` via Jinja, rspamadm client via `os.getenv`, and the url_redirector `.eml` fixtures (fed raw to the scanner) via a new `Render Message Template` keyword.

## 3. Wait for rspamd's own ports to free in teardown
`Rspamd Teardown` only reaped the main rspamd; its listening sockets (shared with forked workers) lingered, so the next suite on the same pabot worker raced them. Added `port_is_free()` + `Wait For Rspamd Ports Released`, looping over all five ports (normal, controller, proxy, controller-SSL, normal-SSL).

## 4. Dedupe concurrent push + pull_request CI runs
`ci.yml` had no `concurrency:` block, so a commit on a PR branch fired two full runs at once, doubling load on shared runners. Added a concurrency group keyed on the head SHA (`pull_request.head.sha || github.sha`) with cancel-in-progress.

## 5. Move test server ports below the ephemeral range (the 440_ssl_server root cause)
The deepest cause of the intermittent `bind 98 / Address already in use` failures: the test server ports sat **inside** Linux's default ephemeral range (`net.ipv4.ip_local_port_range = 32768..60999`) — redis 56379, nginx 56380, rspamd 567xx (incl. both TLS listeners).

So any **outbound client socket** in the test env (redis client, monitored URIBL DNS, an upstream, a dummy-helper connection) could be handed a server port as its **ephemeral source port** on `connect()`; rspamd's later `bind()` of a listener on that port then failed with EADDRINUSE. `SO_REUSEADDR` (which rspamd sets) does nothing against a live socket held by another process. The controller's SSL socket binds **last** — after the controller has opened many client sockets — so it lost this race most often, surfacing as "SSL controller never came up" → HTTPS connection-refused for the whole retry budget. Probabilistic → flaky and distro-dependent.

Fix: move the whole rspamd/redis/nginx block **down by 31000** (normal 56789→25789, controller-SSL 56796→25796, redis 56379→25379, nginx 56380→25380). Relative offsets preserved, so the collision-free per-worker layout is unchanged: across 64 slots the dummy helpers stay ≤24383, this block spans 25379..32097, ephemeral floor 32768 never reached. This is why the prior three band-aids on 440_ssl_server (two retry/wait commits + the teardown wait) never fully worked — the port was genuinely occupied at bind time.

## Verification
- **Serial**: unchanged behaviour on the relocated ports — 001_merged 351/355 (all six 440_ssl_server SSL tests pass; the 4 fails are pre-existing phishing/inject-url symbol-logic, identical on master). vars.py imported for slots 0 and 63: max port 32097 < 32768, zero cross-family collisions.
- **Parallel** (pabot, CI-style): zero dummy-port `Errno 48`, no cross-worker URL mismatches.
- CI dedup confirmed: the push run for this commit was cancelled within seconds, leaving a single run.

## Known pre-existing (not addressed here)
- **169 path-less `?u=` wrapper**: a redirector behaviour bug, fails identically on master.
- A handful of local-only macOS failures (loopback aliases, missing local liblua/redis) that CI's containers don't have.