### PR TITLE
[FEATURE]: src/rspamadm: allow reading password from env

### DIFF
--- a/src/rspamadm/pw.c
+++ b/src/rspamadm/pw.c
@@ -269,8 +269,21 @@ rspamadm_pw_check(void)
 			exit(EXIT_FAILURE);
 		}
 
-		plen = rspamd_read_passphrase(test_password, sizeof(test_password),
-									  0, NULL);
+		if (!isatty(STDIN_FILENO)) {
+			if (fgets(test_password, sizeof(test_password), stdin) != NULL) {
+				plen = strlen(test_password);
+				if (plen > 0 && test_password[plen - 1] == '\n') {
+					test_password[--plen] = '\0';
+				}
+			}
+			else {
+				plen = 0;
+			}
+		}
+		else {
+			plen = rspamd_read_passphrase(test_password, sizeof(test_password),
+										  0, NULL);
+		}
 		if (plen == 0) {
 			rspamd_explicit_memzero(encrypted_password, sizeof(encrypted_password));
 			fprintf(stderr, "Invalid password\n");

--- a/src/rspamadm/pw.c
+++ b/src/rspamadm/pw.c
@@ -269,16 +269,9 @@ rspamadm_pw_check(void)
 			exit(EXIT_FAILURE);
 		}
 
-		if (!isatty(STDIN_FILENO)) {
-			if (fgets(test_password, sizeof(test_password), stdin) != NULL) {
-				plen = strlen(test_password);
-				if (plen > 0 && test_password[plen - 1] == '\n') {
-					test_password[--plen] = '\0';
-				}
-			}
-			else {
-				plen = 0;
-			}
+		const char *env_password = getenv("RSPAMADM_PASSWORD");
+		if (env_password != NULL && env_password[0] != '\0') {
+			plen = rspamd_strlcpy(test_password, env_password, sizeof(test_password));
 		}
 		else {
 			plen = rspamd_read_passphrase(test_password, sizeof(test_password),

--- a/test/functional/cases/150_rspamadm.robot
+++ b/test/functional/cases/150_rspamadm.robot
@@ -55,20 +55,16 @@ Verbose mode
   Should Match Regexp  ${result.stdout}  hello world\n
   Should Be Equal As Integers  ${result.rc}  0
   
-Password Check Via Stdin Correct
+Password Check Via Env Correct
   ${enc} =  Rspamadm  pw  -p  nq1
-  ${handle} =  Start Process  ${RSPAMADM}  pw  -c  -p  ${enc.stdout}  stdin=PIPE
-  ${output} =  Write to stdin  ${handle}  nq1
-  ${result} =  Wait For Process  ${handle}
-  Should Contain  ${output}  password correct
+  ${result} =  Run Process  ${RSPAMADM}  pw  -c  -p  ${enc.stdout}  env:RSPAMADM_PASSWORD=nq1
+  Should Contain  ${result.stdout}  password correct
   Should Be Equal As Integers  ${result.rc}  0
 
-Password Check Via Stdin Wrong
+Password Check Via Env Wrong
   ${enc} =  Rspamadm  pw  -p  nq1
-  ${handle} =  Start Process  ${RSPAMADM}  pw  -c  -p  ${enc.stdout}  stdin=PIPE
-  ${output} =  Write to stdin  ${handle}  wrongpassword
-  ${result} =  Wait For Process  ${handle}
-  Should Contain  ${output}  password incorrect
+  ${result} =  Run Process  ${RSPAMADM}  pw  -c  -p  ${enc.stdout}  env:RSPAMADM_PASSWORD=wrongpassword
+  Should Contain  ${result.stdout}  password incorrect
   Should Be Equal As Integers  ${result.rc}  1
 
 SecretBox rspamadm encrypt/decrypt

--- a/test/functional/cases/150_rspamadm.robot
+++ b/test/functional/cases/150_rspamadm.robot
@@ -55,6 +55,22 @@ Verbose mode
   Should Match Regexp  ${result.stdout}  hello world\n
   Should Be Equal As Integers  ${result.rc}  0
   
+Password Check Via Stdin Correct
+  ${enc} =  Rspamadm  pw  -p  nq1
+  ${handle} =  Start Process  ${RSPAMADM}  pw  -c  -p  ${enc.stdout}  stdin=PIPE
+  ${output} =  Write to stdin  ${handle}  nq1
+  ${result} =  Wait For Process  ${handle}
+  Should Contain  ${output}  password correct
+  Should Be Equal As Integers  ${result.rc}  0
+
+Password Check Via Stdin Wrong
+  ${enc} =  Rspamadm  pw  -p  nq1
+  ${handle} =  Start Process  ${RSPAMADM}  pw  -c  -p  ${enc.stdout}  stdin=PIPE
+  ${output} =  Write to stdin  ${handle}  wrongpassword
+  ${result} =  Wait For Process  ${handle}
+  Should Contain  ${output}  password incorrect
+  Should Be Equal As Integers  ${result.rc}  1
+
 SecretBox rspamadm encrypt/decrypt
   ${result} =  Rspamadm  secret_box  -B  encrypt  -t  ${TEXT}  -k  ${KEY}  -n  ${NONCE}
   Should Match Regexp  ${result.stderr}  ^$


### PR DESCRIPTION
Currently the CLI only allows reading the password from tty. This makes it challenging to check the password via automation, ie. used by continous deployment to ensure a clean state.

This change adds the functionality to read from env, so that passwords can be safely passed in and checked.