### PR TITLE
Fix insertion of HTTP header in get_http_headers

### DIFF
--- a/lualib/lua_scanners/icap.lua
+++ b/lualib/lua_scanners/icap.lua
@@ -282,7 +282,7 @@ local function icap_check(task, content, digest, rule, maybe_part)
 
       local function get_http_headers()
         local http_hlen = 2
-        table.insert(http_headers, 'HTTP/1.0 200 OK\r\n')
+        table.insert(http_headers, 1, 'HTTP/1.0 200 OK\r\n')
         table.insert(http_headers, string.format('Date: %s\r\n', rspamd_util.time_to_string(rspamd_util.get_time())))
         table.insert(http_headers, string.format('Server: %s\r\n', 'Apache/2.4'))
         if rule.user_agent ~= "none" then


### PR DESCRIPTION
`get_req_headers()` under certain configuration would insert `content-type` in `http_headers`, however as it is called before `get_http_headers()`, the `content-type` header would be inserted before `HTTP/1.0 200 OK` line, causing the final headers to be

```
Content-Type: application/octet-stream
HTTP/1.0 200 OK
Date: Tue, 30 Jun 2026 05:55:58 GMT
...
```

ESET unfortunately is strict on the header parsing and would reject the payload with error 400.

This PR fixes it by always insert the HTTP/1.0 line at the head of the list.