### PR TITLE
Disable ratelimit module if custom_keywords cannot be loaded

### DIFF
--- a/src/plugins/lua/ratelimit.lua
+++ b/src/plugins/lua/ratelimit.lua
@@ -723,9 +723,9 @@ if opts then
         settings['custom_keywords']['custom'] = res_or_err
       end
     else
-      rspamd_logger.errx(rspamd_config, 'cannot execute %s: %s',
+      rspamd_logger.info(rspamd_config, 'cannot execute %s: %s, disabling module',
           opts['custom_keywords'], res_or_err)
-      settings['custom_keywords'] = {}
+      lua_util.disable_module(N, "custom_keywords")
     end
   end
 

--- a/src/plugins/lua/ratelimit.lua
+++ b/src/plugins/lua/ratelimit.lua
@@ -725,7 +725,7 @@ if opts then
     else
       rspamd_logger.info(rspamd_config, 'cannot execute %s: %s, disabling module',
           opts['custom_keywords'], res_or_err)
-      lua_util.disable_module(N, "custom_keywords")
+      lua_util.disable_module(N, "config")
     end
   end
 


### PR DESCRIPTION
Disable the ratelimit module when `custom_keywords` is configured but the configured file cannot be loaded or executed.