### PR TITLE
[Fix] lua_selectors: reject selectors that parse only as a prefix

### DIFF
--- a/lualib/lua_selectors/init.lua
+++ b/lualib/lua_selectors/init.lua
@@ -280,7 +280,7 @@ local function make_grammar()
     NAMED_ARG = (l.Ct("") * l.Cg(argument * eqsign * (argument + l.V("LIST_ARGS")) * comma ^ 0) ^ 0),
     LIST_ARGS = l.Ct(tbl_obrace * l.V("LIST_ARG") * tbl_ebrace),
     LIST_ARG = l.Cg(argument * comma ^ 0) ^ 0,
-  }
+  } * spc * l.Cp()
 end
 
 local parser = make_grammar()
@@ -293,6 +293,16 @@ exports.parse_selector = function(cfg, str)
   local output = {}
 
   if not parsed or not parsed[1] then
+    return nil
+  end
+
+  -- The last capture is the parse end position (lpeg.Cp); lpeg matches the
+  -- longest valid prefix, so anything left after that position is a parse
+  -- error, not a selector to be silently ignored
+  local last_pos = table.remove(parsed)
+  if last_pos <= #str then
+    logger.errx(cfg, "invalid selector '%s': unexpected token at position %d ('%s')",
+        str, last_pos, str:sub(last_pos))
     return nil
   end
 

--- a/test/lua/unit/selectors.negative.lua
+++ b/test/lua/unit/selectors.negative.lua
@@ -53,6 +53,18 @@ context("Selectors test", function()
 
       ["unknown transformation"] = {
                 selector = "urls.somethingnew"},
+
+      ["second method"] = {
+                selector = "from('smtp'):domain:lower"},
+
+      ["second method after transform-less method"] = {
+                selector = "urls:get_host:lower"},
+
+      ["stray paren"] = {
+                selector = "header('Subject').lower)"},
+
+      ["junk after list element"] = {
+                selector = "ip;from:addr garbage"},
   }
 
   for case_name, case in pairs(cases) do
@@ -60,6 +72,34 @@ context("Selectors test", function()
       local sels = lua_selectors.parse_selector(cfg, case.selector)
       print(logger.slog("%1", sels))
       assert_nil(sels)
+    end)
+  end
+
+  -- Selectors which must be parsed in whole
+  local valid_cases = {
+      ["method then transform"] = {
+                selector = "from('smtp'):domain.lower"},
+
+      ["method then transform chain"] = {
+                selector = "urls:get_host.lower.uniq"},
+
+      ["transform with arguments"] = {
+                selector = "header('Subject').lower.digest('hex')"},
+
+      ["list of selectors"] = {
+                selector = "from:addr;ip"},
+
+      ["method then transform with tld"] = {
+                selector = "from('smtp'):domain.get_tld"},
+
+      ["trailing whitespace"] = {
+                selector = "from('smtp'):domain.lower "},
+  }
+
+  for case_name, case in pairs(valid_cases) do
+    test("valid case " .. case_name, function()
+      local sels = lua_selectors.parse_selector(cfg, case.selector)
+      assert_not_nil(sels)
     end)
   end
 end)


### PR DESCRIPTION
## The bug

The selector grammar built in `make_grammar()` was not anchored to the end of input. `parse_selector()` called `parser:match(str)` as-is, and lpeg happily matched the longest valid *prefix* of the string, silently discarding the rest.

Since `EXPR = FUNCTION (':' METHOD)^-1 ('.' PROCESSOR)^0`, a second `:` cannot parse, so e.g.

```
from('smtp'):domain:lower
```

stopped after `from('smtp'):domain` and the `:lower` tail was silently dropped — `parse_selector` returned a working pipeline for the prefix. The same happened for any trailing garbage: a stray paren (`header('Subject').lower)`), or junk after a `;` list element (`ip;from:addr garbage`).

Consequence: every selector consumer (multimap, rbl, ratelimit, settings, reputation, the controller's `check_selector` endpoint used by WebUI selector testers) reported such selectors as **valid** while they evaluated as their prefix only.

## The fix

An `lpeg.Cp()` capture is appended after the grammar (with optional trailing whitespace), and `parse_selector` now requires the whole input to be consumed. On an incomplete parse it logs

```
invalid selector 'from('smtp'):domain:lower': unexpected token at position 20 (':lower')
```

and returns `nil`, so configuration load fails with a pointer to the offending tail instead of running a truncated pipeline. Trailing whitespace is still accepted; `;`/`*`-separated selector lists keep working.

All `parse_selector` consumers already handle a `nil` return (it was already possible for unknown extractors/transforms), so none depend on the prefix-tolerant behaviour.

## User-visible change

Selectors that previously "worked" thanks to the silent truncation now fail config load with a position-pointing error. Such selectors were never doing what they were written to do, so failing loudly at load time is the correct behaviour — the error message shows exactly which part of the selector was not understood.

## Tests

New negative cases in `test/lua/unit/selectors.negative.lua` (second `:` method, stray paren, junk after a list element) plus control cases asserting that valid method/transform chains, argument'd transforms, selector lists and trailing whitespace still parse. Full Lua unit suite passes (1132 tests, 0 failures).