### PR TITLE
[Minor] url_redirector: distinguish direct URL errors from redirect errors

### DIFF
--- a/src/plugins/lua/url_redirector.lua
+++ b/src/plugins/lua/url_redirector.lua
@@ -583,9 +583,13 @@ http_walk = function(task, orig_url, url, ntries, chain, seen)
 
   local function http_callback(err, code, _, headers)
     if err then
-      rspamd_logger.infox(task,
-          'found redirect error from %s to %s, err message: %s',
-          orig_url, url, err)
+      if orig_url == url then
+        rspamd_logger.infox(task,
+            'error checking URL %s: %s', url, err)
+      else
+        rspamd_logger.infox(task,
+            'redirect error: %s -> %s: %s', orig_url, url, err)
+      end
       chain_append(chain, url)
       finalize_chain(task, chain, nil)
       return


### PR DESCRIPTION
When http_callback reports an error on the first hop (orig_url == url), no redirect has occurred yet, but the old message "found redirect error from X to X" implied one.  Split the message: "error checking URL" for direct failures and "redirect error: A -> B" for mid-chain failures.