### PR TITLE
[Feature] Settings: policy option for additive symbols_enabled + strict explicit_enable gating

### DIFF
--- a/lualib/lua_settings.lua
+++ b/lualib/lua_settings.lua
@@ -43,6 +43,10 @@ local function register_settings_cb(from_postload)
       return v.flags.explicit_disable
     end, all_symbols))
 
+    local explicit_enable_symbols = lua_util.keys(fun.filter(function(k, v)
+      return v.flags.explicit_enable
+    end, all_symbols))
+
     local symnames = lua_util.list_to_hash(lua_util.keys(all_symbols))
 
     for _, set in pairs(known_ids) do
@@ -53,10 +57,25 @@ local function register_settings_cb(from_postload)
       local disabled_symbols = {}
       local seen_disabled = false
 
+      local policy = s.policy
+      if policy and not (policy == 'default' or policy == 'implicit_allow' or policy == 'implicit_deny') then
+        rspamd_logger.errx(rspamd_config, "invalid settings policy '%s' in settings id %s; ignore it",
+            policy, set.name)
+        policy = nil
+      end
+
       -- Enabled map
-      if s.symbols_enabled then
+      if s.symbols_enabled and policy ~= 'implicit_allow' then
         -- Remove all symbols from set.symbols aside of explicit_disable symbols
         set.symbols = lua_util.list_to_hash(explicit_symbols)
+      else
+        -- All symbols are implicitly allowed, but explicit_enable symbols
+        -- still require to be listed in symbols_enabled
+        for _, sym in ipairs(explicit_enable_symbols) do
+          set.symbols[sym] = nil
+        end
+      end
+      if s.symbols_enabled then
         seen_enabled = true
         for _, sym in ipairs(s.symbols_enabled) do
           enabled_symbols[sym] = true
@@ -112,7 +131,7 @@ local function register_settings_cb(from_postload)
         set.has_specific_symbols = true
       end
 
-      rspamd_config:register_settings_id(set.name, enabled_symbols, disabled_symbols)
+      rspamd_config:register_settings_id(set.name, enabled_symbols, disabled_symbols, policy)
 
       -- Note: we do NOT remove groups_*/symbols_* here anymore, as the C++ runtime
       -- needs them for processing settings when they are applied to tasks.

--- a/src/libserver/symcache/symcache_c.cxx
+++ b/src/libserver/symcache/symcache_c.cxx
@@ -394,6 +394,34 @@ void rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
 		ucl_object_insert_key(this_sym_ucl,
 							  ucl_object_fromstring(sym->get_type_str()),
 							  "type", strlen("type"), false);
+
+		/* Modifier flags; structural types are already covered by `type` */
+		static constexpr const std::pair<int, const char *> flag_names[] = {
+			{SYMBOL_TYPE_FINE, "fine"},
+			{SYMBOL_TYPE_EMPTY, "empty"},
+			{SYMBOL_TYPE_EXPLICIT_DISABLE, "explicit_disable"},
+			{SYMBOL_TYPE_EXPLICIT_ENABLE, "explicit_enable"},
+			{SYMBOL_TYPE_IGNORE_PASSTHROUGH, "ignore_passthrough"},
+			{SYMBOL_TYPE_NOSTAT, "nostat"},
+			{SYMBOL_TYPE_IDEMPOTENT, "idempotent"},
+			{SYMBOL_TYPE_MIME_ONLY, "mime"},
+			{SYMBOL_TYPE_TRIVIAL, "trivial"},
+			{SYMBOL_TYPE_SKIPPED, "skip"},
+			{SYMBOL_TYPE_COMPOSITE, "composite"},
+			{SYMBOL_TYPE_GHOST, "ghost"},
+			{SYMBOL_TYPE_USE_CORO, "coro"},
+		};
+
+		auto *flags_ucl = ucl_object_typed_new(UCL_ARRAY);
+
+		for (const auto &[flag, name]: flag_names) {
+			if (sym->get_flags() & flag) {
+				ucl_array_append(flags_ucl, ucl_object_fromstring(name));
+			}
+		}
+
+		ucl_object_insert_key(this_sym_ucl, flags_ucl,
+							  "flags", strlen("flags"), false);
 	}
 }
 

--- a/src/libserver/symcache/symcache_item.cxx
+++ b/src/libserver/symcache/symcache_item.cxx
@@ -393,10 +393,24 @@ auto cache_item::is_allowed(struct rspamd_task *task, bool exec_only) const -> b
 			if (!allowed_ids.check_id(task->settings_elt->id)) {
 
 				if (task->settings_elt->policy == RSPAMD_SETTINGS_POLICY_IMPLICIT_ALLOW) {
-					msg_debug_cache_task("allow execution of %s settings id %ud "
-										 "allows implicit execution of the symbols;",
+					if (flags & SYMBOL_TYPE_EXPLICIT_ENABLE) {
+						auto *runtime = static_cast<symcache_runtime *>(task->symcache_runtime);
+
+						if (!(runtime && runtime->is_force_enabled(id))) {
+							msg_debug_cache_task("deny %s of %s as it must be explicitly enabled, "
+												 "but settings id %ud merely allows implicit execution",
+												 what,
+												 symbol.c_str(),
+												 task->settings_elt->id);
+
+							return false;
+						}
+					}
+
+					msg_debug_cache_task("allow execution of %s as settings id %ud "
+										 "allows implicit execution of the symbols",
 										 symbol.c_str(),
-										 id);
+										 task->settings_elt->id);
 
 					return true;
 				}
@@ -426,11 +440,15 @@ auto cache_item::is_allowed(struct rspamd_task *task, bool exec_only) const -> b
 								 task->settings_elt->id);
 		}
 	}
-	else if ((flags & SYMBOL_TYPE_EXPLICIT_ENABLE) && !task->settings) {
-		msg_debug_cache_task("deny %s of %s as it must be explicitly enabled",
-							 what,
-							 symbol.c_str());
-		return false;
+	else if (flags & SYMBOL_TYPE_EXPLICIT_ENABLE) {
+		auto *runtime = static_cast<symcache_runtime *>(task->symcache_runtime);
+
+		if (!(runtime && runtime->is_force_enabled(id))) {
+			msg_debug_cache_task("deny %s of %s as it must be explicitly enabled",
+								 what,
+								 symbol.c_str());
+			return false;
+		}
 	}
 
 	/* Allow all symbols with no settings id */

--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -116,30 +116,58 @@ auto symcache_runtime::process_settings(struct rspamd_task *task, const symcache
 	ucl_object_iter_t it = nullptr;
 	const ucl_object_t *cur;
 
+	/*
+	 * Settings policy: with the default policy, `symbols_enabled` is a whitelist
+	 * (disable everything, then enable listed symbols); with `implicit_allow`,
+	 * it is additive: all symbols stay enabled and the listed ones are merely
+	 * unlocked (this is the only way to run `explicit_enable` symbols without
+	 * switching to the whitelist mode).
+	 * The policy is read from the applied settings themselves, as the registered
+	 * settings element might not be attached to the task at this point (the
+	 * settings plugin applies settings before setting the id).
+	 */
+	auto implicit_allow = false;
+	const auto *policy_obj = ucl_object_lookup(task->settings, "policy");
+
+	if (policy_obj && ucl_object_type(policy_obj) == UCL_STRING) {
+		const auto *policy_str = ucl_object_tostring(policy_obj);
+
+		if (g_ascii_strcasecmp(policy_str, "implicit_allow") == 0) {
+			implicit_allow = true;
+		}
+		else if (g_ascii_strcasecmp(policy_str, "default") != 0 &&
+				 g_ascii_strcasecmp(policy_str, "implicit_deny") != 0) {
+			msg_warn_task("unknown settings policy: %s; ignore it", policy_str);
+		}
+	}
+
 	const auto *enabled = ucl_object_lookup(task->settings, "symbols_enabled");
 
 	/*
-	 * Track force-enabled symbols: if settings_elt has a symbol in forbidden_ids
-	 * but the merged settings explicitly enable it, we need to override the bitset
+	 * Track explicitly enabled symbols: they both override settings_elt
+	 * forbidden_ids and unlock symbols with the `explicit_enable` flag
 	 */
 	auto force_enable = [&](const char *sym) {
 		enable_symbol(task, cache, sym);
 
-		if (task->settings_elt) {
-			const auto *item = cache.get_item_by_name(sym, true);
-			if (item && item->forbidden_ids.check_id(task->settings_elt->id)) {
-				add_force_enabled(item->id);
-				msg_debug_cache_task("force-enable %s (id=%d) overriding settings_elt forbidden_ids",
-									 sym, item->id);
-			}
+		const auto *item = cache.get_item_by_name(sym, true);
+		if (item) {
+			add_force_enabled(item->id);
+			msg_debug_cache_task("force-enable %s (id=%d)", sym, item->id);
 		}
 	};
 
 	if (enabled) {
-		msg_debug_cache_task("disable all symbols as `symbols_enabled` is found");
-		/* Disable all symbols but selected */
-		disable_all_symbols(SYMBOL_TYPE_EXPLICIT_DISABLE);
-		already_disabled = true;
+		if (implicit_allow) {
+			msg_debug_cache_task("enable symbols from `symbols_enabled` additively "
+								 "as the policy is `implicit_allow`");
+		}
+		else {
+			msg_debug_cache_task("disable all symbols as `symbols_enabled` is found");
+			/* Disable all symbols but selected */
+			disable_all_symbols(SYMBOL_TYPE_EXPLICIT_DISABLE);
+			already_disabled = true;
+		}
 		it = nullptr;
 
 		while ((cur = ucl_iterate_object(enabled, &it, true)) != nullptr) {
@@ -149,7 +177,7 @@ auto symcache_runtime::process_settings(struct rspamd_task *task, const symcache
 
 	/* Enable groups of symbols */
 	enabled = ucl_object_lookup(task->settings, "groups_enabled");
-	if (enabled && !already_disabled) {
+	if (enabled && !already_disabled && !implicit_allow) {
 		disable_all_symbols(SYMBOL_TYPE_EXPLICIT_DISABLE);
 	}
 	process_group(enabled, [&](const char *sym) {
@@ -252,6 +280,12 @@ auto symcache_runtime::enable_symbol(struct rspamd_task *task, const symcache &c
 
 		if (dyn_item) {
 			dyn_item->status = cache_item_status::not_started;
+
+			if (item->get_flags() & SYMBOL_TYPE_EXPLICIT_ENABLE) {
+				/* An explicit enable call unlocks `explicit_enable` symbols */
+				add_force_enabled(item->id);
+			}
+
 			msg_debug_cache_task("enable execution of %s", name.data());
 
 			return true;

--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -491,11 +491,13 @@ LUA_FUNCTION_DEF(config, get_groups);
 LUA_FUNCTION_DEF(config, promote_symbols_cache_resort);
 
 /***
- * @method rspamd_config:register_settings_id(name, symbols_enabled, symbols_disabled)
+ * @method rspamd_config:register_settings_id(name, symbols_enabled, symbols_disabled[, policy])
  * Register new static settings id in config
  * @param {string} name id name (not numeric!)
  * @param {map|string->string} symbols_enabled map from symbol's name to boolean (currently)
  * @param {map|string->string} symbols_disabled map from symbol's name to boolean (currently)
+ * @param {string} policy one of `default`, `implicit_allow` or `implicit_deny`; when omitted,
+ * `implicit_allow` is assumed if `symbols_enabled` is empty, `default` (whitelist) otherwise
  * @available 2.0+
  */
 LUA_FUNCTION_DEF(config, register_settings_id);

--- a/test/functional/cases/108_settings.robot
+++ b/test/functional/cases/108_settings.robot
@@ -36,6 +36,8 @@ NO SETTINGS SPAM
   Expect Symbol  SIMPLE_PRE
   Expect Symbol  SIMPLE_POST
   Expect Symbol  BAYES_SPAM
+  Do Not Expect Symbol  EXPLICIT_ENABLE_TEST
+  Do Not Expect Symbol  EXPLICIT_ENABLE_OTHER
 
 NO SETTINGS HAM
   Scan File  ${HAM_MESSAGE}
@@ -250,6 +252,49 @@ SETTINGS ID - VIRTUAL DEP
 SETTINGS ID - EXTERNAL MAP
   Scan File  ${MESSAGE}  Settings-Id=external
   Expect Symbol  EXTERNAL_SETTINGS
+
+EXPLICIT ENABLE - IMPLICIT SETTINGS ID
+  Scan File  ${MESSAGE}  Settings-Id=id_disabled_only
+  Expect Symbol  SIMPLE_TEST
+  Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  SIMPLE_POST
+  Do Not Expect Symbol  EXPLICIT_ENABLE_TEST
+  Do Not Expect Symbol  EXPLICIT_ENABLE_OTHER
+
+EXPLICIT ENABLE - RAW SETTINGS NO LIST
+  Scan File  ${MESSAGE}  Settings={symbols_disabled = ["SIMPLE_PRE"]}
+  Expect Symbol  SIMPLE_TEST
+  Do Not Expect Symbol  SIMPLE_PRE
+  Do Not Expect Symbol  EXPLICIT_ENABLE_TEST
+  Do Not Expect Symbol  EXPLICIT_ENABLE_OTHER
+
+EXPLICIT ENABLE - RAW SETTINGS WHITELIST
+  Scan File  ${MESSAGE}  Settings={symbols_enabled = ["EXPLICIT_ENABLE_TEST"]}
+  Expect Symbol  EXPLICIT_ENABLE_TEST
+  Do Not Expect Symbol  EXPLICIT_ENABLE_OTHER
+  Do Not Expect Symbol  SIMPLE_TEST
+
+EXPLICIT ENABLE - ENABLE SYMBOL API
+  Scan File  ${SPAM_MESSAGE}  Enable-Explicit=yes
+  Expect Symbol  EXPLICIT_ENABLE_TEST
+  Do Not Expect Symbol  EXPLICIT_ENABLE_OTHER
+  Expect Symbol  SIMPLE_TEST
+
+POLICY IMPLICIT ALLOW - SETTINGS ID
+  Scan File  ${MESSAGE}  Settings-Id=id_implicit_policy
+  Expect Symbol  EXPLICIT_ENABLE_TEST
+  Do Not Expect Symbol  EXPLICIT_ENABLE_OTHER
+  Do Not Expect Symbol  SIMPLE_TEST
+  Expect Symbol  SIMPLE_PRE
+  Expect Symbol  SIMPLE_POST
+
+POLICY IMPLICIT ALLOW - RAW SETTINGS
+  Scan File  ${MESSAGE}  Settings={policy = "implicit_allow"; symbols_enabled = ["EXPLICIT_ENABLE_TEST"]; symbols_disabled = ["SIMPLE_TEST"]}
+  Expect Symbol  EXPLICIT_ENABLE_TEST
+  Do Not Expect Symbol  EXPLICIT_ENABLE_OTHER
+  Do Not Expect Symbol  SIMPLE_TEST
+  Expect Symbol  SIMPLE_PRE
+  Expect Symbol  SIMPLE_POST
 
 PRIORITY
   Scan File  ${MESSAGE_PRIORITY}  Settings-Id=id_virtual_group  From=user@test.com

--- a/test/functional/configs/settings.conf
+++ b/test/functional/configs/settings.conf
@@ -69,6 +69,22 @@ settings {
     }
   }
 
+  id_disabled_only {
+    id = "id_disabled_only";
+    apply {
+      symbols_disabled = ["SIMPLE_POST"];
+    }
+  }
+
+  id_implicit_policy {
+    id = "id_implicit_policy";
+    apply {
+      policy = "implicit_allow";
+      symbols_enabled = ["EXPLICIT_ENABLE_TEST"];
+      symbols_disabled = ["SIMPLE_TEST"];
+    }
+  }
+
   empty_symbols_enabled {
     ip = "5.5.5.5";
     apply {

--- a/test/functional/lua/settings.lua
+++ b/test/functional/lua/settings.lua
@@ -66,3 +66,33 @@ rspamd_config:register_symbol({
 })
 
 rspamd_config:register_dependency('DEP_VIRTUAL', 'EXPLICIT_VIRTUAL1')
+
+rspamd_config:register_symbol({
+  name = 'EXPLICIT_ENABLE_TEST',
+  score = 1.0,
+  flags = 'explicit_enable',
+  callback = function()
+    return true, 'Fires when explicitly enabled'
+  end
+})
+
+rspamd_config:register_symbol({
+  name = 'EXPLICIT_ENABLE_OTHER',
+  score = 1.0,
+  flags = 'explicit_enable',
+  callback = function()
+    return true, 'Fires when explicitly enabled'
+  end
+})
+
+rspamd_config:register_symbol({
+  name = 'ENABLE_EXPLICIT_PRE',
+  score = 0.0,
+  type = 'prefilter',
+  priority = 5, -- after settings
+  callback = function(task)
+    if task:get_request_header('Enable-Explicit') then
+      task:enable_symbol('EXPLICIT_ENABLE_TEST')
+    end
+  end
+})


### PR DESCRIPTION
## What

### Strict `explicit_enable` gating

Symbols with the `explicit_enable` flag were effectively never gated: the implicit-allow settings branch in `cache_item::is_allowed` returned before consulting the flag, and any non-null `task->settings` (e.g. any `Settings` header, even one not mentioning the symbol) unlocked such symbols entirely. In practice the flag only blocked execution for tasks with no settings at all.

Now `explicit_enable` symbols run only when:

* listed in `symbols_enabled` of the applied settings (any policy), or
* enabled via `task:enable_symbol()`

This is a behaviour change for the flag, but the old semantics were broken enough that nothing could rely on them meaningfully.

### `policy` option for settings

Previously, adding `symbols_enabled` to a settings id always switched it to whitelist mode, so there was no way to have "all symbols by default, minus some, plus a few explicit_enable ones". New `policy` option in the `apply` block:

```ucl
some_id {
  apply {
    policy = "implicit_allow";
    symbols_enabled = ["MY_EXPLICIT_SYM"]; # additive: unlocks, no whitelist flip
    symbols_disabled = ["SOME_SYM"];       # subtractive
  }
}
```

With `policy = implicit_allow`, `symbols_enabled` is additive: all symbols stay enabled and the listed ones are merely unlocked. Honoured in both enforcement layers: the runtime reads `policy` from the applied settings UCL (so it also works for raw `Settings:` header settings), and the static layer receives it via a new optional 4th argument to `rspamd_config:register_settings_id()`.

Symbols listed in `symbols_enabled` are now always tracked as force-enabled; previously this only happened when the settings element was already attached to the task, which missed the map-driven settings path (the settings plugin applies settings before setting the id), so the forbidden_ids override silently did not work there.

### Configdump

`rspamadm configdump --symbol-details` now emits a per-symbol `flags` array (`explicit_enable`, `explicit_disable`, `fine`, `nostat`, …) next to `type`, so flag state can be inspected.

## Tests

Seven new functional cases in `108_settings.robot` covering: no settings / implicit-allow id / raw settings without a list (symbol must not fire), whitelist settings and `task:enable_symbol()` (must fire), and the mixed `implicit_allow` scenario via both a registered settings id and raw header settings. Both `108_settings` (38/38) and `109_settings_merge` (20/20) suites pass locally, along with the C++ and Lua unit tests.