### PR TITLE
[Fix] Redact credentials from map error logs

### DIFF
--- a/src/libserver/maps/map.c
+++ b/src/libserver/maps/map.c
@@ -239,7 +239,7 @@ http_map_error(struct rspamd_http_connection *conn,
 		cbd->periodic->errored = TRUE;
 		msg_err_map("error reading %s(%s): "
 					"connection with http server terminated incorrectly: %e",
-					cbd->bk->uri,
+					cbd->bk->uri_log,
 					cbd->addr ? rspamd_inet_address_to_string_pretty(cbd->addr) : "",
 					err);
 
@@ -466,13 +466,13 @@ rspamd_map_secretbox_decrypt_buf(struct rspamd_map_backend *bk,
 	struct rspamd_map *map = bk ? bk->map : NULL;
 
 	if (!bk->has_secretbox_key) {
-		msg_err_map("%s: secretbox key is not configured", bk->uri);
+		msg_err_map("%s: secretbox key is not configured", bk->uri_log);
 		return FALSE;
 	}
 
 	if (inlen < crypto_secretbox_NONCEBYTES + crypto_secretbox_MACBYTES) {
 		msg_err_map("%s: too short buffer for secretbox: %z bytes (need >= %d)",
-					bk->uri, inlen, (int) (crypto_secretbox_NONCEBYTES + crypto_secretbox_MACBYTES));
+					bk->uri_log, inlen, (int) (crypto_secretbox_NONCEBYTES + crypto_secretbox_MACBYTES));
 		return FALSE;
 	}
 
@@ -482,7 +482,7 @@ rspamd_map_secretbox_decrypt_buf(struct rspamd_map_backend *bk,
 
 	if (clen < crypto_secretbox_MACBYTES) {
 		msg_err_map("%s: invalid ciphertext length for secretbox: %z (< MAC %d)",
-					bk->uri, clen, (int) crypto_secretbox_MACBYTES);
+					bk->uri_log, clen, (int) crypto_secretbox_MACBYTES);
 		return FALSE;
 	}
 
@@ -494,7 +494,7 @@ rspamd_map_secretbox_decrypt_buf(struct rspamd_map_backend *bk,
 
 	if (crypto_secretbox_open_easy(pt, ct, clen, nonce, bk->secretbox_key) != 0) {
 		msg_err_map("%s: secretbox authentication failed (nonce_len=%d, ct_len=%z)",
-					bk->uri, (int) crypto_secretbox_NONCEBYTES, clen);
+					bk->uri_log, (int) crypto_secretbox_NONCEBYTES, clen);
 		g_free(pt);
 		return FALSE;
 	}
@@ -775,7 +775,7 @@ http_map_finish(struct rspamd_http_connection *conn,
 
 		if (cbd->bk->is_encrypted) {
 			if (!rspamd_map_secretbox_decrypt_buf(cbd->bk, in, dlen, &payload, &payload_len)) {
-				msg_err_map("%s(%s): cannot decrypt data", cbd->bk->uri,
+				msg_err_map("%s(%s): cannot decrypt data", cbd->bk->uri_log,
 							rspamd_inet_address_to_string_pretty(cbd->addr));
 				MAP_RELEASE(cbd->shmem_data, "shmem_data");
 				goto err;
@@ -816,7 +816,7 @@ http_map_finish(struct rspamd_http_connection *conn,
 
 				if (ZSTD_isError(r)) {
 					msg_err_map("%s(%s): cannot decompress data: %s",
-								cbd->bk->uri,
+								cbd->bk->uri_log,
 								rspamd_inet_address_to_string_pretty(cbd->addr),
 								ZSTD_getErrorName(r));
 					ZSTD_freeDStream(zstream);
@@ -844,7 +844,7 @@ http_map_finish(struct rspamd_http_connection *conn,
 						 rspamd_inet_address_to_string_pretty(cbd->addr),
 						 payload_len, zout.pos, next_check_date);
 			if (!rspamd_map_save_http_cached_file(map, bk, cbd->data, final_out, zout.pos)) {
-				msg_err_map("%s: failed to save cache file", bk->uri);
+				msg_err_map("%s: failed to save cache file", bk->uri_log);
 				g_free(final_out);
 				MAP_RELEASE(cbd->shmem_data, "shmem_data");
 				goto err;
@@ -871,7 +871,7 @@ http_map_finish(struct rspamd_http_connection *conn,
 						 payload_len, next_check_date);
 
 			if (!rspamd_map_save_http_cached_file(map, bk, cbd->data, payload, payload_len)) {
-				msg_err_map("%s: failed to save cache file", bk->uri);
+				msg_err_map("%s: failed to save cache file", bk->uri_log);
 				MAP_RELEASE(cbd->shmem_data, "shmem_data");
 				goto err;
 			}
@@ -1787,7 +1787,7 @@ rspamd_map_dns_callback(struct rdns_reply *reply, void *arg)
 				cbd->periodic->errored = TRUE;
 				msg_err_map("error reading %s(%s): "
 							"connection with http server terminated incorrectly: %s",
-							cbd->bk->uri,
+							cbd->bk->uri_log,
 							cbd->addr ? rspamd_inet_address_to_string_pretty(cbd->addr) : "",
 							strerror(errno));
 
@@ -1819,7 +1819,7 @@ rspamd_map_read_cached(struct rspamd_map *map, struct rspamd_map_backend *bk,
 		struct stat st;
 
 		if (map->cfg->maps_cache_dir == NULL || map->cfg->maps_cache_dir[0] == '\0') {
-			msg_err_map("%s: no maps cache dir configured for no_file_read map", bk->uri);
+			msg_err_map("%s: no maps cache dir configured for no_file_read map", bk->uri_log);
 			return FALSE;
 		}
 
@@ -1913,7 +1913,7 @@ rspamd_map_read_cached(struct rspamd_map *map, struct rspamd_map_backend *bk,
 
 				if (ZSTD_isError(r)) {
 					msg_err_map("%s: cannot decompress data: %s",
-								bk->uri,
+								bk->uri_log,
 								ZSTD_getErrorName(r));
 					ZSTD_freeDStream(zstream);
 					g_free(out);
@@ -3015,6 +3015,75 @@ void rspamd_map_remove_all(struct rspamd_config *cfg)
 	cfg->maps = NULL;
 }
 
+/*
+ * Return a freshly allocated copy of @uri with the HTTP userinfo
+ * (the "user:pass@" prefix of the authority) replaced by "***@", so
+ * the result is safe to write to logs (e.g. the /errors ring buffer).
+ * URIs without a scheme or without userinfo are duplicated as-is.
+ */
+/* Non-static for unit testing */
+char *
+rspamd_map_uri_redacted(const char *uri)
+{
+	const char *scheme_sep, *authority, *at, *auth_end, *p;
+	char *res;
+	gsize prefix_len, rest_len;
+
+	g_assert(uri != NULL);
+
+	scheme_sep = strstr(uri, "://");
+
+	if (scheme_sep == NULL) {
+		return g_strdup(uri);
+	}
+
+	authority = scheme_sep + 3;
+	/* The authority ends at the first '/', '?' or '#' (or end of string) */
+	auth_end = authority + strcspn(authority, "/?#");
+	/* Userinfo, if present, is everything before the last '@' in the
+	 * authority. Using the last '@' (rather than the first) also covers
+	 * malformed inputs where a raw password itself contains '@'; an IPv6
+	 * host literal in brackets is unaffected since it follows the userinfo
+	 * and never contains '@'. */
+	at = NULL;
+	for (p = auth_end; p-- > authority;) {
+		if (*p == '@') {
+			at = p;
+			break;
+		}
+	}
+
+	if (at == NULL) {
+		return g_strdup(uri);
+	}
+
+	prefix_len = authority - uri; /* scheme + "://" */
+	rest_len = strlen(at + 1);
+	res = g_malloc(prefix_len + 4 /* "***@" */ + rest_len + 1);
+	memcpy(res, uri, prefix_len);
+	memcpy(res + prefix_len, "***@", 4);
+	memcpy(res + prefix_len + 4, at + 1, rest_len + 1); /* includes NUL */
+
+	return res;
+}
+
+/*
+ * Assign the backend uri and a matching redacted copy used for logging.
+ * The real uri is kept verbatim because it serves as a configuration key
+ * (the "maps { <uri> {} }" block) and carries the HTTP userinfo needed to
+ * build the Authorization header; bk->uri_log must be used in log messages
+ * instead.
+ */
+static void
+rspamd_map_backend_set_uri(struct rspamd_map_backend *bk, const char *uri)
+{
+	g_assert(bk != NULL);
+	g_assert(uri != NULL);
+
+	bk->uri = g_strdup(uri);
+	bk->uri_log = rspamd_map_uri_redacted(uri);
+}
+
 static const char *
 rspamd_map_check_proto(struct rspamd_config *cfg,
 					   const char *map_line, struct rspamd_map_backend *bk)
@@ -3029,13 +3098,13 @@ rspamd_map_check_proto(struct rspamd_config *cfg,
 	/* Static check */
 	if (g_ascii_strcasecmp(pos, "static") == 0) {
 		bk->protocol = MAP_PROTO_STATIC;
-		bk->uri = g_strdup(pos);
+		rspamd_map_backend_set_uri(bk, pos);
 
 		return pos;
 	}
 	else if (g_ascii_strcasecmp(pos, "zst+static") == 0) {
 		bk->protocol = MAP_PROTO_STATIC;
-		bk->uri = g_strdup(pos + 4);
+		rspamd_map_backend_set_uri(bk, pos + 4);
 		bk->is_compressed = TRUE;
 
 		return pos + 4;
@@ -3096,23 +3165,23 @@ rspamd_map_check_proto(struct rspamd_config *cfg,
 	if (g_ascii_strncasecmp(pos, "http://", sizeof("http://") - 1) == 0) {
 		bk->protocol = MAP_PROTO_HTTP;
 		/* Include http:// */
-		bk->uri = g_strdup(pos);
+		rspamd_map_backend_set_uri(bk, pos);
 		pos += sizeof("http://") - 1;
 	}
 	else if (g_ascii_strncasecmp(pos, "https://", sizeof("https://") - 1) == 0) {
 		bk->protocol = MAP_PROTO_HTTPS;
 		/* Include https:// */
-		bk->uri = g_strdup(pos);
+		rspamd_map_backend_set_uri(bk, pos);
 		pos += sizeof("https://") - 1;
 	}
 	else if (g_ascii_strncasecmp(pos, "file://", sizeof("file://") - 1) == 0) {
 		pos += sizeof("file://") - 1;
 		/* Exclude file:// */
-		bk->uri = g_strdup(pos);
+		rspamd_map_backend_set_uri(bk, pos);
 	}
 	else if (*pos == '/') {
 		/* Trivial file case */
-		bk->uri = g_strdup(pos);
+		rspamd_map_backend_set_uri(bk, pos);
 	}
 	else {
 		msg_err_config("invalid map fetching protocol: %s", map_line);
@@ -3223,6 +3292,7 @@ rspamd_map_backend_dtor(struct rspamd_map_backend *bk)
 		rspamd_pubkey_unref(bk->trusted_pubkey);
 	}
 
+	g_free(bk->uri_log);
 	g_free(bk->uri);
 	g_free(bk);
 }
@@ -3246,7 +3316,7 @@ rspamd_map_parse_backend(struct rspamd_config *cfg, const char *map_line)
 	}
 
 	if (bk->is_fallback && bk->protocol != MAP_PROTO_FILE) {
-		msg_err_config("fallback backend must be file for %s", bk->uri);
+		msg_err_config("fallback backend must be file for %s", bk->uri_log);
 
 		goto err;
 	}
@@ -3295,12 +3365,12 @@ rspamd_map_parse_backend(struct rspamd_config *cfg, const char *map_line)
 		memset(&up, 0, sizeof(up));
 		if (http_parser_parse_url(bk->uri, strlen(bk->uri), FALSE,
 								  &up) != 0) {
-			msg_err_config("cannot parse HTTP url: %s", bk->uri);
+			msg_err_config("cannot parse HTTP url: %s", bk->uri_log);
 			goto err;
 		}
 		else {
 			if (!(up.field_set & 1u << UF_HOST)) {
-				msg_err_config("cannot parse HTTP url: %s: no host", bk->uri);
+				msg_err_config("cannot parse HTTP url: %s: no host", bk->uri_log);
 				goto err;
 			}
 
@@ -3609,7 +3679,7 @@ rspamd_map_add(struct rspamd_config *cfg,
 	}
 
 	if (bk->is_fallback) {
-		msg_err_config("cannot add map with fallback only backend: %s", bk->uri);
+		msg_err_config("cannot add map with fallback only backend: %s", bk->uri_log);
 		REF_RELEASE(bk);
 
 		return NULL;

--- a/src/libserver/maps/map_private.h
+++ b/src/libserver/maps/map_private.h
@@ -159,6 +159,7 @@ struct rspamd_map_backend {
 	struct rspamd_cryptobox_pubkey *trusted_pubkey;
 	union rspamd_map_backend_data data;
 	char *uri;
+	char *uri_log; /* uri with HTTP userinfo redacted; safe for logging */
 	ref_entry_t ref;
 };
 

--- a/test/playwright/tests/scan.spec.mjs
+++ b/test/playwright/tests/scan.spec.mjs
@@ -248,6 +248,11 @@ test.describe.serial("Scan flow across WebUI tabs", () => {
             // Login as read-only
             await login(page2, readOnlyPassword);
             await page2.waitForSelector("#navBar:not(.d-none)");
+            // Bootstrap dismisses #connectDialog asynchronously (fade transition).
+            // navBar loses d-none from the /auth "complete" callback, which can fire
+            // before the modal finishes closing — the lingering .show then intercepts
+            // nav clicks (seen on WebKit under CI load).
+            await expect(page2.locator("#connectDialog")).toBeHidden({timeout: 10000});
 
             // Go to Scan in RO
             await gotoTabLocal("scan");
@@ -264,6 +269,7 @@ test.describe.serial("Scan flow across WebUI tabs", () => {
             );
             await page2.locator("#connectButton").click();
             await page2.waitForSelector("#navBar:not(.d-none)");
+            await expect(page2.locator("#connectDialog")).toBeHidden({timeout: 10000});
             await p;
 
             // Expect classifiers to be populated

--- a/test/playwright/tests/scan.spec.mjs
+++ b/test/playwright/tests/scan.spec.mjs
@@ -208,12 +208,15 @@ test.describe.serial("Scan flow across WebUI tabs", () => {
 
         test("Throughput `Total messages` counter increased", async ({}, testInfo) => {
             testInfo.setTimeout(140000);
-            // With empty RRD the first PDP is lost, so only +1 is visible
-            // Depending on row boundaries, throughput may show +2 or even +3
+            // With empty RRD the first PDP is lost, so only +1 is visible.
+            // #rrd-total-value is an integral of the message rate (truncated per
+            // series, summed over the 6 action series), so depending on row
+            // boundaries it can overshoot the messages scanned (+2 .. +4).
             const targetValues = [
                 scannedBefore.throughput + 1,
                 scannedBefore.throughput + 2,
                 scannedBefore.throughput + 3,
+                scannedBefore.throughput + 4,
             ];
 
             let lastValue = null;

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -22,6 +22,7 @@
 #include "doctest/doctest.h"
 
 #include "rspamd_cxx_unit_utils.hxx"
+#include "rspamd_cxx_unit_maps.hxx"
 #include "rspamd_cxx_local_ptr.hxx"
 #include "rspamd_cxx_unit_dkim.hxx"
 #include "rspamd_cxx_unit_cryptobox.hxx"

--- a/test/rspamd_cxx_unit_maps.hxx
+++ b/test/rspamd_cxx_unit_maps.hxx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Alexander Moisseev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Unit tests for maps helpers */
+
+#ifndef RSPAMD_RSPAMD_CXX_UNIT_MAPS_HXX
+#define RSPAMD_RSPAMD_CXX_UNIT_MAPS_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+#include <vector>
+#include <utility>
+#include <string>
+
+/* Declared non-static in src/libserver/maps/map.c for unit testing */
+extern "C" char *rspamd_map_uri_redacted(const char *uri);
+
+TEST_SUITE("rspamd_maps")
+{
+
+	TEST_CASE("rspamd_map_uri_redacted")
+	{
+		std::vector<std::pair<std::string, std::string>> cases{
+			/* No scheme separator: returned verbatim */
+			{"not-a-url", "not-a-url"},
+			{"/etc/rspamd/list.map", "/etc/rspamd/list.map"},
+			/* No userinfo: returned verbatim */
+			{"http://example.com/path", "http://example.com/path"},
+			{"http://example.com:8080/path", "http://example.com:8080/path"},
+			{"http://[::1]:8080/path", "http://[::1]:8080/path"},
+			{"http://[::1]/path", "http://[::1]/path"},
+			/* Userinfo redacted */
+			{"http://user:pass@example.com/path", "http://***@example.com/path"},
+			{"http://user@example.com/path", "http://***@example.com/path"},
+			{"http://@example.com/path", "http://***@example.com/path"},
+			{"https://u:p@host:8443/p?q#f", "https://***@host:8443/p?q#f"},
+			{"https://u:p@host", "https://***@host"},
+			/* IPv6 host literal is preserved (it follows the userinfo) */
+			{"http://user:pass@[::1]:8080/path", "http://***@[::1]:8080/path"},
+			{"http://u:p@[2001:db8::1]/path", "http://***@[2001:db8::1]/path"},
+			/* Malformed input with several '@': redact up to the last one */
+			{"http://a@b:p@host/path", "http://***@host/path"},
+			/* '@' outside of the authority (in path / query) must not be touched */
+			{"http://host/path@x", "http://host/path@x"},
+			{"http://host?u@p", "http://host?u@p"},
+		};
+
+		for (const auto &c: cases) {
+			SUBCASE(("redact " + c.first).c_str())
+			{
+				auto *out = rspamd_map_uri_redacted(c.first.c_str());
+				CHECK(std::string{out} == c.second);
+				g_free(out);
+			}
+		}
+	}
+}
+
+#endif


### PR DESCRIPTION
Map URIs may carry HTTP basic-auth userinfo ("user:pass@host"). It was logged verbatim in CRITICAL (msg_err_*) messages, which feed the /errors ring buffer exposed via the controller, leaking credentials to anyone reading it. Add a redacted uri_log copy (userinfo replaced with "***@") used in error logs; the real uri is kept intact as it serves as the "maps { <uri> {} }" configuration key and carries the userinfo needed for the Authorization header.