### PR TITLE
[Fix] ratelimit: Track all buckets in selector rules

### DIFF
--- a/src/plugins/lua/ratelimit.lua
+++ b/src/plugins/lua/ratelimit.lua
@@ -280,19 +280,31 @@ local function make_prefix(redis_key, name, bucket)
   }
 end
 
+-- Distinguishes buckets within a single rule so that, e.g. "200 / 1h" and
+-- "30 / 1m" map to separate Redis keys instead of collapsing onto the same
+-- selector value (see issue #6059). Uses burst + rate, mirroring the burst
+-- component that gen_rate_key already prepends for the non-selector path.
+local function bucket_id(bucket)
+  return string.format('%s:%s',
+    lua_util.round(100000.0 / bucket.burst), bucket.rate)
+end
+
 local function limit_to_prefixes(task, k, v, prefixes)
   local n = 0
   for _, bucket in ipairs(v.buckets) do
     if v.selector then
       local selectors = lua_selectors.process_selectors(task, v.selector)
       if selectors then
+        local bid = bucket_id(bucket)
         local combined = lua_selectors.combine_selectors(task, selectors, ':')
         if type(combined) == 'string' then
-          prefixes[combined] = make_prefix(combined, k, bucket)
+          local rkey = bid .. ':' .. combined
+          prefixes[rkey] = make_prefix(rkey, k, bucket)
           n = n + 1
         else
           fun.each(function(p)
-            prefixes[p] = make_prefix(p, k, bucket)
+            local rkey = bid .. ':' .. p
+            prefixes[rkey] = make_prefix(rkey, k, bucket)
             n = n + 1
           end, combined)
         end

--- a/test/functional/cases/500_ratelimit.robot
+++ b/test/functional/cases/500_ratelimit.robot
@@ -46,3 +46,9 @@ RATELIMIT CHECK BUILTIN
 
 RATELIMIT CHECK SELECTOR
   Basic Test  foo@example.net  special@example.net  2
+
+RATELIMIT CHECK MULTIPLE BUCKETS
+  # Regression for #6059: with two buckets (burst 2 and burst 20) the most
+  # restrictive one must fire. Before the fix only the last bucket (burst 20)
+  # was tracked, so a soft reject would never happen at the third message.
+  Basic Test  bar@example.net  multi@example.net  2

--- a/test/functional/configs/ratelimit.conf
+++ b/test/functional/configs/ratelimit.conf
@@ -19,5 +19,20 @@ ratelimit {
         rate = "1 / 1s";
       }
     }
+    to_multi_buckets {
+      # Two buckets in one rule: the restrictive one (burst = 2) must apply,
+      # not just the last one in the array (burst = 20). Regression for #6059.
+      selector = "id('multi');to.in('multi@example.net')";
+      bucket = [
+        {
+          burst = 2;
+          rate = "1 / 1s";
+        },
+        {
+          burst = 20;
+          rate = "1 / 1s";
+        }
+      ];
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #6059.

When a ratelimit rule defines **multiple buckets** and uses a `selector`, only the **last** bucket in the array was ever tracked — the other limits were silently ignored:

```lua
rates {
  sender_tier_default {
    selector = "from";
    bucket = [
      { rate = "300 / 1h"; },   # ignored
      { rate = "100 / 1m"; }    # only this one tracked
    ];
  }
}
```

### Root cause
In `limit_to_prefixes`, the selector path keyed the `prefixes` table by the selector value (`combined`) alone:

```lua
prefixes[combined] = make_prefix(combined, k, bucket)
```

With several buckets in one rule, every bucket produced the same `combined` key, so each iteration overwrote the previous one and only the last survived. The Redis key (`make_prefix`'s hash) is derived from that same string, so the buckets also shared one Redis key. The non-selector path is unaffected because `gen_rate_key` already prepends `round(100000/burst)` per bucket.

### Fix
Give each bucket a distinct key by prefixing the selector value with a small per-bucket id (`burst:rate`), mirroring the burst component `gen_rate_key` already uses for the non-selector path. The non-selector path is untouched, so its existing Redis keys are preserved (no counter reset on upgrade for those configs).

This matches the approach in the reporter's suggested patch.

## Test
Adds `RATELIMIT CHECK MULTIPLE BUCKETS` to `500_ratelimit.robot` with a two-bucket selector rule (`burst = 2` then `burst = 20`). The restrictive bucket must fire at the third message. Verified the test **fails before the fix** (`no action != soft reject`, because only the `burst = 20` bucket was tracked) and **passes after**. Existing `RATELIMIT CHECK BUILTIN` and `RATELIMIT CHECK SELECTOR` cases still pass.