### PR TITLE
fix(lua-lupa): Use local loop variable

### DIFF
--- a/contrib/lua-lupa/lupa.lua
+++ b/contrib/lua-lupa/lupa.lua
@@ -1849,15 +1849,16 @@ function M.filters.wordwrap(s, width, break_long_words, wrapstring)
       line = ''
     end
     if #word > width and break_long_words then
+      local remaining = word
       if #line > 0 then
         lines[#lines + 1] = line
         line = ''
       end
-      while #word > width do
-        lines[#lines + 1] = word:sub(1, width)
-        word = word:sub(width + 1)
+      while #remaining > width do
+        lines[#lines + 1] = remaining:sub(1, width)
+        remaining = remaining:sub(width + 1)
       end
-      line = word
+      line = remaining
     elseif #line > 0 then
       line = line .. ' ' .. word
     else


### PR DESCRIPTION
Lua 5.5 makes `for` expression variables constant. The recent upgrade to lua 5.5 broke lua-lupa, which previously attempted to modify the loop variable. This caused an unrecoverable error on startup:

```
rspamd_lua_require_function: require of lua_util.jinja_template failed: error loading module 'lupa' from file '/usr/share/rspamd/lualib/lupa.lua':\x0A\x09/usr/share/rspamd/lualib/lupa.lua:1858: attempt to assign to const variable 'word'
```