### PR TITLE
Generic learn framework: a `learn` symcache symbol type; neural trains from learn tasks

### DIFF
--- a/lualib/plugins/neural.lua
+++ b/lualib/plugins/neural.lua
@@ -68,13 +68,15 @@ local default_options = {
     -- means "default to disable_symbols_input" (resolved per-rule at init); set to
     -- false to opt out and keep running the full pipeline for forced learns.
     forced_learn_minimal_scan = nil,
-    -- learn_from_controller: when true, a controller learn task (e.g. /learnspam,
-    -- /learnham) also trains this neural rule -- one corpus push feeds bayes and
-    -- neural. Only symbols-independent rules (disable_symbols_input) are eligible
-    -- (a learn task runs no rule symbol). nil means "default to
-    -- disable_symbols_input" (resolved per-rule at init); set to false to keep a
-    -- fusion rule out of the controller learn path.
-    learn_from_controller = nil,
+    -- learn_from_controller: opt-in (default false) to preserve the historical
+    -- split-learning behaviour -- by default a controller learn task (/learnspam,
+    -- /learnham) trains ONLY the classifiers, and neural keeps training from its
+    -- own scan-time paths (autotrain, ANN-Train, autolearn). Set it to true to
+    -- also train this rule from controller learn tasks, so one corpus push feeds
+    -- bayes and neural. A disable_symbols_input rule then trains from the lean
+    -- learn pipeline; a symbol-dependent rule makes its learn task run a full
+    -- check pass first (its vector reads symbol scores).
+    learn_from_controller = false,
   },
   watch_interval = 60.0,
   lock_expire = 600,

--- a/lualib/plugins/neural.lua
+++ b/lualib/plugins/neural.lua
@@ -68,6 +68,13 @@ local default_options = {
     -- means "default to disable_symbols_input" (resolved per-rule at init); set to
     -- false to opt out and keep running the full pipeline for forced learns.
     forced_learn_minimal_scan = nil,
+    -- learn_from_controller: when true, a controller learn task (e.g. /learnspam,
+    -- /learnham) also trains this neural rule -- one corpus push feeds bayes and
+    -- neural. Only symbols-independent rules (disable_symbols_input) are eligible
+    -- (a learn task runs no rule symbol). nil means "default to
+    -- disable_symbols_input" (resolved per-rule at init); set to false to keep a
+    -- fusion rule out of the controller learn path.
+    learn_from_controller = nil,
   },
   watch_interval = 60.0,
   lock_expire = 600,

--- a/src/controller.c
+++ b/src/controller.c
@@ -2019,7 +2019,7 @@ rspamd_controller_learn_fin_task(void *ud)
 		return TRUE;
 	}
 
-	if (!rspamd_task_process(task, RSPAMD_TASK_PROCESS_LEARN)) {
+	if (!rspamd_task_process(task, rspamd_symcache_learn_needs_check(task->cfg->cache) ? RSPAMD_TASK_PROCESS_LEARN_CHECK : RSPAMD_TASK_PROCESS_LEARN)) {
 		msg_info_task("cannot learn <%s>: %e",
 					  MESSAGE_FIELD_CHECK(task, message_id), task->err);
 
@@ -2184,7 +2184,7 @@ rspamd_controller_handle_learn_common(
 	class_name = is_spam ? "spam" : "ham";
 	rspamd_task_set_autolearn_class(task, class_name);
 
-	if (!rspamd_task_process(task, RSPAMD_TASK_PROCESS_LEARN)) {
+	if (!rspamd_task_process(task, rspamd_symcache_learn_needs_check(task->cfg->cache) ? RSPAMD_TASK_PROCESS_LEARN_CHECK : RSPAMD_TASK_PROCESS_LEARN)) {
 		msg_warn_session("<%s> message cannot be processed",
 						 MESSAGE_FIELD_CHECK(task, message_id));
 		goto end;
@@ -2299,7 +2299,7 @@ rspamd_controller_handle_learnclass(
 	class_name = rspamd_mempool_ftokdup(task->task_pool, class_header);
 	rspamd_task_set_autolearn_class(task, class_name);
 
-	if (!rspamd_task_process(task, RSPAMD_TASK_PROCESS_LEARN)) {
+	if (!rspamd_task_process(task, rspamd_symcache_learn_needs_check(task->cfg->cache) ? RSPAMD_TASK_PROCESS_LEARN_CHECK : RSPAMD_TASK_PROCESS_LEARN)) {
 		msg_warn_session("<%s> message cannot be processed",
 						 MESSAGE_FIELD_CHECK(task, message_id));
 		goto end;

--- a/src/libserver/rspamd_symcache.h
+++ b/src/libserver/rspamd_symcache.h
@@ -60,6 +60,7 @@ enum rspamd_symbol_type {
 	SYMBOL_TYPE_IGNORE_PASSTHROUGH = (1u << 17u), /* Symbol ignores passthrough result */
 	SYMBOL_TYPE_EXPLICIT_ENABLE = (1u << 18u),    /* Symbol should be enabled explicitly only */
 	SYMBOL_TYPE_USE_CORO = (1u << 19u),           /* Symbol uses lua coroutines */
+	SYMBOL_TYPE_LEARN = (1u << 20u),              /* Executed at the LEARN stage of a learn task */
 };
 
 /**

--- a/src/libserver/rspamd_symcache.h
+++ b/src/libserver/rspamd_symcache.h
@@ -61,6 +61,7 @@ enum rspamd_symbol_type {
 	SYMBOL_TYPE_EXPLICIT_ENABLE = (1u << 18u),    /* Symbol should be enabled explicitly only */
 	SYMBOL_TYPE_USE_CORO = (1u << 19u),           /* Symbol uses lua coroutines */
 	SYMBOL_TYPE_LEARN = (1u << 20u),              /* Executed at the LEARN stage of a learn task */
+	SYMBOL_TYPE_LEARN_NEEDS_CHECK = (1u << 21u),  /* A learn symbol that needs a full check pass first */
 };
 
 /**
@@ -279,6 +280,16 @@ unsigned int rspamd_symcache_get_symbol_flags(struct rspamd_symcache *cache,
  */
 unsigned int rspamd_symcache_get_symbol_stage(struct rspamd_symcache *cache,
 											  const char *symbol);
+
+/**
+ * Returns TRUE if any registered learn symbol is flagged
+ * SYMBOL_TYPE_LEARN_NEEDS_CHECK, i.e. some learner needs a full check pass
+ * (symbol scores) during a learn task. The controller uses this to pick the
+ * learn process mask.
+ * @param cache
+ * @return
+ */
+gboolean rspamd_symcache_learn_needs_check(struct rspamd_symcache *cache);
 
 void rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
 										const char *symbol,

--- a/src/libserver/symcache/symcache_c.cxx
+++ b/src/libserver/symcache/symcache_c.cxx
@@ -365,6 +365,14 @@ unsigned int rspamd_symcache_get_symbol_stage(struct rspamd_symcache *cache,
 	return 0;
 }
 
+gboolean
+rspamd_symcache_learn_needs_check(struct rspamd_symcache *cache)
+{
+	auto *real_cache = C_API_SYMCACHE(cache);
+
+	return real_cache->learn_needs_check() ? TRUE : FALSE;
+}
+
 const struct rspamd_symcache_item_stat *
 rspamd_symcache_item_stat(struct rspamd_symcache_item *item)
 {

--- a/src/libserver/symcache/symcache_c.cxx
+++ b/src/libserver/symcache/symcache_c.cxx
@@ -351,6 +351,8 @@ unsigned int rspamd_symcache_get_symbol_stage(struct rspamd_symcache *cache,
 		return SYMBOL_TYPE_POSTFILTER;
 	case rspamd::symcache::symcache_item_type::IDEMPOTENT:
 		return SYMBOL_TYPE_IDEMPOTENT;
+	case rspamd::symcache::symcache_item_type::LEARN:
+		return SYMBOL_TYPE_LEARN;
 	case rspamd::symcache::symcache_item_type::CLASSIFIER:
 		return SYMBOL_TYPE_CLASSIFIER;
 	case rspamd::symcache::symcache_item_type::COMPOSITE:

--- a/src/libserver/symcache/symcache_impl.cxx
+++ b/src/libserver/symcache/symcache_impl.cxx
@@ -231,6 +231,7 @@ auto symcache::init() -> bool
 	std::stable_sort(std::begin(prefilters), std::end(prefilters), prefilters_cmp);
 	std::stable_sort(std::begin(postfilters), std::end(postfilters), postfilters_cmp);
 	std::stable_sort(std::begin(idempotent), std::end(idempotent), postfilters_cmp);
+	std::stable_sort(std::begin(learn), std::end(learn), postfilters_cmp);
 
 	resort();
 
@@ -743,6 +744,7 @@ auto symcache::resort() -> void
 	append_items_vec(prefilters, ord->d, "prefilters");
 	append_items_vec(postfilters, ord->d, "postfilters");
 	append_items_vec(idempotent, ord->d, "idempotent filters");
+	append_items_vec(learn, ord->d, "learn");
 	append_items_vec(composites, ord->d, "composites");
 	append_items_vec(classifiers, ord->d, "classifiers");
 
@@ -1186,6 +1188,8 @@ auto symcache::get_item_specific_vector(const cache_item &it) -> symcache::items
 		return filters;
 	case symcache_item_type::IDEMPOTENT:
 		return idempotent;
+	case symcache_item_type::LEARN:
+		return learn;
 	case symcache_item_type::PREFILTER:
 		return prefilters;
 	case symcache_item_type::POSTFILTER:

--- a/src/libserver/symcache/symcache_impl.cxx
+++ b/src/libserver/symcache/symcache_impl.cxx
@@ -1205,6 +1205,17 @@ auto symcache::get_item_specific_vector(const cache_item &it) -> symcache::items
 	RSPAMD_UNREACHABLE;
 }
 
+auto symcache::learn_needs_check() const -> bool
+{
+	for (const auto &it: learn) {
+		if (it && (it->get_flags() & SYMBOL_TYPE_LEARN_NEEDS_CHECK)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 auto symcache::process_settings_elt(struct rspamd_config_settings_elt *elt) -> void
 {
 

--- a/src/libserver/symcache/symcache_internal.hxx
+++ b/src/libserver/symcache/symcache_internal.hxx
@@ -274,6 +274,7 @@ private:
 	items_ptr_vec postfilters;
 	items_ptr_vec composites;
 	items_ptr_vec idempotent;
+	items_ptr_vec learn;
 	items_ptr_vec classifiers;
 	items_ptr_vec virtual_symbols;
 
@@ -594,6 +595,14 @@ public:
 	auto idempotent_foreach(Functor f) -> bool
 	{
 		return std::all_of(std::begin(idempotent), std::end(idempotent),
+						   [&](const auto &sym_it) {
+							   return f(sym_it);
+						   });
+	}
+	template<typename Functor>
+	auto learn_foreach(Functor f) -> bool
+	{
+		return std::all_of(std::begin(learn), std::end(learn),
 						   [&](const auto &sym_it) {
 							   return f(sym_it);
 						   });

--- a/src/libserver/symcache/symcache_internal.hxx
+++ b/src/libserver/symcache/symcache_internal.hxx
@@ -607,6 +607,12 @@ public:
 							   return f(sym_it);
 						   });
 	}
+	/**
+	 * Returns true if any learn symbol is flagged SYMBOL_TYPE_LEARN_NEEDS_CHECK,
+	 * i.e. it needs a full check pass (symbol scores) to learn. Defined in
+	 * symcache_impl.cxx where cache_item is a complete type.
+	 */
+	auto learn_needs_check() const -> bool;
 	template<typename Functor>
 	auto filters_foreach(Functor f) -> bool
 	{

--- a/src/libserver/symcache/symcache_item.cxx
+++ b/src/libserver/symcache/symcache_item.cxx
@@ -576,7 +576,7 @@ auto virtual_item::resolve_parent(const symcache &cache) -> bool
 
 auto item_type_from_c(int type) -> tl::expected<std::pair<symcache_item_type, int>, std::string>
 {
-	constexpr const auto trivial_types = SYMBOL_TYPE_CONNFILTER | SYMBOL_TYPE_PREFILTER | SYMBOL_TYPE_POSTFILTER | SYMBOL_TYPE_IDEMPOTENT | SYMBOL_TYPE_COMPOSITE | SYMBOL_TYPE_CLASSIFIER | SYMBOL_TYPE_VIRTUAL;
+	constexpr const auto trivial_types = SYMBOL_TYPE_CONNFILTER | SYMBOL_TYPE_PREFILTER | SYMBOL_TYPE_POSTFILTER | SYMBOL_TYPE_IDEMPOTENT | SYMBOL_TYPE_LEARN | SYMBOL_TYPE_COMPOSITE | SYMBOL_TYPE_CLASSIFIER | SYMBOL_TYPE_VIRTUAL;
 
 	constexpr auto all_but_one_ty = [&](int type, int exclude_bit) -> auto {
 		return (type & trivial_types) & (trivial_types & ~exclude_bit);
@@ -602,6 +602,9 @@ auto item_type_from_c(int type) -> tl::expected<std::pair<symcache_item_type, in
 		}
 		else if (type & SYMBOL_TYPE_IDEMPOTENT) {
 			return check_trivial(SYMBOL_TYPE_IDEMPOTENT, symcache_item_type::IDEMPOTENT);
+		}
+		else if (type & SYMBOL_TYPE_LEARN) {
+			return check_trivial(SYMBOL_TYPE_LEARN, symcache_item_type::LEARN);
 		}
 		else if (type & SYMBOL_TYPE_COMPOSITE) {
 			return check_trivial(SYMBOL_TYPE_COMPOSITE, symcache_item_type::COMPOSITE);
@@ -637,11 +640,22 @@ bool operator<(symcache_item_type lhs, symcache_item_type rhs)
 		}
 		break;
 	case symcache_item_type::POSTFILTER:
-		if (rhs != symcache_item_type::IDEMPOTENT) {
+		if (rhs != symcache_item_type::IDEMPOTENT && rhs != symcache_item_type::LEARN) {
 			ret = true;
 		}
 		break;
 	case symcache_item_type::IDEMPOTENT:
+		/* Earlier than LEARN only */
+		if (rhs == symcache_item_type::LEARN) {
+			ret = true;
+		}
+		break;
+	case symcache_item_type::LEARN:
+		/* The latest real stage: later than every other stage */
+		if (rhs != symcache_item_type::LEARN) {
+			ret = true;
+		}
+		break;
 	default:
 		break;
 	}

--- a/src/libserver/symcache/symcache_item.hxx
+++ b/src/libserver/symcache/symcache_item.hxx
@@ -47,6 +47,7 @@ enum class symcache_item_type {
 	FILTER,     /* Normal symbol with a callback */
 	POSTFILTER, /* Executed after all filters */
 	IDEMPOTENT, /* Executed after postfilters, cannot change results */
+	LEARN,      /* Executed at the LEARN stage of a learn task (latest real stage) */
 	CLASSIFIER, /* A virtual classifier symbol */
 	COMPOSITE,  /* A virtual composite symbol */
 	VIRTUAL,    /* A virtual symbol... */
@@ -71,6 +72,8 @@ constexpr static auto item_type_to_str(symcache_item_type t) -> const char *
 		return "postfilter";
 	case symcache_item_type::IDEMPOTENT:
 		return "idempotent";
+	case symcache_item_type::LEARN:
+		return "learn";
 	case symcache_item_type::CLASSIFIER:
 		return "classifier";
 	case symcache_item_type::COMPOSITE:

--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -341,6 +341,7 @@ auto symcache_runtime::process_symbols(struct rspamd_task *task, symcache &cache
 	case RSPAMD_TASK_STAGE_PRE_FILTERS:
 	case RSPAMD_TASK_STAGE_POST_FILTERS:
 	case RSPAMD_TASK_STAGE_IDEMPOTENT:
+	case RSPAMD_TASK_STAGE_LEARN:
 		return process_pre_postfilters(task, cache,
 									   rspamd_session_events_pending(task->s), stage);
 		break;
@@ -370,6 +371,7 @@ auto symcache_runtime::process_pre_postfilters(struct rspamd_task *task,
 		 * those that are marked as ignore passthrough result
 		 */
 		if (stage != RSPAMD_TASK_STAGE_IDEMPOTENT &&
+			stage != RSPAMD_TASK_STAGE_LEARN &&
 			!(item->flags & SYMBOL_TYPE_IGNORE_PASSTHROUGH)) {
 			if (check_process_status(task) == check_status::passthrough) {
 				msg_debug_cache_task_lambda("task has already the passthrough result being set, ignore further checks");
@@ -430,6 +432,10 @@ auto symcache_runtime::process_pre_postfilters(struct rspamd_task *task,
 	case RSPAMD_TASK_STAGE_IDEMPOTENT:
 		compare_functor = +[](int a, int b) { return a > b; };
 		all_done = cache.idempotent_foreach(proc_func);
+		break;
+	case RSPAMD_TASK_STAGE_LEARN:
+		compare_functor = +[](int a, int b) { return a > b; };
+		all_done = cache.learn_foreach(proc_func);
 		break;
 	default:
 		g_error("invalid invocation");

--- a/src/libserver/task.c
+++ b/src/libserver/task.c
@@ -882,6 +882,19 @@ rspamd_task_process(struct rspamd_task *task, unsigned int stages)
 					}
 				}
 			}
+
+			/*
+			 * Run registered `learn` symbols (e.g. neural) at the main LEARN
+			 * stage of a learning task. They read the learn class via the
+			 * autolearn_class mempool variable, exactly like the stat learner
+			 * above, and are async-aware via the standard session machinery.
+			 * The learn-flag gate on the enclosing block keeps them from firing
+			 * on a plain scan.
+			 */
+			if (st == RSPAMD_TASK_STAGE_LEARN && task->err == NULL) {
+				all_done = rspamd_symcache_process_symbols(task, task->cfg->cache, st) &&
+						   all_done;
+			}
 		}
 		break;
 	case RSPAMD_TASK_STAGE_COMPOSITES_POST:

--- a/src/libserver/task.h
+++ b/src/libserver/task.h
@@ -89,6 +89,15 @@ enum rspamd_task_stage {
 								   RSPAMD_TASK_STAGE_LEARN |            \
 								   RSPAMD_TASK_STAGE_LEARN_POST |       \
 								   RSPAMD_TASK_STAGE_DONE)
+/*
+ * Learn with a full check pass: run the whole scan pipeline so symbol scores are
+ * available to symbol-dependent learners, but suppress side-effecting emission by
+ * dropping the IDEMPOTENT stage (ClickHouse, history, clusters, capture, learn
+ * queues all live there). Used for learn tasks when a learner needs symbol inputs
+ * (cfg->learn_needs_check); otherwise the lean RSPAMD_TASK_PROCESS_LEARN is used.
+ */
+#define RSPAMD_TASK_PROCESS_LEARN_CHECK \
+	(RSPAMD_TASK_PROCESS_ALL & ~RSPAMD_TASK_STAGE_IDEMPOTENT)
 
 #define RSPAMD_TASK_FLAG_MIME (1u << 0u)
 #define RSPAMD_TASK_FLAG_SKIP_PROCESS (1u << 1u)

--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -2033,6 +2033,10 @@ lua_parse_symbol_type(const char *str)
 					ret |= SYMBOL_TYPE_GHOST |
 						   SYMBOL_TYPE_IDEMPOTENT | SYMBOL_TYPE_CALLBACK;
 				}
+				else if (g_ascii_strcasecmp(str, "learn") == 0) {
+					ret |= SYMBOL_TYPE_GHOST |
+						   SYMBOL_TYPE_LEARN | SYMBOL_TYPE_CALLBACK;
+				}
 				else {
 					int fl = 0;
 

--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -1982,6 +1982,9 @@ lua_parse_symbol_flags(const char *str)
 		if (strstr(str, "coro") != NULL) {
 			ret |= SYMBOL_TYPE_USE_CORO;
 		}
+		if (strstr(str, "learn_needs_check") != NULL) {
+			ret |= SYMBOL_TYPE_LEARN_NEEDS_CHECK;
+		}
 	}
 
 	return ret;

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -2612,9 +2612,11 @@ lua_task_set_pre_result(lua_State *L)
 									  flags,
 									  rspamd_find_metric_result(task, res_name));
 
-		/* Don't classify or filter message if pre-filter sets results */
-
-		if (res_name == NULL && !(flags & (RSPAMD_PASSTHROUGH_LEAST | RSPAMD_PASSTHROUGH_PROCESS_ALL))) {
+		/* Don't classify or filter message if pre-filter sets results.
+		 * A learn task must still run classifiers and symbols (a learner may need
+		 * the symbol scores), so never short-circuit it on a passthrough result. */
+		if (res_name == NULL && !(flags & (RSPAMD_PASSTHROUGH_LEAST | RSPAMD_PASSTHROUGH_PROCESS_ALL)) &&
+			!(task->flags & (RSPAMD_TASK_FLAG_LEARN_SPAM | RSPAMD_TASK_FLAG_LEARN_HAM | RSPAMD_TASK_FLAG_LEARN_CLASS))) {
 			task->processed_stages |= (RSPAMD_TASK_STAGE_CLASSIFIERS |
 									   RSPAMD_TASK_STAGE_CLASSIFIERS_PRE |
 									   RSPAMD_TASK_STAGE_CLASSIFIERS_POST);

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -6307,6 +6307,7 @@ lua_task_has_flag(lua_State *L)
 		LUA_TASK_GET_FLAG(flag, "skip", RSPAMD_TASK_FLAG_SKIP);
 		LUA_TASK_GET_FLAG(flag, "learn_spam", RSPAMD_TASK_FLAG_LEARN_SPAM);
 		LUA_TASK_GET_FLAG(flag, "learn_ham", RSPAMD_TASK_FLAG_LEARN_HAM);
+		LUA_TASK_GET_FLAG(flag, "learn_auto", RSPAMD_TASK_FLAG_LEARN_AUTO);
 		LUA_TASK_GET_FLAG(flag, "greylisted", RSPAMD_TASK_FLAG_GREYLISTED);
 		LUA_TASK_GET_FLAG(flag, "broken_headers",
 						  RSPAMD_TASK_FLAG_BROKEN_HEADERS);
@@ -6377,6 +6378,10 @@ lua_task_get_flags(lua_State *L)
 					break;
 				case RSPAMD_TASK_FLAG_LEARN_HAM:
 					lua_pushstring(L, "learn_ham");
+					lua_rawseti(L, -2, idx++);
+					break;
+				case RSPAMD_TASK_FLAG_LEARN_AUTO:
+					lua_pushstring(L, "learn_auto");
 					lua_rawseti(L, -2, idx++);
 					break;
 				case RSPAMD_TASK_FLAG_GREYLISTED:

--- a/src/plugins/lua/neural.lua
+++ b/src/plugins/lua/neural.lua
@@ -1702,21 +1702,17 @@ local function ann_push_vector(task)
   end
 end
 
--- Learn-stage callback: collects training vectors from a dedicated learn task
--- (e.g. a /learnspam corpus push), which runs only message parsing + the learn
--- stages -- no scan symbols, no idempotent emitters (ClickHouse/history/...),
--- so it is fast and never pollutes downstream stores.
---
--- Only symbols-independent rules (disable_symbols_input) are eligible here: the
--- learn task does not run any rule symbol, so a symbol-dependent vector would be
--- wrong. Those rules keep training from the live scan path (NEURAL_LEARN
--- idempotent) as before; the dependency-driven closure for hybrid rules is a
--- separate step.
+-- Per-rule learn-stage callback: collects a training vector from a dedicated
+-- learn task (e.g. a /learnspam corpus push) for a single neural rule. Each rule
+-- that opts into controller learning gets its own NEURAL_LEARN_<rule> learn
+-- symbol (registered below); a symbol-dependent rule's symbol carries the
+-- `learn_needs_check` flag so the controller runs a full check pass first
+-- (otherwise the learn task runs no rule symbol and the vector would be wrong).
 --
 -- Explicit learn tasks only: an autolearn-during-scan task (learn_auto flag)
 -- also reaches the learn stage, but neural already decides such cases on the
 -- scan path, so we skip it here to avoid double-storing the same message.
-local function ann_learn_task(task)
+local function neural_learn_one(task, rule)
   if task:has_flag('learn_auto') then
     lua_util.debugm(N, task, 'skip neural learn symbol for autolearn-during-scan task')
     return
@@ -1728,23 +1724,11 @@ local function ann_learn_task(task)
     return
   end
 
-  for _, rule in pairs(settings.rules) do
-    if not rule.disable_symbols_input then
-      lua_util.debugm(N, task,
-        'neural learn task: rule %s needs symbols, not eligible for learn-task training',
-        rule.prefix)
-    elseif not rule.train.learn_from_controller then
-      lua_util.debugm(N, task,
-        'neural learn task: rule %s opted out of controller learning (learn_from_controller=false)',
-        rule.prefix)
-    else
-      local set = neural_common.get_rule_settings(task, rule)
-      if set then
-        lua_util.debugm(N, task, 'neural learn task: store %s vector for %s:%s',
-          cls, rule.prefix, set.name)
-        ann_push_task_result(rule, task, nil, 0.0, set, cls)
-      end
-    end
+  local set = neural_common.get_rule_settings(task, rule)
+  if set then
+    lua_util.debugm(N, task, 'neural learn task: store %s vector for %s:%s',
+      cls, rule.prefix, set.name)
+    ann_push_task_result(rule, task, nil, 0.0, set, cls)
   end
 end
 
@@ -1884,6 +1868,27 @@ for k, r in pairs(rules) do
     flags = 'nostat',
     parent = id
   })
+
+  -- Per-rule learn symbol: lets a controller learn task (/learnspam) train this
+  -- rule. Registered only when the rule opts into controller learning. A
+  -- symbol-dependent rule needs a full check pass first (its vector reads symbol
+  -- scores), signalled by the learn_needs_check flag; a disable_symbols_input
+  -- rule trains from the lean learn pipeline (no check).
+  if rule_elt.train.learn_from_controller then
+    local learn_flags = 'nostat,explicit_disable'
+    if not rule_elt.disable_symbols_input then
+      learn_flags = learn_flags .. ',learn_needs_check'
+    end
+    local this_rule = rule_elt
+    rspamd_config:register_symbol({
+      name = 'NEURAL_LEARN_' .. k,
+      type = 'learn',
+      flags = learn_flags,
+      callback = function(task)
+        neural_learn_one(task, this_rule)
+      end
+    })
+  end
 end
 
 rspamd_config:register_symbol({
@@ -1893,14 +1898,6 @@ rspamd_config:register_symbol({
   callback = ann_push_vector
 })
 
--- Learn-stage symbol: trains symbols-independent rules from a dedicated learn
--- task (e.g. /learnspam) without running any scan symbol or idempotent emitter.
-rspamd_config:register_symbol({
-  name = 'NEURAL_LEARN_TASK',
-  type = 'learn',
-  flags = 'nostat,explicit_disable',
-  callback = ann_learn_task
-})
 
 -- Forced-learn fast path: a prefilter that, for qualifying ANN-Train scans of
 -- disable_symbols_input rules, disables the whole non-neural pipeline. Priority

--- a/src/plugins/lua/neural.lua
+++ b/src/plugins/lua/neural.lua
@@ -1729,17 +1729,21 @@ local function ann_learn_task(task)
   end
 
   for _, rule in pairs(settings.rules) do
-    if rule.disable_symbols_input then
+    if not rule.disable_symbols_input then
+      lua_util.debugm(N, task,
+        'neural learn task: rule %s needs symbols, not eligible for learn-task training',
+        rule.prefix)
+    elseif not rule.train.learn_from_controller then
+      lua_util.debugm(N, task,
+        'neural learn task: rule %s opted out of controller learning (learn_from_controller=false)',
+        rule.prefix)
+    else
       local set = neural_common.get_rule_settings(task, rule)
       if set then
         lua_util.debugm(N, task, 'neural learn task: store %s vector for %s:%s',
           cls, rule.prefix, set.name)
         ann_push_task_result(rule, task, nil, 0.0, set, cls)
       end
-    else
-      lua_util.debugm(N, task,
-        'neural learn task: rule %s needs symbols, not eligible for learn-task training',
-        rule.prefix)
     end
   end
 end
@@ -1799,6 +1803,14 @@ for k, r in pairs(rules) do
   -- change the stored vector relative to the live full-scan path).
   if rule_elt.train.forced_learn_minimal_scan == nil then
     rule_elt.train.forced_learn_minimal_scan = rule_elt.disable_symbols_input and true or false
+  end
+
+  -- learn_from_controller defaults ON for symbols-independent rules (so a
+  -- /learnspam corpus push trains them alongside bayes) and OFF otherwise.
+  -- Operators can set it to false to keep a fusion rule out of the controller
+  -- learn path.
+  if rule_elt.train.learn_from_controller == nil then
+    rule_elt.train.learn_from_controller = rule_elt.disable_symbols_input and true or false
   end
 
   if not rule_elt.profile then

--- a/src/plugins/lua/neural.lua
+++ b/src/plugins/lua/neural.lua
@@ -316,14 +316,25 @@ local function neural_forced_learn_prefilter(task)
     'forced-learn minimal scan: disabled all non-neural symbols for %s training', hv)
 end
 
-local function ann_push_task_result(rule, task, verdict, score, set)
+local function ann_push_task_result(rule, task, verdict, score, set, forced_class)
   local train_opts = rule.train
   local learn_spam, learn_ham
   local skip_reason = 'unknown'
   local manual_train = false
 
+  -- A forced class is supplied by the learn-task path (e.g. /learnspam routed to
+  -- the neural learn symbol). It is authoritative and bypasses the
+  -- header/autolearn/verdict determination below, behaving like a manual train.
+  if forced_class == 'spam' then
+    learn_spam = true
+    manual_train = true
+  elseif forced_class == 'ham' then
+    learn_ham = true
+    manual_train = true
+  end
+
   -- First, honor explicit manual training header if present
-  do
+  if not manual_train then
     local hv = get_ann_train_header(task)
     if hv then
       lua_util.debugm(N, task, 'found ANN-Train header, enable manual train mode: %s', hv)
@@ -1691,6 +1702,48 @@ local function ann_push_vector(task)
   end
 end
 
+-- Learn-stage callback: collects training vectors from a dedicated learn task
+-- (e.g. a /learnspam corpus push), which runs only message parsing + the learn
+-- stages -- no scan symbols, no idempotent emitters (ClickHouse/history/...),
+-- so it is fast and never pollutes downstream stores.
+--
+-- Only symbols-independent rules (disable_symbols_input) are eligible here: the
+-- learn task does not run any rule symbol, so a symbol-dependent vector would be
+-- wrong. Those rules keep training from the live scan path (NEURAL_LEARN
+-- idempotent) as before; the dependency-driven closure for hybrid rules is a
+-- separate step.
+--
+-- Explicit learn tasks only: an autolearn-during-scan task (learn_auto flag)
+-- also reaches the learn stage, but neural already decides such cases on the
+-- scan path, so we skip it here to avoid double-storing the same message.
+local function ann_learn_task(task)
+  if task:has_flag('learn_auto') then
+    lua_util.debugm(N, task, 'skip neural learn symbol for autolearn-during-scan task')
+    return
+  end
+
+  local cls = task:get_mempool():get_variable('autolearn_class')
+  if cls ~= 'spam' and cls ~= 'ham' then
+    lua_util.debugm(N, task, 'neural learn symbol: no spam/ham class (%s), skip', cls)
+    return
+  end
+
+  for _, rule in pairs(settings.rules) do
+    if rule.disable_symbols_input then
+      local set = neural_common.get_rule_settings(task, rule)
+      if set then
+        lua_util.debugm(N, task, 'neural learn task: store %s vector for %s:%s',
+          cls, rule.prefix, set.name)
+        ann_push_task_result(rule, task, nil, 0.0, set, cls)
+      end
+    else
+      lua_util.debugm(N, task,
+        'neural learn task: rule %s needs symbols, not eligible for learn-task training',
+        rule.prefix)
+    end
+  end
+end
+
 
 -- Initialization part
 if not (neural_common.module_config and type(neural_common.module_config) == 'table')
@@ -1826,6 +1879,15 @@ rspamd_config:register_symbol({
   type = 'idempotent,callback',
   flags = 'nostat,explicit_disable,ignore_passthrough',
   callback = ann_push_vector
+})
+
+-- Learn-stage symbol: trains symbols-independent rules from a dedicated learn
+-- task (e.g. /learnspam) without running any scan symbol or idempotent emitter.
+rspamd_config:register_symbol({
+  name = 'NEURAL_LEARN_TASK',
+  type = 'learn',
+  flags = 'nostat,explicit_disable',
+  callback = ann_learn_task
 })
 
 -- Forced-learn fast path: a prefilter that, for qualifying ANN-Train scans of

--- a/src/plugins/lua/neural.lua
+++ b/src/plugins/lua/neural.lua
@@ -1789,14 +1789,6 @@ for k, r in pairs(rules) do
     rule_elt.train.forced_learn_minimal_scan = rule_elt.disable_symbols_input and true or false
   end
 
-  -- learn_from_controller defaults ON for symbols-independent rules (so a
-  -- /learnspam corpus push trains them alongside bayes) and OFF otherwise.
-  -- Operators can set it to false to keep a fusion rule out of the controller
-  -- learn path.
-  if rule_elt.train.learn_from_controller == nil then
-    rule_elt.train.learn_from_controller = rule_elt.disable_symbols_input and true or false
-  end
-
   if not rule_elt.profile then
     rule_elt.profile = {}
   end

--- a/test/functional/cases/330_neural/008_learn_task.robot
+++ b/test/functional/cases/330_neural/008_learn_task.robot
@@ -1,0 +1,67 @@
+*** Settings ***
+Suite Setup      Rspamd Redis Setup
+Suite Teardown   Rspamd Redis Teardown
+Library         Process
+Library         Collections
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/neural_learn_task.conf
+${SPAM_MSG}        ${RSPAMD_TESTDIR}/messages/spam.eml
+${HAM_MSG}         ${RSPAMD_TESTDIR}/messages/ham.eml
+${REDIS_SCOPE}     Suite
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+Learn task trains a symbols-independent neural rule
+  # /learnspam runs a learn task (no scan symbols, no idempotent emitters). The
+  # neural learn symbol must still store a training vector for the
+  # disable_symbols_input rule under its providers-digest profile key.
+  Sleep  2s  Wait for redis and initial check_anns
+  ${result} =  Run Rspamc  -h  ${RSPAMD_LOCAL_ADDR}:${RSPAMD_PORT_CONTROLLER}  learn_spam  ${SPAM_MSG}
+  Check Rspamc  ${result}
+  ${spam_set} =  Get Neural Train Set  spam
+  Should Not Be Empty  ${spam_set}  msg=/learnspam did not create a neural training set
+  ${n} =  Redis SCARD  ${spam_set}
+  Should Be True  ${n} >= 1  msg=/learnspam did not store a neural training vector
+
+Learn-task vector is byte-identical to the full-scan vector
+  # The same message stored via the full-scan path (/checkv2 + ANN-Train) must
+  # land in the SAME providers-digest key and dedup to a single member: the
+  # learn-task vector and the scan-path vector are identical.
+  ${spam_set} =  Get Neural Train Set  spam
+  Scan File  ${SPAM_MSG}  ANN-Train=spam
+  Sleep  0.5s  Let the async SADD settle
+  ${n} =  Redis SCARD  ${spam_set}
+  Should Be Equal As Integers  ${n}  1
+  ...  msg=learn-task and full-scan vectors for the same message are not identical
+
+Learn-task corpus trains the model end to end
+  # Add a ham sample via /learnham; with max_trains=1 the balanced trigger fires
+  # and the model trains purely from the learn-task corpus. Inference must then
+  # fire on both classes.
+  ${result} =  Run Rspamc  -h  ${RSPAMD_LOCAL_ADDR}:${RSPAMD_PORT_CONTROLLER}  learn_ham  ${HAM_MSG}
+  Check Rspamc  ${result}
+  Sleep  6s  Wait for training to complete and ANN to be reloaded
+  Scan File  ${SPAM_MSG}  Settings={groups_enabled=["neural"];symbols_disabled=["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_SPAM_SHORT
+  Scan File  ${HAM_MSG}   Settings={groups_enabled=["neural"];symbols_disabled=["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_HAM_SHORT
+
+*** Keywords ***
+Get Neural Train Set
+  [Arguments]  ${class}
+  ${res} =  Run Process  redis-cli  -h  ${RSPAMD_REDIS_ADDR}  -p  ${RSPAMD_REDIS_PORT}
+  ...  KEYS  rn_SHORT_*_${class}_set
+  ${key} =  Evaluate  $res.stdout.strip().split('\\n')[0]
+  [Return]  ${key}
+
+Redis SCARD
+  [Arguments]  ${key}
+  ${res} =  Run Process  redis-cli  -h  ${RSPAMD_REDIS_ADDR}  -p  ${RSPAMD_REDIS_PORT}
+  ...  SCARD  ${key}
+  ${n} =  Convert To Integer  ${res.stdout.strip()}
+  [Return]  ${n}

--- a/test/functional/cases/330_neural/009_learn_check.robot
+++ b/test/functional/cases/330_neural/009_learn_check.robot
@@ -1,0 +1,56 @@
+*** Settings ***
+Suite Setup      Rspamd Redis Setup
+Suite Teardown   Rspamd Redis Teardown
+Library         Process
+Library         Collections
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/neural_learn_check.conf
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/spam_message.eml
+${REDIS_SCOPE}     Suite
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+Symbol-dependent rule trains via a learn-task check pass
+  # A symbol-based rule's vector reads symbol scores, so /learnspam must run a
+  # full check pass (NEURAL_LEARN_SHORT carries learn_needs_check). The learn
+  # task then stores a training vector built from the scored symbols.
+  Sleep  2s  Wait for redis and initial check_anns
+  ${result} =  Run Rspamc  -h  ${RSPAMD_LOCAL_ADDR}:${RSPAMD_PORT_CONTROLLER}  learn_spam  ${MESSAGE}
+  Check Rspamc  ${result}
+  ${spam_set} =  Get Neural Train Set  spam
+  Should Not Be Empty  ${spam_set}  msg=/learnspam did not create a neural training set
+  ${n} =  Redis SCARD  ${spam_set}
+  Should Be True  ${n} >= 1  msg=/learnspam did not store a symbol-derived vector
+
+Check-pass vector is byte-identical to the full-scan vector
+  # The same message stored via the full-scan path (/checkv2 + ANN-Train) must
+  # dedup into the SAME key. If the learn task had NOT run the check pass, the
+  # symbols would not have fired and the stored vector would differ (SCARD 2):
+  # SCARD == 1 proves the check pass ran and scored the symbols identically.
+  ${spam_set} =  Get Neural Train Set  spam
+  Scan File  ${MESSAGE}  ANN-Train=spam
+  Expect Symbol  SPAM_SYMBOL1
+  Sleep  0.5s  Let the async SADD settle
+  ${n} =  Redis SCARD  ${spam_set}
+  Should Be Equal As Integers  ${n}  1
+  ...  msg=learn-task check-pass vector differs from the full-scan vector
+
+*** Keywords ***
+Get Neural Train Set
+  [Arguments]  ${class}
+  ${res} =  Run Process  redis-cli  -h  ${RSPAMD_REDIS_ADDR}  -p  ${RSPAMD_REDIS_PORT}
+  ...  KEYS  rn_SHORT_*_${class}_set
+  ${key} =  Evaluate  $res.stdout.strip().split('\\n')[0]
+  [Return]  ${key}
+
+Redis SCARD
+  [Arguments]  ${key}
+  ${res} =  Run Process  redis-cli  -h  ${RSPAMD_REDIS_ADDR}  -p  ${RSPAMD_REDIS_PORT}
+  ...  SCARD  ${key}
+  ${n} =  Convert To Integer  ${res.stdout.strip()}
+  [Return]  ${n}

--- a/test/functional/configs/neural_learn_check.conf
+++ b/test/functional/configs/neural_learn_check.conf
@@ -1,0 +1,73 @@
+options = {
+  url_tld = "{= env.URL_TLD =}"
+  pidfile = "{= env.TMPDIR =}/rspamd.pid"
+  lua_path = "{= env.INSTALLROOT =}/share/rspamd/lib/?.lua"
+  filters = [];
+  explicit_modules = ["settings"];
+}
+
+logging = {
+  type = "file",
+  level = "debug"
+  filename = "{= env.TMPDIR =}/rspamd.log"
+  log_usec = true;
+}
+metric = {
+  name = "default",
+  actions = {
+    reject = 100500,
+    add_header = 50500,
+  }
+  unknown_weight = 1
+}
+worker {
+  type = normal
+  bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_NORMAL =}"
+  count = 1
+  task_timeout = 10s;
+}
+worker {
+  type = controller
+  bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_CONTROLLER =}"
+  count = 1
+  secure_ip = ["127.0.0.1", "::1"];
+  stats_path = "{= env.TMPDIR =}/stats.ucl"
+}
+
+modules {
+  path = "{= env.TESTDIR =}/../../src/plugins/lua/"
+}
+
+lua = "{= env.TESTDIR =}/lua/test_coverage.lua";
+
+neural {
+  rules {
+      SHORT {
+          train {
+              learning_rate = 0.001;
+              max_usages = 2;
+              spam_score = 1;
+              ham_score = -1;
+              # high enough that a single spam push never rotates the key during
+              # the equivalence assertion (no ham => no balanced training).
+              max_trains = 10;
+              max_iterations = 250;
+              # symbol-based rule (no providers): its vector reads symbol scores,
+              # so a /learnspam learn task must run a full check pass. Opt this
+              # rule into controller learning (off by default for such rules).
+              learn_from_controller = true;
+          }
+          symbol_spam = "NEURAL_SPAM_SHORT";
+          symbol_ham = "NEURAL_HAM_SHORT";
+          ann_expire = 86400;
+          watch_interval = 0.5;
+      }
+  }
+  allow_local = true;
+}
+redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+  expand_keys = true;
+}
+
+lua = "{= env.TESTDIR =}/lua/neural.lua";

--- a/test/functional/configs/neural_learn_task.conf
+++ b/test/functional/configs/neural_learn_task.conf
@@ -1,0 +1,93 @@
+options = {
+  url_tld = "{= env.URL_TLD =}"
+  pidfile = "{= env.TMPDIR =}/rspamd.pid"
+  lua_path = "{= env.INSTALLROOT =}/share/rspamd/lib/?.lua"
+  filters = [];
+  explicit_modules = ["settings"];
+}
+
+logging = {
+  type = "file",
+  level = "debug"
+  filename = "{= env.TMPDIR =}/rspamd.log"
+  log_usec = true;
+}
+metric = {
+  name = "default",
+  actions = {
+    reject = 100500,
+    add_header = 50500,
+  }
+  unknown_weight = 1
+}
+worker {
+  type = normal
+  bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_NORMAL =}"
+  count = 1
+  task_timeout = 10s;
+}
+worker {
+  type = controller
+  bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_CONTROLLER =}"
+  count = 1
+  secure_ip = ["127.0.0.1", "::1"];
+  stats_path = "{= env.TMPDIR =}/stats.ucl"
+}
+
+modules {
+  path = "{= env.TESTDIR =}/../../src/plugins/lua/"
+}
+
+lua = "{= env.TESTDIR =}/lua/test_coverage.lua";
+
+neural {
+  rules {
+      SHORT {
+          train {
+              learning_rate = 0.001;
+              max_usages = 2;
+              spam_score = 1;
+              ham_score = -1;
+              # metatokens-only vectors dedup per message, so one sample per
+              # class is enough for balanced training.
+              max_trains = 1;
+              max_iterations = 250;
+              classes_bias = 0.0;
+          }
+          symbol_spam = "NEURAL_SPAM_SHORT";
+          symbol_ham = "NEURAL_HAM_SHORT";
+          ann_expire = 86400;
+          watch_interval = 0.5;
+          # Symbols-independent rule: trainable from a /learnspam learn task,
+          # which runs no scan symbol and no idempotent emitter.
+          providers = [
+            { type = "metatokens"; }
+          ];
+          disable_symbols_input = true;
+          fusion {
+            include_meta = false;
+            normalization = "none";
+          }
+      }
+  }
+  allow_local = true;
+}
+
+# A bayes classifier so that /learnspam is a representative learn request: one
+# corpus push trains bayes AND fires the neural learn symbol (symbols-independent
+# rule), with no scan symbols and no idempotent emitters running.
+classifier "bayes" {
+  tokenizer { name = "osb"; }
+  backend = "redis";
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+  min_learns = 1;
+  statfile { symbol = "BAYES_SPAM"; spam = true; }
+  statfile { symbol = "BAYES_HAM"; spam = false; }
+}
+
+redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+  expand_keys = true;
+}
+
+lua = "{= env.TESTDIR =}/lua/neural_rotation.lua";

--- a/test/functional/configs/neural_learn_task.conf
+++ b/test/functional/configs/neural_learn_task.conf
@@ -53,6 +53,9 @@ neural {
               max_trains = 1;
               max_iterations = 250;
               classes_bias = 0.0;
+              # opt into controller learning (off by default to preserve the
+              # historical split-learning behaviour).
+              learn_from_controller = true;
           }
           symbol_spam = "NEURAL_SPAM_SHORT";
           symbol_ham = "NEURAL_HAM_SHORT";


### PR DESCRIPTION
## Summary

Introduces a generic **learn framework** so plugins can train on a learn task
(e.g. `/learnspam`) instead of piggybacking the scan pipeline, and moves neural
network corpus training onto it.

rspamd already runs a reduced pipeline for `/learnspam`/`/learnham`
(`RSPAMD_TASK_PROCESS_LEARN`): message parse + classifiers + learn stages, with
no scan symbols (RBL/DNS, fuzzy) and no idempotent emitters (ClickHouse,
history, clusters, capture). Bayes learning lives there; neural's training hook
was an `idempotent` symbol on the scan path, so corpus training via
`/checkv2 + ANN-Train` ran — and polluted — the whole scan pipeline.

## What's here

1. **`learn` symcache symbol type** — `register_symbol{type='learn'}`. A learn
   symbol fires only on a learn task, at the LEARN stage, async-aware (same path
   as pre/postfilters), alongside `rspamd_stat_learn`. Ordered as the latest
   real stage so `learn -> filter/classifier` dependencies validate as natural
   order (groundwork for symbol-dependent learners). It reads the class from the
   `autolearn_class` mempool variable, like the stat learner.

2. **Neural trains from learn tasks** — `NEURAL_LEARN_TASK` (a learn symbol)
   stores a training vector for `disable_symbols_input` rules on `/learnspam`.
   One corpus push now trains bayes and neural together. The stored vector and
   profile key are byte-for-byte identical to the scan path (a `/learnspam`
   vector and a `/checkv2 + ANN-Train` vector for the same message dedup to a
   single Redis set member). Gated by `train.learn_from_controller` (default on
   for fusion rules). Autolearn-during-scan is unaffected — it is handled on the
   scan path, and the learn symbol skips `learn_auto` tasks to avoid
   double-storing the same message.

## Scope / not included

- Symbol-dependent / hybrid neural rules are **not** yet trainable from a learn
  task (a learn task runs no rule symbol, so their vector would be wrong). They
  keep training from the scan path. The dependency-driven closure that would run
  only the needed symbols in a learn task is a planned follow-up.
- This branch is stacked on `fa03089b7` (forced-learn fast path + first-class
  freeze + the `task:disable_all_symbols` binding). Once that commit lands on
  `master`, the net diff of this PR is the three framework commits.

## Testing

- New functional suite `test/functional/cases/330_neural/008_learn_task`
  (learn-task training, scan-path vector equivalence, end-to-end train +
  inference).
- A spike confirmed a `type='learn'` symbol fires on `/learnspam` (class=spam)
  but not on `/checkv2`, and that bayes learning is unchanged.
- Green: neural (330), LLM (335), statistics / bayes-learn (110) functional
  suites. **Not yet run: the full functional suite and the C++ unit tests** —
  the symcache change is broad and these should run before this leaves draft.

## Risk

Touches the symcache item-type machinery: a new enum value, the four exhaustive
type switches, runtime dispatch, and the order/sort. Existing learn (bayes) and
scan paths are unchanged in behaviour; verified by the statistics and neural
suites.
