### PR TITLE
Fuzzy check: configurable probability weight curve and better diagnostics

### DIFF
--- a/src/libserver/cfg_utils.cxx
+++ b/src/libserver/cfg_utils.cxx
@@ -1577,6 +1577,26 @@ rspamd_check_worker(struct rspamd_config *cfg, worker_t *wrk)
 	return ret;
 }
 
+static void
+rspamd_config_check_duplicate_sections(struct rspamd_config *cfg, const char *mname)
+{
+	const ucl_object_t *sec = ucl_object_lookup(cfg->cfg_ucl_obj, mname);
+
+	if (sec != nullptr && sec->next != nullptr) {
+		unsigned int nsec = 0;
+
+		for (const ucl_object_t *cur = sec; cur != nullptr; cur = cur->next) {
+			nsec++;
+		}
+
+		msg_warn_config("section '%s' is defined %ud times in the configuration, "
+						"but module %s reads only the first one; the remaining "
+						"sections are IGNORED; merge them into a single section "
+						"(check for stray files in modules.d or duplicate includes)",
+						mname, nsec, mname);
+	}
+}
+
 gboolean
 rspamd_init_filters(struct rspamd_config *cfg, bool reconfig, bool strict)
 {
@@ -1618,6 +1638,7 @@ rspamd_init_filters(struct rspamd_config *cfg, bool reconfig, bool strict)
 		if (mod_ctx) {
 			mod = mod_ctx->mod;
 			mod_ctx->enabled = rspamd_config_is_module_enabled(cfg, mod->name);
+			rspamd_config_check_duplicate_sections(cfg, mod->name);
 
 			if (reconfig) {
 				if (!mod->module_reconfig_func(cfg)) {

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -115,9 +115,9 @@ struct fuzzy_rule {
 	gboolean skip_unknown;
 	gboolean no_share;
 	gboolean no_subject;
-	gboolean html_shingles;     /* Enable HTML fuzzy hashing */
-	gboolean text_hashes;       /* Enable/disable generation of text hashes */
-	unsigned int min_html_tags; /* Minimum tags for HTML hash */
+	gboolean html_shingles;       /* Enable HTML fuzzy hashing */
+	gboolean text_hashes;         /* Enable/disable generation of text hashes */
+	unsigned int min_html_tags;   /* Minimum tags for HTML hash */
 	gboolean html_ignore_domains; /* Ignore link domains in HTML structural tokens */
 	int learn_condition_cb;
 	uint32_t retransmits;
@@ -1554,14 +1554,24 @@ fuzzy_tcp_process_reply(struct fuzzy_tcp_connection *conn,
 	}
 	else if (rep->v1.value == 403) {
 		/* In fact, it should be 429, but we preserve compatibility */
+		msg_info_task("fuzzy rule %s: rate limit reached on %s",
+					  rule->name,
+					  rspamd_upstream_name(conn->server));
 		rspamd_task_insert_result(task, RSPAMD_FUZZY_SYMBOL_RATELIMITED, 1.0,
 								  rule->name);
 	}
 	else if (rep->v1.value == 503) {
+		msg_info_task("fuzzy rule %s: access denied by %s",
+					  rule->name,
+					  rspamd_upstream_name(conn->server));
 		rspamd_task_insert_result(task, RSPAMD_FUZZY_SYMBOL_FORBIDDEN, 1.0,
 								  rule->name);
 	}
 	else if (rep->v1.value == 415) {
+		msg_info_task("fuzzy rule %s: encryption is required by %s; "
+					  "add encryption_key option to the rule",
+					  rule->name,
+					  rspamd_upstream_name(conn->server));
 		rspamd_task_insert_result(task, RSPAMD_FUZZY_SYMBOL_ENCRYPTION_REQUIRED, 1.0,
 								  rule->name);
 	}
@@ -4730,14 +4740,24 @@ fuzzy_check_try_read(struct fuzzy_client_session *session)
 			}
 			else if (rep->v1.value == 403) {
 				/* In fact, it should be 429, but we preserve compatibility */
+				msg_info_task("fuzzy rule %s: rate limit reached on %s",
+							  session->rule->name,
+							  rspamd_upstream_name(session->server));
 				rspamd_task_insert_result(task, RSPAMD_FUZZY_SYMBOL_RATELIMITED, 1.0,
 										  session->rule->name);
 			}
 			else if (rep->v1.value == 503) {
+				msg_info_task("fuzzy rule %s: access denied by %s",
+							  session->rule->name,
+							  rspamd_upstream_name(session->server));
 				rspamd_task_insert_result(task, RSPAMD_FUZZY_SYMBOL_FORBIDDEN, 1.0,
 										  session->rule->name);
 			}
 			else if (rep->v1.value == 415) {
+				msg_info_task("fuzzy rule %s: encryption is required by %s; "
+							  "add encryption_key option to the rule",
+							  session->rule->name,
+							  rspamd_upstream_name(session->server));
 				rspamd_task_insert_result(task, RSPAMD_FUZZY_SYMBOL_ENCRYPTION_REQUIRED, 1.0,
 										  session->rule->name);
 			}

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -110,6 +110,8 @@ struct fuzzy_rule {
 	struct rspamd_cryptobox_pubkey *write_peer_key;
 	double hits_limit;
 	double weight_threshold;
+	double prob_bias;   /* Anchor of the probability weight curve (default 0.5, the shingle match threshold) */
+	double prob_power;  /* Exponent of the curve (default 1.0) */
 	double html_weight; /* Weight multiplier for HTML hashes (default 1.0) */
 	enum fuzzy_rule_mode mode;
 	gboolean skip_unknown;
@@ -532,6 +534,27 @@ fuzzy_normalize(int32_t in, double weight)
 #endif
 }
 
+/*
+ * Convert the reply probability into a weight multiplier.
+ *
+ * The server never replies with prob below the shingle match threshold
+ * (0.5), so a curve anchored at zero (like the old sqrt(prob)) collapses
+ * the whole reachable range into (~0.73 .. 1.0] and barely depends on the
+ * match quality: a marginal 17/32 shingle overlap yields almost the same
+ * score as an exact match. Anchor at prob_bias instead:
+ * ((prob - bias) / (1 - bias)) ^ prob_power, which spreads match quality
+ * over the full 0..1 range.
+ */
+static double
+fuzzy_weight_from_prob(struct fuzzy_rule *rule, double prob)
+{
+	double norm = (prob - rule->prob_bias) / (1.0 - rule->prob_bias);
+
+	norm = MIN(1.0, MAX(0.0, norm));
+
+	return pow(norm, rule->prob_power);
+}
+
 static struct fuzzy_rule *
 fuzzy_rule_new(const char *default_symbol, rspamd_mempool_t *pool)
 {
@@ -546,6 +569,8 @@ fuzzy_rule_new(const char *default_symbol, rspamd_mempool_t *pool)
 								  rule->mappings);
 	rule->mode = fuzzy_rule_read_write;
 	rule->weight_threshold = NAN;
+	rule->prob_bias = 0.5;
+	rule->prob_power = 1.0;
 	rule->html_weight = 1.0;
 	rule->html_shingles = FALSE;
 	rule->text_hashes = TRUE;
@@ -2233,6 +2258,28 @@ fuzzy_parse_rule(struct rspamd_config *cfg, const ucl_object_t *obj,
 		rule->weight_threshold = ucl_object_todouble(value);
 	}
 
+	if ((value = ucl_object_lookup(obj, "prob_power")) != NULL) {
+		rule->prob_power = ucl_object_todouble(value);
+
+		if (!(rule->prob_power > 0)) {
+			msg_warn_config("prob_power must be positive in rule %s, "
+							"using the default 1.0",
+							rule->name);
+			rule->prob_power = 1.0;
+		}
+	}
+
+	if ((value = ucl_object_lookup(obj, "prob_bias")) != NULL) {
+		rule->prob_bias = ucl_object_todouble(value);
+
+		if (rule->prob_bias < 0 || rule->prob_bias >= 1.0) {
+			msg_warn_config("prob_bias must be in [0, 1) in rule %s, "
+							"using the default 0.5",
+							rule->name);
+			rule->prob_bias = 0.5;
+		}
+	}
+
 	if ((value = ucl_object_lookup(obj, "text_hashes")) != NULL) {
 		rule->text_hashes = ucl_obj_toboolean(value);
 	}
@@ -2500,6 +2547,27 @@ int fuzzy_check_module_init(struct rspamd_config *cfg, struct module_ctx **ctx)
 							   "Legacy name: max_score",
 							   "hits_limit",
 							   UCL_INT,
+							   NULL,
+							   0,
+							   NULL,
+							   0);
+	rspamd_rcl_add_doc_by_path(cfg,
+							   "fuzzy_check.rule",
+							   "Exponent of the probability weight curve: score multiplier is "
+							   "((prob - prob_bias) / (1 - prob_bias)) ^ prob_power, so weak shingle "
+							   "matches score much lower than exact ones (default: 1.0)",
+							   "prob_power",
+							   UCL_FLOAT,
+							   NULL,
+							   0,
+							   NULL,
+							   0);
+	rspamd_rcl_add_doc_by_path(cfg,
+							   "fuzzy_check.rule",
+							   "Anchor of the probability weight curve, normally the shingle match "
+							   "threshold (default: 0.5)",
+							   "prob_bias",
+							   UCL_FLOAT,
 							   NULL,
 							   0,
 							   NULL,
@@ -4525,7 +4593,7 @@ fuzzy_insert_result(struct fuzzy_client_session *session,
 		}
 		else if ((io->flags & FUZZY_CMD_FLAG_HTML_DOMAINS)) {
 			/* HTML domain-sensitive hash (structure + domains) */
-			nval *= sqrtf(rep->v1.prob);
+			nval *= fuzzy_weight_from_prob(session->rule, rep->v1.prob);
 			nval *= session->rule->html_weight;
 
 			type = "htmld";
@@ -4533,7 +4601,7 @@ fuzzy_insert_result(struct fuzzy_client_session *session,
 		}
 		else if ((io->flags & FUZZY_CMD_FLAG_HTML)) {
 			/* HTML structural hash (template mode, domains ignored) */
-			nval *= sqrtf(rep->v1.prob);
+			nval *= fuzzy_weight_from_prob(session->rule, rep->v1.prob);
 			/* Apply HTML weight multiplier from rule config */
 			nval *= session->rule->html_weight;
 
@@ -4542,7 +4610,7 @@ fuzzy_insert_result(struct fuzzy_client_session *session,
 		}
 		else {
 			/* Calc real probability */
-			nval *= sqrtf(rep->v1.prob);
+			nval *= fuzzy_weight_from_prob(session->rule, rep->v1.prob);
 
 			if (cmd->shingles_count > 0) {
 				type = "txt";


### PR DESCRIPTION
Three related changes coming from a real-world false positive investigation, where a weak 19/32 shingle match on a legitimate newsletter was enough to push the message into rejection, and the diagnostics around it made the investigation harder than it should have been.

## 1. fuzzy_check: probability weight curve anchored at the match threshold

The score multiplier for non-exact fuzzy matches was `sqrt(prob)`: a concave curve anchored at zero. Since the storage never returns matches below the shingle threshold (0.5), the whole reachable range (17/32 … 32/32 shingles) collapsed into ~(0.73 … 1.0] of the full weight — a marginal 53% overlap scored almost like an exact match. Combined with high-weight deny lists this turned weak matches into instant rejects.

The multiplier is now `((prob - prob_bias) / (1 - prob_bias)) ^ prob_power`, anchored at the match threshold. **The old zero-anchored sqrt curve is not preserved — it was simply broken.** This changes scores for all non-exact matches (exact matches are unaffected):

| shingles matched | prob | sqrt (old) | power=1 (new default) | power=2 |
|---|---|---|---|---|
| 19/32 | 0.59 | 0.77 | 0.19 | 0.04 |
| 24/32 | 0.75 | 0.87 | 0.50 | 0.25 |
| 28/32 | 0.88 | 0.94 | 0.75 | 0.56 |
| 32/32 | 1.00 | 1.00 | 1.00 | 1.00 |

With the default `prob_power = 1.0` the multiplier is simply the fraction of the way from the threshold to an exact match. Per-rule tuning:

```hcl
rule "..." {
  prob_power = 2.0; # harsher discounting of weak matches
  prob_bias = 0.5;  # anchor; defaults to the shingle match threshold
}
```

Applies to text and HTML hashes; small images keep their existing `rspamd_normalize_probability()` handling (same idea, already threshold-anchored). Invalid values (non-positive power, bias outside [0, 1)) log a warning and fall back to the defaults.

## 2. fuzzy_check: log rule and server for error replies

403 (rate limit), 503 (access denied) and 415 (encryption required) replies used to insert their symbols silently; with several rules configured there was no way to tell from the logs which rule and which server produced the error. Now both the UDP and TCP reply paths log an info message:

```
fuzzy rule myrule: encryption is required by 127.0.0.1:11335; add encryption_key option to the rule
```

## 3. cfg: warn when a module section is defined multiple times

When a module section is duplicated at the top level (e.g. a stray file in `modules.d`), `rspamd_config_get_module_opt()` returns options from the first section only, so the remaining sections are silently ignored — fuzzy rules simply vanish with no trace. Lua modules are unaffected (`get_all_opt()` flattens the whole duplicate chain). Every configured C module now emits an explicit warning:

```
section 'fuzzy_check' is defined 2 times in the configuration, but module fuzzy_check reads only the first one; the remaining sections are IGNORED; merge them into a single section (check for stray files in modules.d or duplicate includes)
```

## Testing

- Build + full C++ unit test suite (76812 assertions pass)
- Live A/B against a scratch fuzzy storage: a 22/32 shingle match (prob 0.69) gets weight 0.38 with the default curve (vs 0.83 with the old sqrt) and 0.14 with `prob_power = 2.0`; an exact match stays at 1.00 in all modes
- Duplicate-section warning verified with `rspamadm configtest` on a config with a duplicated `fuzzy_check` section
- 415 logging verified against an `encrypted_only` storage with a keyless rule
