### PR TITLE
[Feature] neural: force-train endpoint from stored Redis vectors

### DIFF
--- a/lualib/plugins/neural.lua
+++ b/lualib/plugins/neural.lua
@@ -1082,9 +1082,50 @@ local function spawn_train(params)
   if params.set.learning_spawned then
     lua_util.debugm(N, rspamd_config, 'spawn_train: training already in progress for %s:%s, skipping',
       params.rule.prefix, params.set.name)
+    if params.on_complete_cb then
+      params.on_complete_cb('training already in progress')
+    end
     return
   end
   params.set.learning_spawned = true
+
+  -- Stats reported to an optional completion callback (used by the controller
+  -- force-train endpoint to reply with the trained model's metadata). spam/ham
+  -- counts are known up front; version/bytes are filled in once the child
+  -- process returns a model.
+  local train_result = {
+    spam = #params.spam_vec,
+    ham = #params.ham_vec,
+  }
+  -- Fire the completion callback exactly once on every terminal outcome. On
+  -- failure `err` is a string and the result is nil; on success err is nil and
+  -- the populated result table is passed through. Callers that don't pass
+  -- on_complete_cb (the periodic auto-train path) are unaffected.
+  local cb_fired = false
+  local function report(err)
+    if params.on_complete_cb and not cb_fired then
+      cb_fired = true
+      params.on_complete_cb(err, err and nil or train_result)
+    end
+  end
+
+  -- Release the trained-from key's Redis lock on the pre-fork failure paths
+  -- below. The post-fork paths already unlock via gen_unlock_cb / save_unlock;
+  -- before this, a create_ann/insufficient-data bailout stranded the lock the
+  -- caller (do_train_ann) had acquired until it expired. HDEL on a key with no
+  -- lock field (e.g. the handle_learn path, which never locks) is a harmless
+  -- no-op.
+  local function unlock_on_failure()
+    lua_redis.redis_make_request_taskless(params.ev_base,
+      rspamd_config,
+      params.rule.redis,
+      nil,
+      true, -- is write
+      gen_unlock_cb(params.rule, params.set, params.ann_key),
+      'HDEL',
+      { params.ann_key, 'lock' }
+    )
+  end
 
   -- Check training data sanity
   -- Now we need to join inputs and create the appropriate test vectors
@@ -1113,15 +1154,22 @@ local function spawn_train(params)
     rspamd_logger.errx(rspamd_config, 'failed to create ANN for %s:%s: %s',
       params.rule.prefix, params.set.name, train_ann)
     params.set.learning_spawned = false
+    unlock_on_failure()
+    report(string.format('failed to create ANN: %s', train_ann))
     return
   end
 
-  if #params.ham_vec + #params.spam_vec < params.rule.train.max_trains / 2 then
+  -- The minimum-corpus gate is skipped for forced training (controller
+  -- force-train endpoint), which only requires both classes to be non-empty.
+  if not params.force and #params.ham_vec + #params.spam_vec < params.rule.train.max_trains / 2 then
     -- Insufficient training data, reset flag and return
     rspamd_logger.errx(rspamd_config, 'insufficient training data for ANN %s:%s: spam=%s ham=%s (need at least %s total)',
       params.rule.prefix, params.set.name,
       #params.spam_vec, #params.ham_vec, params.rule.train.max_trains / 2)
     params.set.learning_spawned = false
+    unlock_on_failure()
+    report(string.format('insufficient training data: spam=%s ham=%s (need %s total)',
+      #params.spam_vec, #params.ham_vec, params.rule.train.max_trains / 2))
     return
   else
     local inputs, outputs = {}, {}
@@ -1334,9 +1382,11 @@ local function spawn_train(params)
           'HDEL',                                                 -- command
           { params.ann_key, 'lock' }
         )
+        report(string.format('cannot save trained ANN to redis: %s', err))
       else
         rspamd_logger.infox(rspamd_config, 'saved ANN %s:%s to redis: %s',
           params.rule.prefix, params.set.name, params.set.ann.redis_key)
+        report(nil)
 
         -- Clean up pending training keys if they were used
         if params.pending_key then
@@ -1379,6 +1429,7 @@ local function spawn_train(params)
           'HDEL',                                                 -- command
           { params.ann_key, 'lock' }
         )
+        report(err or 'training child returned no model (rejected or failed)')
       else
         local parser = ucl.parser()
         local ok, parse_err = parser:parse_text(data, 'msgpack')
@@ -1394,6 +1445,7 @@ local function spawn_train(params)
             'HDEL',
             { params.ann_key, 'lock' }
           )
+          report(string.format('cannot parse training result: %s', parse_err))
           return
         end
         local parsed = parser:get_object()
@@ -1412,6 +1464,7 @@ local function spawn_train(params)
             'HDEL',
             { params.ann_key, 'lock' }
           )
+          report(string.format('rejected: %s', parsed.rejected))
           return
         end
 
@@ -1452,6 +1505,12 @@ local function spawn_train(params)
         params.set.ann.ann = loaded_ann
         params.set.ann.symbols = params.set.symbols
         params.set.ann.redis_key = new_ann_key(params.rule, params.set, version)
+
+        -- Record the trained model's metadata for the completion callback
+        -- (reported once the save_unlock script confirms the write).
+        train_result.version = version
+        train_result.bytes = #ann_data
+        train_result.redis_key = params.set.ann.redis_key
 
         local profile = {
           symbols = params.set.symbols,
@@ -1513,6 +1572,166 @@ local function spawn_train(params)
     register_lock_extender(params.rule, params.set, params.ev_base, params.ann_key)
     return
   end
+end
+
+-- Decompress (zstd) and parse stored training vectors into tables of numbers.
+local function process_training_vectors(data)
+  return fun.totable(fun.map(function(tok)
+    local _, str = rspamd_util.zstd_decompress(tok)
+    return fun.totable(fun.map(tonumber, lua_util.str_split(tostring(str), ';')))
+  end, data))
+end
+
+-- Force a single training run from the vectors already stored in Redis for the
+-- best-matching profile of `set`, bypassing the max_trains / frozen-marker
+-- gate: only both classes being non-empty is required. This decouples the
+-- corpus feed from the train so feed -> train -> serve is deterministic and
+-- repeatable (used by the controller force-train endpoint).
+--
+-- Single-flight is enforced two ways: the in-memory `set.learning_spawned`
+-- flag (per worker) and the cross-process Redis lock on the profile key. The
+-- lock is always released -- spawn_train unlocks on every terminal path
+-- (including its pre-fork bailouts), and the read/selection failures here
+-- unlock explicitly via unlock_and_fail.
+--
+-- Invokes cb(err) on failure or cb(nil, result) on success, exactly once;
+-- result carries { spam, ham, bytes, version, redis_key }.
+local function force_train_from_redis(worker, ev_base, rule, set, cb)
+  local has_providers = rule.providers and #rule.providers > 0
+  local current_providers_digest = has_providers and
+      providers_config_digest(rule.providers, rule) or nil
+
+  if set.learning_spawned then
+    cb('training already in progress for this rule/settings')
+    return
+  end
+
+  -- Step 1: read the profile registry and pick the profile training vectors
+  -- were accumulated against (compatible, dist == 0, highest version). This
+  -- mirrors the selection in maybe_train_existing_ann / process_existing_ann.
+  local function profiles_cb(err, data)
+    if err then
+      cb(string.format('cannot read ANN profiles from redis: %s', err))
+      return
+    end
+    if type(data) ~= 'table' or #data == 0 then
+      cb('no ANN profiles found for this rule/settings (feed training vectors first)')
+      return
+    end
+
+    local sel_elt
+    for _, raw in ipairs(data) do
+      local parser = ucl.parser()
+      if parser:parse_string(raw) then
+        local elt = parser:get_object()
+        local compatible, dist = is_profile_compatible(rule, set, elt, current_providers_digest)
+        if compatible and dist == 0 then
+          if not sel_elt or (elt.version or 0) > (sel_elt.version or 0) then
+            sel_elt = elt
+          end
+        end
+      end
+    end
+
+    if not sel_elt then
+      cb('no compatible ANN profile found (feed training vectors first)')
+      return
+    end
+
+    local ann_key = sel_elt.redis_key
+    local pending_key = pending_train_key(rule, set)
+
+    -- Step 2: acquire the per-profile training lock (cross-process guard).
+    local function lock_cb(lock_err, lock_data)
+      if lock_err then
+        cb(string.format('cannot acquire training lock: %s', lock_err))
+        return
+      end
+      if not (type(lock_data) == 'number' and lock_data == 1) then
+        local host = (type(lock_data) == 'table' and lock_data[2]) or 'another host'
+        cb(string.format('ANN %s is locked for training by %s', ann_key, host))
+        return
+      end
+
+      -- Lock held from here. Any failure path before spawn_train must release
+      -- it; once spawn_train starts it owns unlocking (all its terminal paths
+      -- unlock).
+      local function unlock_and_fail(msg)
+        lua_redis.redis_make_request_taskless(ev_base, rspamd_config, rule.redis,
+          nil, true, gen_unlock_cb(rule, set, ann_key), 'HDEL', { ann_key, 'lock' })
+        cb(msg)
+      end
+
+      local spam_elts
+
+      -- Step 3: load spam+ham vectors, unioning the versioned key with the
+      -- version-independent pending key (same as do_train_ann).
+      local function ham_cb(herr, hdata)
+        if herr or type(hdata) ~= 'table' then
+          unlock_and_fail(string.format('cannot read ham vectors: %s', herr or 'unexpected reply'))
+          return
+        end
+        local ham_elts = process_training_vectors(hdata)
+
+        if #spam_elts == 0 or #ham_elts == 0 then
+          unlock_and_fail(string.format('both classes must be non-empty (spam=%s ham=%s)',
+            #spam_elts, #ham_elts))
+          return
+        end
+
+        -- Final single-flight check immediately before handing the lock to
+        -- spawn_train. There is no await between this check and spawn_train
+        -- setting learning_spawned, so it is atomic against the controller's
+        -- periodic trainer touching the same set in-process.
+        if set.learning_spawned then
+          unlock_and_fail('training already in progress for this rule/settings')
+          return
+        end
+
+        spawn_train {
+          worker = worker,
+          ev_base = ev_base,
+          rule = rule,
+          set = set,
+          ann_key = ann_key,
+          spam_vec = spam_elts,
+          ham_vec = ham_elts,
+          pending_key = pending_key,
+          force = true,
+          on_complete_cb = cb,
+        }
+      end
+
+      local function spam_cb(serr, sdata)
+        if serr or type(sdata) ~= 'table' then
+          unlock_and_fail(string.format('cannot read spam vectors: %s', serr or 'unexpected reply'))
+          return
+        end
+        spam_elts = process_training_vectors(sdata)
+        lua_redis.redis_make_request_taskless(ev_base, rspamd_config, rule.redis,
+          nil, false, ham_cb, 'SUNION',
+          { ann_key .. '_ham_set', pending_key .. '_ham_set' })
+      end
+
+      lua_redis.redis_make_request_taskless(ev_base, rspamd_config, rule.redis,
+        nil, false, spam_cb, 'SUNION',
+        { ann_key .. '_spam_set', pending_key .. '_spam_set' })
+    end
+
+    lua_redis.exec_redis_script(redis_script_id.maybe_lock,
+      { ev_base = ev_base, is_write = true },
+      lock_cb,
+      {
+        ann_key,
+        tostring(os.time()),
+        tostring(math.floor(math.max(10.0, rule.watch_interval * 2))),
+        rspamd_util.get_hostname()
+      })
+  end
+
+  lua_redis.redis_make_request_taskless(ev_base, rspamd_config, rule.redis,
+    nil, false, profiles_cb, 'ZREVRANGE',
+    { set.prefix, '0', tostring(settings.max_profiles) })
 end
 
 -- This function is used to adjust profiles and allowed setting ids for each rule
@@ -1726,6 +1945,7 @@ return {
   default_options = default_options,
   build_providers_meta = build_providers_meta,
   apply_normalization = apply_normalization,
+  force_train_from_redis = force_train_from_redis,
   gen_unlock_cb = gen_unlock_cb,
   get_provider = get_provider,
   get_rule_settings = get_rule_settings,

--- a/lualib/rspamadm/classifier_test.lua
+++ b/lualib/rspamadm/classifier_test.lua
@@ -3,6 +3,7 @@ local lua_util = require "lua_util"
 local argparse = require "argparse"
 local ucl = require "ucl"
 local rspamd_logger = require "rspamd_logger"
+local rspamd_http = require "rspamd_http"
 
 local parser = argparse()
     :name "rspamadm classifier_test"
@@ -57,6 +58,18 @@ parser:option "--train-wait"
       :argname("<sec>")
       :convert(tonumber)
       :default(90)
+parser:flag "--force-train"
+      :description("Trigger neural training via the controller from stored vectors, then poll until served (neural only, default on)")
+parser:flag "--no-force-train"
+      :description("Disable the forced-train trigger; fall back to waiting --train-wait seconds (neural only)")
+parser:option "--rule"
+      :description("Neural rule name to force-train (neural only)")
+      :argname("<name>")
+      :default('default')
+parser:option "--password"
+      :description("Controller password for the force-train endpoint (if required)")
+      :argname("<pass>")
+      :default('')
 
 local opts
 
@@ -179,6 +192,80 @@ local function classify_files(files, known_spam_files, known_ham_files)
   os.remove(fname)
 
   return results
+end
+
+-- POST /plugins/neural/train to force a training run from the vectors already
+-- stored in Redis (decouples the corpus feed from the train). Returns
+-- true, <reply-table> on success or false, <err-string> otherwise.
+local function neural_force_train()
+  local url = string.format('http://%s/plugins/neural/train?rule=%s&settings_id=default&timeout=%d',
+      opts.connect, opts.rule, math.floor(opts.train_wait))
+  local headers = {}
+  if opts.password and opts.password ~= '' then
+    headers['Password'] = opts.password
+  end
+
+  local err, response = rspamd_http.request {
+    config = rspamd_config,
+    ev_base = rspamadm_ev_base,
+    session = rspamadm_session,
+    resolver = rspamadm_dns_resolver,
+    log_obj = rspamd_config,
+    url = url,
+    method = 'POST',
+    headers = headers,
+    timeout = opts.train_wait + 10,
+  }
+
+  if err then
+    return false, err
+  end
+  if not response or response.code ~= 200 then
+    return false, string.format('HTTP code %s: %s',
+        response and response.code or '?', response and response.content or '')
+  end
+
+  local rep_parser = ucl.parser()
+  local ok, perr = rep_parser:parse_string(response.content)
+  if not ok then
+    return false, string.format('cannot parse reply: %s', perr)
+  end
+  local obj = rep_parser:get_object()
+  if not obj.trained then
+    return false, obj.error or 'training did not run'
+  end
+
+  return true, obj
+end
+
+-- Probe scan of a single message; returns true once the scanner emits a neural
+-- verdict symbol (i.e. the freshly trained model is being served).
+local function neural_serves(probe_file)
+  if not probe_file then
+    return false
+  end
+  local rspamc_command = string.format(
+      '%s --connect %s -j --compact -n 1 -t %.3f ' ..
+      '--header Settings="{symbols_enabled=[%s, %s]}" %s',
+      opts.rspamc, opts.connect, opts.timeout,
+      opts.spam_symbol, opts.ham_symbol, probe_file)
+  local handle = io.popen(rspamc_command)
+  if not handle then
+    return false
+  end
+  local output = handle:read("*all")
+  handle:close()
+
+  for line in output:gmatch("[^\n]+") do
+    local pr = ucl.parser()
+    if pr:parse_string(line) then
+      local symbols = (pr:get_object() or {}).symbols or {}
+      if symbols[opts.spam_symbol] or symbols[opts.ham_symbol] then
+        return true
+      end
+    end
+  end
+  return false
 end
 
 -- Function to evaluate classifier performance
@@ -336,10 +423,47 @@ local function handler(args)
       print(string.format("  Submitted %d spam + %d ham samples in %.2f seconds",
         spam_trained, ham_trained, train_spam_time))
 
-      -- Wait for neural network to train using ev_base sleep
-      print(string.format("\nWaiting %d seconds for neural network training...", opts.train_wait))
-      rspamadm_ev_base:sleep(opts.train_wait)
-      print("Training wait complete.")
+      -- Forced training is on by default for neural; --no-force-train opts out.
+      local force_train = not opts.no_force_train
+
+      if force_train then
+        -- Deterministic path: trigger one training run from the stored vectors
+        -- and poll until the scanner serves it, instead of sleeping and hoping
+        -- the periodic max_trains trigger fired.
+        print(string.format("\nForcing neural training from stored vectors (rule=%s)...", opts.rule))
+        local ok, res = neural_force_train()
+        if ok then
+          print(string.format("  Trained ANN version %s from %s spam + %s ham vectors (%s bytes)",
+            res.version, res.spam, res.ham, res.bytes))
+
+          print("Polling until the trained model is served...")
+          local probe = train_spam[1] or train_ham[1]
+          local deadline = rspamd_util.get_time() + opts.train_wait
+          local serving = false
+          while rspamd_util.get_time() < deadline do
+            if neural_serves(probe) then
+              serving = true
+              break
+            end
+            rspamadm_ev_base:sleep(0.5)
+          end
+          if serving then
+            print("Model is being served.")
+          else
+            print(string.format("WARNING: model not served within %d seconds; proceeding anyway.",
+              opts.train_wait))
+          end
+        else
+          print(string.format("Forced training failed (%s); falling back to waiting %d seconds...",
+            res, opts.train_wait))
+          rspamadm_ev_base:sleep(opts.train_wait)
+        end
+      else
+        -- Wait for neural network to train using ev_base sleep
+        print(string.format("\nWaiting %d seconds for neural network training...", opts.train_wait))
+        rspamadm_ev_base:sleep(opts.train_wait)
+        print("Training wait complete.")
+      end
     else
       -- Bayes training using learn_spam/learn_ham
       print(string.format("Start learn spam, %d messages, %d connections", #train_spam, opts.nconns))

--- a/rules/controller/neural.lua
+++ b/rules/controller/neural.lua
@@ -20,6 +20,7 @@ local ucl = require "ucl"
 local lua_util = require "lua_util"
 local rspamd_util = require "rspamd_util"
 local lua_redis = require "lua_redis"
+local lua_settings = require "lua_settings"
 local rspamd_logger = require "rspamd_logger"
 
 local E = {}
@@ -380,91 +381,160 @@ local function handle_learn_message(task, conn)
   end
 end
 
-local function handle_train(task, conn, req_params)
-  local rule_name = req_params.rule or 'default'
-  local rule = neural_common.settings.rules[rule_name]
-  if not rule then
-    conn:send_error(400, 'unknown rule')
-    return
+-- Resolve a rule's settings element (`set`) from an explicit settings id.
+-- Accepts a numeric id, a named settings id, or nil/'default' for the default
+-- set (rule.settings[-1]). Follows reference entries (number -> another id).
+local function resolve_set(rule, settings_id)
+  local set
+  if settings_id == nil or settings_id == '' or settings_id == 'default' then
+    set = rule.settings[-1]
+  else
+    local sid = tonumber(settings_id)
+    if not sid then
+      sid = lua_settings.numeric_settings_id(tostring(settings_id))
+    end
+    set = rule.settings[sid]
   end
 
-  -- Get the set for this rule
-  local set = neural_common.get_rule_settings(task, rule)
-  if not set then
-    -- Try to find any available set
-    for sid, s in pairs(rule.settings or {}) do
-      if type(s) == 'table' then
-        set = s
-        set.name = set.name or sid
-        break
+  local guard = 0
+  while type(set) == 'number' and guard < 16 do
+    set = rule.settings[set]
+    guard = guard + 1
+  end
+
+  if type(set) == 'table' then
+    return set
+  end
+  return nil
+end
+
+-- Force a training run from the vectors already stored in Redis, decoupling the
+-- corpus feed from the train. Reads the current profile's _spam_set/_ham_set,
+-- runs exactly one training via neural_common.force_train_from_redis (which
+-- bypasses the max_trains/frozen gate, requiring only both classes non-empty,
+-- and is single-flight with a guaranteed lock release), then replies with the
+-- trained model's metadata. The HTTP connection is held open until training
+-- completes via a polling task timer (which keeps the controller session
+-- alive across the training subprocess).
+--
+-- Parameters come from the query string (rule, settings_id, timeout) and, if a
+-- JSON body is present, from {rule, settings_id} there as a fallback.
+local function handle_train(task, conn, req_params)
+  local p = req_params or {}
+
+  -- Optional JSON body fallback for {rule, settings_id}. The endpoint is
+  -- normally driven by query parameters (no body), so guard the read.
+  local _, body = pcall(function()
+    return task:get_rawbody()
+  end)
+  if body and #tostring(body) > 0 then
+    local bparser = ucl.parser()
+    if bparser:parse_text(tostring(body)) then
+      local obj = bparser:get_object()
+      if type(obj) == 'table' then
+        p.rule = p.rule or obj.rule
+        p.settings_id = p.settings_id or obj.settings_id
+        p.timeout = p.timeout or obj.timeout
       end
     end
   end
 
-  if not set then
-    conn:send_error(400, 'no settings found for rule')
+  local rule_name = p.rule or 'default'
+  local rule = neural_common.settings.rules[rule_name]
+  if not rule then
+    conn:send_error(404, 'unknown rule')
     return
   end
 
-  -- Check pending vectors count
-  local pending_key = neural_common.pending_train_key(rule, set)
+  local set = resolve_set(rule, p.settings_id)
+  if not set then
+    conn:send_error(404, 'no settings found for rule')
+    return
+  end
 
-  local function check_and_train(spam_count, ham_count)
-    if spam_count > 0 and ham_count > 0 then
-      rspamd_logger.infox(task, 'manual train trigger for %s:%s with %s spam, %s ham vectors',
-        rule.prefix, set.name, spam_count, ham_count)
+  local deadline = tonumber(p.timeout) or 60.0
+  local poll_interval = 0.1
+  local started = rspamd_util.get_time()
 
-      -- The training will be picked up by the next check_anns cycle
-      -- For immediate training, we'd need access to the worker object
-      conn:send_ucl({
-        success = true,
-        message = 'training vectors available',
-        spam_vectors = spam_count,
-        ham_vectors = ham_count,
-        pending_key = pending_key
-      })
-    else
+  -- Filled in by the force-train callback; the polling timer below observes
+  -- these and writes the HTTP reply exactly once.
+  local train_done, train_err, train_res = false, nil, nil
+  local replied = false
+
+  local function reply_now()
+    if replied then
+      return
+    end
+    replied = true
+
+    if train_err then
       conn:send_ucl({
         success = false,
-        message = 'not enough vectors for training',
-        spam_vectors = spam_count,
-        ham_vectors = ham_count
+        trained = false,
+        rule = rule_name,
+        settings = set.name,
+        error = train_err,
+      })
+    else
+      local res = train_res or {}
+      conn:send_ucl({
+        success = true,
+        trained = true,
+        rule = rule_name,
+        settings = set.name,
+        spam = res.spam,
+        ham = res.ham,
+        bytes = res.bytes,
+        version = res.version,
+        redis_key = res.redis_key,
       })
     end
   end
 
-  -- Count pending vectors
-  local spam_count = 0
-  local function count_ham_cb(err, data)
-    local ham_count = 0
-    if not err and (type(data) == 'number' or type(data) == 'string') then
-      ham_count = tonumber(data) or 0
+  -- Polling timer: keeps the controller session alive across the training
+  -- subprocess and writes the reply once training resolves (or on deadline).
+  --
+  -- task:add_timer cannot reschedule itself (its native re-arm calls
+  -- ev_timer_again with repeat=0 on an already-stopped one-shot timer, a no-op),
+  -- so each tick that still needs to wait arms a *fresh* one-shot timer and then
+  -- returns nil. The new timer's session event is added before the current one
+  -- is removed, so the controller session never drains to zero events (which
+  -- would finalize the request and drop the connection) until we deliberately
+  -- stop re-arming after the reply is sent.
+  local poll_cb
+  local function schedule_poll()
+    task:add_timer(poll_interval, poll_cb)
+  end
+  poll_cb = function(_)
+    if train_done then
+      reply_now()
+      return -- stop polling: event drains, session finalizes, connection closes
     end
-    check_and_train(spam_count, ham_count)
+    if (rspamd_util.get_time() - started) >= deadline then
+      train_err = train_err or string.format('training did not complete within %s seconds', deadline)
+      reply_now()
+      return
+    end
+    schedule_poll()
+    return
   end
 
-  local function count_spam_cb(err, data)
-    if not err and (type(data) == 'number' or type(data) == 'string') then
-      spam_count = tonumber(data) or 0
-    end
-    lua_redis.redis_make_request(task,
-      rule.redis,
-      nil,
-      false,
-      count_ham_cb,
-      'SCARD',
-      { pending_key .. '_ham_set' }
-    )
-  end
+  schedule_poll()
 
-  lua_redis.redis_make_request(task,
-    rule.redis,
-    nil,
-    false,
-    count_spam_cb,
-    'SCARD',
-    { pending_key .. '_spam_set' }
-  )
+  rspamd_logger.infox(task, 'force-train requested for %s:%s', rule.prefix, set.name)
+
+  neural_common.force_train_from_redis(task:get_worker(), task:get_ev_base(), rule, set,
+    function(err, res)
+      train_done = true
+      if err then
+        train_err = err
+        rspamd_logger.infox(task, 'force-train for %s:%s failed: %s', rule.prefix, set.name, err)
+      else
+        train_res = res
+        rspamd_logger.infox(task, 'force-train for %s:%s done: version=%s spam=%s ham=%s bytes=%s',
+          rule.prefix, set.name, res.version, res.spam, res.ham, res.bytes)
+      end
+    end)
 end
 
 return {

--- a/test/functional/cases/330_neural/008_force_train.robot
+++ b/test/functional/cases/330_neural/008_force_train.robot
@@ -1,0 +1,82 @@
+*** Settings ***
+Suite Setup      Rspamd Redis Setup
+Suite Teardown   Rspamd Redis Teardown
+Library         Process
+Library         Collections
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/neural_force_train.conf
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/spam_message.eml
+${REDIS_SCOPE}     Suite
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+Feed training vectors without auto-training
+  # ANN-Train scans store vectors into the versioned Redis sets. max_trains is
+  # 500, so 10 + 10 vectors are far below the auto-train threshold: the periodic
+  # trainer must NOT train the model here.
+  Sleep  2s  Wait for redis and initial check_anns
+  FOR    ${INDEX}    IN RANGE    4    14
+    Scan File  ${MESSAGE}  Settings={symbols_enabled = ["SPAM_SYMBOL1", "SPAM_SYMBOL2", "SPAM_SYMBOL3", "SPAM_SYMBOL${INDEX}"]}  ANN-Train=spam
+    Expect Symbol  SPAM_SYMBOL${INDEX}
+    Scan File  ${MESSAGE}  Settings={symbols_enabled = ["HAM_SYMBOL1", "HAM_SYMBOL2", "HAM_SYMBOL3", "HAM_SYMBOL${INDEX}"]}  ANN-Train=ham
+    Expect Symbol  HAM_SYMBOL${INDEX}
+  END
+  Sleep  1s  Let the async SADDs settle
+
+  # Both training sets must be populated, and no ANN may be served yet.
+  ${spam_set} =  Get Neural Train Set  spam
+  Should Not Be Empty  ${spam_set}  msg=no spam training set was created by the feed
+  ${n_spam} =  Redis SCARD  ${spam_set}
+  Should Be True  ${n_spam} >= 10  msg=feed did not store enough spam vectors
+
+  Scan File  ${MESSAGE}  Settings={symbols_enabled = ["SPAM_SYMBOL1","SPAM_SYMBOL2","SPAM_SYMBOL3","SPAM_SYMBOL8"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Do Not Expect Symbol  NEURAL_SPAM_SHORT
+  Do Not Expect Symbol  NEURAL_HAM_SHORT
+
+Force train from stored vectors
+  # The controller endpoint must train one model from the stored vectors and
+  # report the trained metadata, even though the corpus is well below max_trains.
+  ${result} =  HTTP  POST  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_CONTROLLER}  /plugins/neural/train?rule=SHORT
+  Should Be Equal As Integers  ${result}[0]  200
+  ${reply} =  Evaluate  json.loads($result[1])  json
+  Should Be True  ${reply}[trained]  msg=force-train did not train: ${result}[1]
+  Should Be True  ${reply}[spam] >= 10
+  Should Be True  ${reply}[ham] >= 10
+  Should Be True  ${reply}[version] >= 1
+  Should Be True  ${reply}[bytes] > 0
+
+Trained model is served
+  Sleep  2s  Wait for the scanner to reload the freshly trained ANN
+  Scan File  ${MESSAGE}  Settings={symbols_enabled = ["SPAM_SYMBOL1","SPAM_SYMBOL2","SPAM_SYMBOL3","SPAM_SYMBOL8"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_SPAM_SHORT
+  Do Not Expect Symbol  NEURAL_HAM_SHORT
+
+  Scan File  ${MESSAGE}  Settings={symbols_enabled = ["HAM_SYMBOL1","HAM_SYMBOL2","HAM_SYMBOL3","HAM_SYMBOL8"];groups_enabled=["neural"];symbols_disabled = ["NEURAL_LEARN"]}
+  Expect Symbol  NEURAL_HAM_SHORT
+  Do Not Expect Symbol  NEURAL_SPAM_SHORT
+
+Force train rejects an unknown rule
+  ${result} =  HTTP  POST  ${RSPAMD_LOCAL_ADDR}  ${RSPAMD_PORT_CONTROLLER}  /plugins/neural/train?rule=NOPE
+  Should Be Equal As Integers  ${result}[0]  404
+
+*** Keywords ***
+Get Neural Train Set
+  [Arguments]  ${class}
+  # The training set keys use the rn_ prefix (ANN blobs/sets), distinct from the
+  # rn3_ profile zset. Return the first rn_SHORT_*_<class>_set key.
+  ${res} =  Run Process  redis-cli  -h  ${RSPAMD_REDIS_ADDR}  -p  ${RSPAMD_REDIS_PORT}
+  ...  KEYS  rn_SHORT_*_${class}_set
+  ${key} =  Evaluate  $res.stdout.strip().split('\\n')[0]
+  [Return]  ${key}
+
+Redis SCARD
+  [Arguments]  ${key}
+  ${res} =  Run Process  redis-cli  -h  ${RSPAMD_REDIS_ADDR}  -p  ${RSPAMD_REDIS_PORT}
+  ...  SCARD  ${key}
+  ${n} =  Convert To Integer  ${res.stdout.strip()}
+  [Return]  ${n}

--- a/test/functional/configs/neural_force_train.conf
+++ b/test/functional/configs/neural_force_train.conf
@@ -1,0 +1,72 @@
+options = {
+  url_tld = "{= env.URL_TLD =}"
+  pidfile = "{= env.TMPDIR =}/rspamd.pid"
+  lua_path = "{= env.INSTALLROOT =}/share/rspamd/lib/?.lua"
+  filters = [];
+  explicit_modules = ["settings"];
+}
+
+logging = {
+  type = "file",
+  level = "debug"
+  filename = "{= env.TMPDIR =}/rspamd.log"
+  log_usec = true;
+}
+metric = {
+  name = "default",
+  actions = {
+    reject = 100500,
+    add_header = 50500,
+  }
+  unknown_weight = 1
+}
+worker {
+  type = normal
+  bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_NORMAL =}"
+  count = 1
+  task_timeout = 10s;
+}
+worker {
+  type = controller
+  bind_socket = "{= env.LOCAL_ADDR =}:{= env.PORT_CONTROLLER =}"
+  count = 1
+  secure_ip = ["127.0.0.1", "::1"];
+  stats_path = "{= env.TMPDIR =}/stats.ucl"
+}
+
+modules {
+  path = "{= env.TESTDIR =}/../../src/plugins/lua/"
+}
+
+lua = "{= env.TESTDIR =}/lua/test_coverage.lua";
+
+neural {
+  rules {
+      SHORT {
+          train {
+              learning_rate = 0.001;
+              max_usages = 2;
+              spam_score = 1;
+              ham_score = -1;
+              # Deliberately high so the periodic auto-train never fires for the
+              # small corpus this suite feeds: a NEURAL verdict therefore proves
+              # the controller force-train endpoint (not auto-train) trained the
+              # model.
+              max_trains = 500;
+              max_iterations = 250;
+          }
+          symbol_spam = "NEURAL_SPAM_SHORT";
+          symbol_ham = "NEURAL_HAM_SHORT";
+          ann_expire = 86400;
+          watch_interval = 0.5;
+      }
+  }
+  allow_local = true;
+
+}
+redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+  expand_keys = true;
+}
+
+lua = "{= env.TESTDIR =}/lua/neural.lua";


### PR DESCRIPTION
## Summary

Adds a controller endpoint that force-trains a neural network from the vectors
already stored in Redis, **decoupling the corpus feed from the train**. Today,
feeding training vectors (via `ANN-Train` scans) and getting a trained model are
two loosely-coupled steps: you feed, then wait and hope the periodic
`max_trains` trigger fires. That is fragile under a real corpus push (a roll
mid-feed leaves the vectors below threshold, a frozen model never auto-trains,
concurrent feeders race). This makes `feed -> train -> serve` deterministic and
repeatable.

`POST /plugins/neural/train?rule=<rule>&settings_id=<id>` reads the current
profile's stored `_spam_set`/`_ham_set`, runs exactly one training (requiring
only that both classes are non-empty — the `max_trains`/frozen gate is
bypassed), and replies once the model is trained and registered:

```json
{ "trained": true, "spam": 10, "ham": 10, "bytes": 33460, "version": 1 }
```

## Changes

- **`lualib/plugins/neural.lua`**
  - `force_train_from_redis(worker, ev_base, rule, set, cb)`: selects the
    current profile (compatible, `dist==0`, highest version), acquires the
    per-profile lock, unions the versioned and pending spam/ham sets, and trains
    when both classes are non-empty. Single-flight via `learning_spawned` plus
    the cross-process Redis lock; the lock is always released.
  - `spawn_train` gains `force` (bypass the `max_trains/2` minimum-corpus gate)
    and `on_complete_cb(err, result)` fired on every terminal outcome. Its
    pre-fork bailouts now release the lock too, fixing a latent lock strand on
    the existing auto-train path.
- **`rules/controller/neural.lua`**: `handle_train` (previously a no-op that
  only counted pending vectors) now runs the training and replies with the
  trained model's metadata, holding the controller HTTP session open across the
  training subprocess.
- **`lualib/rspamadm/classifier_test.lua`**: `--force-train` (default on for
  `-C neural`, with `--no-force-train` to opt out), `--rule`, `--password`.
  After the feed it POSTs the endpoint and polls a probe scan until the model is
  served, replacing the fixed `--train-wait` sleep.

## Tests

- New `test/functional/cases/330_neural/008_force_train.robot` +
  `configs/neural_force_train.conf` (`max_trains=500` so auto-train cannot fire,
  proving the endpoint is what trained the model).
- Full `330 Neural` suite: **36/36 pass**, including the auto/manual/frozen
  cases that exercise the modified `spawn_train` (no regression).

## Notes

Marked draft pending an end-to-end `classifier_test -C neural` run against a
real corpus (`--nconns 1` and `16`).
