### PR TITLE
[Feature] Experimental DKIM2 verification (draft-ietf-dkim-dkim2-spec)

### DIFF
--- a/src/libserver/CMakeLists.txt
+++ b/src/libserver/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(LIBRSPAMDSERVERSRC
         ${CMAKE_CURRENT_SOURCE_DIR}/composites/composites.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/composites/composites_manager.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/dkim.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/dkim2.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/dns.c
         ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_cfg.c
         ${CMAKE_CURRENT_SOURCE_DIR}/async_session.c

--- a/src/libserver/dkim.c
+++ b/src/libserver/dkim.c
@@ -1458,6 +1458,40 @@ rspamd_dkim_key_id(rspamd_dkim_key_t *key)
 	return NULL;
 }
 
+enum rspamd_dkim_key_type
+rspamd_dkim_key_get_type(rspamd_dkim_key_t *key)
+{
+	if (key) {
+		return key->type;
+	}
+
+	return RSPAMD_DKIM_KEY_INVALID;
+}
+
+void *
+rspamd_dkim_key_evp(rspamd_dkim_key_t *key)
+{
+	if (key && key->type != RSPAMD_DKIM_KEY_EDDSA) {
+		return key->specific.key_ssl.key_evp;
+	}
+
+	return NULL;
+}
+
+const unsigned char *
+rspamd_dkim_key_eddsa(rspamd_dkim_key_t *key, gsize *len)
+{
+	if (key && key->type == RSPAMD_DKIM_KEY_EDDSA) {
+		if (len) {
+			*len = key->decoded_len;
+		}
+
+		return key->specific.key_eddsa;
+	}
+
+	return NULL;
+}
+
 /**
 * Free DKIM key
 * @param key

--- a/src/libserver/dkim.h
+++ b/src/libserver/dkim.h
@@ -277,6 +277,29 @@ rspamd_dkim_key_t *rspamd_dkim_make_key(const char *keydata, unsigned int keylen
 const unsigned char *rspamd_dkim_key_id(rspamd_dkim_key_t *key);
 
 /**
+ * Returns the type of a public key
+ * @param key
+ * @return
+ */
+enum rspamd_dkim_key_type rspamd_dkim_key_get_type(rspamd_dkim_key_t *key);
+
+/**
+ * Returns the EVP_PKEY of an RSA/ECDSA public key (as void * to avoid
+ * including OpenSSL headers), NULL for eddsa keys
+ * @param key
+ * @return
+ */
+void *rspamd_dkim_key_evp(rspamd_dkim_key_t *key);
+
+/**
+ * Returns the raw eddsa public key and its length, NULL for other key types
+ * @param key
+ * @param len
+ * @return
+ */
+const unsigned char *rspamd_dkim_key_eddsa(rspamd_dkim_key_t *key, gsize *len);
+
+/**
  * Parse DKIM public key from a TXT record
  * @param txt
  * @param keylen

--- a/src/libserver/dkim2.cxx
+++ b/src/libserver/dkim2.cxx
@@ -34,6 +34,7 @@
 #include "dkim2.h"
 #include "dkim2.hxx"
 #include "utlist.h"
+#include "libutil/cxx/util.hxx"
 
 #include "contrib/ankerl/unordered_dense.h"
 #include "contrib/fmt/include/fmt/core.h"
@@ -42,7 +43,6 @@
 #include <openssl/evp.h>
 
 #include <algorithm>
-#include <charconv>
 #include <memory>
 #include <optional>
 #include <string>
@@ -77,20 +77,14 @@ constexpr std::string_view sha256_alg_name = "sha256";
 constexpr std::string_view rsa_alg_name = "rsa-sha256";
 constexpr std::string_view ed25519_alg_name = "ed25519-sha256";
 
-static constexpr auto
-is_wsp(char c) -> bool
-{
-	/* Values are unfolded by the caller, so treat CR/LF remnants as WSP too */
-	return c == ' ' || c == '\t' || c == '\r' || c == '\n';
-}
-
 static auto
 trim(std::string_view in) -> std::string_view
 {
-	while (!in.empty() && is_wsp(in.front())) {
+	/* Values are unfolded by the caller, g_ascii_isspace covers CR/LF remnants */
+	while (!in.empty() && g_ascii_isspace(in.front())) {
 		in.remove_prefix(1);
 	}
-	while (!in.empty() && is_wsp(in.back())) {
+	while (!in.empty() && g_ascii_isspace(in.back())) {
 		in.remove_suffix(1);
 	}
 
@@ -104,7 +98,7 @@ strip_wsp(std::string_view in) -> std::string
 	out.reserve(in.size());
 
 	for (auto c: in) {
-		if (!is_wsp(c)) {
+		if (!g_ascii_isspace(c)) {
 			out.push_back(c);
 		}
 	}
@@ -115,12 +109,8 @@ strip_wsp(std::string_view in) -> std::string
 static auto
 lc_string(std::string_view in) -> std::string
 {
-	std::string out;
-	out.reserve(in.size());
-
-	for (auto c: in) {
-		out.push_back(static_cast<char>(g_ascii_tolower(c)));
-	}
+	std::string out{in};
+	rspamd_str_lc(out.data(), out.size());
 
 	return out;
 }
@@ -129,23 +119,15 @@ static auto
 eq_icase(std::string_view a, std::string_view b) -> bool
 {
 	return a.size() == b.size() &&
-		   std::equal(a.begin(), a.end(), b.begin(), [](char c1, char c2) {
-			   return g_ascii_tolower(c1) == g_ascii_tolower(c2);
-		   });
+		   rspamd_lc_cmp(a.data(), b.data(), a.size()) == 0;
 }
 
 static auto
-parse_uint(std::string_view in) -> std::optional<unsigned int>
+parse_uint(std::string_view in) -> std::optional<unsigned long>
 {
-	unsigned int res;
+	gulong res;
 
-	if (in.empty()) {
-		return std::nullopt;
-	}
-
-	auto [ptr, ec] = std::from_chars(in.data(), in.data() + in.size(), res);
-
-	if (ec != std::errc{} || ptr != in.data() + in.size()) {
+	if (!rspamd_strtoul(in.data(), in.size(), &res)) {
 		return std::nullopt;
 	}
 
@@ -155,34 +137,22 @@ parse_uint(std::string_view in) -> std::optional<unsigned int>
 static auto
 b64_decode(std::string_view in) -> std::optional<std::string>
 {
-	auto cleaned = strip_wsp(in);
+	/* rspamd_cryptobox_base64_decode skips whitespace internally */
 	std::string out;
-	out.resize(cleaned.size() / 4 * 3 + 3);
+	out.resize(in.size() / 4 * 3 + 3);
 	std::size_t outlen = out.size();
 
-	if (!cleaned.empty() &&
-		!rspamd_cryptobox_base64_decode(cleaned.data(), cleaned.size(),
+	in = trim(in);
+
+	if (!in.empty() &&
+		!rspamd_cryptobox_base64_decode(in.data(), in.size(),
 										reinterpret_cast<unsigned char *>(out.data()), &outlen)) {
 		return std::nullopt;
 	}
 
-	out.resize(cleaned.empty() ? 0 : outlen);
+	out.resize(in.empty() ? 0 : outlen);
 
 	return out;
-}
-
-template<typename Func>
-static void
-split_foreach(std::string_view in, char sep, Func &&f)
-{
-	std::size_t start = 0;
-
-	for (std::size_t pos = 0; pos <= in.size(); pos++) {
-		if (pos == in.size() || in[pos] == sep) {
-			f(in.substr(start, pos - start));
-			start = pos + 1;
-		}
-	}
 }
 
 auto parse_tag_list(std::string_view input) -> tl::expected<std::vector<tag_t>, std::string>
@@ -190,7 +160,7 @@ auto parse_tag_list(std::string_view input) -> tl::expected<std::vector<tag_t>, 
 	std::vector<tag_t> res;
 	std::string err;
 
-	split_foreach(input, ';', [&](std::string_view seg) {
+	rspamd::string_foreach_delim(input, ";", [&](std::string_view seg) {
 		if (!err.empty()) {
 			return;
 		}
@@ -235,16 +205,18 @@ parse_hash_sets(std::string_view value) -> tl::expected<std::vector<hash_set_t>,
 	std::vector<hash_set_t> res;
 	std::string err;
 
-	split_foreach(value, ',', [&](std::string_view set_str) {
+	rspamd::string_foreach_delim(value, ",", [&](std::string_view set_str) {
 		if (!err.empty()) {
 			return;
 		}
 
 		/* hash-set = hash-name ":" header-hash ":" body-hash */
 		std::vector<std::string_view> parts;
-		split_foreach(set_str, ':', [&](std::string_view part) {
-			parts.push_back(part);
-		});
+		rspamd::string_foreach_delim(
+			set_str, ":", [&](std::string_view part) {
+				parts.push_back(part);
+			},
+			false);
 
 		if (parts.size() != 3) {
 			err = fmt::format("invalid hash-set: '{}'", set_str);
@@ -294,7 +266,7 @@ auto parse_mi(std::string_view value) -> tl::expected<mi_header_t, std::string>
 				return tl::make_unexpected(std::string{"duplicate m= tag"});
 			}
 			auto m = parse_uint(tag.value);
-			if (!m || *m == 0) {
+			if (!m || *m == 0 || *m > RSPAMD_DKIM2_MAX_HOPS) {
 				return tl::make_unexpected(fmt::format("invalid m= tag: '{}'", tag.value));
 			}
 			res.m = *m;
@@ -334,16 +306,18 @@ parse_sig_sets(std::string_view value) -> tl::expected<std::vector<sig_set_t>, s
 	std::vector<sig_set_t> res;
 	std::string err;
 
-	split_foreach(value, ',', [&](std::string_view set_str) {
+	rspamd::string_foreach_delim(value, ",", [&](std::string_view set_str) {
 		if (!err.empty()) {
 			return;
 		}
 
 		/* sig-set = selector ":" sig-name ":" message-sig */
 		std::vector<std::string_view> parts;
-		split_foreach(set_str, ':', [&](std::string_view part) {
-			parts.push_back(part);
-		});
+		rspamd::string_foreach_delim(
+			set_str, ":", [&](std::string_view part) {
+				parts.push_back(part);
+			},
+			false);
 
 		if (parts.size() != 3) {
 			err = fmt::format("invalid sig-set: '{}'", set_str);
@@ -401,7 +375,7 @@ auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string
 				return tl::make_unexpected(std::string{"duplicate i= tag"});
 			}
 			auto i = parse_uint(tag.value);
-			if (!i || *i == 0) {
+			if (!i || *i == 0 || *i > RSPAMD_DKIM2_MAX_HOPS) {
 				return tl::make_unexpected(fmt::format("invalid i= tag: '{}'", tag.value));
 			}
 			res.i = *i;
@@ -412,7 +386,7 @@ auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string
 				return tl::make_unexpected(std::string{"duplicate m= tag"});
 			}
 			auto m = parse_uint(tag.value);
-			if (!m || *m == 0) {
+			if (!m || *m == 0 || *m > RSPAMD_DKIM2_MAX_HOPS) {
 				return tl::make_unexpected(fmt::format("invalid m= tag: '{}'", tag.value));
 			}
 			res.m = *m;
@@ -420,7 +394,7 @@ auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string
 		}
 		else if (tag.name == "t") {
 			auto t = parse_uint(tag.value);
-			if (!t) {
+			if (!t || *t > (gulong) G_MAXINT64) {
 				return tl::make_unexpected(fmt::format("invalid t= tag: '{}'", tag.value));
 			}
 			res.t = static_cast<std::time_t>(*t);
@@ -441,7 +415,7 @@ auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string
 				return tl::make_unexpected(std::string{"duplicate rt= tag"});
 			}
 			std::string err;
-			split_foreach(tag.value, ',', [&](std::string_view rcpt_b64) {
+			rspamd::string_foreach_delim(tag.value, ",", [&](std::string_view rcpt_b64) {
 				if (!err.empty()) {
 					return;
 				}
@@ -479,7 +453,7 @@ auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string
 			seen_s = true;
 		}
 		else if (tag.name == "f") {
-			split_foreach(tag.value, ',', [&](std::string_view flag) {
+			rspamd::string_foreach_delim(tag.value, ",", [&](std::string_view flag) {
 				flag = trim(flag);
 				if (flag == "donotmodify") {
 					res.flags |= DKIM2_SIG_FLAG_DONOTMODIFY;
@@ -518,7 +492,7 @@ auto canon_hash_line(std::string_view name, std::string_view unfolded_value) -> 
 	bool got_sp = false;
 
 	for (auto c: value) {
-		if (is_wsp(c)) {
+		if (g_ascii_isspace(c)) {
 			got_sp = true;
 		}
 		else {
@@ -541,7 +515,7 @@ auto canon_sig_line(std::string_view name, std::string_view unfolded_value) -> s
 	out.push_back(':');
 
 	for (auto c: unfolded_value) {
-		if (!is_wsp(c)) {
+		if (!g_ascii_isspace(c)) {
 			out.push_back(c);
 		}
 	}
@@ -568,36 +542,52 @@ auto blank_sig_values(std::string_view canon_line) -> std::string
 	std::string out{line.substr(0, colon_pos + 1)};
 	auto tag_list = line.substr(colon_pos + 1);
 
+	/*
+	 * string_foreach_delim does not emit a trailing empty element, so trailing
+	 * separators are restored explicitly to keep the canonical form byte-exact
+	 */
 	bool first_tag = true;
-	split_foreach(tag_list, ';', [&](std::string_view seg) {
-		if (!first_tag) {
-			out.push_back(';');
-		}
-		first_tag = false;
+	rspamd::string_foreach_delim(
+		tag_list, ";", [&](std::string_view seg) {
+			if (!first_tag) {
+				out.push_back(';');
+			}
+			first_tag = false;
 
-		if (seg.starts_with("s=")) {
-			out.append("s=");
-			auto sets = seg.substr(2);
-			bool first_set = true;
-			split_foreach(sets, ',', [&](std::string_view set_str) {
-				if (!first_set) {
+			if (seg.starts_with("s=")) {
+				out.append("s=");
+				auto sets = seg.substr(2);
+				bool first_set = true;
+				rspamd::string_foreach_delim(
+					sets, ",", [&](std::string_view set_str) {
+						if (!first_set) {
+							out.push_back(',');
+						}
+						first_set = false;
+						/* selector ":" sig-name ":" message-sig -> blank the sig */
+						auto last_colon = set_str.rfind(':');
+						if (last_colon != std::string_view::npos) {
+							out.append(set_str.substr(0, last_colon + 1));
+						}
+						else {
+							out.append(set_str);
+						}
+					},
+					false);
+
+				if (sets.ends_with(',')) {
 					out.push_back(',');
 				}
-				first_set = false;
-				/* selector ":" sig-name ":" message-sig -> blank the sig */
-				auto last_colon = set_str.rfind(':');
-				if (last_colon != std::string_view::npos) {
-					out.append(set_str.substr(0, last_colon + 1));
-				}
-				else {
-					out.append(set_str);
-				}
-			});
-		}
-		else {
-			out.append(seg);
-		}
-	});
+			}
+			else {
+				out.append(seg);
+			}
+		},
+		false);
+
+	if (tag_list.ends_with(';')) {
+		out.push_back(';');
+	}
 
 	out.append("\r\n");
 
@@ -1264,7 +1254,6 @@ dkim2_verify_one_hop(rspamd_dkim2_chain_t *chain,
 			}
 		}
 		else if (ss.alg == ed25519_alg_name) {
-#ifdef HAVE_ED25519
 			supported_algs++;
 
 			if (slot.key == nullptr) {
@@ -1297,10 +1286,6 @@ dkim2_verify_one_hop(rspamd_dkim2_chain_t *chain,
 							   sig.i, sig.domain.c_str(), ss.selector.c_str());
 				merge_hop(RSPAMD_DKIM2_FAIL, "ed25519-sha256 signature did not verify");
 			}
-#else
-			merge_hop(RSPAMD_DKIM2_PERMERROR,
-					  "ed25519 signatures are not supported (OpenSSL 1.1.1+ required)");
-#endif
 		}
 		/* Unknown algorithms are skipped */
 	}

--- a/src/libserver/dkim2.cxx
+++ b/src/libserver/dkim2.cxx
@@ -1,0 +1,1481 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DKIM2 verification, see draft-ietf-dkim-dkim2-spec.
+ *
+ * Unlike DKIM (RFC 6376), a DKIM2 signature covers only the Message-Instance
+ * and DKIM2-Signature header fields; the message content is bound indirectly
+ * via the hashes in the Message-Instance h= tag. Therefore all hop signatures
+ * can be verified cryptographically even if the message was modified in
+ * transit; only the hashes of the *current* instance are checked against the
+ * message itself. Reconstruction of previous instances from r= recipes is not
+ * implemented in this draft.
+ */
+
+#include "config.h"
+#include "rspamd.h"
+#include "message.h"
+#include "dns.h"
+#include "dkim.h"
+#include "dkim2.h"
+#include "dkim2.hxx"
+#include "utlist.h"
+
+#include "contrib/ankerl/unordered_dense.h"
+#include "contrib/fmt/include/fmt/core.h"
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+#include <algorithm>
+#include <charconv>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#define msg_err_dkim2(...) rspamd_default_log_function(G_LOG_LEVEL_CRITICAL,              \
+													   "dkim2", task->task_pool->tag.uid, \
+													   RSPAMD_LOG_FUNC,                   \
+													   __VA_ARGS__)
+#define msg_info_dkim2(...) rspamd_default_log_function(G_LOG_LEVEL_INFO,                  \
+														"dkim2", task->task_pool->tag.uid, \
+														RSPAMD_LOG_FUNC,                   \
+														__VA_ARGS__)
+#define msg_debug_dkim2(...) rspamd_conditional_debug_fast(NULL, NULL,                   \
+														   rspamd_dkim2_log_id, "dkim2", \
+														   task->task_pool->tag.uid,     \
+														   RSPAMD_LOG_FUNC,              \
+														   __VA_ARGS__)
+
+INIT_LOG_MODULE(dkim2)
+
+#define DKIM2_ERROR dkim2_error_quark()
+static GQuark
+dkim2_error_quark(void)
+{
+	return g_quark_from_static_string("dkim2-error-quark");
+}
+
+namespace rspamd::dkim2 {
+
+constexpr std::string_view sha256_alg_name = "sha256";
+constexpr std::string_view rsa_alg_name = "rsa-sha256";
+constexpr std::string_view ed25519_alg_name = "ed25519-sha256";
+
+static constexpr auto
+is_wsp(char c) -> bool
+{
+	/* Values are unfolded by the caller, so treat CR/LF remnants as WSP too */
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+static auto
+trim(std::string_view in) -> std::string_view
+{
+	while (!in.empty() && is_wsp(in.front())) {
+		in.remove_prefix(1);
+	}
+	while (!in.empty() && is_wsp(in.back())) {
+		in.remove_suffix(1);
+	}
+
+	return in;
+}
+
+static auto
+strip_wsp(std::string_view in) -> std::string
+{
+	std::string out;
+	out.reserve(in.size());
+
+	for (auto c: in) {
+		if (!is_wsp(c)) {
+			out.push_back(c);
+		}
+	}
+
+	return out;
+}
+
+static auto
+lc_string(std::string_view in) -> std::string
+{
+	std::string out;
+	out.reserve(in.size());
+
+	for (auto c: in) {
+		out.push_back(static_cast<char>(g_ascii_tolower(c)));
+	}
+
+	return out;
+}
+
+static auto
+eq_icase(std::string_view a, std::string_view b) -> bool
+{
+	return a.size() == b.size() &&
+		   std::equal(a.begin(), a.end(), b.begin(), [](char c1, char c2) {
+			   return g_ascii_tolower(c1) == g_ascii_tolower(c2);
+		   });
+}
+
+static auto
+parse_uint(std::string_view in) -> std::optional<unsigned int>
+{
+	unsigned int res;
+
+	if (in.empty()) {
+		return std::nullopt;
+	}
+
+	auto [ptr, ec] = std::from_chars(in.data(), in.data() + in.size(), res);
+
+	if (ec != std::errc{} || ptr != in.data() + in.size()) {
+		return std::nullopt;
+	}
+
+	return res;
+}
+
+static auto
+b64_decode(std::string_view in) -> std::optional<std::string>
+{
+	auto cleaned = strip_wsp(in);
+	std::string out;
+	out.resize(cleaned.size() / 4 * 3 + 3);
+	std::size_t outlen = out.size();
+
+	if (!cleaned.empty() &&
+		!rspamd_cryptobox_base64_decode(cleaned.data(), cleaned.size(),
+										reinterpret_cast<unsigned char *>(out.data()), &outlen)) {
+		return std::nullopt;
+	}
+
+	out.resize(cleaned.empty() ? 0 : outlen);
+
+	return out;
+}
+
+template<typename Func>
+static void
+split_foreach(std::string_view in, char sep, Func &&f)
+{
+	std::size_t start = 0;
+
+	for (std::size_t pos = 0; pos <= in.size(); pos++) {
+		if (pos == in.size() || in[pos] == sep) {
+			f(in.substr(start, pos - start));
+			start = pos + 1;
+		}
+	}
+}
+
+auto parse_tag_list(std::string_view input) -> tl::expected<std::vector<tag_t>, std::string>
+{
+	std::vector<tag_t> res;
+	std::string err;
+
+	split_foreach(input, ';', [&](std::string_view seg) {
+		if (!err.empty()) {
+			return;
+		}
+
+		seg = trim(seg);
+
+		if (seg.empty()) {
+			/* Empty segment, e.g. a trailing `;` */
+			return;
+		}
+
+		auto eq_pos = seg.find('=');
+
+		if (eq_pos == std::string_view::npos || eq_pos == 0) {
+			err = fmt::format("invalid tag: '{}'", seg);
+			return;
+		}
+
+		auto name = trim(seg.substr(0, eq_pos));
+		auto value = trim(seg.substr(eq_pos + 1));
+
+		for (auto c: name) {
+			if (!g_ascii_isalnum(c) && c != '-') {
+				err = fmt::format("invalid tag name: '{}'", name);
+				return;
+			}
+		}
+
+		res.emplace_back(tag_t{name, value});
+	});
+
+	if (!err.empty()) {
+		return tl::make_unexpected(std::move(err));
+	}
+
+	return res;
+}
+
+static auto
+parse_hash_sets(std::string_view value) -> tl::expected<std::vector<hash_set_t>, std::string>
+{
+	std::vector<hash_set_t> res;
+	std::string err;
+
+	split_foreach(value, ',', [&](std::string_view set_str) {
+		if (!err.empty()) {
+			return;
+		}
+
+		/* hash-set = hash-name ":" header-hash ":" body-hash */
+		std::vector<std::string_view> parts;
+		split_foreach(set_str, ':', [&](std::string_view part) {
+			parts.push_back(part);
+		});
+
+		if (parts.size() != 3) {
+			err = fmt::format("invalid hash-set: '{}'", set_str);
+			return;
+		}
+
+		auto hh = b64_decode(parts[1]);
+		auto bh = b64_decode(parts[2]);
+
+		if (!hh || !bh || hh->empty() || bh->empty()) {
+			err = fmt::format("invalid base64 in hash-set: '{}'", set_str);
+			return;
+		}
+
+		res.emplace_back(hash_set_t{
+			std::string{trim(parts[0])},
+			std::move(*hh),
+			std::move(*bh),
+		});
+	});
+
+	if (!err.empty()) {
+		return tl::make_unexpected(std::move(err));
+	}
+
+	if (res.empty()) {
+		return tl::make_unexpected(std::string{"empty h= tag"});
+	}
+
+	return res;
+}
+
+auto parse_mi(std::string_view value) -> tl::expected<mi_header_t, std::string>
+{
+	auto tags = parse_tag_list(value);
+
+	if (!tags) {
+		return tl::make_unexpected(tags.error());
+	}
+
+	mi_header_t res;
+	bool seen_m = false, seen_h = false;
+
+	for (const auto &tag: *tags) {
+		if (tag.name == "m") {
+			if (seen_m) {
+				return tl::make_unexpected(std::string{"duplicate m= tag"});
+			}
+			auto m = parse_uint(tag.value);
+			if (!m || *m == 0) {
+				return tl::make_unexpected(fmt::format("invalid m= tag: '{}'", tag.value));
+			}
+			res.m = *m;
+			seen_m = true;
+		}
+		else if (tag.name == "h") {
+			if (seen_h) {
+				return tl::make_unexpected(std::string{"duplicate h= tag"});
+			}
+			auto hashes = parse_hash_sets(tag.value);
+			if (!hashes) {
+				return tl::make_unexpected(hashes.error());
+			}
+			res.hashes = std::move(*hashes);
+			seen_h = true;
+		}
+		else if (tag.name == "r") {
+			res.has_recipe = true;
+			res.recipe_b64 = strip_wsp(tag.value);
+		}
+		/* Unknown tags are ignored, but covered by the signature input */
+	}
+
+	if (!seen_m) {
+		return tl::make_unexpected(std::string{"missing mandatory m= tag"});
+	}
+	if (!seen_h) {
+		return tl::make_unexpected(std::string{"missing mandatory h= tag"});
+	}
+
+	return res;
+}
+
+static auto
+parse_sig_sets(std::string_view value) -> tl::expected<std::vector<sig_set_t>, std::string>
+{
+	std::vector<sig_set_t> res;
+	std::string err;
+
+	split_foreach(value, ',', [&](std::string_view set_str) {
+		if (!err.empty()) {
+			return;
+		}
+
+		/* sig-set = selector ":" sig-name ":" message-sig */
+		std::vector<std::string_view> parts;
+		split_foreach(set_str, ':', [&](std::string_view part) {
+			parts.push_back(part);
+		});
+
+		if (parts.size() != 3) {
+			err = fmt::format("invalid sig-set: '{}'", set_str);
+			return;
+		}
+
+		auto selector = trim(parts[0]);
+		auto alg = trim(parts[1]);
+		auto sig = b64_decode(parts[2]);
+
+		if (selector.empty() || alg.empty()) {
+			err = fmt::format("invalid sig-set: '{}'", set_str);
+			return;
+		}
+
+		if (!sig || sig->empty()) {
+			err = fmt::format("invalid base64 signature in sig-set for selector '{}'",
+							  selector);
+			return;
+		}
+
+		res.emplace_back(sig_set_t{
+			std::string{selector},
+			std::string{alg},
+			std::move(*sig),
+		});
+	});
+
+	if (!err.empty()) {
+		return tl::make_unexpected(std::move(err));
+	}
+
+	if (res.empty()) {
+		return tl::make_unexpected(std::string{"empty s= tag"});
+	}
+
+	return res;
+}
+
+auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string>
+{
+	auto tags = parse_tag_list(value);
+
+	if (!tags) {
+		return tl::make_unexpected(tags.error());
+	}
+
+	sig_header_t res;
+	bool seen_i = false, seen_m = false, seen_mf = false, seen_rt = false,
+		 seen_d = false, seen_s = false;
+
+	for (const auto &tag: *tags) {
+		if (tag.name == "i") {
+			if (seen_i) {
+				return tl::make_unexpected(std::string{"duplicate i= tag"});
+			}
+			auto i = parse_uint(tag.value);
+			if (!i || *i == 0) {
+				return tl::make_unexpected(fmt::format("invalid i= tag: '{}'", tag.value));
+			}
+			res.i = *i;
+			seen_i = true;
+		}
+		else if (tag.name == "m") {
+			if (seen_m) {
+				return tl::make_unexpected(std::string{"duplicate m= tag"});
+			}
+			auto m = parse_uint(tag.value);
+			if (!m || *m == 0) {
+				return tl::make_unexpected(fmt::format("invalid m= tag: '{}'", tag.value));
+			}
+			res.m = *m;
+			seen_m = true;
+		}
+		else if (tag.name == "t") {
+			auto t = parse_uint(tag.value);
+			if (!t) {
+				return tl::make_unexpected(fmt::format("invalid t= tag: '{}'", tag.value));
+			}
+			res.t = static_cast<std::time_t>(*t);
+		}
+		else if (tag.name == "mf") {
+			if (seen_mf) {
+				return tl::make_unexpected(std::string{"duplicate mf= tag"});
+			}
+			auto mf = b64_decode(tag.value);
+			if (!mf) {
+				return tl::make_unexpected(std::string{"invalid base64 in mf= tag"});
+			}
+			res.mf = std::move(*mf);
+			seen_mf = true;
+		}
+		else if (tag.name == "rt") {
+			if (seen_rt) {
+				return tl::make_unexpected(std::string{"duplicate rt= tag"});
+			}
+			std::string err;
+			split_foreach(tag.value, ',', [&](std::string_view rcpt_b64) {
+				if (!err.empty()) {
+					return;
+				}
+				auto rcpt = b64_decode(rcpt_b64);
+				if (!rcpt) {
+					err = "invalid base64 in rt= tag";
+					return;
+				}
+				res.rt.emplace_back(std::move(*rcpt));
+			});
+			if (!err.empty()) {
+				return tl::make_unexpected(std::move(err));
+			}
+			seen_rt = true;
+		}
+		else if (tag.name == "d") {
+			if (seen_d) {
+				return tl::make_unexpected(std::string{"duplicate d= tag"});
+			}
+			if (tag.value.empty()) {
+				return tl::make_unexpected(std::string{"empty d= tag"});
+			}
+			res.domain = strip_wsp(tag.value);
+			seen_d = true;
+		}
+		else if (tag.name == "s") {
+			if (seen_s) {
+				return tl::make_unexpected(std::string{"duplicate s= tag"});
+			}
+			auto sigs = parse_sig_sets(tag.value);
+			if (!sigs) {
+				return tl::make_unexpected(sigs.error());
+			}
+			res.sigs = std::move(*sigs);
+			seen_s = true;
+		}
+		else if (tag.name == "f") {
+			split_foreach(tag.value, ',', [&](std::string_view flag) {
+				flag = trim(flag);
+				if (flag == "donotmodify") {
+					res.flags |= DKIM2_SIG_FLAG_DONOTMODIFY;
+				}
+				else if (flag == "donotexplode") {
+					res.flags |= DKIM2_SIG_FLAG_DONOTEXPLODE;
+				}
+				else if (flag == "feedback") {
+					res.flags |= DKIM2_SIG_FLAG_FEEDBACK;
+				}
+				else if (flag == "exploded") {
+					res.flags |= DKIM2_SIG_FLAG_EXPLODED;
+				}
+				/* Unknown flags are ignored */
+			});
+		}
+		/* n= and unknown tags are ignored, but covered by the signature input */
+	}
+
+	if (!seen_i || !seen_m || !seen_mf || !seen_rt || !seen_d || !seen_s) {
+		return tl::make_unexpected(fmt::format(
+			"missing mandatory tag(s):{}{}{}{}{}{}",
+			seen_i ? "" : " i=", seen_m ? "" : " m=", seen_mf ? "" : " mf=",
+			seen_rt ? "" : " rt=", seen_d ? "" : " d=", seen_s ? "" : " s="));
+	}
+
+	return res;
+}
+
+auto canon_hash_line(std::string_view name, std::string_view unfolded_value) -> std::string
+{
+	auto out = lc_string(name);
+	out.push_back(':');
+
+	auto value = trim(unfolded_value);
+	bool got_sp = false;
+
+	for (auto c: value) {
+		if (is_wsp(c)) {
+			got_sp = true;
+		}
+		else {
+			if (got_sp) {
+				out.push_back(' ');
+				got_sp = false;
+			}
+			out.push_back(c);
+		}
+	}
+
+	out.append("\r\n");
+
+	return out;
+}
+
+auto canon_sig_line(std::string_view name, std::string_view unfolded_value) -> std::string
+{
+	auto out = lc_string(name);
+	out.push_back(':');
+
+	for (auto c: unfolded_value) {
+		if (!is_wsp(c)) {
+			out.push_back(c);
+		}
+	}
+
+	out.append("\r\n");
+
+	return out;
+}
+
+auto blank_sig_values(std::string_view canon_line) -> std::string
+{
+	/* Strip the trailing CRLF, process the tag list and restore it */
+	auto line = canon_line;
+	if (line.ends_with("\r\n")) {
+		line.remove_suffix(2);
+	}
+
+	auto colon_pos = line.find(':');
+
+	if (colon_pos == std::string_view::npos) {
+		return std::string{canon_line};
+	}
+
+	std::string out{line.substr(0, colon_pos + 1)};
+	auto tag_list = line.substr(colon_pos + 1);
+
+	bool first_tag = true;
+	split_foreach(tag_list, ';', [&](std::string_view seg) {
+		if (!first_tag) {
+			out.push_back(';');
+		}
+		first_tag = false;
+
+		if (seg.starts_with("s=")) {
+			out.append("s=");
+			auto sets = seg.substr(2);
+			bool first_set = true;
+			split_foreach(sets, ',', [&](std::string_view set_str) {
+				if (!first_set) {
+					out.push_back(',');
+				}
+				first_set = false;
+				/* selector ":" sig-name ":" message-sig -> blank the sig */
+				auto last_colon = set_str.rfind(':');
+				if (last_colon != std::string_view::npos) {
+					out.append(set_str.substr(0, last_colon + 1));
+				}
+				else {
+					out.append(set_str);
+				}
+			});
+		}
+		else {
+			out.append(seg);
+		}
+	});
+
+	out.append("\r\n");
+
+	return out;
+}
+
+auto build_sig_input(std::span<const std::string> mi_lines,
+					 std::span<const std::string> prev_sig_lines,
+					 std::string_view current_sig_line) -> std::string
+{
+	std::string out;
+	std::size_t total = current_sig_line.size();
+
+	for (const auto &line: mi_lines) {
+		total += line.size();
+	}
+	for (const auto &line: prev_sig_lines) {
+		total += line.size();
+	}
+
+	out.reserve(total);
+
+	for (const auto &line: mi_lines) {
+		out.append(line);
+	}
+	for (const auto &line: prev_sig_lines) {
+		out.append(line);
+	}
+
+	out.append(blank_sig_values(current_sig_line));
+
+	return out;
+}
+
+auto relaxed_domain_match(std::string_view child, std::string_view base) -> bool
+{
+	if (base.empty() || child.empty()) {
+		return false;
+	}
+
+	for (;;) {
+		if (eq_icase(child, base)) {
+			return true;
+		}
+
+		auto dot_pos = child.find('.');
+
+		if (dot_pos == std::string_view::npos) {
+			return false;
+		}
+
+		child.remove_prefix(dot_pos + 1);
+	}
+}
+
+static auto
+strip_angle(std::string_view addr) -> std::string_view
+{
+	addr = trim(addr);
+
+	if (addr.size() >= 2 && addr.front() == '<' && addr.back() == '>') {
+		addr.remove_prefix(1);
+		addr.remove_suffix(1);
+	}
+
+	return addr;
+}
+
+auto smtp_addr_domain(std::string_view addr) -> std::string_view
+{
+	addr = strip_angle(addr);
+	auto at_pos = addr.rfind('@');
+
+	if (at_pos == std::string_view::npos) {
+		return {};
+	}
+
+	return addr.substr(at_pos + 1);
+}
+
+auto smtp_addr_equal(std::string_view a, std::string_view b) -> bool
+{
+	a = strip_angle(a);
+	b = strip_angle(b);
+
+	auto at_a = a.rfind('@');
+	auto at_b = b.rfind('@');
+
+	if (at_a != at_b) {
+		return false;
+	}
+
+	if (at_a == std::string_view::npos) {
+		/* Both have no domain, e.g. null reverse-paths */
+		return a == b;
+	}
+
+	/* Local part is case-sensitive, domain is not */
+	return a.substr(0, at_a) == b.substr(0, at_b) &&
+		   eq_icase(a.substr(at_a + 1), b.substr(at_b + 1));
+}
+
+}// namespace rspamd::dkim2
+
+/*
+ * Task-bound verification logic
+ */
+
+using namespace rspamd::dkim2;
+
+namespace {
+
+struct mi_entry_t {
+	mi_header_t parsed;
+	std::string canon_line;
+};
+
+struct sig_entry_t {
+	sig_header_t parsed;
+	std::string canon_line;
+};
+
+struct dkim2_key_slot {
+	rspamd_dkim_key_t *key = nullptr;
+	enum rspamd_dkim2_result_code rcode = RSPAMD_DKIM2_TEMPERROR;
+	std::string reason = "key not yet fetched";
+};
+
+constexpr unsigned int DKIM2_DEFAULT_MAX_AGE = 14 * 24 * 3600;
+
+static auto
+severity(enum rspamd_dkim2_result_code rcode) -> int
+{
+	switch (rcode) {
+	case RSPAMD_DKIM2_NONE:
+	case RSPAMD_DKIM2_PASS:
+		return 0;
+	case RSPAMD_DKIM2_TEMPERROR:
+		return 1;
+	case RSPAMD_DKIM2_PERMERROR:
+		return 2;
+	case RSPAMD_DKIM2_FAIL:
+		return 3;
+	}
+
+	return 0;
+}
+
+}// anonymous namespace
+
+struct rspamd_dkim2_chain_s {
+	struct rspamd_task *task = nullptr;
+	std::vector<mi_entry_t> mis;   /* sorted by m=, mis[k] has m == k + 1 */
+	std::vector<sig_entry_t> sigs; /* sorted by i=, sigs[k] has i == k + 1 */
+	ankerl::unordered_dense::map<std::string, dkim2_key_slot> keys;
+	struct rspamd_dkim2_verify_params params{};
+	rspamd_dkim2_verify_cb cb = nullptr;
+	void *ud = nullptr;
+	unsigned int pending = 0;
+	/* Results of the synchronous (hash, envelope, timestamp) checks */
+	enum rspamd_dkim2_result_code prelim_rcode = RSPAMD_DKIM2_PASS;
+	std::string prelim_reason;
+
+	~rspamd_dkim2_chain_s()
+	{
+		for (auto &kv: keys) {
+			if (kv.second.key) {
+				rspamd_dkim_key_unref(kv.second.key);
+			}
+		}
+	}
+
+	void merge_prelim(enum rspamd_dkim2_result_code rcode, std::string reason)
+	{
+		if (severity(rcode) > severity(prelim_rcode)) {
+			prelim_rcode = rcode;
+			prelim_reason = std::move(reason);
+		}
+	}
+};
+
+struct dkim2_dns_cbdata {
+	rspamd_dkim2_chain_t *chain;
+	char *dns_name;
+};
+
+static void
+dkim2_chain_dtor(void *p)
+{
+	delete static_cast<rspamd_dkim2_chain_s *>(p);
+}
+
+static auto
+dkim2_validate_chain(rspamd_dkim2_chain_s *chain) -> tl::expected<void, std::string>
+{
+	if (chain->mis.empty()) {
+		return tl::make_unexpected(std::string{"no Message-Instance headers"});
+	}
+	if (chain->sigs.empty()) {
+		return tl::make_unexpected(std::string{"no DKIM2-Signature headers"});
+	}
+
+	for (std::size_t k = 0; k < chain->mis.size(); k++) {
+		if (chain->mis[k].parsed.m != k + 1) {
+			return tl::make_unexpected(fmt::format(
+				"Message-Instance m= sequence broken: expected {}, got {}",
+				k + 1, chain->mis[k].parsed.m));
+		}
+	}
+
+	unsigned int prev_m = 0;
+
+	for (std::size_t k = 0; k < chain->sigs.size(); k++) {
+		const auto &sig = chain->sigs[k].parsed;
+
+		if (sig.i != k + 1) {
+			return tl::make_unexpected(fmt::format(
+				"DKIM2-Signature i= sequence broken: expected {}, got {}",
+				k + 1, sig.i));
+		}
+		if (sig.m > chain->mis.size()) {
+			return tl::make_unexpected(fmt::format(
+				"DKIM2-Signature i={} references unknown Message-Instance m={}",
+				sig.i, sig.m));
+		}
+		if (sig.m < prev_m) {
+			return tl::make_unexpected(fmt::format(
+				"DKIM2-Signature i={} references older Message-Instance m={} than the previous hop",
+				sig.i, sig.m));
+		}
+		prev_m = sig.m;
+	}
+
+	if (chain->sigs.back().parsed.m != chain->mis.size()) {
+		return tl::make_unexpected(std::string{
+			"the last DKIM2-Signature does not reference the latest Message-Instance"});
+	}
+
+	/* The latest instance must have a usable sha256 hash set */
+	const auto &latest = chain->mis.back().parsed;
+	auto found = std::find_if(latest.hashes.begin(), latest.hashes.end(),
+							  [](const hash_set_t &hs) {
+								  return hs.alg == sha256_alg_name &&
+										 hs.header_hash.size() == 32 &&
+										 hs.body_hash.size() == 32;
+							  });
+
+	if (found == latest.hashes.end()) {
+		return tl::make_unexpected(std::string{
+			"no valid sha256 hash-set in the latest Message-Instance"});
+	}
+
+	return {};
+}
+
+rspamd_dkim2_chain_t *
+rspamd_dkim2_chain_parse(struct rspamd_task *task, GError **err)
+{
+	struct rspamd_mime_header *mi_hdrs, *sig_hdrs, *cur;
+
+	if (task->message == nullptr) {
+		return nullptr;
+	}
+
+	mi_hdrs = rspamd_message_get_header_array(task, RSPAMD_DKIM2_MIHEADER, false);
+	sig_hdrs = rspamd_message_get_header_array(task, RSPAMD_DKIM2_SIGNHEADER, false);
+
+	if (mi_hdrs == nullptr && sig_hdrs == nullptr) {
+		/* No DKIM2 headers at all */
+		return nullptr;
+	}
+
+	if (mi_hdrs == nullptr || sig_hdrs == nullptr) {
+		g_set_error(err, DKIM2_ERROR, RSPAMD_DKIM2_PERMERROR,
+					"%s headers without %s headers",
+					mi_hdrs ? RSPAMD_DKIM2_MIHEADER : RSPAMD_DKIM2_SIGNHEADER,
+					mi_hdrs ? RSPAMD_DKIM2_SIGNHEADER : RSPAMD_DKIM2_MIHEADER);
+		return nullptr;
+	}
+
+	auto *chain = new rspamd_dkim2_chain_s;
+	rspamd_mempool_add_destructor(task->task_pool, dkim2_chain_dtor, chain);
+
+	DL_FOREACH(mi_hdrs, cur)
+	{
+		if (cur->value == nullptr) {
+			continue;
+		}
+
+		auto parsed = parse_mi(cur->value);
+
+		if (!parsed) {
+			g_set_error(err, DKIM2_ERROR, RSPAMD_DKIM2_PERMERROR,
+						"invalid Message-Instance header: %s", parsed.error().c_str());
+			return nullptr;
+		}
+
+		chain->mis.emplace_back(mi_entry_t{
+			std::move(*parsed),
+			canon_sig_line(RSPAMD_DKIM2_MIHEADER, cur->value),
+		});
+
+		if (chain->mis.size() > RSPAMD_DKIM2_MAX_HOPS) {
+			g_set_error(err, DKIM2_ERROR, RSPAMD_DKIM2_PERMERROR,
+						"too many Message-Instance headers (max %d)",
+						RSPAMD_DKIM2_MAX_HOPS);
+			return nullptr;
+		}
+	}
+
+	DL_FOREACH(sig_hdrs, cur)
+	{
+		if (cur->value == nullptr) {
+			continue;
+		}
+
+		auto parsed = parse_sig(cur->value);
+
+		if (!parsed) {
+			g_set_error(err, DKIM2_ERROR, RSPAMD_DKIM2_PERMERROR,
+						"invalid DKIM2-Signature header: %s", parsed.error().c_str());
+			return nullptr;
+		}
+
+		chain->sigs.emplace_back(sig_entry_t{
+			std::move(*parsed),
+			canon_sig_line(RSPAMD_DKIM2_SIGNHEADER, cur->value),
+		});
+
+		if (chain->sigs.size() > RSPAMD_DKIM2_MAX_HOPS) {
+			g_set_error(err, DKIM2_ERROR, RSPAMD_DKIM2_PERMERROR,
+						"too many DKIM2-Signature headers (max %d)",
+						RSPAMD_DKIM2_MAX_HOPS);
+			return nullptr;
+		}
+	}
+
+	std::sort(chain->mis.begin(), chain->mis.end(),
+			  [](const mi_entry_t &a, const mi_entry_t &b) {
+				  return a.parsed.m < b.parsed.m;
+			  });
+	std::sort(chain->sigs.begin(), chain->sigs.end(),
+			  [](const sig_entry_t &a, const sig_entry_t &b) {
+				  return a.parsed.i < b.parsed.i;
+			  });
+
+	auto valid = dkim2_validate_chain(chain);
+
+	if (!valid) {
+		g_set_error(err, DKIM2_ERROR, RSPAMD_DKIM2_PERMERROR,
+					"invalid DKIM2 chain: %s", valid.error().c_str());
+		return nullptr;
+	}
+
+	msg_debug_dkim2("parsed DKIM2 chain: %z instances, %z signatures, last domain %s",
+					chain->mis.size(), chain->sigs.size(),
+					chain->sigs.back().parsed.domain.c_str());
+
+	return chain;
+}
+
+unsigned int
+rspamd_dkim2_chain_len(const rspamd_dkim2_chain_t *chain)
+{
+	return chain ? chain->sigs.size() : 0;
+}
+
+static auto
+dkim2_ignored_header(const char *name) -> bool
+{
+	static const char *exact[] = {
+		"Received",
+		"Return-Path",
+		"Authentication-Results",
+		"DKIM-Signature",
+		RSPAMD_DKIM2_MIHEADER,
+		RSPAMD_DKIM2_SIGNHEADER,
+	};
+
+	for (auto *ex: exact) {
+		if (g_ascii_strcasecmp(name, ex) == 0) {
+			return true;
+		}
+	}
+
+	return g_ascii_strncasecmp(name, "X-", 2) == 0 ||
+		   g_ascii_strncasecmp(name, "ARC-", 4) == 0;
+}
+
+static void
+dkim2_check_hashes(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
+{
+	unsigned char digest[EVP_MAX_MD_SIZE];
+
+	/* Body hash (Section 5.1) */
+	const char *body_start = MESSAGE_FIELD(task, raw_headers_content).body_start;
+	const char *msg_end = task->msg.begin + task->msg.len;
+	std::string_view body;
+
+	if (body_start != nullptr && msg_end > body_start) {
+		body = std::string_view{body_start, static_cast<std::size_t>(msg_end - body_start)};
+	}
+
+	auto *md_ctx = EVP_MD_CTX_new();
+	EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
+	body_canon_foreach(body, [&](const char *p, std::size_t len) {
+		EVP_DigestUpdate(md_ctx, p, len);
+	});
+	EVP_DigestFinal_ex(md_ctx, digest, nullptr);
+
+	const auto &latest = chain->mis.back().parsed;
+	const auto *hs = &*std::find_if(latest.hashes.begin(), latest.hashes.end(),
+									[](const hash_set_t &h) {
+										return h.alg == sha256_alg_name &&
+											   h.header_hash.size() == 32 &&
+											   h.body_hash.size() == 32;
+									});
+
+	if (memcmp(hs->body_hash.data(), digest, 32) != 0) {
+		msg_info_dkim2("body hash mismatch for the current message instance m=%d",
+					   latest.m);
+		chain->merge_prelim(RSPAMD_DKIM2_FAIL,
+							fmt::format("body hash mismatch for instance m={}", latest.m));
+	}
+
+	/* Header hash (Section 5.2) */
+	struct hdr_row {
+		std::string lc_name;
+		unsigned int order;
+		std::string canon;
+	};
+	std::vector<hdr_row> rows;
+	unsigned int order = 0;
+
+	for (auto *cur = MESSAGE_FIELD(task, headers_order); cur != nullptr;
+		 cur = cur->ord_next, order++) {
+		if (cur->name == nullptr || cur->value == nullptr) {
+			continue;
+		}
+		if (dkim2_ignored_header(cur->name)) {
+			continue;
+		}
+
+		rows.emplace_back(hdr_row{
+			lc_string(cur->name),
+			order,
+			canon_hash_line(cur->name, cur->value),
+		});
+	}
+
+	/*
+	 * Sort alphabetically; header fields with the same name are emitted in
+	 * the order they were likely inserted, i.e. from the bottom of the
+	 * header block (oldest) to the top (newest)
+	 */
+	std::sort(rows.begin(), rows.end(), [](const hdr_row &a, const hdr_row &b) {
+		if (a.lc_name != b.lc_name) {
+			return a.lc_name < b.lc_name;
+		}
+		return a.order > b.order;
+	});
+
+	EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
+	for (const auto &row: rows) {
+		EVP_DigestUpdate(md_ctx, row.canon.data(), row.canon.size());
+	}
+	EVP_DigestFinal_ex(md_ctx, digest, nullptr);
+	EVP_MD_CTX_free(md_ctx);
+
+	if (memcmp(hs->header_hash.data(), digest, 32) != 0) {
+		msg_info_dkim2("header hash mismatch for the current message instance m=%d",
+					   latest.m);
+		chain->merge_prelim(RSPAMD_DKIM2_FAIL,
+							fmt::format("header hash mismatch for instance m={}", latest.m));
+	}
+}
+
+static void
+dkim2_check_envelope(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
+{
+	const auto &last = chain->sigs.back().parsed;
+
+	if (chain->params.check_envelope) {
+		if (task->from_envelope != nullptr) {
+			std::string_view smtp_from;
+
+			if (task->from_envelope->addr_len > 0) {
+				smtp_from = std::string_view{task->from_envelope->addr,
+											 task->from_envelope->addr_len};
+			}
+
+			if (!smtp_addr_equal(last.mf, smtp_from)) {
+				msg_info_dkim2("MAIL FROM does not match mf= of the last hop");
+				chain->merge_prelim(RSPAMD_DKIM2_PERMERROR,
+									"MAIL FROM did not match mf= of the last hop");
+			}
+		}
+
+		if (task->rcpt_envelope != nullptr) {
+			unsigned int i;
+			struct rspamd_email_address *rcpt;
+
+			PTR_ARRAY_FOREACH(task->rcpt_envelope, i, rcpt)
+			{
+				if (rcpt->addr == nullptr) {
+					continue;
+				}
+
+				std::string_view rcpt_sv{rcpt->addr, rcpt->addr_len};
+				auto found = std::any_of(last.rt.begin(), last.rt.end(),
+										 [&](const std::string &rt) {
+											 return smtp_addr_equal(rt, rcpt_sv);
+										 });
+
+				if (!found) {
+					msg_info_dkim2("RCPT TO <%*s> not found in rt= of the last hop",
+								   (int) rcpt->addr_len, rcpt->addr);
+					chain->merge_prelim(RSPAMD_DKIM2_PERMERROR,
+										"RCPT TO did not match rt= of the last hop");
+					break;
+				}
+			}
+		}
+	}
+
+	/* Per-hop alignment of d= with the mf= domain (Section 8.3) */
+	for (const auto &sig_entry: chain->sigs) {
+		const auto &sig = sig_entry.parsed;
+		auto mf_dom = smtp_addr_domain(sig.mf);
+
+		if (mf_dom.empty()) {
+			/* Null reverse-path (bounce), nothing to align */
+			continue;
+		}
+
+		if (!relaxed_domain_match(mf_dom, sig.domain)) {
+			msg_info_dkim2("hop i=%d: mf= domain does not align with d=%s",
+						   sig.i, sig.domain.c_str());
+			chain->merge_prelim(RSPAMD_DKIM2_PERMERROR,
+								fmt::format("mf= domain is not aligned with d= for hop i={}",
+											sig.i));
+			break;
+		}
+	}
+}
+
+static void
+dkim2_check_timestamps(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
+{
+	/*
+	 * The last hop has the most recent timestamp, so it is the only one
+	 * checked against the maximum age in this draft implementation
+	 */
+	const auto &last = chain->sigs.back().parsed;
+
+	if (last.t == 0) {
+		return;
+	}
+
+	auto now = time(nullptr);
+	auto max_age = chain->params.max_age ? chain->params.max_age : DKIM2_DEFAULT_MAX_AGE;
+
+	if (last.t > now + chain->params.time_jitter) {
+		/* Implementations MAY ignore future timestamps; just log it */
+		msg_info_dkim2("DKIM2 signature i=%d has a future timestamp %ud",
+					   last.i, (unsigned int) last.t);
+	}
+	else if (now - last.t > (time_t) max_age) {
+		chain->merge_prelim(RSPAMD_DKIM2_FAIL,
+							fmt::format("signature is too old: {} seconds", now - last.t));
+	}
+}
+
+static void
+dkim2_verify_one_hop(rspamd_dkim2_chain_t *chain,
+					 const sig_entry_t &entry,
+					 std::size_t hop_idx,
+					 struct rspamd_dkim2_hop_result *hop)
+{
+	struct rspamd_task *task = chain->task;
+	const auto &sig = entry.parsed;
+	unsigned char digest[EVP_MAX_MD_SIZE];
+
+	auto merge_hop = [&](enum rspamd_dkim2_result_code rcode, std::string_view reason) {
+		if (severity(rcode) > severity(hop->rcode)) {
+			hop->rcode = rcode;
+			hop->fail_reason = rspamd_mempool_strdup(task->task_pool,
+													 std::string{reason}.c_str());
+		}
+	};
+
+	hop->rcode = RSPAMD_DKIM2_PASS;
+	hop->fail_reason = nullptr;
+	hop->idx = sig.i;
+	hop->domain = rspamd_mempool_strdup(task->task_pool, sig.domain.c_str());
+	hop->selector = rspamd_mempool_strdup(task->task_pool, sig.sigs[0].selector.c_str());
+
+	/* Build the signature input: MI lines up to m=, previous sig lines, self */
+	std::vector<std::string> mi_lines, prev_lines;
+	mi_lines.reserve(sig.m);
+	prev_lines.reserve(hop_idx);
+
+	for (std::size_t k = 0; k < sig.m; k++) {
+		mi_lines.push_back(chain->mis[k].canon_line);
+	}
+	for (std::size_t k = 0; k < hop_idx; k++) {
+		prev_lines.push_back(chain->sigs[k].canon_line);
+	}
+
+	auto input = build_sig_input(mi_lines, prev_lines, entry.canon_line);
+	EVP_Digest(input.data(), input.size(), digest, nullptr, EVP_sha256(), nullptr);
+
+	msg_debug_dkim2("hop i=%d: signature input is %z bytes", sig.i, input.size());
+
+	auto supported_algs = 0;
+
+	for (const auto &ss: sig.sigs) {
+		auto dns_name = fmt::format("{}._domainkey.{}", ss.selector, sig.domain);
+		auto slot_it = chain->keys.find(dns_name);
+
+		if (slot_it == chain->keys.end()) {
+			/* Should not happen: all names are inserted in chain_verify */
+			merge_hop(RSPAMD_DKIM2_PERMERROR, "internal error: no key slot");
+			continue;
+		}
+
+		const auto &slot = slot_it->second;
+
+		if (ss.alg == rsa_alg_name) {
+			supported_algs++;
+
+			if (slot.key == nullptr) {
+				merge_hop(slot.rcode, slot.reason);
+				continue;
+			}
+
+			if (rspamd_dkim_key_get_type(slot.key) != RSPAMD_DKIM_KEY_RSA) {
+				merge_hop(RSPAMD_DKIM2_PERMERROR,
+						  fmt::format("key type mismatch for rsa-sha256, selector {}",
+									  ss.selector));
+				continue;
+			}
+
+			GError *err = nullptr;
+
+			if (!rspamd_cryptobox_verify_evp_rsa(NID_sha256,
+												 reinterpret_cast<const unsigned char *>(ss.sig.data()),
+												 ss.sig.size(),
+												 digest, 32,
+												 static_cast<EVP_PKEY *>(rspamd_dkim_key_evp(slot.key)),
+												 &err)) {
+				if (err != nullptr) {
+					merge_hop(RSPAMD_DKIM2_PERMERROR,
+							  fmt::format("openssl error: {}", err->message));
+					g_error_free(err);
+					ERR_clear_error();
+				}
+				else {
+					msg_info_dkim2("hop i=%d: rsa-sha256 signature did not verify; "
+								   "d=%s, selector=%s",
+								   sig.i, sig.domain.c_str(), ss.selector.c_str());
+					merge_hop(RSPAMD_DKIM2_FAIL, "rsa-sha256 signature did not verify");
+				}
+			}
+		}
+		else if (ss.alg == ed25519_alg_name) {
+#ifdef HAVE_ED25519
+			supported_algs++;
+
+			if (slot.key == nullptr) {
+				merge_hop(slot.rcode, slot.reason);
+				continue;
+			}
+
+			if (rspamd_dkim_key_get_type(slot.key) != RSPAMD_DKIM_KEY_EDDSA) {
+				merge_hop(RSPAMD_DKIM2_PERMERROR,
+						  fmt::format("key type mismatch for ed25519-sha256, selector {}",
+									  ss.selector));
+				continue;
+			}
+
+			gsize pklen = 0;
+			const unsigned char *pk = rspamd_dkim_key_eddsa(slot.key, &pklen);
+
+			if (pk == nullptr || pklen != crypto_sign_publickeybytes() ||
+				ss.sig.size() != crypto_sign_bytes()) {
+				merge_hop(RSPAMD_DKIM2_PERMERROR, "invalid ed25519 key or signature size");
+				continue;
+			}
+
+			if (!rspamd_cryptobox_verify(reinterpret_cast<const unsigned char *>(ss.sig.data()),
+										 ss.sig.size(),
+										 digest, 32,
+										 pk)) {
+				msg_info_dkim2("hop i=%d: ed25519-sha256 signature did not verify; "
+							   "d=%s, selector=%s",
+							   sig.i, sig.domain.c_str(), ss.selector.c_str());
+				merge_hop(RSPAMD_DKIM2_FAIL, "ed25519-sha256 signature did not verify");
+			}
+#else
+			merge_hop(RSPAMD_DKIM2_PERMERROR,
+					  "ed25519 signatures are not supported (OpenSSL 1.1.1+ required)");
+#endif
+		}
+		/* Unknown algorithms are skipped */
+	}
+
+	if (supported_algs == 0) {
+		merge_hop(RSPAMD_DKIM2_PERMERROR, "no supported signature algorithms");
+	}
+}
+
+static void
+dkim2_finalize(rspamd_dkim2_chain_t *chain)
+{
+	struct rspamd_task *task = chain->task;
+	auto nhops = chain->sigs.size();
+
+	auto *hops = rspamd_mempool_alloc_array_type(task->task_pool, nhops,
+												 struct rspamd_dkim2_hop_result);
+	auto *res = rspamd_mempool_alloc0_type(task->task_pool,
+										   struct rspamd_dkim2_verify_result);
+
+	res->rcode = chain->prelim_rcode;
+	res->fail_reason = chain->prelim_reason.empty() ? nullptr : rspamd_mempool_strdup(task->task_pool, chain->prelim_reason.c_str());
+	res->nhops = nhops;
+	res->hops = hops;
+
+	for (std::size_t k = 0; k < nhops; k++) {
+		dkim2_verify_one_hop(chain, chain->sigs[k], k, &hops[k]);
+
+		if (severity(hops[k].rcode) > severity(res->rcode)) {
+			res->rcode = hops[k].rcode;
+			res->fail_reason = hops[k].fail_reason != nullptr ? rspamd_mempool_strdup(task->task_pool, fmt::format("hop i={}: {}", hops[k].idx, hops[k].fail_reason).c_str()) : nullptr;
+		}
+	}
+
+	msg_debug_dkim2("DKIM2 chain verification finished: rcode=%d, %z hops",
+					(int) res->rcode, nhops);
+
+	chain->cb(task, res, chain->ud);
+}
+
+static void
+dkim2_dns_key_cb(struct rdns_reply *reply, void *arg)
+{
+	auto *cbd = static_cast<dkim2_dns_cbdata *>(arg);
+	auto *chain = cbd->chain;
+	struct rspamd_task *task = chain->task;
+
+	auto slot_it = chain->keys.find(cbd->dns_name);
+
+	if (slot_it != chain->keys.end()) {
+		auto &slot = slot_it->second;
+
+		if (reply->code == RDNS_RC_NOERROR) {
+			struct rdns_reply_entry *elt;
+			GError *err = nullptr;
+
+			slot.rcode = RSPAMD_DKIM2_PERMERROR;
+			slot.reason = "no DKIM2 key record";
+
+			LL_FOREACH(reply->entries, elt)
+			{
+				if (elt->type != RDNS_REQUEST_TXT) {
+					continue;
+				}
+
+				if (err != nullptr) {
+					g_error_free(err);
+					err = nullptr;
+				}
+
+				std::size_t keylen = 0;
+				auto *key = rspamd_dkim_parse_key(elt->content.txt.data, &keylen, &err);
+
+				if (key != nullptr) {
+					slot.key = key;
+					slot.rcode = RSPAMD_DKIM2_PASS;
+					slot.reason.clear();
+					break;
+				}
+			}
+
+			if (slot.key == nullptr && err != nullptr) {
+				slot.reason = fmt::format("invalid key record for {}: {}",
+										  cbd->dns_name, err->message);
+			}
+
+			if (err != nullptr) {
+				g_error_free(err);
+			}
+		}
+		else if (reply->code == RDNS_RC_NXDOMAIN || reply->code == RDNS_RC_NOREC) {
+			slot.rcode = RSPAMD_DKIM2_PERMERROR;
+			slot.reason = fmt::format("no DKIM2 key record for {}", cbd->dns_name);
+		}
+		else {
+			slot.rcode = RSPAMD_DKIM2_TEMPERROR;
+			slot.reason = fmt::format("DNS request for {} failed: {}",
+									  cbd->dns_name, rdns_strerror(reply->code));
+		}
+
+		msg_debug_dkim2("DKIM2 key %s: %s", cbd->dns_name,
+						slot.key ? "fetched" : slot.reason.c_str());
+	}
+
+	chain->pending--;
+
+	if (chain->pending == 0) {
+		dkim2_finalize(chain);
+	}
+}
+
+bool rspamd_dkim2_chain_verify(rspamd_dkim2_chain_t *chain,
+							   struct rspamd_task *task,
+							   const struct rspamd_dkim2_verify_params *params,
+							   rspamd_dkim2_verify_cb cb,
+							   void *ud)
+{
+	if (chain == nullptr || cb == nullptr || task->message == nullptr) {
+		return false;
+	}
+
+	chain->task = task;
+	chain->cb = cb;
+	chain->ud = ud;
+
+	if (params != nullptr) {
+		chain->params = *params;
+	}
+
+	/* Synchronous checks first */
+	dkim2_check_hashes(chain, task);
+	dkim2_check_envelope(chain, task);
+	dkim2_check_timestamps(chain, task);
+
+	/* Collect all unique key names */
+	for (const auto &sig_entry: chain->sigs) {
+		for (const auto &ss: sig_entry.parsed.sigs) {
+			if (ss.alg != rsa_alg_name && ss.alg != ed25519_alg_name) {
+				/* Do not fetch keys for unsupported algorithms */
+				continue;
+			}
+
+			auto dns_name = fmt::format("{}._domainkey.{}", ss.selector,
+										sig_entry.parsed.domain);
+			chain->keys.try_emplace(std::move(dns_name));
+		}
+	}
+
+	unsigned int scheduled = 0;
+
+	for (auto &kv: chain->keys) {
+		auto *cbd = rspamd_mempool_alloc_type(task->task_pool, struct dkim2_dns_cbdata);
+
+		cbd->chain = chain;
+		cbd->dns_name = rspamd_mempool_strdup(task->task_pool, kv.first.c_str());
+
+		if (rspamd_dns_resolver_request_task_forced(task,
+													dkim2_dns_key_cb,
+													cbd,
+													RDNS_REQUEST_TXT,
+													cbd->dns_name)) {
+			scheduled++;
+		}
+		else {
+			kv.second.rcode = RSPAMD_DKIM2_TEMPERROR;
+			kv.second.reason = "cannot schedule DNS request";
+		}
+	}
+
+	chain->pending = scheduled;
+
+	if (scheduled == 0) {
+		/* No DNS requests could be scheduled: finalize synchronously */
+		dkim2_finalize(chain);
+	}
+
+	return true;
+}

--- a/src/libserver/dkim2.cxx
+++ b/src/libserver/dkim2.cxx
@@ -690,6 +690,289 @@ auto smtp_addr_equal(std::string_view a, std::string_view b) -> bool
 		   eq_icase(a.substr(at_a + 1), b.substr(at_b + 1));
 }
 
+auto split_body_lines(std::string_view body, std::size_t max_lines)
+	-> tl::expected<std::vector<std::string_view>, std::string>
+{
+	std::vector<std::string_view> lines;
+	std::size_t run_start = 0;
+
+	auto push_line = [&](std::string_view line) -> bool {
+		if (lines.size() >= max_lines) {
+			return false;
+		}
+
+		lines.emplace_back(line);
+
+		return true;
+	};
+
+	for (std::size_t pos = 0; pos < body.size(); pos++) {
+		auto c = body[pos];
+
+		if (c == '\r' || c == '\n') {
+			if (!push_line(body.substr(run_start, pos - run_start))) {
+				return tl::make_unexpected(fmt::format("too many body lines (max {})",
+													   max_lines));
+			}
+
+			if (c == '\r' && pos + 1 < body.size() && body[pos + 1] == '\n') {
+				pos++;
+			}
+
+			run_start = pos + 1;
+		}
+	}
+
+	if (run_start < body.size()) {
+		if (!push_line(body.substr(run_start))) {
+			return tl::make_unexpected(fmt::format("too many body lines (max {})",
+												   max_lines));
+		}
+	}
+
+	return lines;
+}
+
+/*
+ * Parse one recipe part (an "h" entry or the "b" value): an array of steps,
+ * or null meaning that the prior state cannot be recreated.
+ * Returns an error message or nullopt on success.
+ */
+static auto
+parse_recipe_steps(const ucl_object_t *obj, const recipe_limits_t &limits,
+				   recipe_part_t &part) -> std::optional<std::string>
+{
+	if (ucl_object_type(obj) == UCL_NULL) {
+		part.unrecoverable = true;
+
+		return std::nullopt;
+	}
+
+	if (ucl_object_type(obj) != UCL_ARRAY) {
+		return "recipe part is not an array";
+	}
+
+	ucl_object_iter_t it = nullptr;
+	const ucl_object_t *cur;
+
+	while ((cur = ucl_object_iterate(obj, &it, true)) != nullptr) {
+		if (part.steps.size() >= limits.max_steps) {
+			return fmt::format("too many recipe steps (max {})", limits.max_steps);
+		}
+
+		if (ucl_object_type(cur) != UCL_OBJECT) {
+			return "recipe step is not an object";
+		}
+
+		const auto *c_obj = ucl_object_lookup(cur, "c");
+		const auto *d_obj = ucl_object_lookup(cur, "d");
+		recipe_step_t step;
+
+		if (c_obj != nullptr && d_obj == nullptr) {
+			/* Copy step: {"c": [start, end]} */
+			const auto *start_obj = ucl_array_find_index(c_obj, 0);
+			const auto *end_obj = ucl_array_find_index(c_obj, 1);
+
+			if (ucl_object_type(c_obj) != UCL_ARRAY ||
+				start_obj == nullptr || end_obj == nullptr ||
+				ucl_object_type(start_obj) != UCL_INT ||
+				ucl_object_type(end_obj) != UCL_INT) {
+				return "invalid copy step";
+			}
+
+			auto start = ucl_object_toint(start_obj);
+			auto end = ucl_object_toint(end_obj);
+
+			if (start < 1 || end < start) {
+				return fmt::format("invalid copy range [{}, {}]", start, end);
+			}
+
+			step.is_copy = true;
+			step.start = start;
+			step.end = end;
+		}
+		else if (d_obj != nullptr && c_obj == nullptr) {
+			/* Data step: {"d": ["elt", ...]} */
+			if (ucl_object_type(d_obj) != UCL_ARRAY) {
+				return "data step is not an array";
+			}
+
+			ucl_object_iter_t dit = nullptr;
+			const ucl_object_t *delt;
+
+			while ((delt = ucl_object_iterate(d_obj, &dit, true)) != nullptr) {
+				if (ucl_object_type(delt) != UCL_STRING) {
+					return "data step element is not a string";
+				}
+
+				std::size_t dlen = 0;
+				const auto *dstr = ucl_object_tolstring(delt, &dlen);
+				std::string_view dsv{dstr, dlen};
+
+				if (dsv.find_first_of("\r\n") != std::string_view::npos) {
+					return "data step element contains CR or LF";
+				}
+
+				step.data.emplace_back(dsv);
+			}
+		}
+		else {
+			return "recipe step must have exactly one of c= or d=";
+		}
+
+		part.steps.emplace_back(std::move(step));
+	}
+
+	return std::nullopt;
+}
+
+auto parse_recipe(std::string_view json, const recipe_limits_t &limits)
+	-> tl::expected<recipe_t, std::string>
+{
+	if (json.size() > limits.max_recipe_len) {
+		return tl::make_unexpected(fmt::format("recipe is too large: {} bytes (max {})",
+											   json.size(), limits.max_recipe_len));
+	}
+
+	auto *parser = ucl_parser_new(UCL_PARSER_NO_FILEVARS | UCL_PARSER_NO_TIME);
+
+	if (!ucl_parser_add_chunk(parser,
+							  reinterpret_cast<const unsigned char *>(json.data()),
+							  json.size())) {
+		auto err = fmt::format("cannot parse recipe JSON: {}",
+							   ucl_parser_get_error(parser));
+		ucl_parser_free(parser);
+
+		return tl::make_unexpected(std::move(err));
+	}
+
+	auto *top = ucl_parser_get_object(parser);
+	ucl_parser_free(parser);
+
+	if (top == nullptr || ucl_object_type(top) != UCL_OBJECT) {
+		if (top != nullptr) {
+			ucl_object_unref(top);
+		}
+
+		return tl::make_unexpected(std::string{"recipe is not a JSON object"});
+	}
+
+	recipe_t res;
+	std::string err;
+	const auto *h_obj = ucl_object_lookup(top, "h");
+	const auto *b_obj = ucl_object_lookup(top, "b");
+
+	if (h_obj == nullptr && b_obj == nullptr) {
+		err = "recipe has neither h nor b";
+	}
+
+	if (err.empty() && h_obj != nullptr) {
+		res.has_headers = true;
+
+		if (ucl_object_type(h_obj) == UCL_NULL) {
+			res.headers_unrecoverable = true;
+		}
+		else if (ucl_object_type(h_obj) == UCL_OBJECT) {
+			ucl_object_iter_t it = nullptr;
+			const ucl_object_t *cur;
+
+			while (err.empty() &&
+				   (cur = ucl_object_iterate(h_obj, &it, true)) != nullptr) {
+				if (res.headers.size() >= limits.max_names) {
+					err = fmt::format("too many header names in recipe (max {})",
+									  limits.max_names);
+					break;
+				}
+
+				const auto *key = ucl_object_key(cur);
+
+				if (key == nullptr || *key == '\0') {
+					err = "empty header name in recipe";
+					break;
+				}
+
+				recipe_part_t part;
+				auto part_err = parse_recipe_steps(cur, limits, part);
+
+				if (part_err) {
+					err = fmt::format("header '{}': {}", key, *part_err);
+					break;
+				}
+
+				res.headers.emplace_back(lc_string(key), std::move(part));
+			}
+		}
+		else {
+			err = "recipe h element is not an object";
+		}
+	}
+
+	if (err.empty() && b_obj != nullptr) {
+		res.has_body = true;
+		auto part_err = parse_recipe_steps(b_obj, limits, res.body);
+
+		if (part_err) {
+			err = fmt::format("body recipe: {}", *part_err);
+		}
+	}
+
+	ucl_object_unref(top);
+
+	if (!err.empty()) {
+		return tl::make_unexpected(std::move(err));
+	}
+
+	return res;
+}
+
+auto apply_recipe_steps(const std::vector<std::string_view> &current,
+						const std::vector<recipe_step_t> &steps,
+						std::size_t max_elements,
+						std::size_t &budget)
+	-> tl::expected<std::vector<std::string_view>, std::string>
+{
+	std::vector<std::string_view> out;
+
+	auto emit = [&](std::string_view elt) -> bool {
+		/* Two extra octets per element account for the line terminator */
+		auto cost = elt.size() + 2;
+
+		if (budget < cost || out.size() >= max_elements) {
+			return false;
+		}
+
+		budget -= cost;
+		out.emplace_back(elt);
+
+		return true;
+	};
+
+	for (const auto &step: steps) {
+		if (step.is_copy) {
+			if (step.end > current.size()) {
+				return tl::make_unexpected(fmt::format(
+					"copy range [{}, {}] is out of bounds ({} elements)",
+					step.start, step.end, current.size()));
+			}
+
+			for (auto k = step.start; k <= step.end; k++) {
+				if (!emit(current[k - 1])) {
+					return tl::make_unexpected(std::string{"recipe output limits exceeded"});
+				}
+			}
+		}
+		else {
+			for (const auto &d: step.data) {
+				if (!emit(d)) {
+					return tl::make_unexpected(std::string{"recipe output limits exceeded"});
+				}
+			}
+		}
+	}
+
+	return out;
+}
+
 }// namespace rspamd::dkim2
 
 /*
@@ -717,6 +1000,39 @@ struct dkim2_key_slot {
 };
 
 constexpr unsigned int DKIM2_DEFAULT_MAX_AGE = 14 * 24 * 3600;
+
+/*
+ * Shared output budget for recipe application across the whole chain:
+ * proportional to the message size with a floor and a hard ceiling. This is
+ * the main protection against copy-step amplification bombs.
+ */
+constexpr std::size_t DKIM2_RECIPE_MIN_BUDGET = 1024 * 1024;
+constexpr std::size_t DKIM2_RECIPE_MAX_BUDGET = 64 * 1024 * 1024;
+constexpr std::size_t DKIM2_RECIPE_BUDGET_FACTOR = 8;
+
+/*
+ * A reconstructed message state: header field instances per name and body
+ * lines. Views point into the original message, or into the data strings of
+ * the recipes applied so far (which must outlive the state).
+ */
+struct dkim2_msg_state {
+	/* lc header name -> instances; index 0 is the bottom-most one (number 1) */
+	ankerl::unordered_dense::map<std::string, std::vector<std::string_view>> headers;
+	std::vector<std::string_view> body_lines;
+};
+
+static auto
+dkim2_find_sha256_set(const mi_header_t &mi) -> const hash_set_t *
+{
+	auto found = std::find_if(mi.hashes.begin(), mi.hashes.end(),
+							  [](const hash_set_t &hs) {
+								  return hs.alg == sha256_alg_name &&
+										 hs.header_hash.size() == 32 &&
+										 hs.body_hash.size() == 32;
+							  });
+
+	return found == mi.hashes.end() ? nullptr : &*found;
+}
 
 static auto
 severity(enum rspamd_dkim2_result_code rcode) -> int
@@ -747,6 +1063,8 @@ struct rspamd_dkim2_chain_s {
 	rspamd_dkim2_verify_cb cb = nullptr;
 	void *ud = nullptr;
 	unsigned int pending = 0;
+	unsigned int ninstances = 0;
+	unsigned int verified_instances = 0;
 	/* Results of the synchronous (hash, envelope, timestamp) checks */
 	enum rspamd_dkim2_result_code prelim_rcode = RSPAMD_DKIM2_PASS;
 	std::string prelim_reason;
@@ -977,10 +1295,11 @@ dkim2_ignored_header(const char *name) -> bool
 		   g_ascii_strncasecmp(name, "ARC-", 4) == 0;
 }
 
-static void
+static bool
 dkim2_check_hashes(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 {
 	unsigned char digest[EVP_MAX_MD_SIZE];
+	bool ok = true;
 
 	/* Body hash (Section 5.1) */
 	const char *body_start = MESSAGE_FIELD(task, raw_headers_content).body_start;
@@ -998,19 +1317,16 @@ dkim2_check_hashes(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 	});
 	EVP_DigestFinal_ex(md_ctx, digest, nullptr);
 
+	/* Guaranteed to exist by the chain validation */
 	const auto &latest = chain->mis.back().parsed;
-	const auto *hs = &*std::find_if(latest.hashes.begin(), latest.hashes.end(),
-									[](const hash_set_t &h) {
-										return h.alg == sha256_alg_name &&
-											   h.header_hash.size() == 32 &&
-											   h.body_hash.size() == 32;
-									});
+	const auto *hs = dkim2_find_sha256_set(latest);
 
 	if (memcmp(hs->body_hash.data(), digest, 32) != 0) {
 		msg_info_dkim2("body hash mismatch for the current message instance m=%d",
 					   latest.m);
 		chain->merge_prelim(RSPAMD_DKIM2_FAIL,
 							fmt::format("body hash mismatch for instance m={}", latest.m));
+		ok = false;
 	}
 
 	/* Header hash (Section 5.2) */
@@ -1062,6 +1378,305 @@ dkim2_check_hashes(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 					   latest.m);
 		chain->merge_prelim(RSPAMD_DKIM2_FAIL,
 							fmt::format("header hash mismatch for instance m={}", latest.m));
+		ok = false;
+	}
+
+	return ok;
+}
+
+/*
+ * Build the current (latest instance) message state for recipe application.
+ * Only the headers participating in the hash are collected. Returns false if
+ * the message exceeds the reconstruction limits.
+ */
+static bool
+dkim2_build_current_state(struct rspamd_task *task,
+						  const recipe_limits_t &limits,
+						  dkim2_msg_state &state)
+{
+	for (auto *cur = MESSAGE_FIELD(task, headers_order); cur != nullptr;
+		 cur = cur->ord_next) {
+		if (cur->name == nullptr || cur->value == nullptr ||
+			dkim2_ignored_header(cur->name)) {
+			continue;
+		}
+
+		auto &vec = state.headers[lc_string(cur->name)];
+
+		if (vec.size() >= limits.max_header_instances) {
+			return false;
+		}
+
+		vec.emplace_back(cur->value);
+	}
+
+	/* Recipe numbering is bottom-up: index 0 must be the bottom-most instance */
+	for (auto &kv: state.headers) {
+		std::reverse(kv.second.begin(), kv.second.end());
+	}
+
+	const char *body_start = MESSAGE_FIELD(task, raw_headers_content).body_start;
+	const char *msg_end = task->msg.begin + task->msg.len;
+	std::string_view body;
+
+	if (body_start != nullptr && msg_end > body_start) {
+		body = std::string_view{body_start, static_cast<std::size_t>(msg_end - body_start)};
+	}
+
+	auto lines = split_body_lines(body, limits.max_body_lines);
+
+	if (!lines) {
+		return false;
+	}
+
+	state.body_lines = std::move(*lines);
+
+	return true;
+}
+
+/*
+ * Compute the header and body hashes (Sections 5.1, 5.2) of a reconstructed
+ * message state; both digests are SHA256 (32 bytes)
+ */
+static void
+dkim2_hash_state(const dkim2_msg_state &state,
+				 unsigned char *hdr_digest,
+				 unsigned char *body_digest)
+{
+	auto *md_ctx = EVP_MD_CTX_new();
+
+	/* Header hash: names alphabetically, instances bottom-up within a name */
+	using hdr_entry_t = std::pair<std::string, std::vector<std::string_view>>;
+	std::vector<const hdr_entry_t *> entries;
+	entries.reserve(state.headers.size());
+
+	for (const auto &kv: state.headers) {
+		if (!kv.second.empty()) {
+			entries.push_back(&kv);
+		}
+	}
+
+	std::sort(entries.begin(), entries.end(),
+			  [](const hdr_entry_t *a, const hdr_entry_t *b) {
+				  return a->first < b->first;
+			  });
+
+	EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
+
+	for (const auto *entry: entries) {
+		for (auto value: entry->second) {
+			auto line = canon_hash_line(entry->first, value);
+			EVP_DigestUpdate(md_ctx, line.data(), line.size());
+		}
+	}
+
+	EVP_DigestFinal_ex(md_ctx, hdr_digest, nullptr);
+
+	/* Body hash: lines joined with CRLF, trailing empty lines ignored */
+	auto nlines = state.body_lines.size();
+
+	while (nlines > 0 && state.body_lines[nlines - 1].empty()) {
+		nlines--;
+	}
+
+	EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
+
+	if (nlines == 0) {
+		EVP_DigestUpdate(md_ctx, "\r\n", 2);
+	}
+	else {
+		for (std::size_t k = 0; k < nlines; k++) {
+			const auto &line = state.body_lines[k];
+
+			if (!line.empty()) {
+				EVP_DigestUpdate(md_ctx, line.data(), line.size());
+			}
+
+			EVP_DigestUpdate(md_ctx, "\r\n", 2);
+		}
+	}
+
+	EVP_DigestFinal_ex(md_ctx, body_digest, nullptr);
+	EVP_MD_CTX_free(md_ctx);
+}
+
+/*
+ * Verify the hashes of the older message instances by applying recipes from
+ * the latest instance backwards. A missing/unparseable recipe or an exceeded
+ * limit leaves the remaining instances unverified (this is not an error);
+ * a hash mismatch of a successfully reconstructed instance is a failure.
+ */
+static void
+dkim2_check_instances(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
+{
+	recipe_limits_t limits;
+	auto nmis = chain->mis.size();
+
+	auto budget = std::clamp(task->msg.len * DKIM2_RECIPE_BUDGET_FACTOR,
+							 DKIM2_RECIPE_MIN_BUDGET,
+							 DKIM2_RECIPE_MAX_BUDGET);
+
+	dkim2_msg_state state;
+
+	if (!dkim2_build_current_state(task, limits, state)) {
+		msg_info_dkim2("message is too large for DKIM2 instance reconstruction; "
+					   "%d older instances left unverified",
+					   (int) (nmis - 1));
+		return;
+	}
+
+	/* Reconstructed states reference recipe data, keep all recipes alive */
+	std::vector<recipe_t> recipes;
+	recipes.reserve(nmis - 1);
+
+	for (auto m = nmis; m >= 2; m--) {
+		const auto &mi = chain->mis[m - 1].parsed;
+
+		if (!mi.has_recipe) {
+			msg_debug_dkim2("Message-Instance m=%z has no recipe; "
+							"older instances left unverified",
+							m);
+			return;
+		}
+
+		if (mi.recipe_b64.size() > limits.max_recipe_len / 3 * 4 + 4) {
+			msg_info_dkim2("recipe of instance m=%z is too large", m);
+			return;
+		}
+
+		auto decoded = b64_decode(mi.recipe_b64);
+
+		if (!decoded || decoded->empty()) {
+			msg_info_dkim2("invalid base64 in recipe of instance m=%z", m);
+			return;
+		}
+
+		auto recipe = parse_recipe(*decoded, limits);
+
+		if (!recipe) {
+			msg_info_dkim2("cannot parse recipe of instance m=%z: %s",
+						   m, recipe.error().c_str());
+			return;
+		}
+
+		recipes.emplace_back(std::move(*recipe));
+		const auto &r = recipes.back();
+
+		if ((r.has_headers && r.headers_unrecoverable) ||
+			(r.has_body && r.body.unrecoverable)) {
+			msg_debug_dkim2("instance m=%z is marked as unrecoverable", m - 1);
+			return;
+		}
+
+		if (r.has_headers) {
+			for (const auto &[name, part]: r.headers) {
+				if (dkim2_ignored_header(name.c_str())) {
+					/* Does not participate in the hash */
+					continue;
+				}
+
+				if (part.unrecoverable) {
+					msg_debug_dkim2("header %s of instance m=%z is unrecoverable",
+									name.c_str(), m - 1);
+					return;
+				}
+
+				auto &vec = state.headers[name];
+				auto out = apply_recipe_steps(vec, part.steps,
+											  limits.max_header_instances, budget);
+
+				if (!out) {
+					msg_info_dkim2("cannot apply header recipe of instance m=%z: %s",
+								   m, out.error().c_str());
+					return;
+				}
+
+				vec = std::move(*out);
+			}
+		}
+
+		if (r.has_body) {
+			auto out = apply_recipe_steps(state.body_lines, r.body.steps,
+										  limits.max_body_lines, budget);
+
+			if (!out) {
+				msg_info_dkim2("cannot apply body recipe of instance m=%z: %s",
+							   m, out.error().c_str());
+				return;
+			}
+
+			state.body_lines = std::move(*out);
+		}
+
+		/* The state is now instance m-1; verify its hashes */
+		const auto &prev_mi = chain->mis[m - 2].parsed;
+		const auto *hs = dkim2_find_sha256_set(prev_mi);
+
+		if (hs == nullptr) {
+			msg_info_dkim2("instance m=%z has no usable sha256 hash set", m - 1);
+			return;
+		}
+
+		unsigned char hdr_digest[EVP_MAX_MD_SIZE], body_digest[EVP_MAX_MD_SIZE];
+		dkim2_hash_state(state, hdr_digest, body_digest);
+
+		if (memcmp(hs->header_hash.data(), hdr_digest, 32) != 0) {
+			msg_info_dkim2("header hash mismatch for reconstructed instance m=%z", m - 1);
+			chain->merge_prelim(RSPAMD_DKIM2_FAIL,
+								fmt::format("header hash mismatch for reconstructed instance m={}",
+											m - 1));
+			return;
+		}
+
+		if (memcmp(hs->body_hash.data(), body_digest, 32) != 0) {
+			msg_info_dkim2("body hash mismatch for reconstructed instance m=%z", m - 1);
+			chain->merge_prelim(RSPAMD_DKIM2_FAIL,
+								fmt::format("body hash mismatch for reconstructed instance m={}",
+											m - 1));
+			return;
+		}
+
+		chain->verified_instances++;
+		msg_debug_dkim2("verified reconstructed instance m=%z, budget left %z",
+						m - 1, budget);
+	}
+}
+
+/*
+ * Flag compliance (Section 10.8): donotmodify and donotexplode
+ */
+static void
+dkim2_check_flags(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
+{
+	auto nmis = (unsigned int) chain->mis.size();
+
+	for (std::size_t k = 0; k < chain->sigs.size(); k++) {
+		const auto &sig = chain->sigs[k].parsed;
+
+		if ((sig.flags & DKIM2_SIG_FLAG_DONOTMODIFY) && nmis > sig.m) {
+			msg_info_dkim2("message was modified despite the donotmodify request "
+						   "of hop i=%d",
+						   sig.i);
+			chain->merge_prelim(RSPAMD_DKIM2_FAIL,
+								fmt::format("message was modified despite a donotmodify "
+											"request (hop i={})",
+											sig.i));
+		}
+
+		if (sig.flags & DKIM2_SIG_FLAG_DONOTEXPLODE) {
+			for (auto j = k + 1; j < chain->sigs.size(); j++) {
+				if (chain->sigs[j].parsed.flags & DKIM2_SIG_FLAG_EXPLODED) {
+					msg_info_dkim2("message was exploded despite the donotexplode "
+								   "request of hop i=%d",
+								   sig.i);
+					chain->merge_prelim(RSPAMD_DKIM2_FAIL,
+										fmt::format("message was exploded despite a "
+													"donotexplode request (hop i={})",
+													sig.i));
+					break;
+				}
+			}
+		}
 	}
 }
 
@@ -1310,6 +1925,8 @@ dkim2_finalize(rspamd_dkim2_chain_t *chain)
 	res->fail_reason = chain->prelim_reason.empty() ? nullptr : rspamd_mempool_strdup(task->task_pool, chain->prelim_reason.c_str());
 	res->nhops = nhops;
 	res->hops = hops;
+	res->ninstances = chain->ninstances;
+	res->verified_instances = chain->verified_instances;
 
 	for (std::size_t k = 0; k < nhops; k++) {
 		dkim2_verify_one_hop(chain, chain->sigs[k], k, &hops[k]);
@@ -1416,7 +2033,18 @@ bool rspamd_dkim2_chain_verify(rspamd_dkim2_chain_t *chain,
 	}
 
 	/* Synchronous checks first */
-	dkim2_check_hashes(chain, task);
+	chain->ninstances = chain->mis.size();
+
+	if (dkim2_check_hashes(chain, task)) {
+		chain->verified_instances = 1;
+
+		if (chain->mis.size() > 1) {
+			/* Reconstruct and verify the older instances using recipes */
+			dkim2_check_instances(chain, task);
+		}
+	}
+
+	dkim2_check_flags(chain, task);
 	dkim2_check_envelope(chain, task);
 	dkim2_check_timestamps(chain, task);
 

--- a/src/libserver/dkim2.cxx
+++ b/src/libserver/dkim2.cxx
@@ -1015,6 +1015,24 @@ constexpr std::size_t DKIM2_RECIPE_MIN_BUDGET = 1024 * 1024;
 constexpr std::size_t DKIM2_RECIPE_MAX_BUDGET = 64 * 1024 * 1024;
 constexpr std::size_t DKIM2_RECIPE_BUDGET_FACTOR = 8;
 
+/* Shared input-hashing budget for all hop signatures in a chain */
+constexpr std::size_t DKIM2_SIGNATURE_MIN_BUDGET = 1024 * 1024;
+constexpr std::size_t DKIM2_SIGNATURE_MAX_BUDGET = 64 * 1024 * 1024;
+constexpr std::size_t DKIM2_SIGNATURE_BUDGET_FACTOR = 16;
+
+static auto
+dkim2_bounded_budget(std::size_t message_len,
+					 std::size_t factor,
+					 std::size_t minimum,
+					 std::size_t maximum) -> std::size_t
+{
+	if (message_len > maximum / factor) {
+		return maximum;
+	}
+
+	return std::clamp(message_len * factor, minimum, maximum);
+}
+
 /*
  * A reconstructed message state: header field instances per name and body
  * lines. Views point into the original message, or into the data strings of
@@ -1070,6 +1088,7 @@ struct rspamd_dkim2_chain_s {
 	unsigned int pending = 0;
 	unsigned int ninstances = 0;
 	unsigned int verified_instances = 0;
+	std::size_t signature_work_budget = 0;
 	/* Results of the synchronous (hash, envelope, timestamp) checks */
 	enum rspamd_dkim2_result_code prelim_rcode = RSPAMD_DKIM2_PASS;
 	std::string prelim_reason;
@@ -1551,9 +1570,10 @@ dkim2_check_instances(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 	recipe_limits_t limits;
 	auto nmis = chain->mis.size();
 
-	auto work_budget = std::clamp(task->msg.len * DKIM2_RECIPE_BUDGET_FACTOR,
-								  DKIM2_RECIPE_MIN_BUDGET,
-								  DKIM2_RECIPE_MAX_BUDGET);
+	auto work_budget = dkim2_bounded_budget(task->msg.len,
+											DKIM2_RECIPE_BUDGET_FACTOR,
+											DKIM2_RECIPE_MIN_BUDGET,
+											DKIM2_RECIPE_MAX_BUDGET);
 
 	dkim2_msg_state state;
 
@@ -1844,22 +1864,60 @@ dkim2_verify_one_hop(rspamd_dkim2_chain_t *chain,
 	hop->domain = rspamd_mempool_strdup(task->task_pool, sig.domain.c_str());
 	hop->selector = rspamd_mempool_strdup(task->task_pool, sig.sigs[0].selector.c_str());
 
-	/* Build the signature input: MI lines up to m=, previous sig lines, self */
-	std::vector<std::string> mi_lines, prev_lines;
-	mi_lines.reserve(sig.m);
-	prev_lines.reserve(hop_idx);
+	/* Stream the signature input and charge repeated input across all hops */
+	auto md_ctx = EVP_MD_CTX_new();
+	std::size_t input_size = 0;
+	bool budget_exceeded = false;
 
-	for (std::size_t k = 0; k < sig.m; k++) {
-		mi_lines.push_back(chain->mis[k].canon_line);
+	if (md_ctx == nullptr || EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr) != 1) {
+		EVP_MD_CTX_free(md_ctx);
+		merge_hop(RSPAMD_DKIM2_PERMERROR, "cannot initialize signature digest");
+		return;
 	}
-	for (std::size_t k = 0; k < hop_idx; k++) {
-		prev_lines.push_back(chain->sigs[k].canon_line);
+
+	auto update_digest = [&](std::string_view data) -> bool {
+		if (data.size() > chain->signature_work_budget) {
+			budget_exceeded = true;
+			return false;
+		}
+
+		chain->signature_work_budget -= data.size();
+		input_size += data.size();
+
+		return EVP_DigestUpdate(md_ctx, data.data(), data.size()) == 1;
+	};
+
+	bool digest_ok = true;
+
+	for (std::size_t k = 0; k < sig.m && digest_ok; k++) {
+		digest_ok = update_digest(chain->mis[k].canon_line);
+	}
+	for (std::size_t k = 0; k < hop_idx && digest_ok; k++) {
+		digest_ok = update_digest(chain->sigs[k].canon_line);
 	}
 
-	auto input = build_sig_input(mi_lines, prev_lines, entry.canon_line);
-	EVP_Digest(input.data(), input.size(), digest, nullptr, EVP_sha256(), nullptr);
+	auto blanked_line = blank_sig_values(entry.canon_line);
+	if (digest_ok) {
+		digest_ok = update_digest(blanked_line);
+	}
 
-	msg_debug_dkim2("hop i=%d: signature input is %z bytes", sig.i, input.size());
+	unsigned int digest_len = 0;
+	if (digest_ok) {
+		digest_ok = EVP_DigestFinal_ex(md_ctx, digest, &digest_len) == 1 &&
+					digest_len == 32;
+	}
+	EVP_MD_CTX_free(md_ctx);
+
+	if (!digest_ok) {
+		merge_hop(RSPAMD_DKIM2_PERMERROR,
+				  budget_exceeded
+					  ? "signature input work budget exceeded"
+					  : "cannot compute signature digest");
+		return;
+	}
+
+	msg_debug_dkim2("hop i=%d: signature input is %z bytes; work budget left %z",
+					sig.i, input_size, chain->signature_work_budget);
 
 	auto supported_algs = 0;
 
@@ -2071,6 +2129,10 @@ bool rspamd_dkim2_chain_verify(rspamd_dkim2_chain_t *chain,
 	chain->task = task;
 	chain->cb = cb;
 	chain->ud = ud;
+	chain->signature_work_budget = dkim2_bounded_budget(task->msg.len,
+														DKIM2_SIGNATURE_BUDGET_FACTOR,
+														DKIM2_SIGNATURE_MIN_BUDGET,
+														DKIM2_SIGNATURE_MAX_BUDGET);
 
 	if (params != nullptr) {
 		chain->params = *params;

--- a/src/libserver/dkim2.cxx
+++ b/src/libserver/dkim2.cxx
@@ -1002,9 +1002,9 @@ struct dkim2_key_slot {
 constexpr unsigned int DKIM2_DEFAULT_MAX_AGE = 14 * 24 * 3600;
 
 /*
- * Shared output budget for recipe application across the whole chain:
- * proportional to the message size with a floor and a hard ceiling. This is
- * the main protection against copy-step amplification bombs.
+ * Shared work budget for recipe application and reconstructed-state hashing
+ * across the whole chain. It is proportional to the message size with a floor
+ * and a hard ceiling.
  */
 constexpr std::size_t DKIM2_RECIPE_MIN_BUDGET = 1024 * 1024;
 constexpr std::size_t DKIM2_RECIPE_MAX_BUDGET = 64 * 1024 * 1024;
@@ -1438,12 +1438,21 @@ dkim2_build_current_state(struct rspamd_task *task,
  * Compute the header and body hashes (Sections 5.1, 5.2) of a reconstructed
  * message state; both digests are SHA256 (32 bytes)
  */
-static void
+static bool
 dkim2_hash_state(const dkim2_msg_state &state,
 				 unsigned char *hdr_digest,
-				 unsigned char *body_digest)
+				 unsigned char *body_digest,
+				 std::size_t &work_budget)
 {
 	auto *md_ctx = EVP_MD_CTX_new();
+	auto consume_work = [&](std::size_t amount) -> bool {
+		if (amount > work_budget) {
+			return false;
+		}
+
+		work_budget -= amount;
+		return true;
+	};
 
 	/* Header hash: names alphabetically, instances bottom-up within a name */
 	using hdr_entry_t = std::pair<std::string, std::vector<std::string_view>>;
@@ -1466,6 +1475,12 @@ dkim2_hash_state(const dkim2_msg_state &state,
 	for (const auto *entry: entries) {
 		for (auto value: entry->second) {
 			auto line = canon_hash_line(entry->first, value);
+
+			if (!consume_work(line.size())) {
+				EVP_MD_CTX_free(md_ctx);
+				return false;
+			}
+
 			EVP_DigestUpdate(md_ctx, line.data(), line.size());
 		}
 	}
@@ -1482,11 +1497,20 @@ dkim2_hash_state(const dkim2_msg_state &state,
 	EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
 
 	if (nlines == 0) {
+		if (!consume_work(2)) {
+			EVP_MD_CTX_free(md_ctx);
+			return false;
+		}
+
 		EVP_DigestUpdate(md_ctx, "\r\n", 2);
 	}
 	else {
 		for (std::size_t k = 0; k < nlines; k++) {
 			const auto &line = state.body_lines[k];
+			if (!consume_work(line.size()) || !consume_work(2)) {
+				EVP_MD_CTX_free(md_ctx);
+				return false;
+			}
 
 			if (!line.empty()) {
 				EVP_DigestUpdate(md_ctx, line.data(), line.size());
@@ -1498,6 +1522,8 @@ dkim2_hash_state(const dkim2_msg_state &state,
 
 	EVP_DigestFinal_ex(md_ctx, body_digest, nullptr);
 	EVP_MD_CTX_free(md_ctx);
+
+	return true;
 }
 
 /*
@@ -1512,9 +1538,9 @@ dkim2_check_instances(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 	recipe_limits_t limits;
 	auto nmis = chain->mis.size();
 
-	auto budget = std::clamp(task->msg.len * DKIM2_RECIPE_BUDGET_FACTOR,
-							 DKIM2_RECIPE_MIN_BUDGET,
-							 DKIM2_RECIPE_MAX_BUDGET);
+	auto work_budget = std::clamp(task->msg.len * DKIM2_RECIPE_BUDGET_FACTOR,
+								  DKIM2_RECIPE_MIN_BUDGET,
+								  DKIM2_RECIPE_MAX_BUDGET);
 
 	dkim2_msg_state state;
 
@@ -1583,7 +1609,7 @@ dkim2_check_instances(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 
 				auto &vec = state.headers[name];
 				auto out = apply_recipe_steps(vec, part.steps,
-											  limits.max_header_instances, budget);
+											  limits.max_header_instances, work_budget);
 
 				if (!out) {
 					msg_info_dkim2("cannot apply header recipe of instance m=%z: %s",
@@ -1597,7 +1623,7 @@ dkim2_check_instances(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 
 		if (r.has_body) {
 			auto out = apply_recipe_steps(state.body_lines, r.body.steps,
-										  limits.max_body_lines, budget);
+										  limits.max_body_lines, work_budget);
 
 			if (!out) {
 				msg_info_dkim2("cannot apply body recipe of instance m=%z: %s",
@@ -1618,7 +1644,12 @@ dkim2_check_instances(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 		}
 
 		unsigned char hdr_digest[EVP_MAX_MD_SIZE], body_digest[EVP_MAX_MD_SIZE];
-		dkim2_hash_state(state, hdr_digest, body_digest);
+		if (!dkim2_hash_state(state, hdr_digest, body_digest, work_budget)) {
+			msg_info_dkim2("cannot hash reconstructed instance m=%z: "
+						   "recipe work budget exceeded",
+						   m - 1);
+			return;
+		}
 
 		if (memcmp(hs->header_hash.data(), hdr_digest, 32) != 0) {
 			msg_info_dkim2("header hash mismatch for reconstructed instance m=%z", m - 1);
@@ -1637,8 +1668,8 @@ dkim2_check_instances(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 		}
 
 		chain->verified_instances++;
-		msg_debug_dkim2("verified reconstructed instance m=%z, budget left %z",
-						m - 1, budget);
+		msg_debug_dkim2("verified reconstructed instance m=%z, work budget left %z",
+						m - 1, work_budget);
 	}
 }
 

--- a/src/libserver/dkim2.cxx
+++ b/src/libserver/dkim2.cxx
@@ -310,6 +310,11 @@ parse_sig_sets(std::string_view value) -> tl::expected<std::vector<sig_set_t>, s
 		if (!err.empty()) {
 			return;
 		}
+		if (res.size() >= DKIM2_MAX_SIG_SETS_PER_HOP) {
+			err = fmt::format("too many signature sets (max {})",
+							  DKIM2_MAX_SIG_SETS_PER_HOP);
+			return;
+		}
 
 		/* sig-set = selector ":" sig-name ":" message-sig */
 		std::vector<std::string_view> parts;
@@ -1117,9 +1122,17 @@ dkim2_validate_chain(rspamd_dkim2_chain_s *chain) -> tl::expected<void, std::str
 	}
 
 	unsigned int prev_m = 0;
+	std::size_t nsig_sets = 0;
 
 	for (std::size_t k = 0; k < chain->sigs.size(); k++) {
 		const auto &sig = chain->sigs[k].parsed;
+		nsig_sets += sig.sigs.size();
+
+		if (nsig_sets > DKIM2_MAX_SIG_SETS_TOTAL) {
+			return tl::make_unexpected(fmt::format(
+				"too many signature sets in DKIM2 chain (max {})",
+				DKIM2_MAX_SIG_SETS_TOTAL));
+		}
 
 		if (sig.i != k + 1) {
 			return tl::make_unexpected(fmt::format(
@@ -2101,11 +2114,11 @@ bool rspamd_dkim2_chain_verify(rspamd_dkim2_chain_t *chain,
 		cbd->chain = chain;
 		cbd->dns_name = rspamd_mempool_strdup(task->task_pool, kv.first.c_str());
 
-		if (rspamd_dns_resolver_request_task_forced(task,
-													dkim2_dns_key_cb,
-													cbd,
-													RDNS_REQUEST_TXT,
-													cbd->dns_name)) {
+		if (rspamd_dns_resolver_request_task(task,
+											 dkim2_dns_key_cb,
+											 cbd,
+											 RDNS_REQUEST_TXT,
+											 cbd->dns_name)) {
 			scheduled++;
 		}
 		else {

--- a/src/libserver/dkim2.cxx
+++ b/src/libserver/dkim2.cxx
@@ -424,6 +424,11 @@ auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string
 				if (!err.empty()) {
 					return;
 				}
+				if (res.rt.size() >= DKIM2_MAX_RT_ENTRIES) {
+					err = fmt::format("too many rt= entries (max {})",
+									  DKIM2_MAX_RT_ENTRIES);
+					return;
+				}
 				auto rcpt = b64_decode(rcpt_b64);
 				if (!rcpt) {
 					err = "invalid base64 in rt= tag";
@@ -673,26 +678,23 @@ auto smtp_addr_domain(std::string_view addr) -> std::string_view
 	return addr.substr(at_pos + 1);
 }
 
+static auto
+smtp_addr_key(std::string_view addr) -> std::string
+{
+	addr = strip_angle(addr);
+	std::string key{addr};
+	auto at_pos = key.rfind('@');
+
+	if (at_pos != std::string::npos) {
+		rspamd_str_lc(key.data() + at_pos + 1, key.size() - at_pos - 1);
+	}
+
+	return key;
+}
+
 auto smtp_addr_equal(std::string_view a, std::string_view b) -> bool
 {
-	a = strip_angle(a);
-	b = strip_angle(b);
-
-	auto at_a = a.rfind('@');
-	auto at_b = b.rfind('@');
-
-	if (at_a != at_b) {
-		return false;
-	}
-
-	if (at_a == std::string_view::npos) {
-		/* Both have no domain, e.g. null reverse-paths */
-		return a == b;
-	}
-
-	/* Local part is case-sensitive, domain is not */
-	return a.substr(0, at_a) == b.substr(0, at_b) &&
-		   eq_icase(a.substr(at_a + 1), b.substr(at_b + 1));
+	return smtp_addr_key(a) == smtp_addr_key(b);
 }
 
 auto split_body_lines(std::string_view body, std::size_t max_lines)
@@ -1766,6 +1768,13 @@ dkim2_check_envelope(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 		}
 
 		if (task->rcpt_envelope != nullptr) {
+			ankerl::unordered_dense::set<std::string> rt_index;
+			rt_index.reserve(last.rt.size());
+
+			for (const auto &rt: last.rt) {
+				rt_index.emplace(smtp_addr_key(rt));
+			}
+
 			unsigned int i;
 			struct rspamd_email_address *rcpt;
 
@@ -1776,10 +1785,7 @@ dkim2_check_envelope(rspamd_dkim2_chain_t *chain, struct rspamd_task *task)
 				}
 
 				std::string_view rcpt_sv{rcpt->addr, rcpt->addr_len};
-				auto found = std::any_of(last.rt.begin(), last.rt.end(),
-										 [&](const std::string &rt) {
-											 return smtp_addr_equal(rt, rcpt_sv);
-										 });
+				auto found = rt_index.contains(smtp_addr_key(rcpt_sv));
 
 				if (!found) {
 					msg_info_dkim2("RCPT TO <%*s> not found in rt= of the last hop",

--- a/src/libserver/dkim2.cxx
+++ b/src/libserver/dkim2.cxx
@@ -834,7 +834,7 @@ auto parse_recipe(std::string_view json, const recipe_limits_t &limits)
 											   json.size(), limits.max_recipe_len));
 	}
 
-	auto *parser = ucl_parser_new(UCL_PARSER_NO_FILEVARS | UCL_PARSER_NO_TIME);
+	auto *parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
 
 	if (!ucl_parser_add_chunk(parser,
 							  reinterpret_cast<const unsigned char *>(json.data()),

--- a/src/libserver/dkim2.h
+++ b/src/libserver/dkim2.h
@@ -63,6 +63,13 @@ struct rspamd_dkim2_verify_result {
 	const char *fail_reason;             /* NULL if ok */
 	unsigned int nhops;
 	const struct rspamd_dkim2_hop_result *hops; /* array of nhops elements */
+	unsigned int ninstances;                    /* number of Message-Instance headers */
+	/*
+	 * Instances with verified hashes, counting from the latest backwards;
+	 * older instances are verified by applying r= recipes within internal
+	 * limits, so this can legitimately be less than ninstances
+	 */
+	unsigned int verified_instances;
 };
 
 struct rspamd_dkim2_verify_params {

--- a/src/libserver/dkim2.h
+++ b/src/libserver/dkim2.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DKIM2 verification (draft-ietf-dkim-dkim2-spec)
+ *
+ * DKIM2 is a separate protocol from DKIM (RFC 6376): signatures are computed
+ * over the Message-Instance and DKIM2-Signature header fields only, while the
+ * binding to the actual message content is indirect, via hashes stored in
+ * Message-Instance headers. Hence this module shares no verification logic
+ * with dkim.c; only the DNS key record handling is reused.
+ */
+
+#ifndef RSPAMD_DKIM2_H
+#define RSPAMD_DKIM2_H
+
+#include "config.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RSPAMD_DKIM2_SIGNHEADER "DKIM2-Signature"
+#define RSPAMD_DKIM2_MIHEADER "Message-Instance"
+
+/* Sanity limit for the number of hops in a DKIM2 chain */
+#define RSPAMD_DKIM2_MAX_HOPS 50
+
+struct rspamd_task;
+
+enum rspamd_dkim2_result_code {
+	RSPAMD_DKIM2_NONE = 0, /* no DKIM2 headers found */
+	RSPAMD_DKIM2_PASS,
+	RSPAMD_DKIM2_FAIL,      /* hash or signature mismatch */
+	RSPAMD_DKIM2_TEMPERROR, /* e.g. DNS temporary failure */
+	RSPAMD_DKIM2_PERMERROR, /* malformed/missing fields, no key, etc */
+};
+
+struct rspamd_dkim2_hop_result {
+	const char *domain;      /* d= tag */
+	const char *selector;    /* selector of the first signature set */
+	const char *fail_reason; /* NULL if hop is ok */
+	unsigned int idx;        /* i= tag */
+	enum rspamd_dkim2_result_code rcode;
+};
+
+struct rspamd_dkim2_verify_result {
+	enum rspamd_dkim2_result_code rcode; /* overall result */
+	const char *fail_reason;             /* NULL if ok */
+	unsigned int nhops;
+	const struct rspamd_dkim2_hop_result *hops; /* array of nhops elements */
+};
+
+struct rspamd_dkim2_verify_params {
+	unsigned int time_jitter; /* allowed clock skew for future t= values, seconds */
+	unsigned int max_age;     /* max signature age in seconds, 0 = default (14 days) */
+	bool check_envelope;      /* match mf=/rt= of the last hop against SMTP envelope */
+};
+
+typedef struct rspamd_dkim2_chain_s rspamd_dkim2_chain_t;
+
+/**
+ * Parse all Message-Instance and DKIM2-Signature headers of a task and
+ * perform structural validation of the chain (consecutive m=/i= numbering,
+ * mandatory tags etc).
+ * The returned object is allocated in the task pool and destroyed with it.
+ * @return chain object or NULL; if NULL and *err is NULL, the message simply
+ * has no DKIM2 headers; otherwise *err describes a permanent error
+ */
+rspamd_dkim2_chain_t *rspamd_dkim2_chain_parse(struct rspamd_task *task,
+											   GError **err);
+
+/**
+ * Number of hops (DKIM2-Signature headers) in the chain
+ */
+unsigned int rspamd_dkim2_chain_len(const rspamd_dkim2_chain_t *chain);
+
+typedef void (*rspamd_dkim2_verify_cb)(struct rspamd_task *task,
+									   const struct rspamd_dkim2_verify_result *res,
+									   void *ud);
+
+/**
+ * Verify a parsed DKIM2 chain: computes current message hashes, checks the
+ * envelope (optionally), fetches public keys via DNS and verifies all hop
+ * signatures. The callback may be called synchronously if no DNS requests
+ * could be scheduled.
+ * @return false if verification could not be started (callback is not called)
+ */
+bool rspamd_dkim2_chain_verify(rspamd_dkim2_chain_t *chain,
+							   struct rspamd_task *task,
+							   const struct rspamd_dkim2_verify_params *params,
+							   rspamd_dkim2_verify_cb cb,
+							   void *ud);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RSPAMD_DKIM2_H */

--- a/src/libserver/dkim2.hxx
+++ b/src/libserver/dkim2.hxx
@@ -97,6 +97,73 @@ auto parse_mi(std::string_view value) -> tl::expected<mi_header_t, std::string>;
  */
 auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string>;
 
+/*
+ * Recipes (the r= tag of Message-Instance): JSON instructions to recreate
+ * the previous message state. The spec imposes NO limits on them, while copy
+ * steps allow content duplication, which makes an unconstrained recipe chain
+ * a decompression bomb. All limits below are therefore internal hard caps;
+ * exceeding any of them makes the older instances unverifiable, it is never
+ * an error that affects the verdict.
+ */
+
+struct recipe_limits_t {
+	std::size_t max_recipe_len = 256 * 1024; /* decoded recipe JSON size */
+	std::size_t max_steps = 256;             /* steps per recipe part */
+	std::size_t max_names = 256;             /* header field names per recipe */
+	std::size_t max_body_lines = 1000000;    /* body lines per message state */
+	std::size_t max_header_instances = 1000; /* header instances per name */
+};
+
+struct recipe_step_t {
+	bool is_copy = false;
+	/* Copy steps: 1-based inclusive range of elements of the current state */
+	std::size_t start = 0;
+	std::size_t end = 0;
+	/* Data steps: literal elements (header values or body lines) */
+	std::vector<std::string> data;
+};
+
+struct recipe_part_t {
+	bool unrecoverable = false; /* null in JSON: prior state cannot be recreated */
+	std::vector<recipe_step_t> steps;
+};
+
+struct recipe_t {
+	bool has_headers = false;           /* "h" key present */
+	bool headers_unrecoverable = false; /* "h" is null */
+	bool has_body = false;              /* "b" key present */
+	/* lowercased header field name -> recipe part */
+	std::vector<std::pair<std::string, recipe_part_t>> headers;
+	recipe_part_t body;
+};
+
+/**
+ * Parse a decoded (JSON) recipe, enforcing the limits
+ */
+auto parse_recipe(std::string_view json, const recipe_limits_t &limits)
+	-> tl::expected<recipe_t, std::string>;
+
+/**
+ * Apply recipe steps to a list of elements (body lines or header field
+ * instances of one name, index 0 corresponding to element number 1) producing
+ * the previous state. Output views point into `current` elements or into the
+ * data strings of the owning recipe_t, which must outlive the result.
+ * `budget` is the shared output allowance in bytes for the whole chain; it is
+ * decremented by every emitted byte and the application fails when exhausted.
+ */
+auto apply_recipe_steps(const std::vector<std::string_view> &current,
+						const std::vector<recipe_step_t> &steps,
+						std::size_t max_elements,
+						std::size_t &budget)
+	-> tl::expected<std::vector<std::string_view>, std::string>;
+
+/**
+ * Split a message body into lines (line terminators are not included);
+ * a trailing terminator does not produce an extra empty line
+ */
+auto split_body_lines(std::string_view body, std::size_t max_lines)
+	-> tl::expected<std::vector<std::string_view>, std::string>;
+
 /**
  * Canonicalize a header for the *message header hash* (Section 5.2):
  * lowercase name, collapse WSP runs to a single SP, trim trailing WSP and

--- a/src/libserver/dkim2.hxx
+++ b/src/libserver/dkim2.hxx
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Internal C++ interface of the DKIM2 module: header tag parsing and
+ * canonicalization primitives, kept free of task/DNS dependencies so that
+ * they can be unit tested in isolation.
+ *
+ * Reference: draft-ietf-dkim-dkim2-spec
+ */
+
+#ifndef RSPAMD_DKIM2_HXX
+#define RSPAMD_DKIM2_HXX
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <span>
+#include <cstdint>
+#include <ctime>
+
+#include "contrib/expected/expected.hpp"
+
+namespace rspamd::dkim2 {
+
+/* f= tag flags */
+constexpr unsigned int DKIM2_SIG_FLAG_DONOTMODIFY = (1u << 0u);
+constexpr unsigned int DKIM2_SIG_FLAG_DONOTEXPLODE = (1u << 1u);
+constexpr unsigned int DKIM2_SIG_FLAG_FEEDBACK = (1u << 2u);
+constexpr unsigned int DKIM2_SIG_FLAG_EXPLODED = (1u << 3u);
+
+struct tag_t {
+	std::string_view name;
+	std::string_view value;
+};
+
+/**
+ * Split a DKIM2 tag-list (`tag=value;tag=value...`) into tags, trimming FWS.
+ * Unknown tags are preserved as is; empty segments (e.g. a trailing `;`)
+ * are skipped.
+ */
+auto parse_tag_list(std::string_view input) -> tl::expected<std::vector<tag_t>, std::string>;
+
+/* A single hash-set from the Message-Instance h= tag: `alg:hdr-hash:body-hash` */
+struct hash_set_t {
+	std::string alg;         /* e.g. "sha256" */
+	std::string header_hash; /* decoded binary */
+	std::string body_hash;   /* decoded binary */
+};
+
+struct mi_header_t {
+	unsigned int m = 0; /* instance number */
+	std::vector<hash_set_t> hashes;
+	bool has_recipe = false;
+	std::string recipe_b64; /* r= tag, not decoded in the draft implementation */
+};
+
+/* A single signature set from the DKIM2-Signature s= tag: `selector:alg:sig` */
+struct sig_set_t {
+	std::string selector;
+	std::string alg; /* "rsa-sha256" or "ed25519-sha256" */
+	std::string sig; /* decoded binary */
+};
+
+struct sig_header_t {
+	unsigned int i = 0;          /* hop sequence number */
+	unsigned int m = 0;          /* referenced Message-Instance number */
+	std::time_t t = 0;           /* timestamp, 0 if missing */
+	std::string mf;              /* decoded MAIL FROM reverse-path, with angle brackets */
+	std::vector<std::string> rt; /* decoded RCPT TO forward-paths */
+	std::string domain;          /* d= tag */
+	std::vector<sig_set_t> sigs;
+	unsigned int flags = 0;
+};
+
+/**
+ * Parse an unfolded Message-Instance header value
+ */
+auto parse_mi(std::string_view value) -> tl::expected<mi_header_t, std::string>;
+
+/**
+ * Parse an unfolded DKIM2-Signature header value
+ */
+auto parse_sig(std::string_view value) -> tl::expected<sig_header_t, std::string>;
+
+/**
+ * Canonicalize a header for the *message header hash* (Section 5.2):
+ * lowercase name, collapse WSP runs to a single SP, trim trailing WSP and
+ * WSP around the colon; result is `name:value\r\n`.
+ * The value must be already unfolded.
+ */
+auto canon_hash_line(std::string_view name, std::string_view unfolded_value) -> std::string;
+
+/**
+ * Canonicalize a Message-Instance/DKIM2-Signature header for the *signature
+ * input* (Section 8.5): lowercase name, delete ALL WSP; result is
+ * `name:value\r\n`. The value must be already unfolded.
+ */
+auto canon_sig_line(std::string_view name, std::string_view unfolded_value) -> std::string;
+
+/**
+ * Given a canonical signature line (output of canon_sig_line for a
+ * DKIM2-Signature header), set all signature values within the s= tag to the
+ * null string, as required when constructing the signature input for the hop
+ * being verified.
+ */
+auto blank_sig_values(std::string_view canon_line) -> std::string;
+
+/**
+ * Build the signature input for one hop: Message-Instance lines in ascending
+ * m= order, complete signature lines of the previous hops in ascending i=
+ * order, then the canonical line of the hop being verified with blanked
+ * signature values.
+ */
+auto build_sig_input(std::span<const std::string> mi_lines,
+					 std::span<const std::string> prev_sig_lines,
+					 std::string_view current_sig_line) -> std::string;
+
+/**
+ * Relaxed domain match (Section 8.3): strip leftmost labels from `child`
+ * until it equals `base` (case-insensitively) or no labels remain.
+ */
+auto relaxed_domain_match(std::string_view child, std::string_view base) -> bool;
+
+/**
+ * Compare two SMTP paths: angle brackets are stripped, the local part is
+ * compared case-sensitively and the domain case-insensitively. The null
+ * reverse-path `<>` only matches an empty address.
+ */
+auto smtp_addr_equal(std::string_view a, std::string_view b) -> bool;
+
+/**
+ * Extract the domain part of an SMTP path (`<local@domain>` or `local@domain`),
+ * empty view if there is none
+ */
+auto smtp_addr_domain(std::string_view addr) -> std::string_view;
+
+/**
+ * Body canonicalization (Section 5.1): all trailing empty lines are ignored
+ * and a single final CRLF is appended; bare LF/CR line endings are emitted as
+ * CRLF. Yields chunks via `out(const char *, std::size_t)`.
+ */
+template<typename Func>
+void body_canon_foreach(std::string_view body, Func &&out)
+{
+	/* Strip all trailing CR/LF octets: this removes trailing empty lines
+	 * together with the line terminator of the last non-empty line, which is
+	 * then restored as the single final CRLF */
+	auto end = body.size();
+	while (end > 0 && (body[end - 1] == '\n' || body[end - 1] == '\r')) {
+		end--;
+	}
+
+	std::size_t run_start = 0;
+	for (std::size_t pos = 0; pos < end; pos++) {
+		auto c = body[pos];
+		if (c == '\r' || c == '\n') {
+			if (pos > run_start) {
+				out(body.data() + run_start, pos - run_start);
+			}
+			out("\r\n", 2);
+			if (c == '\r' && pos + 1 < end && body[pos + 1] == '\n') {
+				pos++;
+			}
+			run_start = pos + 1;
+		}
+	}
+
+	if (end > run_start) {
+		out(body.data() + run_start, end - run_start);
+	}
+
+	/* Final CRLF: always present, also for an empty body */
+	out("\r\n", 2);
+}
+
+}// namespace rspamd::dkim2
+
+#endif /* RSPAMD_DKIM2_HXX */

--- a/src/libserver/dkim2.hxx
+++ b/src/libserver/dkim2.hxx
@@ -37,6 +37,9 @@
 
 namespace rspamd::dkim2 {
 
+constexpr std::size_t DKIM2_MAX_SIG_SETS_PER_HOP = 8;
+constexpr std::size_t DKIM2_MAX_SIG_SETS_TOTAL = 64;
+
 /* f= tag flags */
 constexpr unsigned int DKIM2_SIG_FLAG_DONOTMODIFY = (1u << 0u);
 constexpr unsigned int DKIM2_SIG_FLAG_DONOTEXPLODE = (1u << 1u);

--- a/src/libserver/dkim2.hxx
+++ b/src/libserver/dkim2.hxx
@@ -39,6 +39,7 @@ namespace rspamd::dkim2 {
 
 constexpr std::size_t DKIM2_MAX_SIG_SETS_PER_HOP = 8;
 constexpr std::size_t DKIM2_MAX_SIG_SETS_TOTAL = 64;
+constexpr std::size_t DKIM2_MAX_RT_ENTRIES = 1024;
 
 /* f= tag flags */
 constexpr unsigned int DKIM2_SIG_FLAG_DONOTMODIFY = (1u << 0u);

--- a/src/libserver/dkim2.hxx
+++ b/src/libserver/dkim2.hxx
@@ -148,8 +148,9 @@ auto parse_recipe(std::string_view json, const recipe_limits_t &limits)
  * instances of one name, index 0 corresponding to element number 1) producing
  * the previous state. Output views point into `current` elements or into the
  * data strings of the owning recipe_t, which must outlive the result.
- * `budget` is the shared output allowance in bytes for the whole chain; it is
- * decremented by every emitted byte and the application fails when exhausted.
+ * `budget` is the shared work allowance in bytes for the whole chain. Recipe
+ * application charges every emitted byte; reconstructed-state hashing charges
+ * the same budget separately.
  */
 auto apply_recipe_steps(const std::vector<std::string_view> &current,
 						const std::vector<recipe_step_t> &steps,

--- a/src/plugins/dkim_check.c
+++ b/src/plugins/dkim_check.c
@@ -33,6 +33,7 @@
 #include "config.h"
 #include "libmime/message.h"
 #include "libserver/dkim.h"
+#include "libserver/dkim2.h"
 #include "libutil/hash.h"
 #include "libserver/maps/map.h"
 #include "libserver/maps/map_helpers.h"
@@ -47,6 +48,11 @@
 #define DEFAULT_SYMBOL_ALLOW "R_DKIM_ALLOW"
 #define DEFAULT_SYMBOL_NA "R_DKIM_NA"
 #define DEFAULT_SYMBOL_PERMFAIL "R_DKIM_PERMFAIL"
+#define DKIM2_SYMBOL_REJECT "R_DKIM2_REJECT"
+#define DKIM2_SYMBOL_TEMPFAIL "R_DKIM2_TEMPFAIL"
+#define DKIM2_SYMBOL_ALLOW "R_DKIM2_ALLOW"
+#define DKIM2_SYMBOL_NA "R_DKIM2_NA"
+#define DKIM2_SYMBOL_PERMFAIL "R_DKIM2_PERMFAIL"
 #define DEFAULT_CACHE_SIZE 2048
 #define DEFAULT_TIME_JITTER 60
 #define DEFAULT_MAX_SIGS 5
@@ -87,6 +93,7 @@ struct dkim_ctx {
 	gboolean trusted_only;
 	gboolean check_local;
 	gboolean check_authed;
+	gboolean enable_dkim2;
 };
 
 struct dkim_check_result {
@@ -103,6 +110,9 @@ struct dkim_check_result {
 static void dkim_symbol_callback(struct rspamd_task *task,
 								 struct rspamd_symcache_dynamic_item *item,
 								 void *unused);
+static void dkim2_symbol_callback(struct rspamd_task *task,
+								  struct rspamd_symcache_dynamic_item *item,
+								  void *unused);
 
 static int lua_dkim_sign_handler(lua_State *L);
 static int lua_dkim_verify_handler(lua_State *L);
@@ -242,6 +252,15 @@ int dkim_module_init(struct rspamd_config *cfg, struct module_ctx **ctx)
 							   NULL,
 							   0,
 							   DEFAULT_SYMBOL_PERMFAIL,
+							   0);
+	rspamd_rcl_add_doc_by_path(cfg,
+							   "dkim",
+							   "Enable experimental DKIM2 (draft-ietf-dkim-dkim2-spec) verification",
+							   "enable_dkim2",
+							   UCL_BOOLEAN,
+							   NULL,
+							   0,
+							   "false",
 							   0);
 	rspamd_rcl_add_doc_by_path(cfg,
 							   "dkim",
@@ -470,6 +489,14 @@ int dkim_module_config(struct rspamd_config *cfg, bool validate)
 	}
 
 	if ((value =
+			 rspamd_config_get_module_opt(cfg, "dkim", "enable_dkim2")) != NULL) {
+		dkim_module_ctx->enable_dkim2 = ucl_object_toboolean(value);
+	}
+	else {
+		dkim_module_ctx->enable_dkim2 = FALSE;
+	}
+
+	if ((value =
 			 rspamd_config_get_module_opt(cfg, "dkim", "whitelist")) != NULL) {
 
 		rspamd_config_radix_from_ucl(cfg, value, "DKIM whitelist",
@@ -662,6 +689,59 @@ int dkim_module_config(struct rspamd_config *cfg, bool validate)
 								 1,
 								 1);
 		rspamd_config_add_symbol_group(cfg, "DKIM_TRACE", "dkim");
+
+		if (dkim_module_ctx->enable_dkim2) {
+			int dkim2_cb_id;
+
+			dkim2_cb_id = rspamd_symcache_add_symbol(cfg->cache,
+													 "DKIM2_CHECK",
+													 0,
+													 dkim2_symbol_callback,
+													 NULL,
+													 SYMBOL_TYPE_CALLBACK,
+													 -1);
+			rspamd_config_add_symbol(cfg,
+									 "DKIM2_CHECK",
+									 0.0,
+									 "DKIM2 check callback",
+									 "policies",
+									 RSPAMD_SYMBOL_FLAG_IGNORE_METRIC,
+									 1,
+									 1);
+			rspamd_config_add_symbol_group(cfg, "DKIM2_CHECK", "dkim");
+			rspamd_symcache_add_symbol(cfg->cache,
+									   DKIM2_SYMBOL_ALLOW,
+									   0,
+									   NULL, NULL,
+									   SYMBOL_TYPE_VIRTUAL | SYMBOL_TYPE_FINE,
+									   dkim2_cb_id);
+			rspamd_symcache_add_symbol(cfg->cache,
+									   DKIM2_SYMBOL_REJECT,
+									   0,
+									   NULL, NULL,
+									   SYMBOL_TYPE_VIRTUAL | SYMBOL_TYPE_FINE,
+									   dkim2_cb_id);
+			rspamd_symcache_add_symbol(cfg->cache,
+									   DKIM2_SYMBOL_TEMPFAIL,
+									   0,
+									   NULL, NULL,
+									   SYMBOL_TYPE_VIRTUAL | SYMBOL_TYPE_FINE,
+									   dkim2_cb_id);
+			rspamd_symcache_add_symbol(cfg->cache,
+									   DKIM2_SYMBOL_PERMFAIL,
+									   0,
+									   NULL, NULL,
+									   SYMBOL_TYPE_VIRTUAL | SYMBOL_TYPE_FINE,
+									   dkim2_cb_id);
+			rspamd_symcache_add_symbol(cfg->cache,
+									   DKIM2_SYMBOL_NA,
+									   0,
+									   NULL, NULL,
+									   SYMBOL_TYPE_VIRTUAL | SYMBOL_TYPE_FINE,
+									   dkim2_cb_id);
+
+			msg_info_config("enabled experimental DKIM2 verification");
+		}
 
 		msg_info_config("init internal dkim module");
 #ifndef HAVE_OPENSSL
@@ -1357,6 +1437,105 @@ dkim_module_key_handler(rspamd_dkim_key_t *key,
 	}
 
 	dkim_module_check(res);
+}
+
+static void
+dkim2_module_verify_cb(struct rspamd_task *task,
+					   const struct rspamd_dkim2_verify_result *res,
+					   void *ud)
+{
+	const char *symbol;
+	char optbuf[512];
+
+	switch (res->rcode) {
+	case RSPAMD_DKIM2_PASS:
+		symbol = DKIM2_SYMBOL_ALLOW;
+		break;
+	case RSPAMD_DKIM2_FAIL:
+		symbol = DKIM2_SYMBOL_REJECT;
+		break;
+	case RSPAMD_DKIM2_TEMPERROR:
+		symbol = DKIM2_SYMBOL_TEMPFAIL;
+		break;
+	default:
+		symbol = DKIM2_SYMBOL_PERMFAIL;
+		break;
+	}
+
+	if (res->nhops > 0) {
+		const struct rspamd_dkim2_hop_result *last = &res->hops[res->nhops - 1];
+
+		if (res->fail_reason != NULL) {
+			rspamd_snprintf(optbuf, sizeof(optbuf), "%s:i=%ud:%s",
+							last->domain, last->idx, res->fail_reason);
+		}
+		else {
+			rspamd_snprintf(optbuf, sizeof(optbuf), "%s:i=%ud",
+							last->domain, last->idx);
+		}
+
+		msg_info_task("DKIM2 chain verification result: %s; %s",
+					  symbol, optbuf);
+		rspamd_task_insert_result(task, symbol, 1.0,
+								  rspamd_mempool_strdup(task->task_pool, optbuf));
+	}
+	else {
+		rspamd_task_insert_result(task, symbol, 1.0, res->fail_reason);
+	}
+}
+
+static void
+dkim2_symbol_callback(struct rspamd_task *task,
+					  struct rspamd_symcache_dynamic_item *item,
+					  void *unused)
+{
+	GError *err = NULL;
+	rspamd_dkim2_chain_t *chain;
+	struct dkim_ctx *dkim_module_ctx = dkim_get_context(task->cfg);
+	struct rspamd_dkim2_verify_params params;
+
+	/* Honour the same local/authenticated exclusions as DKIM */
+	if ((!dkim_module_ctx->check_authed && task->auth_user != NULL) ||
+		(!dkim_module_ctx->check_local &&
+		 rspamd_ip_is_local_cfg(task->cfg, task->from_addr))) {
+		rspamd_symcache_finalize_item(task, item);
+
+		return;
+	}
+
+	chain = rspamd_dkim2_chain_parse(task, &err);
+
+	if (chain == NULL) {
+		if (err != NULL) {
+			msg_info_task("cannot parse DKIM2 chain: %e", err);
+			rspamd_task_insert_result(task, DKIM2_SYMBOL_PERMFAIL, 1.0,
+									  rspamd_mempool_strdup(task->task_pool,
+															err->message));
+			g_error_free(err);
+		}
+		else {
+			rspamd_task_insert_result(task, DKIM2_SYMBOL_NA, 1.0, NULL);
+		}
+
+		rspamd_symcache_finalize_item(task, item);
+
+		return;
+	}
+
+	memset(&params, 0, sizeof(params));
+	params.time_jitter = dkim_module_ctx->time_jitter;
+	params.max_age = 0; /* Use the default (14 days) */
+	params.check_envelope = task->from_envelope != NULL;
+
+	rspamd_symcache_item_async_inc(task, item, M);
+
+	if (!rspamd_dkim2_chain_verify(chain, task, &params,
+								   dkim2_module_verify_cb, NULL)) {
+		rspamd_task_insert_result(task, DKIM2_SYMBOL_TEMPFAIL, 1.0,
+								  "cannot start DKIM2 verification");
+	}
+
+	rspamd_symcache_item_async_dec_check(task, item, M);
 }
 
 static void

--- a/src/plugins/dkim_check.c
+++ b/src/plugins/dkim_check.c
@@ -1466,12 +1466,15 @@ dkim2_module_verify_cb(struct rspamd_task *task,
 		const struct rspamd_dkim2_hop_result *last = &res->hops[res->nhops - 1];
 
 		if (res->fail_reason != NULL) {
-			rspamd_snprintf(optbuf, sizeof(optbuf), "%s:i=%ud:%s",
-							last->domain, last->idx, res->fail_reason);
+			rspamd_snprintf(optbuf, sizeof(optbuf), "%s:i=%ud:m=%ud/%ud:%s",
+							last->domain, last->idx,
+							res->verified_instances, res->ninstances,
+							res->fail_reason);
 		}
 		else {
-			rspamd_snprintf(optbuf, sizeof(optbuf), "%s:i=%ud",
-							last->domain, last->idx);
+			rspamd_snprintf(optbuf, sizeof(optbuf), "%s:i=%ud:m=%ud/%ud",
+							last->domain, last->idx,
+							res->verified_instances, res->ninstances);
 		}
 
 		msg_info_task("DKIM2 chain verification result: %s; %s",

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -24,6 +24,7 @@
 #include "rspamd_cxx_unit_utils.hxx"
 #include "rspamd_cxx_local_ptr.hxx"
 #include "rspamd_cxx_unit_dkim.hxx"
+#include "rspamd_cxx_unit_dkim2.hxx"
 #include "rspamd_cxx_unit_cryptobox.hxx"
 #include "rspamd_cxx_unit_rfc2047.hxx"
 #include "rspamd_cxx_unit_html_url_rewrite.hxx"

--- a/test/rspamd_cxx_unit_dkim2.hxx
+++ b/test/rspamd_cxx_unit_dkim2.hxx
@@ -131,6 +131,12 @@ TEST_SUITE("rspamd_dkim2")
 		CHECK(sig2->sigs.size() == 2);
 		CHECK(sig2->sigs[1].selector == "b");
 
+		/* FWS inside base64 values is tolerated (folded header remnants) */
+		auto sig3 = parse_sig("i=1; m=1; mf=PGJvdW5jZUBleGFt cGxlLmNvbT4=; rt=" DKIM2_TEST_RT
+							  "; d=example.com; s=a:rsa-sha256:" DKIM2_TEST_SIG);
+		REQUIRE(sig3.has_value());
+		CHECK(sig3->mf == "<bounce@example.com>");
+
 		/* Missing mandatory tag (d=) */
 		auto bad = parse_sig("i=1; m=1; mf=" DKIM2_TEST_MF "; rt=" DKIM2_TEST_RT
 							 "; s=a:rsa-sha256:" DKIM2_TEST_SIG);

--- a/test/rspamd_cxx_unit_dkim2.hxx
+++ b/test/rspamd_cxx_unit_dkim2.hxx
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Detached unit tests for the dkim2 parsing and canonicalization */
+
+#ifndef RSPAMD_RSPAMD_CXX_UNIT_DKIM2_HXX
+#define RSPAMD_RSPAMD_CXX_UNIT_DKIM2_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+#include "libserver/dkim2.hxx"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+/* base64("<bounce@example.com>") */
+#define DKIM2_TEST_MF "PGJvdW5jZUBleGFtcGxlLmNvbT4="
+/* base64("<user@example.net>") */
+#define DKIM2_TEST_RT "PHVzZXJAZXhhbXBsZS5uZXQ+"
+/* base64 of 32 'A' bytes */
+#define DKIM2_TEST_HH "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE="
+/* base64 of 32 'B' bytes */
+#define DKIM2_TEST_BH "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI="
+/* base64("0123456789abcdef") */
+#define DKIM2_TEST_SIG "MDEyMzQ1Njc4OWFiY2RlZg=="
+
+TEST_SUITE("rspamd_dkim2")
+{
+	using namespace rspamd::dkim2;
+
+	static auto body_canon_str(std::string_view in) -> std::string
+	{
+		std::string out;
+
+		body_canon_foreach(in, [&](const char *p, std::size_t len) {
+			out.append(p, len);
+		});
+
+		return out;
+	}
+
+	TEST_CASE("dkim2 parse_tag_list")
+	{
+		auto tags = parse_tag_list("i=1; m = 2 ;mf=abc;");
+		REQUIRE(tags.has_value());
+		REQUIRE(tags->size() == 3);
+		CHECK((*tags)[0].name == "i");
+		CHECK((*tags)[0].value == "1");
+		CHECK((*tags)[1].name == "m");
+		CHECK((*tags)[1].value == "2");
+		CHECK((*tags)[2].name == "mf");
+		CHECK((*tags)[2].value == "abc");
+
+		/* Tag without a name */
+		CHECK(!parse_tag_list("=1").has_value());
+		/* Invalid name */
+		CHECK(!parse_tag_list("foo bar=1").has_value());
+		/* Empty input is structurally fine */
+		auto empty = parse_tag_list("");
+		REQUIRE(empty.has_value());
+		CHECK(empty->empty());
+	}
+
+	TEST_CASE("dkim2 parse_mi")
+	{
+		auto mi = parse_mi("m=1; h=sha256:" DKIM2_TEST_HH ":" DKIM2_TEST_BH);
+		REQUIRE(mi.has_value());
+		CHECK(mi->m == 1);
+		REQUIRE(mi->hashes.size() == 1);
+		CHECK(mi->hashes[0].alg == "sha256");
+		CHECK(mi->hashes[0].header_hash == std::string(32, 'A'));
+		CHECK(mi->hashes[0].body_hash == std::string(32, 'B'));
+		CHECK(!mi->has_recipe);
+
+		/* Multiple hash sets */
+		auto mi2 = parse_mi("m=2; h=sha256:" DKIM2_TEST_HH ":" DKIM2_TEST_BH
+							",sha512:" DKIM2_TEST_HH ":" DKIM2_TEST_BH);
+		REQUIRE(mi2.has_value());
+		CHECK(mi2->hashes.size() == 2);
+
+		/* Missing mandatory tags */
+		CHECK(!parse_mi("m=1").has_value());
+		CHECK(!parse_mi("h=sha256:" DKIM2_TEST_HH ":" DKIM2_TEST_BH).has_value());
+		/* Invalid m= */
+		CHECK(!parse_mi("m=0; h=sha256:" DKIM2_TEST_HH ":" DKIM2_TEST_BH).has_value());
+		CHECK(!parse_mi("m=x; h=sha256:" DKIM2_TEST_HH ":" DKIM2_TEST_BH).has_value());
+		/* Broken hash set */
+		CHECK(!parse_mi("m=1; h=sha256:" DKIM2_TEST_HH).has_value());
+	}
+
+	TEST_CASE("dkim2 parse_sig")
+	{
+		auto sig = parse_sig("i=2; m=1; t=1700000000; mf=" DKIM2_TEST_MF
+							 "; rt=" DKIM2_TEST_RT "; d=example.com; "
+							 "s=sel:ed25519-sha256:" DKIM2_TEST_SIG "; f=donotmodify,exploded");
+		REQUIRE(sig.has_value());
+		CHECK(sig->i == 2);
+		CHECK(sig->m == 1);
+		CHECK(sig->t == 1700000000);
+		CHECK(sig->mf == "<bounce@example.com>");
+		REQUIRE(sig->rt.size() == 1);
+		CHECK(sig->rt[0] == "<user@example.net>");
+		CHECK(sig->domain == "example.com");
+		REQUIRE(sig->sigs.size() == 1);
+		CHECK(sig->sigs[0].selector == "sel");
+		CHECK(sig->sigs[0].alg == "ed25519-sha256");
+		CHECK(sig->sigs[0].sig == "0123456789abcdef");
+		CHECK((sig->flags & DKIM2_SIG_FLAG_DONOTMODIFY) != 0);
+		CHECK((sig->flags & DKIM2_SIG_FLAG_EXPLODED) != 0);
+		CHECK((sig->flags & DKIM2_SIG_FLAG_FEEDBACK) == 0);
+
+		/* Multiple signature sets */
+		auto sig2 = parse_sig("i=1; m=1; mf=" DKIM2_TEST_MF "; rt=" DKIM2_TEST_RT
+							  "; d=example.com; s=a:rsa-sha256:" DKIM2_TEST_SIG
+							  ",b:ed25519-sha256:" DKIM2_TEST_SIG);
+		REQUIRE(sig2.has_value());
+		CHECK(sig2->sigs.size() == 2);
+		CHECK(sig2->sigs[1].selector == "b");
+
+		/* Missing mandatory tag (d=) */
+		auto bad = parse_sig("i=1; m=1; mf=" DKIM2_TEST_MF "; rt=" DKIM2_TEST_RT
+							 "; s=a:rsa-sha256:" DKIM2_TEST_SIG);
+		REQUIRE(!bad.has_value());
+		CHECK(bad.error().find("d=") != std::string::npos);
+
+		/* Invalid base64 in mf= */
+		CHECK(!parse_sig("i=1; m=1; mf=@@@; rt=" DKIM2_TEST_RT
+						 "; d=example.com; s=a:rsa-sha256:" DKIM2_TEST_SIG)
+				   .has_value());
+	}
+
+	TEST_CASE("dkim2 canon_hash_line")
+	{
+		CHECK(canon_hash_line("Subject", "  Hello   world\t!  ") ==
+			  "subject:Hello world !\r\n");
+		CHECK(canon_hash_line("FROM", "Foo <foo@example.com>") ==
+			  "from:Foo <foo@example.com>\r\n");
+		CHECK(canon_hash_line("X-Empty", "") == "x-empty:\r\n");
+		/* Unfolded continuation remnants are treated as WSP */
+		CHECK(canon_hash_line("To", "a@b,\r\n\tc@d") == "to:a@b, c@d\r\n");
+	}
+
+	TEST_CASE("dkim2 canon_sig_line and blank_sig_values")
+	{
+		auto line = canon_sig_line("DKIM2-Signature",
+								   "i=1; m=1; d=example.com; s = sel : rsa-sha256 : AbCd ;");
+		CHECK(line == "dkim2-signature:i=1;m=1;d=example.com;s=sel:rsa-sha256:AbCd;\r\n");
+
+		CHECK(blank_sig_values(line) ==
+			  "dkim2-signature:i=1;m=1;d=example.com;s=sel:rsa-sha256:;\r\n");
+
+		/* Multiple signature sets, s= tag in the middle */
+		auto line2 = canon_sig_line("DKIM2-Signature",
+									"i=1;s=a:rsa-sha256:XXX,b:ed25519-sha256:YYY;d=example.com");
+		CHECK(blank_sig_values(line2) ==
+			  "dkim2-signature:i=1;s=a:rsa-sha256:,b:ed25519-sha256:;d=example.com\r\n");
+	}
+
+	TEST_CASE("dkim2 build_sig_input")
+	{
+		std::vector<std::string> mi_lines{
+			"message-instance:m=1;h=sha256:AA:BB\r\n",
+		};
+		std::vector<std::string> prev_lines{
+			"dkim2-signature:i=1;s=a:rsa-sha256:XXX;d=example.com\r\n",
+		};
+
+		auto input = build_sig_input(mi_lines, prev_lines,
+									 "dkim2-signature:i=2;s=b:rsa-sha256:YYY;d=example.net\r\n");
+
+		CHECK(input ==
+			  "message-instance:m=1;h=sha256:AA:BB\r\n"
+			  "dkim2-signature:i=1;s=a:rsa-sha256:XXX;d=example.com\r\n"
+			  "dkim2-signature:i=2;s=b:rsa-sha256:;d=example.net\r\n");
+	}
+
+	TEST_CASE("dkim2 relaxed_domain_match")
+	{
+		CHECK(relaxed_domain_match("example.com", "example.com"));
+		CHECK(relaxed_domain_match("bounce.example.com", "example.com"));
+		CHECK(relaxed_domain_match("a.b.example.com", "example.com"));
+		CHECK(relaxed_domain_match("EXAMPLE.com", "example.COM"));
+		CHECK(!relaxed_domain_match("example.com", "bounce.example.com"));
+		CHECK(!relaxed_domain_match("examplexcom", "example.com"));
+		CHECK(!relaxed_domain_match("", "example.com"));
+		CHECK(!relaxed_domain_match("example.com", ""));
+	}
+
+	TEST_CASE("dkim2 smtp_addr_equal")
+	{
+		CHECK(smtp_addr_equal("<Foo@Example.COM>", "Foo@example.com"));
+		CHECK(smtp_addr_equal("foo@example.com", "<foo@EXAMPLE.com>"));
+		/* The local part is case-sensitive */
+		CHECK(!smtp_addr_equal("<foo@example.com>", "Foo@example.com"));
+		/* Null reverse-path */
+		CHECK(smtp_addr_equal("<>", ""));
+		CHECK(!smtp_addr_equal("<>", "foo@example.com"));
+	}
+
+	TEST_CASE("dkim2 smtp_addr_domain")
+	{
+		CHECK(smtp_addr_domain("<foo@example.com>") == "example.com");
+		CHECK(smtp_addr_domain("foo@example.com") == "example.com");
+		CHECK(smtp_addr_domain("<>") == "");
+		CHECK(smtp_addr_domain("foo") == "");
+	}
+
+	TEST_CASE("dkim2 body canonicalization")
+	{
+		/* Empty body still hashes a CRLF */
+		CHECK(body_canon_str("") == "\r\n");
+		/* Missing final CRLF is added */
+		CHECK(body_canon_str("foo") == "foo\r\n");
+		CHECK(body_canon_str("foo\r\n") == "foo\r\n");
+		/* Trailing empty lines are ignored */
+		CHECK(body_canon_str("foo\r\n\r\n\r\n") == "foo\r\n");
+		CHECK(body_canon_str("\r\n\r\n") == "\r\n");
+		/* Bare line endings are normalized to CRLF */
+		CHECK(body_canon_str("foo\nbar") == "foo\r\nbar\r\n");
+		CHECK(body_canon_str("foo\rbar\r") == "foo\r\nbar\r\n");
+		CHECK(body_canon_str("foo\n\n\n") == "foo\r\n");
+		/* WSP-only lines are not empty per the spec */
+		CHECK(body_canon_str("foo \r\n") == "foo \r\n");
+		CHECK(body_canon_str(" \r\n") == " \r\n");
+		/* Multi-line content */
+		CHECK(body_canon_str("foo\r\nbar\r\nbaz") == "foo\r\nbar\r\nbaz\r\n");
+		/* Empty lines in the middle are preserved */
+		CHECK(body_canon_str("foo\r\n\r\nbar\r\n") == "foo\r\n\r\nbar\r\n");
+	}
+}
+
+#endif /* RSPAMD_RSPAMD_CXX_UNIT_DKIM2_HXX */

--- a/test/rspamd_cxx_unit_dkim2.hxx
+++ b/test/rspamd_cxx_unit_dkim2.hxx
@@ -225,6 +225,226 @@ TEST_SUITE("rspamd_dkim2")
 		CHECK(smtp_addr_domain("foo") == "");
 	}
 
+	TEST_CASE("dkim2 split_body_lines")
+	{
+		auto lines = split_body_lines("foo\r\nbar\nbaz", 100);
+		REQUIRE(lines.has_value());
+		REQUIRE(lines->size() == 3);
+		CHECK((*lines)[0] == "foo");
+		CHECK((*lines)[1] == "bar");
+		CHECK((*lines)[2] == "baz");
+
+		/* A trailing terminator does not produce an extra empty line */
+		auto lines2 = split_body_lines("foo\r\n", 100);
+		REQUIRE(lines2.has_value());
+		CHECK(lines2->size() == 1);
+
+		/* Empty lines are preserved */
+		auto lines3 = split_body_lines("foo\r\n\r\nbar\r\n", 100);
+		REQUIRE(lines3.has_value());
+		REQUIRE(lines3->size() == 3);
+		CHECK((*lines3)[1] == "");
+
+		CHECK(split_body_lines("", 100)->empty());
+
+		/* Line limit */
+		CHECK(!split_body_lines("a\nb\nc\nd\n", 3).has_value());
+	}
+
+	TEST_CASE("dkim2 split_body_lines matches body canonicalization")
+	{
+		/*
+		 * The line-based body hashing used for reconstructed instances must
+		 * agree with the streaming canonicalization used for the current one
+		 */
+		const std::vector<std::string> bodies{
+			"",
+			"foo",
+			"foo\r\n",
+			"foo\r\n\r\n\r\n",
+			"foo\nbar",
+			"foo\rbar\r",
+			"foo \r\n",
+			" \r\n",
+			"foo\r\n\r\nbar\r\n",
+			"\r\n\r\n",
+		};
+
+		for (const auto &body: bodies) {
+			auto lines = split_body_lines(body, 1000);
+			REQUIRE(lines.has_value());
+
+			auto nlines = lines->size();
+			while (nlines > 0 && (*lines)[nlines - 1].empty()) {
+				nlines--;
+			}
+
+			std::string from_lines;
+			if (nlines == 0) {
+				from_lines = "\r\n";
+			}
+			else {
+				for (std::size_t k = 0; k < nlines; k++) {
+					from_lines.append((*lines)[k]);
+					from_lines.append("\r\n");
+				}
+			}
+
+			CHECK(from_lines == body_canon_str(body));
+		}
+	}
+
+	TEST_CASE("dkim2 parse_recipe")
+	{
+		recipe_limits_t limits;
+
+		auto r = parse_recipe(
+			R"({"h":{"Subject":[{"d":["old subject"]}]},"b":[{"c":[1,3]},{"d":["a footer"]}]})",
+			limits);
+		REQUIRE(r.has_value());
+		CHECK(r->has_headers);
+		CHECK(!r->headers_unrecoverable);
+		CHECK(r->has_body);
+		CHECK(!r->body.unrecoverable);
+		REQUIRE(r->headers.size() == 1);
+		CHECK(r->headers[0].first == "subject");
+		REQUIRE(r->headers[0].second.steps.size() == 1);
+		CHECK(!r->headers[0].second.steps[0].is_copy);
+		REQUIRE(r->headers[0].second.steps[0].data.size() == 1);
+		CHECK(r->headers[0].second.steps[0].data[0] == "old subject");
+		REQUIRE(r->body.steps.size() == 2);
+		CHECK(r->body.steps[0].is_copy);
+		CHECK(r->body.steps[0].start == 1);
+		CHECK(r->body.steps[0].end == 3);
+		CHECK(!r->body.steps[1].is_copy);
+
+		/* null parts mean unrecoverable state */
+		auto r2 = parse_recipe(R"({"h":null,"b":[{"c":[1,1]}]})", limits);
+		REQUIRE(r2.has_value());
+		CHECK(r2->headers_unrecoverable);
+
+		auto r3 = parse_recipe(R"({"b":null})", limits);
+		REQUIRE(r3.has_value());
+		CHECK(r3->has_body);
+		CHECK(r3->body.unrecoverable);
+		CHECK(!r3->has_headers);
+
+		/* Errors */
+		CHECK(!parse_recipe(R"({})", limits).has_value());
+		CHECK(!parse_recipe(R"(garbage)", limits).has_value());
+		CHECK(!parse_recipe(R"([1,2])", limits).has_value());
+		/* Step with both c and d */
+		CHECK(!parse_recipe(R"({"b":[{"c":[1,2],"d":["x"]}]})", limits).has_value());
+		/* Step with neither */
+		CHECK(!parse_recipe(R"({"b":[{}]})", limits).has_value());
+		/* Invalid copy range */
+		CHECK(!parse_recipe(R"({"b":[{"c":[3,1]}]})", limits).has_value());
+		CHECK(!parse_recipe(R"({"b":[{"c":[0,1]}]})", limits).has_value());
+		/* CR/LF smuggling in data steps */
+		CHECK(!parse_recipe("{\"b\":[{\"d\":[\"foo\\r\\nbar\"]}]}", limits).has_value());
+
+		/* DoS limits: steps */
+		recipe_limits_t small_limits;
+		small_limits.max_steps = 2;
+		CHECK(!parse_recipe(R"({"b":[{"c":[1,1]},{"c":[1,1]},{"c":[1,1]}]})",
+							small_limits)
+				   .has_value());
+		/* DoS limits: recipe size */
+		small_limits = recipe_limits_t{};
+		small_limits.max_recipe_len = 10;
+		CHECK(!parse_recipe(R"({"b":[{"c":[1,1]}]})", small_limits).has_value());
+		/* DoS limits: header names */
+		small_limits = recipe_limits_t{};
+		small_limits.max_names = 1;
+		CHECK(!parse_recipe(R"({"h":{"a":[{"d":["x"]}],"b":[{"d":["y"]}]}})",
+							small_limits)
+				   .has_value());
+	}
+
+	TEST_CASE("dkim2 apply_recipe_steps")
+	{
+		std::vector<std::string_view> current{"line1", "line2", "line3"};
+		std::size_t budget = 1024;
+
+		std::vector<recipe_step_t> steps;
+		recipe_step_t copy_step;
+		copy_step.is_copy = true;
+		copy_step.start = 2;
+		copy_step.end = 3;
+		steps.push_back(copy_step);
+
+		recipe_step_t data_step;
+		data_step.data = {"inserted"};
+		steps.push_back(data_step);
+
+		auto out = apply_recipe_steps(current, steps, 100, budget);
+		REQUIRE(out.has_value());
+		REQUIRE(out->size() == 3);
+		CHECK((*out)[0] == "line2");
+		CHECK((*out)[1] == "line3");
+		CHECK((*out)[2] == "inserted");
+		/* 5 + 2 + 5 + 2 + 8 + 2 = 24 octets charged */
+		CHECK(budget == 1024 - 24);
+
+		/* Out of bounds copy */
+		recipe_step_t oob;
+		oob.is_copy = true;
+		oob.start = 1;
+		oob.end = 4;
+		std::size_t budget2 = 1024;
+		CHECK(!apply_recipe_steps(current, {oob}, 100, budget2).has_value());
+
+		/* Element count limit */
+		recipe_step_t all;
+		all.is_copy = true;
+		all.start = 1;
+		all.end = 3;
+		std::size_t budget3 = 1024;
+		CHECK(!apply_recipe_steps(current, {all}, 2, budget3).has_value());
+	}
+
+	TEST_CASE("dkim2 recipe amplification bomb is stopped by the budget")
+	{
+		/*
+		 * Each application duplicates the whole state: with N chained
+		 * instances this is 2^N amplification, which the shared byte budget
+		 * must cut short
+		 */
+		std::vector<std::string> arena{std::string(100, 'A')};
+		std::vector<std::string_view> state{arena[0]};
+
+		recipe_step_t dup;
+		dup.is_copy = true;
+		dup.start = 1;
+		dup.end = 1;
+
+		std::size_t budget = 100 * 1024; /* 100KB budget */
+		bool stopped = false;
+
+		for (int round = 0; round < 50; round++) {
+			/* Duplicate every element of the state */
+			std::vector<recipe_step_t> steps;
+			recipe_step_t all;
+			all.is_copy = true;
+			all.start = 1;
+			all.end = state.size();
+			steps.push_back(all);
+			steps.push_back(all);
+
+			auto out = apply_recipe_steps(state, steps, 1000000, budget);
+
+			if (!out) {
+				stopped = true;
+				CHECK(round < 11); /* 100 bytes * 2^10 > 100KB */
+				break;
+			}
+
+			state = std::move(*out);
+		}
+
+		CHECK(stopped);
+	}
+
 	TEST_CASE("dkim2 body canonicalization")
 	{
 		/* Empty body still hashes a CRLF */

--- a/test/rspamd_cxx_unit_dkim2.hxx
+++ b/test/rspamd_cxx_unit_dkim2.hxx
@@ -131,6 +131,20 @@ TEST_SUITE("rspamd_dkim2")
 		CHECK(sig2->sigs.size() == 2);
 		CHECK(sig2->sigs[1].selector == "b");
 
+		std::string too_many_sets;
+		for (std::size_t i = 0; i <= DKIM2_MAX_SIG_SETS_PER_HOP; i++) {
+			if (!too_many_sets.empty()) {
+				too_many_sets.push_back(',');
+			}
+			too_many_sets.append("s");
+			too_many_sets.append(std::to_string(i));
+			too_many_sets.append(":rsa-sha256:" DKIM2_TEST_SIG);
+		}
+		auto sig_too_many = parse_sig("i=1; m=1; mf=" DKIM2_TEST_MF
+									  "; rt=" DKIM2_TEST_RT "; d=example.com; s=" +
+									  too_many_sets);
+		CHECK(!sig_too_many.has_value());
+
 		/* FWS inside base64 values is tolerated (folded header remnants) */
 		auto sig3 = parse_sig("i=1; m=1; mf=PGJvdW5jZUBleGFt cGxlLmNvbT4=; rt=" DKIM2_TEST_RT
 							  "; d=example.com; s=a:rsa-sha256:" DKIM2_TEST_SIG);

--- a/test/rspamd_cxx_unit_dkim2.hxx
+++ b/test/rspamd_cxx_unit_dkim2.hxx
@@ -145,6 +145,19 @@ TEST_SUITE("rspamd_dkim2")
 									  too_many_sets);
 		CHECK(!sig_too_many.has_value());
 
+		std::string too_many_recipients;
+		for (std::size_t i = 0; i <= DKIM2_MAX_RT_ENTRIES; i++) {
+			if (!too_many_recipients.empty()) {
+				too_many_recipients.push_back(',');
+			}
+			too_many_recipients.append(DKIM2_TEST_RT);
+		}
+		auto sig_too_many_recipients = parse_sig("i=1; m=1; mf=" DKIM2_TEST_MF
+												 "; rt=" +
+												 too_many_recipients +
+												 "; d=example.com; s=a:rsa-sha256:" DKIM2_TEST_SIG);
+		CHECK(!sig_too_many_recipients.has_value());
+
 		/* FWS inside base64 values is tolerated (folded header remnants) */
 		auto sig3 = parse_sig("i=1; m=1; mf=PGJvdW5jZUBleGFt cGxlLmNvbT4=; rt=" DKIM2_TEST_RT
 							  "; d=example.com; s=a:rsa-sha256:" DKIM2_TEST_SIG);


### PR DESCRIPTION
## Summary

This PR adds a draft implementation of DKIM2 verification per [draft-ietf-dkim-dkim2-spec-02](https://datatracker.ietf.org/doc/draft-ietf-dkim-dkim2-spec/), implemented as a separate module from `dkim.c` since the two protocols share almost no logic.

DKIM2 signatures cover only the `Message-Instance` and `DKIM2-Signature` header fields; the message content is bound indirectly via the hashes in the `Message-Instance` `h=` tag. This means all hop signatures remain cryptographically verifiable even after in-transit modification — only the hashes of the *current* instance are checked against the message itself, while older instances are verified by reconstructing them with `r=` recipes.

## What is implemented

- **`src/libserver/dkim2.h`** — C API: `rspamd_dkim2_chain_parse()` and async `rspamd_dkim2_chain_verify()` with per-hop and overall results, including `verified_instances`/`ninstances` counters
- **`src/libserver/dkim2.hxx`** — pure C++20 internals (no task/DNS dependencies, unit-testable): tag-list/Message-Instance/DKIM2-Signature parsers, both canonicalization forms, signature input construction, relaxed domain matching, SMTP path comparison, body canonicalization, recipe parsing and application
- **`src/libserver/dkim2.cxx`** — task-bound logic:
  - structural chain validation (consecutive `m=`/`i=` numbering, mandatory tags, non-decreasing `m` across hops, usable sha256 hash-set)
  - current-instance header hash (sorted canonicalization with the fixed ignore list) and body hash (trailing empty lines stripped, final CRLF)
  - **recipe (`r=`) processing**: older message instances are reconstructed by applying recipes from the latest instance backwards and their hashes verified; reconstructed states are zero-copy (views into the message and recipe data)
  - `donotmodify`/`donotexplode` flag compliance (Section 10.8)
  - SMTP envelope checks (`mf=`/`rt=` of the last hop) and per-hop relaxed alignment of `d=` with the `mf=` domain
  - timestamp policy (rejects signatures older than 14 days by default)
  - parallel DNS key fetch and per-hop verification of `rsa-sha256` and `ed25519-sha256` signature sets (all sets of a hop must verify)
- **`src/libserver/dkim.c/.h`** — three small accessors (`rspamd_dkim_key_get_type/evp/eddsa`) so the DKIM2 module can reuse the existing DNS key record parser, which is the one genuinely shared piece between the protocols
- **`src/plugins/dkim_check.c`** — opt-in integration: `dkim { enable_dkim2 = true; }` registers a `DKIM2_CHECK` callback inserting `R_DKIM2_{ALLOW,REJECT,TEMPFAIL,PERMFAIL,NA}` with a `domain:i=N:m=verified/total` option. Default is off, so existing configurations see no behavior change
- **`test/rspamd_cxx_unit_dkim2.hxx`** — doctest suite (15 cases / 161 assertions) covering the parsers including error paths, both canonicalization forms, signature value blanking, signature input construction, domain/address matching, body canonicalization edge cases, recipe parsing/application and the amplification bomb defense

## Recipe DoS limits

The draft spec imposes **no limits on recipes whatsoever**, while copy steps allow content duplication: a chain of small recipes can direct exponential output growth across up to 50 instances (a decompression bomb). All limits are therefore internal hard caps:

- decoded recipe JSON size (256KB) and steps per recipe part (256)
- header field names per recipe (256), header instances per name (1000), body lines per state (1M)
- a shared output budget for the **whole chain**, proportional to the message size (8×, clamped to [1MB, 64MB]), charged per emitted byte

Exceeding a limit (like a missing or unrecoverable recipe) only leaves the remaining older instances unverified and never affects the verdict; a hash mismatch of a successfully reconstructed instance is a failure. This asymmetry should arguably be raised with the WG as a missing Security Considerations item.

## Not implemented (follow-ups)

- Key LRU caching for the DKIM2 path
- Signing support and bounce handling
- Authentication-Results output for the `dkim2` method, Lua API, functional tests

## Caveats

The draft is still evolving (tags were renamed between gondwana-01 and ietf-02). Two spots where the spec prose is loose are implemented with the most defensible reading and marked with comments: the same-name header ordering in the sorted canonicalization (bottom-up, i.e. insertion order) and the `m=` reference semantics for intermediate hops. These should be re-validated against the next draft revision and other implementations' test vectors before this leaves experimental status.
