### PR TITLE
[Fix] unit test checks upstream rate limit state using custom fake_clock

### DIFF
--- a/test/rspamd_test_fake_time.hxx
+++ b/test/rspamd_test_fake_time.hxx
@@ -70,11 +70,17 @@ public:
 			seconds = 0.0;
 		}
 		now_ += seconds;
+		if (loop_) {
+			ev_now_resync(loop_);
+		}
 	}
 
 	void set(double t)
 	{
 		now_ = t;
+		if (loop_) {
+			ev_now_resync(loop_);
+		}
 	}
 
 	double now() const


### PR DESCRIPTION
under a mock environment where the event loop (ev_run()) is never actually executed on the s390x arch.

Full Failure Log: https://gitlab.alpinelinux.org/a16bitsysop/aports/-/jobs/2384825

```
ninja: job failed: cd /builds/a16bitsysop/aports/community/rspamd/src/rspamd-4.1.0/build && test/rspamd-test-cxx
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
===============================================================================
/builds/a16bitsysop/aports/community/rspamd/src/rspamd-4.1.0/test/rspamd_cxx_unit_upstream_srv.hxx:295:
TEST SUITE: upstream_srv
TEST CASE:  error budget is per member, not shared across SRV cluster
/builds/a16bitsysop/aports/community/rspamd/src/rspamd-4.1.0/test/rspamd_cxx_unit_upstream_srv.hxx:344: ERROR: CHECK( rspamd_upstreams_alive(t.ups) == 2 ) is NOT correct!
  values: CHECK( 3 == 2 )
/builds/a16bitsysop/aports/community/rspamd/src/rspamd-4.1.0/test/rspamd_cxx_unit_upstream_srv.hxx:354: ERROR: CHECK( seen_names.count("a.example.com") == 0 ) is NOT correct!
  values: CHECK( 1 == 0 )
===============================================================================
[doctest] test cases:   219 |   218 passed | 1 failed | 0 skipped
[doctest] assertions: 73330 | 73328 passed | 2 failed |
[doctest] Status: FAILURE!
ninja: subcommand failed

```

Explanation from antigravity:
Here is the chain of events that leads to the failure on s390x:

1. Fake Clock Advancement: In the failing test case (error budget is per member, not shared across SRV cluster in rspamd_cxx_unit_upstream_srv.hxx), the virtual time is advanced inside a loop via clk.advance(0.1). This updates now_ inside fake_clock but does not automatically resynchronize the loop's internal cached time cache unless explicitly requested.
2. Time Refresh Hook: During each failure event, rspamd_upstream_fail() calls rspamd_upstream_now_fresh(), which calls ev_now_update_if_cheap(loop) to refresh the event loop's time cache.
3. Low-Resolution Coarse Clocks on s390x:

- ev_now_update_if_cheap() is a no-op unless the global flag have_cheap_timer is set to 1 in libev (ev.c).
- have_cheap_timer is set to 1 only if the coarse monotonic clock (e.g. CLOCK_MONOTONIC_COARSE) has a resolution strictly less than 10ms (ts.tv_nsec < 10000000).
- On Linux s390x (as well as virtualized environments or kernels built with lower tick rates, e.g., HZ=100), the resolution of CLOCK_MONOTONIC_COARSE is exactly 10ms.
- Since 10000000 < 10000000 evaluates to FALSE, have_cheap_timer remains 0.

4. Stale Event Loop Time: Since have_cheap_timer is 0, ev_now_update_if_cheap() is a no-op. Because ev_run() is never called in this test, the event loop's cached time is never updated. Every call to rspamd_upstream_fail() queries ev_now(loop) and retrieves the stale initialization timestamp (1000.0).
5. No Failures Registered: Since the time delta (sec_cur - sec_last) is always 0.0, the code never evaluates the error rate (0.0 >= 1.0 is false). Thus, bad is never marked inactive, and rspamd_upstreams_alive(t.ups) remains 3 instead of 2.