### PR TITLE
Preserve the sender identity from alias rewriting (DMARC/SPF, issue 6137)

### DIFF
--- a/lualib/lua_aliases.lua
+++ b/lualib/lua_aliases.lua
@@ -581,18 +581,12 @@ local function apply_service_rules(email_addr)
     return nil
   end
 
-  local function check_googlemail(addr)
-    local nd = 'gmail.com'
-    local nu, tags = check_gmail_user(addr)
-    if nu then
-      return nu, tags, nd
-    end
-    return nil, nil, nd
-  end
-
   local specific_domains = {
     ['gmail.com'] = check_gmail,
-    ['googlemail.com'] = check_googlemail,
+    -- googlemail.com shares gmail.com user-part semantics, but the domain is
+    -- never rewritten: it is DNS-distinct from gmail.com (own SPF/DMARC
+    -- records), so a rewrite would break alignment and policy lookups
+    ['googlemail.com'] = check_gmail,
   }
 
   if email_addr then

--- a/lualib/lua_selectors/extractors.lua
+++ b/lualib/lua_selectors/extractors.lua
@@ -94,7 +94,8 @@ For example, `list('foo', 'bar')` returns a list {'foo', 'bar'}]],
       return nil
     end,
     ['description'] = [[Get MIME or SMTP from (e.g. `from('smtp')` or `from('mime')`,
-uses any type by default)]],
+uses any type by default); add `orig` (e.g. `from('mime', 'orig')`) to get the
+address as it was seen in the message, before any rewrite (e.g. by the aliases module)]],
   },
   ['rcpts'] = {
     ['get_value'] = function(task, args)
@@ -110,7 +111,8 @@ uses any type by default)]],
       return nil
     end,
     ['description'] = [[Get MIME or SMTP rcpts (e.g. `rcpts('smtp')` or `rcpts('mime')`,
-uses any type by default)]],
+uses any type by default); add `orig` (e.g. `rcpts('mime', 'orig')`) to get the
+addresses as they were seen in the message, before any rewrite (e.g. by the aliases module)]],
   },
   -- Get country (ASN module must be executed first)
   ['country'] = {

--- a/src/libserver/spf.c
+++ b/src/libserver/spf.c
@@ -2670,7 +2670,11 @@ rspamd_spf_cache_domain(struct rspamd_task *task)
 	struct rspamd_email_address *addr;
 	struct rspamd_spf_cred *cred = NULL;
 
-	addr = rspamd_task_get_sender(task);
+	/*
+	 * SPF checks the RFC5321.MailFrom as it was transmitted, so use the
+	 * original sender even if the envelope from has been rewritten
+	 */
+	addr = rspamd_task_get_original_sender(task);
 	if (!addr || (addr->flags & RSPAMD_EMAIL_ADDR_EMPTY)) {
 		/* Get domain from helo */
 

--- a/src/libserver/task.c
+++ b/src/libserver/task.c
@@ -954,6 +954,16 @@ rspamd_task_get_sender(struct rspamd_task *task)
 	return task->from_envelope;
 }
 
+struct rspamd_email_address *
+rspamd_task_get_original_sender(struct rspamd_task *task)
+{
+	if (task->from_envelope_orig) {
+		return task->from_envelope_orig;
+	}
+
+	return task->from_envelope;
+}
+
 static const char *
 rspamd_task_cache_principal_recipient(struct rspamd_task *task,
 									  const char *rcpt, gsize len)

--- a/src/libserver/task.h
+++ b/src/libserver/task.h
@@ -281,6 +281,14 @@ gboolean rspamd_task_process(struct rspamd_task *task, unsigned int stages);
 struct rspamd_email_address *rspamd_task_get_sender(struct rspamd_task *task);
 
 /**
+ * Return the original (pre-rewrite) envelope sender if the envelope from has
+ * been modified (e.g. by aliases resolution), or the current sender otherwise
+ * @param task
+ * @return
+ */
+struct rspamd_email_address *rspamd_task_get_original_sender(struct rspamd_task *task);
+
+/**
  * Return addresses in the following precedence:
  * - deliver to
  * - the first smtp recipient

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -627,7 +627,9 @@ LUA_FUNCTION_DEF(task, has_from);
  *   - [empty] - empty address
  *   - [backslash] - user part contains backslash
  *   - [8bit] - contains 8bit characters
- * @param {integer|string} type if specified has the following meaning: `0` or `any` means try SMTP sender and fallback to MIME if failed, `1` or `smtp` means checking merely SMTP sender and `2` or `mime` means MIME `From:` only
+ *   - [aliased] - address was rewritten by aliases resolution
+ *   - [original] - address is the pre-rewrite original preserved by `task:set_from`
+ * @param {integer|string|table} type if specified has the following meaning: `0` or `any` means try SMTP sender and fallback to MIME if failed, `1` or `smtp` means checking merely SMTP sender and `2` or `mime` means MIME `From:` only. A table of strings may combine the type with additional flavours: `orig` (or `original`) returns the addresses as they were seen in the message, before any rewrite done via `task:set_from`, e.g. `task:get_from({'mime', 'orig'})`
  * @return {address} sender or `nil`
  */
 LUA_FUNCTION_DEF(task, get_from);
@@ -4005,7 +4007,7 @@ lua_push_email_address(lua_State *L, struct rspamd_email_address *addr)
 		}
 
 		lua_pushstring(L, "flags");
-		lua_createtable(L, 0, 7);
+		lua_createtable(L, 0, 9);
 
 		EMAIL_CHECK_FLAG(RSPAMD_EMAIL_ADDR_VALID, "valid");
 		EMAIL_CHECK_FLAG(RSPAMD_EMAIL_ADDR_IP, "ip");
@@ -4014,6 +4016,8 @@ lua_push_email_address(lua_State *L, struct rspamd_email_address *addr)
 		EMAIL_CHECK_FLAG(RSPAMD_EMAIL_ADDR_EMPTY, "empty");
 		EMAIL_CHECK_FLAG(RSPAMD_EMAIL_ADDR_HAS_BACKSLASH, "backslash");
 		EMAIL_CHECK_FLAG(RSPAMD_EMAIL_ADDR_HAS_8BIT, "8bit");
+		EMAIL_CHECK_FLAG(RSPAMD_EMAIL_ADDR_ALIASED, "aliased");
+		EMAIL_CHECK_FLAG(RSPAMD_EMAIL_ADDR_ORIGINAL, "original");
 
 		lua_settable(L, -3);
 	}
@@ -4023,24 +4027,44 @@ void lua_push_emails_address_list(lua_State *L, GPtrArray *addrs, int flags)
 {
 	struct rspamd_email_address *addr;
 	unsigned int i, pos = 1;
+	gboolean has_original = FALSE;
+
+	if (flags & LUA_ADDRESS_ORIGINAL) {
+		for (i = 0; i < addrs->len; i++) {
+			addr = g_ptr_array_index(addrs, i);
+
+			if (addr->flags & RSPAMD_EMAIL_ADDR_ORIGINAL) {
+				has_original = TRUE;
+				break;
+			}
+		}
+	}
 
 	lua_createtable(L, addrs->len, 0);
 
 	for (i = 0; i < addrs->len; i++) {
 		addr = g_ptr_array_index(addrs, i);
 
-		if (addr->flags & RSPAMD_EMAIL_ADDR_ORIGINAL) {
-			if (flags & LUA_ADDRESS_ORIGINAL) {
-				lua_push_email_address(L, addr);
-				lua_rawseti(L, -2, pos);
-				pos++;
+		if (flags & LUA_ADDRESS_ORIGINAL) {
+			/*
+			 * Return addresses as they were seen in the message: if some of
+			 * them were preserved as originals during a rewrite, hide the
+			 * rewritten versions
+			 */
+			if (has_original && !(addr->flags & RSPAMD_EMAIL_ADDR_ORIGINAL)) {
+				continue;
 			}
 		}
 		else {
-			lua_push_email_address(L, addr);
-			lua_rawseti(L, -2, pos);
-			pos++;
+			/* Return the current (possibly rewritten) view */
+			if (addr->flags & RSPAMD_EMAIL_ADDR_ORIGINAL) {
+				continue;
+			}
 		}
+
+		lua_push_email_address(L, addr);
+		lua_rawseti(L, -2, pos);
+		pos++;
 	}
 }
 

--- a/src/plugins/lua/aliases.lua
+++ b/src/plugins/lua/aliases.lua
@@ -340,6 +340,9 @@ local function aliases_callback(task)
   })
 
   --- Check and resolve From address
+  -- The From address is the sender's identity: SPF, DKIM and DMARC all key on
+  -- its domain, so only the local part may be rewritten here; any rewrite that
+  -- would change the domain is discarded
   -- @param addr_type 'smtp' or 'mime'
   local function check_from(addr_type)
     if not task:has_from(addr_type) then
@@ -347,11 +350,23 @@ local function aliases_callback(task)
     end
 
     local addr = task:get_from(addr_type)[1]
-    local original_addr = addr.addr
+    local original_domain = addr.domain
+    local modified = false
+
+    local function same_domain(domain)
+      return domain and original_domain and
+          domain:lower() == original_domain:lower()
+    end
 
     -- Apply service-specific rules (Gmail, plus-aliases)
     if settings.enable_gmail_rules or settings.enable_plus_aliases then
       local nu, tags, nd = lua_aliases.apply_service_rules(addr)
+
+      if nd and not same_domain(nd) then
+        lua_util.debugm(N, task, 'refuse to rewrite %s from domain: %s -> %s',
+            addr_type, original_domain, nd)
+        nd = nil
+      end
 
       if nu or nd then
         set_addr(addr, nu, nd)
@@ -364,24 +379,30 @@ local function aliases_callback(task)
           end, tags)
         end
 
-        alias_resolved = true
+        modified = true
       end
     end
 
     -- Resolve through alias system
     local canonical = lua_aliases.resolve_address(addr, resolve_opts)
-    if canonical and canonical:lower() ~= original_addr:lower() then
+    if canonical and canonical:lower() ~= addr.addr:lower() then
       -- Update address
       local user, domain = canonical:match('^([^@]+)@(.+)$')
       if user and domain then
-        set_addr(addr, user, domain)
-        alias_resolved = true
+        if same_domain(domain) then
+          set_addr(addr, user, domain)
+          modified = true
+        else
+          lua_util.debugm(N, task, 'refuse to resolve %s from %s -> %s: domain change',
+              addr_type, addr.addr, canonical)
+        end
       end
     end
 
     -- Update in task
-    if alias_resolved then
+    if modified then
       task:set_from(addr_type, addr, 'alias')
+      alias_resolved = true
     end
   end
 

--- a/src/plugins/lua/dmarc.lua
+++ b/src/plugins/lua/dmarc.lua
@@ -76,7 +76,9 @@ local function dmarc_validate_policy(task, policy, hdrfromdom, dmarc_esld)
   local spf_tmpfail = false
   local dkim_tmpfail = false
 
-  local spf_domain = ((task:get_from(1) or E)[1] or E).domain
+  -- SPF alignment is checked against the envelope domain as it was seen in
+  -- the message, before any rewrite (e.g. by the aliases module)
+  local spf_domain = ((task:get_from({ 'smtp', 'orig' }) or E)[1] or E).domain
 
   if not spf_domain or spf_domain == '' then
     spf_domain = task:get_helo() or ''
@@ -450,7 +452,10 @@ local function dmarc_validate_policy(task, policy, hdrfromdom, dmarc_esld)
 end
 
 local function dmarc_callback(task)
-  local from = task:get_from(2)
+  -- DMARC must evaluate the RFC5322.From domain as it was seen in the
+  -- message; rewrites done via task:set_from (e.g. by the aliases module)
+  -- must not affect alignment, policy lookup or reporting
+  local from = task:get_from({ 'mime', 'orig' })
   local hfromdom = ((from or E)[1] or E).domain
   local dmarc_domain
   local ip_addr = task:get_ip()

--- a/src/plugins/lua/forged_recipients.lua
+++ b/src/plugins/lua/forged_recipients.lua
@@ -37,8 +37,11 @@ local E = {}
 local function check_forged_headers(task)
   local auser = task:get_user()
   local delivered_to = task:get_header('Delivered-To')
-  local smtp_rcpts = task:get_recipients(1)
-  local smtp_from = task:get_from(1)
+  -- Compare the envelope and the headers as they were transmitted: alias
+  -- rewrites (e.g. a cross-domain virtual alias applied to the envelope
+  -- recipients) must not make the wire To/Cc headers look forged
+  local smtp_rcpts = task:get_recipients({ 'smtp', 'orig' })
+  local smtp_from = task:get_from({ 'smtp', 'orig' })
 
   if not smtp_rcpts then
     return
@@ -144,7 +147,7 @@ local function check_forged_headers(task)
 
   -- Check sender
   if smtp_from and smtp_from[1] and smtp_from[1]['addr'] ~= '' then
-    local mime_from = task:get_from(2)
+    local mime_from = task:get_from({ 'mime', 'orig' })
     if not mime_from or not mime_from[1] or
         not rspamd_util.strequal_caseless_utf8(mime_from[1]['addr'], smtp_from[1]['addr']) then
       task:insert_result(symbol_sender, 1, ((mime_from or E)[1] or E).addr or '', smtp_from[1].addr)

--- a/test/functional/cases/001_merged/104_get_from.robot
+++ b/test/functional/cases/001_merged/104_get_from.robot
@@ -55,3 +55,15 @@ task:get_from('mime') - quoted in the middle of DN (inner spaces)
   Scan File  ${RSPAMD_TESTDIR}/messages/from/from_quoted_dn_middle_inner.eml
   ...  Settings=${SETTINGS_GETFROM}
   Expect Symbol With Exact Options  ${SYMBOL}  ${OPTIONS3}
+
+task:get_from('mime') - orig without rewrite
+  Scan File  ${RSPAMD_TESTDIR}/messages/from/from_dn.eml
+  ...  Settings={symbols_enabled = [GET_FROM_ORIG]}
+  Expect Symbol With Exact Options  GET_FROM_ORIG  First Last,user@example.org,user,example.org,1
+
+task:get_from('mime') - orig returns wire address after rewrite
+  Scan File  ${RSPAMD_TESTDIR}/messages/from/from_dn.eml
+  ...  Rewrite-Mime-From=yes
+  ...  Settings={symbols_enabled = [REWRITE_MIME_FROM, GET_FROM, GET_FROM_ORIG]}
+  Expect Symbol With Exact Options  ${SYMBOL}  Forged,forged@forged.example.net,forged,forged.example.net
+  Expect Symbol With Exact Options  GET_FROM_ORIG  First Last,user@example.org,user,example.org,1

--- a/test/functional/cases/001_merged/115_dmarc.robot
+++ b/test/functional/cases/001_merged/115_dmarc.robot
@@ -106,6 +106,16 @@ DMARC PCT ZERO SP QUARANTINE
   ...  Settings=${DMARC_SETTINGS}
   Expect Symbol  DMARC_POLICY_SOFTFAIL
 
+DMARC EVALUATES WIRE FROM AFTER REWRITE
+  [Documentation]  DMARC must align and look up the policy for the From domain
+  ...  as it was seen in the message, even if another module rewrote the MIME
+  ...  From via task:set_from (issue 6137)
+  Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/pass_none.eml
+  ...  Rewrite-Mime-From=yes
+  ...  Settings={symbols_enabled = [REWRITE_MIME_FROM, DMARC_CHECK, DKIM_CHECK, SPF_CHECK]}
+  Expect Symbol With Option  DMARC_POLICY_ALLOW  cacophony.za.org
+  Do Not Expect Symbol  DMARC_NA
+
 # DMARC Reporting Tests
 # These tests verify that DMARC report data is saved to Redis when reporting is enabled.
 # The domain reject.cacophony.za.org has rua=mailto:dmarc-reports@rspamd.com configured.

--- a/test/functional/cases/001_merged/270_selector.robot
+++ b/test/functional/cases/001_merged/270_selector.robot
@@ -19,3 +19,11 @@ Rspamd_text selector
   Scan File  ${MESSAGE}
   ...  Settings={symbols_enabled = [RSPAMD_TEXT_SELECTOR]}
   Expect Symbol  RSPAMD_TEXT_SELECTOR
+
+From selector orig flavour
+  [Documentation]  from('mime', 'orig') must return the wire From through the
+  ...  selector pipeline even after a task:set_from rewrite
+  Scan File  ${RSPAMD_TESTDIR}/messages/from/from_dn.eml
+  ...  Rewrite-Mime-From=yes
+  ...  Settings={symbols_enabled = [REWRITE_MIME_FROM, SELECTOR_FROM_ORIG]}
+  Expect Symbol With Exact Options  SELECTOR_FROM_ORIG  forged@forged.example.net|user@example.org

--- a/test/functional/cases/001_merged/360_aliases.robot
+++ b/test/functional/cases/001_merged/360_aliases.robot
@@ -154,3 +154,33 @@ FROM AND RCPT TAGGED
   ...  Rcpt=user+tag@example.com
   Expect Symbol  TAGGED_FROM
   Expect Symbol  TAGGED_RCPT
+
+# From identity protection tests (issue 6137)
+
+GOOGLEMAIL FROM - DOMAIN PRESERVED
+  [Documentation]  Gmail user-part rules apply to googlemail.com, but the
+  ...  domain must not be rewritten to gmail.com: the two are DNS-distinct
+  ...  and publish different SPF/DMARC records
+  Scan File  ${RSPAMD_TESTDIR}/messages/aliases_googlemail.eml
+  ...  From=sender@external.com
+  ...  Rcpt=user@example.com
+  Expect Symbol  ALIAS_RESOLVED
+  Expect Symbol With Exact Options  GET_FROM  First Last,firstlast@googlemail.com,firstlast,googlemail.com
+
+FROM CROSS-DOMAIN ALIAS - NOT APPLIED
+  [Documentation]  Alias resolution that would change the From domain must be
+  ...  discarded: the From domain is an authentication identifier
+  Scan File  ${RSPAMD_TESTDIR}/messages/aliases_from_virtual.eml
+  ...  From=sender@external.com
+  ...  Rcpt=user@example.com
+  Do Not Expect Symbol  ALIAS_RESOLVED
+  Expect Symbol With Exact Options  GET_FROM  Virtual Sender,virtual@example.com,virtual,example.com
+
+FROM SAME-DOMAIN ALIAS - APPLIED
+  [Documentation]  Same-domain alias resolution of the From local part is
+  ...  still allowed
+  Scan File  ${RSPAMD_TESTDIR}/messages/aliases_from_unix.eml
+  ...  From=sender@external.com
+  ...  Rcpt=user@example.com
+  Expect Symbol  ALIAS_RESOLVED
+  Expect Symbol With Exact Options  GET_FROM  Abuse Desk,admin@example.com,admin,example.com

--- a/test/functional/cases/001_merged/360_aliases.robot
+++ b/test/functional/cases/001_merged/360_aliases.robot
@@ -184,3 +184,14 @@ FROM SAME-DOMAIN ALIAS - APPLIED
   ...  Rcpt=user@example.com
   Expect Symbol  ALIAS_RESOLVED
   Expect Symbol With Exact Options  GET_FROM  Abuse Desk,admin@example.com,admin,example.com
+
+RCPT CROSS-DOMAIN ALIAS - NOT FORGED
+  [Documentation]  A recipient rewritten to another domain (allowed for
+  ...  recipients) must not make the matching wire To header look forged:
+  ...  forged_recipients compares the addresses as transmitted
+  Scan File  ${RSPAMD_TESTDIR}/messages/aliases_rcpt_virtual.eml
+  ...  From=sender@external.com
+  ...  Rcpt=virtual@example.com
+  Expect Symbol  ALIAS_RESOLVED
+  Do Not Expect Symbol  FORGED_RECIPIENTS
+  Do Not Expect Symbol  FORGED_SENDER

--- a/test/functional/cases/001_merged/360_aliases.robot
+++ b/test/functional/cases/001_merged/360_aliases.robot
@@ -160,9 +160,11 @@ FROM AND RCPT TAGGED
 GOOGLEMAIL FROM - DOMAIN PRESERVED
   [Documentation]  Gmail user-part rules apply to googlemail.com, but the
   ...  domain must not be rewritten to gmail.com: the two are DNS-distinct
-  ...  and publish different SPF/DMARC records
+  ...  and publish different SPF/DMARC records.
+  ...  Note: each test needs a unique envelope From/Rcpt pair, otherwise the
+  ...  greylist module soft-rejects the repeated pair and skips the filters
   Scan File  ${RSPAMD_TESTDIR}/messages/aliases_googlemail.eml
-  ...  From=sender@external.com
+  ...  From=sender-gm@external.com
   ...  Rcpt=user@example.com
   Expect Symbol  ALIAS_RESOLVED
   Expect Symbol With Exact Options  GET_FROM  First Last,firstlast@googlemail.com,firstlast,googlemail.com
@@ -171,7 +173,7 @@ FROM CROSS-DOMAIN ALIAS - NOT APPLIED
   [Documentation]  Alias resolution that would change the From domain must be
   ...  discarded: the From domain is an authentication identifier
   Scan File  ${RSPAMD_TESTDIR}/messages/aliases_from_virtual.eml
-  ...  From=sender@external.com
+  ...  From=sender-vx@external.com
   ...  Rcpt=user@example.com
   Do Not Expect Symbol  ALIAS_RESOLVED
   Expect Symbol With Exact Options  GET_FROM  Virtual Sender,virtual@example.com,virtual,example.com
@@ -180,7 +182,7 @@ FROM SAME-DOMAIN ALIAS - APPLIED
   [Documentation]  Same-domain alias resolution of the From local part is
   ...  still allowed
   Scan File  ${RSPAMD_TESTDIR}/messages/aliases_from_unix.eml
-  ...  From=sender@external.com
+  ...  From=sender-ux@external.com
   ...  Rcpt=user@example.com
   Expect Symbol  ALIAS_RESOLVED
   Expect Symbol With Exact Options  GET_FROM  Abuse Desk,admin@example.com,admin,example.com

--- a/test/functional/lua/get_from.lua
+++ b/test/functional/lua/get_from.lua
@@ -8,3 +8,36 @@ rspamd_config:register_symbol({
     return true, (a.name or '') .. ',' .. (a.addr or '') .. ',' .. (a.user or '') .. ',' .. (a.domain or '')
   end
 })
+
+-- Rewrites the MIME from, simulating a module like aliases; the original
+-- address must remain reachable via the 'orig' flavour.
+-- Gated on the Rewrite-Mime-From request header to stay inert in tests that
+-- do not opt in (the merged suite runs all symbols when no settings passed)
+rspamd_config:register_symbol({
+  name = 'REWRITE_MIME_FROM',
+  type = 'prefilter',
+  callback = function(task)
+    if not task:get_request_header('Rewrite-Mime-From') then
+      return
+    end
+    task:set_from('mime', {
+      name = 'Forged',
+      user = 'forged',
+      domain = 'forged.example.net',
+      addr = 'forged@forged.example.net',
+    }, 'alias')
+  end
+})
+
+rspamd_config:register_symbol({
+  name = 'GET_FROM_ORIG',
+  score = 1.0,
+  callback = function(task)
+    local a = task:get_from({ 'mime', 'orig' })
+    if not a then return end
+    local naddrs = #a
+    a = a[1]
+    return true, string.format('%s,%s,%s,%s,%s',
+        a.name or '', a.addr or '', a.user or '', a.domain or '', naddrs)
+  end
+})

--- a/test/functional/lua/selector_test.lua
+++ b/test/functional/lua/selector_test.lua
@@ -21,3 +21,20 @@ config['regexp']['RSPAMD_TEXT_SELECTOR'] = {
   re = 'some_rspamd_text_re=/^hello$/{selector}',
   score = 1,
 }
+
+-- The 'orig' flavour must be reachable through selectors and return the
+-- address as it was seen in the message, before any task:set_from rewrite
+local selector_from = lua_selectors.create_selector_closure(
+    rspamd_config, "from('mime'):addr", '')
+local selector_from_orig = lua_selectors.create_selector_closure(
+    rspamd_config, "from('mime', 'orig'):addr", '')
+
+rspamd_config:register_symbol({
+  name = 'SELECTOR_FROM_ORIG',
+  score = 1.0,
+  callback = function(task)
+    local cur = selector_from(task)
+    local orig = selector_from_orig(task)
+    return true, string.format('%s|%s', cur or 'nil', orig or 'nil')
+  end
+})

--- a/test/functional/messages/aliases_from_unix.eml
+++ b/test/functional/messages/aliases_from_unix.eml
@@ -1,0 +1,7 @@
+From: Abuse Desk <abuse@example.com>
+To: user@example.com
+Subject: Test same-domain alias on From
+Message-ID: <test-from-unix@example.com>
+Date: Mon, 01 Jan 2025 10:00:00 +0000
+
+Same-domain aliases may still rewrite the From local part.

--- a/test/functional/messages/aliases_from_virtual.eml
+++ b/test/functional/messages/aliases_from_virtual.eml
@@ -1,0 +1,7 @@
+From: Virtual Sender <virtual@example.com>
+To: user@example.com
+Subject: Test cross-domain virtual alias on From
+Message-ID: <test-from-virtual@example.com>
+Date: Mon, 01 Jan 2025 10:00:00 +0000
+
+A virtual alias pointing to another domain must not rewrite the From domain.

--- a/test/functional/messages/aliases_googlemail.eml
+++ b/test/functional/messages/aliases_googlemail.eml
@@ -1,0 +1,7 @@
+From: First Last <first.last@googlemail.com>
+To: user@example.com
+Subject: Test googlemail domain preservation
+Message-ID: <test-googlemail@example.com>
+Date: Mon, 01 Jan 2025 10:00:00 +0000
+
+Googlemail user part is canonicalized, but the domain must stay googlemail.com.

--- a/test/functional/messages/aliases_rcpt_virtual.eml
+++ b/test/functional/messages/aliases_rcpt_virtual.eml
@@ -1,0 +1,8 @@
+From: Sender <sender@external.com>
+To: virtual@example.com
+Subject: Test cross-domain recipient alias vs forged recipients
+Message-ID: <test-rcpt-virtual@example.com>
+Date: Mon, 01 Jan 2025 10:00:00 +0000
+
+A recipient rewritten to another domain must not make the wire To header
+look forged.

--- a/test/lua/unit/lua_aliases.lua
+++ b/test/lua/unit/lua_aliases.lua
@@ -1,0 +1,60 @@
+context("Lua aliases - apply_service_rules", function()
+  local lua_aliases = require 'lua_aliases'
+
+  local function mk_addr(user, domain)
+    return {
+      user = user,
+      domain = domain,
+      addr = string.format('%s@%s', user, domain),
+    }
+  end
+
+  test('gmail: dots are removed from user part', function()
+    local nu, tags, nd = lua_aliases.apply_service_rules(mk_addr('first.last', 'gmail.com'))
+    assert_equal(nu, 'firstlast')
+    assert_nil(nd)
+    assert_rspamd_table_eq({ actual = tags, expect = {} })
+  end)
+
+  -- str_split of '+tag1+tag2' on '+' yields a leading empty element;
+  -- consumers filter empty tags out
+  test('gmail: plus tags are stripped', function()
+    local nu, tags, nd = lua_aliases.apply_service_rules(mk_addr('user+tag1+tag2', 'gmail.com'))
+    assert_equal(nu, 'user')
+    assert_nil(nd)
+    assert_rspamd_table_eq({ actual = tags, expect = { '', 'tag1', 'tag2' } })
+  end)
+
+  test('gmail: plain address is not modified', function()
+    local nu, tags, nd = lua_aliases.apply_service_rules(mk_addr('user', 'gmail.com'))
+    assert_nil(nu)
+    assert_nil(tags)
+    assert_nil(nd)
+  end)
+
+  test('googlemail: user part canonicalized, domain preserved', function()
+    local nu, tags, nd = lua_aliases.apply_service_rules(mk_addr('first.last+tag', 'googlemail.com'))
+    assert_equal(nu, 'firstlast')
+    assert_nil(nd)
+    assert_rspamd_table_eq({ actual = tags, expect = { '', 'tag' } })
+  end)
+
+  test('googlemail: plain address is not modified', function()
+    local nu, tags, nd = lua_aliases.apply_service_rules(mk_addr('mailer-daemon', 'googlemail.com'))
+    assert_nil(nu)
+    assert_nil(tags)
+    assert_nil(nd)
+  end)
+
+  test('generic domain: plus tags are stripped', function()
+    local nu, tags, nd = lua_aliases.apply_service_rules(mk_addr('user+tag', 'example.com'))
+    assert_equal(nu, 'user')
+    assert_nil(nd)
+    assert_rspamd_table_eq({ actual = tags, expect = { '', 'tag' } })
+  end)
+
+  test('generic domain: dots are kept', function()
+    local nu = lua_aliases.apply_service_rules(mk_addr('first.last', 'example.com'))
+    assert_nil(nu)
+  end)
+end)


### PR DESCRIPTION
Fixes #6137.

## Problem

The `aliases` module (enabled by default since 3.14.2) runs as a top-priority prefilter and rewrote the task's From addresses, including the `googlemail.com` → `gmail.com` domain substitution. The two domains are DNS-distinct with independent SPF and DMARC records (`gmail.com` publishes `p=none`, `googlemail.com` publishes `p=quarantine`), so downstream consumers broke:

- DMARC aligned DKIM `header.d=googlemail.com` against the rewritten `gmail.com` From domain, yielding a false "DKIM not aligned"
- The policy was looked up at `_dmarc.gmail.com`, silently downgrading `quarantine` to `none`
- rua report data was recorded for the wrong domain
- SPF resolved the record of the rewritten envelope domain, while the Authentication-Results header reported the original `smtp.mailfrom` — a self-inconsistent header

## Changes

The guiding principle: recipients are ours to interpret (the receiving host owns the local part per RFC 5321), while the sender is someone else's identity that SPF, DKIM and DMARC all key on. Recipient rewriting (aliases, plus-addressing, and the settings behaviour restored for #5768) is unchanged; sender rewriting is restricted to the local part.

- `lua_aliases`: `googlemail.com` shares the gmail user-part rules (dots and plus tags) but its domain is never rewritten. The domain equivalence remains available in `lua_util.remove_email_aliases` for dedup-only consumers such as email hash lookups in RBL checks.
- `aliases` plugin: any From rewrite that would change the domain is discarded — including alias resolution results, so a cross-domain virtual alias cannot reintroduce the problem via configuration. Also fixes a spurious `task:set_from` call: a rewritten recipient caused the unmodified MIME From to be marked as aliased and duplicated.
- Lua API: `task:get_from({'mime', 'orig'})` previously returned the preserved originals and the rewritten addresses in a single list, which made the flavour unusable for consumers needing the message as it arrived. When a rewrite occurred, it now returns only the original addresses; without a rewrite the behaviour is unchanged. The `aliased` and `original` address flags are exposed to Lua. **Note:** this is a behaviour change for out-of-tree modules that relied on the combined list; all in-tree consumers were audited.
- DMARC uses the original MIME From for alignment, policy lookup and reporting, and the original envelope domain for SPF alignment. SPF resolves the record and credentials from the original envelope sender (new `rspamd_task_get_original_sender`), matching what the Authentication-Results header already reported.
- `forged_recipients` compares the envelope and the headers at the same altitude — both as transmitted — so a recipient alias mapping to another domain (legal for recipients) no longer risks a false `FORGED_RECIPIENTS`.
- Selectors: the `from`/`rcpts` extractors already pass the `orig` flavour through; it is now documented and covered by a test.

## Tests

- Unit tests for `lua_aliases.apply_service_rules` (googlemail domain preservation, dots and plus handling)
- Functional: googlemail From keeps its domain while the user part is canonicalized; a cross-domain virtual alias on the From is discarded while a same-domain alias still applies; the `orig` flavour returns the wire From (and only it) after a `task:set_from` rewrite; DMARC evaluates the wire From domain even when a prefilter rewrote the MIME From; recipient aliasing does not trigger `FORGED_RECIPIENTS`; the `orig` flavour works through the selector pipeline

Full merged functional suite passes (373 tests), along with the C++ (257) and Lua (1136) unit tests.
