### PR TITLE
Fix synchronous context_augment firing two GPT requests for one model

### DIFF
--- a/src/plugins/lua/gpt.lua
+++ b/src/plugins/lua/gpt.lua
@@ -1316,11 +1316,6 @@ local function gpt_check(task)
         maybe_proceed()
       end
     end
-
-    -- If no fetches were initiated, proceed immediately
-    if pending_fetches == 0 then
-      proceed(nil)
-    end
   else
     proceed(nil)
   end


### PR DESCRIPTION
When your context_augment function calls the callback synchronously
(e.g., return function(task, content, cb) cb('some context') end),
the pending_fetches counter drops to 0 inside the callback,
triggering maybe_proceed() which calls proceed().

Then control returns to the main flow where the now-redundant guard
also sees pending_fetches == 0 and calls proceed(nil) a second time
— this time without the context snippet.

The else branch (line 1324) already handles the case where none
of the context features are enabled, so the removed fallback
was purely a duplicate path for synchronous callbacks.

Fixes https://github.com/rspamd/rspamd/issues/6134