### PR TITLE
[Test] Run push-triggered CI on all branches in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,28 +4,42 @@ on:
   pull_request:
     branches:
       - master
-  # Push only triggers on master. Feature branches are covered by the
-  # `pull_request` event once a PR is open, so we never fire both `push`
-  # (refs/heads/<branch>) and `pull_request` (refs/pull/<n>/merge) for the
-  # same commit -- which previously left a spurious *cancelled* run that
-  # reads like a CI failure. Trade-off: pushing to a branch with no open
-  # PR doesn't run CI; open (or draft) the PR to get it.
+  # In rspamd/rspamd push only triggers on master -- feature branches are
+  # covered by the `pull_request` event once a PR is open, so we never fire
+  # both `push` (refs/heads/<branch>) and `pull_request` (refs/pull/<n>/merge)
+  # for the same commit, which previously left a spurious *cancelled* run that
+  # reads like a CI failure.
+  # In forks push triggers on all branches so that CI runs without opening a PR.
   push:
     branches:
-      - master
+      - '**'
 
-# Cancel a still-running CI when a newer commit supersedes it: per PR for
-# pull_request events, per ref for master pushes. This only reaps genuinely
-# outdated runs now -- the push/pull_request duplicate is gone at the source.
+# A commit pushed to a branch that also has an open PR fires two runs at once:
+# one for `push` (refs/heads/<branch>) and one for `pull_request`
+# (refs/pull/<n>/merge). Key the concurrency group on the head SHA so both
+# events for the same commit share a group: cancel-in-progress reaps the older
+# run. In rspamd/rspamd the push trigger is restricted to master so the
+# duplicate never occurs there; the SHA key is a no-op for that repo but keeps
+# the behaviour correct in forks where push fires on all branches.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:
   linters:
+    # In rspamd/rspamd skip push runs on feature branches: pull_request already
+    # covers them. In forks run on every push so CI works without an open PR.
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/master' ||
+      github.repository != 'rspamd/rspamd'
     uses: ./.github/workflows/ci_linters.yml
 
   fedora:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/master' ||
+      github.repository != 'rspamd/rspamd'
     uses: ./.github/workflows/ci_rspamd.yml
     with:
       image: ghcr.io/rspamd/rspamd-build-docker:fedora-ci
@@ -33,13 +47,22 @@ jobs:
       enable_luajit: 'OFF'
 
   ubuntu_amd64:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/master' ||
+      github.repository != 'rspamd/rspamd'
     uses: ./.github/workflows/ci_rspamd.yml
     with:
       image: ghcr.io/rspamd/rspamd-build-docker:ubuntu-ci
       name: ubuntu-ci-amd64
 
   ubuntu_arm64:
-    if: ${{ !vars.NO_ARM }}
+    if: |
+      !vars.NO_ARM && (
+        github.event_name == 'pull_request' ||
+        github.ref == 'refs/heads/master' ||
+        github.repository != 'rspamd/rspamd'
+      )
     uses: ./.github/workflows/ci_rspamd.yml
     with:
       image: ghcr.io/rspamd/rspamd-build-docker:ubuntu-ci
@@ -47,18 +70,30 @@ jobs:
       runner: ${{ vars.ARM_RUNNER || 'ubuntu-24.04-arm' }}
 
   ubuntu-focal:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/master' ||
+      github.repository != 'rspamd/rspamd'
     uses: ./.github/workflows/ci_rspamd_build.yml
     with:
       image: ghcr.io/rspamd/rspamd-build-docker:ubuntu-focal
       name: ubuntu-focal
 
   centos-8:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/master' ||
+      github.repository != 'rspamd/rspamd'
     uses: ./.github/workflows/ci_rspamd_build.yml
     with:
       image: ghcr.io/rspamd/rspamd-build-docker:centos-8
       name: centos-8
 
   centos-9:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/master' ||
+      github.repository != 'rspamd/rspamd'
     uses: ./.github/workflows/ci_rspamd_build.yml
     with:
       image: ghcr.io/rspamd/rspamd-build-docker:centos-9
@@ -66,6 +101,10 @@ jobs:
 
   webui-e2e-playwright:
     needs: ubuntu_amd64
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/master' ||
+      github.repository != 'rspamd/rspamd'
     uses: ./.github/workflows/ci_webui_e2e_playwright.yml
     with:
       image: ghcr.io/rspamd/rspamd-build-docker:ubuntu-ci


### PR DESCRIPTION
rspamd/rspamd restricts push to master (71605c25) to avoid the duplicate push+pull_request run on feature branches that leaves a spurious *cancelled* status. This trade-off is acceptable for the main repo where contributors open PRs, but inconvenient in forks where CI is needed on every push without opening a PR.