### PR TITLE
Fuzzy check: hash observability (structured results, matched-digest flag, rspamadm fuzzy_hash)

### DIFF
--- a/lualib/rspamadm/fuzzy_hash.lua
+++ b/lualib/rspamadm/fuzzy_hash.lua
@@ -1,0 +1,216 @@
+--[[
+Copyright (c) 2026, Vsevolod Stakhov <vsevolod@rspamd.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]]--
+
+local argparse = require "argparse"
+local ansicolors = require "ansicolors"
+local rspamd_logger = require "rspamd_logger"
+
+local E = {}
+
+local parser = argparse()
+    :name 'rspamadm fuzzy_hash'
+    :description 'Computes fuzzy hashes of messages and queries fuzzy storages'
+    :help_description_margin(30)
+
+parser:argument "file"
+      :description "Message file(s) to process"
+      :argname "<file>"
+      :args "*"
+parser:option "-c --config"
+      :description "Path to config file"
+      :argname("<cfg>")
+      :default(rspamd_paths["CONFDIR"] .. "/" .. "rspamd.conf")
+parser:option "-r --rule"
+      :description "Rule to use (all configured rules if not set)"
+      :argname("<name>")
+parser:option "-H --hash"
+      :description "Query the storage for a specific hex digest instead of a file (can be repeated, requires -r)"
+      :argname("<hex>")
+      :count "*"
+parser:flag "-C --check"
+      :description "Also query the storage for the computed hashes (shingles included, like a real scan)"
+parser:option "-s --server"
+      :description "Override server for the queries"
+      :argname("<addr>")
+parser:option "-t --timeout"
+      :description "Timeout for requests"
+      :argname("<timeout>")
+      :convert(tonumber)
+      :default(5)
+
+local function load_config(opts)
+  local _r, err = rspamd_config:load_ucl(opts['config'])
+
+  if not _r then
+    rspamd_logger.errx('cannot parse %s: %s', opts['config'], err)
+    os.exit(1)
+  end
+
+  _r, err = rspamd_config:parse_rcl({ 'logging', 'worker' })
+  if not _r then
+    rspamd_logger.errx('cannot process %s: %s', opts['config'], err)
+    os.exit(1)
+  end
+
+  _r, err = rspamd_config:init_modules()
+  if not _r then
+    rspamd_logger.errx('cannot init modules from %s: %s', opts['config'], err)
+    os.exit(1)
+  end
+
+  -- Tokenization must match the scanner, otherwise text hashes differ
+  rspamd_config:init_subsystem('langdet')
+end
+
+local function highlight(fmt, ...)
+  return ansicolors.white .. string.format(fmt, ...) .. ansicolors.reset
+end
+
+local function highlight_err(fmt, ...)
+  return ansicolors.red .. string.format(fmt, ...) .. ansicolors.reset
+end
+
+local function selected_rules(opts)
+  local all_rules = rspamd_plugins.fuzzy_check.list_storages(rspamd_config)
+  local res = {}
+
+  for name, rule in pairs(all_rules) do
+    if not opts.rule or opts.rule == name then
+      res[name] = rule
+    end
+  end
+
+  if not next(res) then
+    print(highlight_err('no fuzzy rules matched (rule filter: %s)', opts.rule or 'none'))
+    os.exit(1)
+  end
+
+  return res
+end
+
+local function print_check_result(ok, server, result)
+  if not ok then
+    print(highlight_err('  error from %s: %s', server, result))
+    return
+  end
+
+  if result.found then
+    local when = (result.added and result.added > 0)
+        and os.date('!%Y-%m-%d %H:%M:%S', result.added) or 'unknown'
+    print(highlight('  %s (%s): FOUND %s; flag=%s value=%s prob=%.2f added=%s confirmed=%s',
+        result.queried, result.type, result.digest, result.flag, result.value,
+        result.prob, when, result.confirmed))
+  elseif result.value ~= 0 then
+    print(highlight_err('  %s (%s): server error %s', result.queried, result.type, result.value))
+  else
+    print(string.format('  %s (%s): not found', result.queried, result.type))
+  end
+end
+
+local function make_task(fname)
+  local rspamd_task = require "rspamd_task"
+  local task = rspamd_task.create(rspamd_config, rspamadm_ev_base)
+
+  task:set_session(rspamadm_session)
+  task:set_resolver(rspamadm_dns_resolver)
+
+  if fname then
+    if not task:load_from_file(fname) then
+      print(highlight_err('cannot load message from %s', fname))
+      os.exit(1)
+    end
+
+    if not task:process_message() then
+      print(highlight_err('cannot process message %s', fname))
+      os.exit(1)
+    end
+  end
+
+  return task
+end
+
+local function query_hashes(opts)
+  if not opts.rule then
+    print(highlight_err('-H/--hash requires an explicit rule (-r)'))
+    os.exit(1)
+  end
+
+  local task = make_task(nil)
+  local ret, err = rspamd_plugins.fuzzy_check.check(task, print_check_result,
+      opts.rule, opts.timeout, opts.hash, opts.server)
+
+  if not ret then
+    print(highlight_err('cannot query %s: %s', opts.rule, err))
+  end
+end
+
+local function process_file(opts, fname, rules)
+  local task = make_task(fname)
+
+  print(highlight('%s:', fname))
+
+  for name, rule in pairs(rules) do
+    -- Pick any flag defined for the rule: computed hashes do not depend on it
+    local _, flag = next(rule.flags or E)
+
+    if flag then
+      local hashes = rspamd_plugins.fuzzy_check.hex_hashes(task, flag) or E
+
+      for _, h in ipairs(hashes[name] or E) do
+        print(string.format('  rule %s: %s', name, h))
+      end
+    end
+
+    if opts.check then
+      print(highlight('  checking rule %s (%s):', name,
+          opts.server or 'configured servers'))
+      local ret, err = rspamd_plugins.fuzzy_check.check(task, print_check_result,
+          name, opts.timeout, nil, opts.server)
+
+      if not ret then
+        print(highlight_err('  cannot query %s: %s', name, err))
+      end
+    end
+  end
+end
+
+local function handler(args)
+  local opts = parser:parse(args)
+
+  load_config(opts)
+
+  if #opts.hash > 0 then
+    query_hashes(opts)
+    return
+  end
+
+  if #opts.file == 0 then
+    parser:error('no files or hashes given')
+  end
+
+  local rules = selected_rules(opts)
+
+  for _, fname in ipairs(opts.file) do
+    process_file(opts, fname, rules)
+  end
+end
+
+return {
+  name = 'fuzzy_hash',
+  aliases = { 'fuzzyhash' },
+  handler = handler,
+  description = parser._description
+}

--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -619,6 +619,8 @@ enum rspamd_fuzzy_reply_flags {
 	RSPAMD_FUZZY_REPLY_ENCRYPTED = 0x1u << 0u,
 	RSPAMD_FUZZY_REPLY_SHINGLE = 0x1u << 1u,
 	RSPAMD_FUZZY_REPLY_DELAY = 0x1u << 2u,
+	/* The reply digest is the actual digest resolved by the backend */
+	RSPAMD_FUZZY_REPLY_MATCHED = 0x1u << 3u,
 };
 
 /*
@@ -743,6 +745,10 @@ rspamd_fuzzy_make_reply(struct rspamd_fuzzy_cmd *cmd,
 			/* Filter forbidden flags from primary and extra flags */
 			rspamd_fuzzy_filter_forbidden_v2(rep_v2, session, flags);
 
+			if ((flags & RSPAMD_FUZZY_REPLY_MATCHED) && rep_v2->v1.prob > 0.5f) {
+				rep_v2->reserved[0] |= RSPAMD_FUZZY_REPLY_FLAG_MATCHED_DIGEST;
+			}
+
 			if (flags & RSPAMD_FUZZY_REPLY_ENCRYPTED) {
 
 				/* Use a temporary v1 reply for stats (stats API expects rspamd_fuzzy_reply) */
@@ -805,6 +811,11 @@ rspamd_fuzzy_make_reply(struct rspamd_fuzzy_cmd *cmd,
 				session->reply.v1.rep.ts = 0;
 				session->reply.v1.rep.v1.prob = 0.0f;
 				session->reply.v1.rep.v1.value = 0;
+			}
+
+			if ((flags & RSPAMD_FUZZY_REPLY_MATCHED) &&
+				session->reply.v1.rep.v1.prob > 0.5f) {
+				session->reply.v1.rep.reserved[0] |= RSPAMD_FUZZY_REPLY_FLAG_MATCHED_DIGEST;
 			}
 
 			bool default_disabled = false;
@@ -1183,6 +1194,11 @@ rspamd_fuzzy_check_callback(struct rspamd_fuzzy_multiflag_result *mf_result, voi
 				g_free(up_req);
 			}
 		}
+	}
+
+	if (result->v1.prob > 0.5) {
+		/* The digest in the reply is the one resolved by the backend */
+		send_flags |= RSPAMD_FUZZY_REPLY_MATCHED;
 	}
 
 	rspamd_fuzzy_make_reply(cmd, result, mf_result, session, send_flags);

--- a/src/libserver/fuzzy_wire.h
+++ b/src/libserver/fuzzy_wire.h
@@ -80,6 +80,15 @@ RSPAMD_PACKED(rspamd_fuzzy_reply_v1)
 	float prob;
 };
 
+/*
+ * Flags stored in the first reserved byte of a reply.
+ * MATCHED_DIGEST is set when the digest field contains the actual digest
+ * stored in the storage (a direct or shingle match resolved by the
+ * backend); legacy storages leave the reserved bytes zeroed, so its
+ * absence merely means "unknown".
+ */
+#define RSPAMD_FUZZY_REPLY_FLAG_MATCHED_DIGEST (1u << 0u)
+
 RSPAMD_PACKED(rspamd_fuzzy_reply)
 {
 	struct rspamd_fuzzy_reply_v1 v1;

--- a/src/libserver/mempool_vars_internal.h
+++ b/src/libserver/mempool_vars_internal.h
@@ -38,6 +38,8 @@
 #define RSPAMD_MEMPOOL_ARC_SIGN_SELECTOR "arc_selector"
 #define RSPAMD_MEMPOOL_STAT_SIGNATURE "stat_signature"
 #define RSPAMD_MEMPOOL_FUZZY_RESULT "fuzzy_hashes"
+#define RSPAMD_MEMPOOL_FUZZY_MATCHES "fuzzy_matches"
+#define RSPAMD_MEMPOOL_FUZZY_CHECKED "fuzzy_checked"
 #define RSPAMD_MEMPOOL_SPAM_LEARNS "spam_learns"
 #define RSPAMD_MEMPOOL_HAM_LEARNS "ham_learns"
 #define RSPAMD_MEMPOOL_RE_MAPS_CACHE "re_maps_cache"

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -1070,6 +1070,26 @@ LUA_FUNCTION_DEF(task, merge_and_apply_settings);
 LUA_FUNCTION_DEF(task, get_settings);
 
 /***
+ * @method task:get_fuzzy_results()
+ * Returns an array of fuzzy matches found during the fuzzy check. Each element
+ * is a table with the following fields:
+ *
+ * - `rule` - fuzzy rule name
+ * - `symbol` - symbol inserted for the match
+ * - `server` - upstream that returned the match
+ * - `found` - hex digest stored in the storage that matched
+ * - `queried` - hex digest of the message part that was queried
+ * - `type` - hash type: txt, img, html, htmld, content or bin
+ * - `prob` - match probability (shingle overlap ratio, 1.0 for exact matches)
+ * - `score` - normalized score multiplier
+ * - `flag` - storage flag, `value` - stored value, `added` - hash timestamp
+ * - `exact` - true when the found digest equals the queried one
+ * - `confirmed` - true when the storage explicitly marked the digest as matched
+ * @return {table} array of match tables (empty if there were no matches)
+ */
+LUA_FUNCTION_DEF(task, get_fuzzy_results);
+
+/***
  * @method task:lookup_settings(key)
  * Gets users settings object with the specified key for a task.
  * @param {string} key key to lookup
@@ -1510,6 +1530,7 @@ static const struct luaL_reg tasklib_m[] = {
 	LUA_INTERFACE_DEF(task, learn),
 	LUA_INTERFACE_DEF(task, set_settings),
 	LUA_INTERFACE_DEF(task, get_settings),
+	LUA_INTERFACE_DEF(task, get_fuzzy_results),
 	LUA_INTERFACE_DEF(task, lookup_settings),
 	LUA_INTERFACE_DEF(task, get_metadata),
 	LUA_INTERFACE_DEF(task, get_metadata_field),
@@ -6876,6 +6897,29 @@ lua_task_set_milter_reply(lua_State *L)
 	}
 
 	return 0;
+}
+
+static int
+lua_task_get_fuzzy_results(lua_State *L)
+{
+	LUA_TRACE_POINT;
+	struct rspamd_task *task = lua_check_task(L, 1);
+
+	if (task != NULL) {
+		const ucl_object_t *matches = rspamd_mempool_get_variable(task->task_pool,
+																  RSPAMD_MEMPOOL_FUZZY_MATCHES);
+
+		if (matches != NULL) {
+			return ucl_object_push_lua(L, matches, true);
+		}
+
+		lua_newtable(L);
+	}
+	else {
+		return luaL_error(L, "invalid arguments");
+	}
+
+	return 1;
 }
 
 static int

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -327,6 +327,7 @@ static int fuzzy_lua_gen_hashes_handler(lua_State *L);
 static int fuzzy_lua_hex_hashes_handler(lua_State *L);
 static int fuzzy_lua_list_storages(lua_State *L);
 static int fuzzy_lua_ping_storage(lua_State *L);
+static int fuzzy_lua_check_storage(lua_State *L);
 
 module_t fuzzy_check_module = {
 	"fuzzy_check",
@@ -1471,6 +1472,7 @@ fuzzy_tcp_process_reply(struct fuzzy_tcp_connection *conn,
 			synthetic_rep.v1 = rep_v2->v1;
 			memcpy(synthetic_rep.digest, rep_v2->digest, sizeof(synthetic_rep.digest));
 			synthetic_rep.ts = rep_v2->ts;
+			synthetic_rep.reserved[0] = rep_v2->reserved[0];
 			rep = &synthetic_rep;
 		}
 		else {
@@ -1496,6 +1498,7 @@ fuzzy_tcp_process_reply(struct fuzzy_tcp_connection *conn,
 			synthetic_rep.v1 = rep_v2->v1;
 			memcpy(synthetic_rep.digest, rep_v2->digest, sizeof(synthetic_rep.digest));
 			synthetic_rep.ts = rep_v2->ts;
+			synthetic_rep.reserved[0] = rep_v2->reserved[0];
 			rep = &synthetic_rep;
 		}
 		else {
@@ -3083,6 +3086,9 @@ int fuzzy_check_module_config(struct rspamd_config *cfg, bool validate)
 		lua_pushstring(L, "ping_storage");
 		lua_pushcfunction(L, fuzzy_lua_ping_storage);
 		lua_settable(L, -3);
+		lua_pushstring(L, "check");
+		lua_pushcfunction(L, fuzzy_lua_check_storage);
+		lua_settable(L, -3);
 		/* Finish fuzzy_check key */
 		lua_settable(L, -3);
 	}
@@ -4496,6 +4502,7 @@ fuzzy_process_reply(unsigned char **pos, int *r, GPtrArray *req,
 		synthetic_rep.v1 = rv2->v1;
 		memcpy(synthetic_rep.digest, rv2->digest, sizeof(synthetic_rep.digest));
 		synthetic_rep.ts = rv2->ts;
+		synthetic_rep.reserved[0] = rv2->reserved[0];
 		rep = &synthetic_rep;
 		if (p_rep_v2) {
 			*p_rep_v2 = rv2;
@@ -4654,6 +4661,13 @@ fuzzy_insert_result(struct fuzzy_client_session *session,
 							  hexbuf, sizeof(hexbuf) - 1);
 		hexbuf[sizeof(hexbuf) - 1] = '\0';
 
+		char qhexbuf[rspamd_cryptobox_HASHBYTES * 2 + 1];
+		gboolean confirmed = (rep->reserved[0] & RSPAMD_FUZZY_REPLY_FLAG_MATCHED_DIGEST) != 0;
+
+		rspamd_encode_hex_buf(cmd->digest, sizeof(cmd->digest),
+							  qhexbuf, sizeof(qhexbuf) - 1);
+		qhexbuf[sizeof(qhexbuf) - 1] = '\0';
+
 		rspamd_gmtime(rep->ts, &tm_split);
 		rspamd_snprintf(timebuf, sizeof(timebuf), "%02d.%02d.%4d %02d:%02d:%02d GMT",
 						tm_split.tm_mday,
@@ -4689,15 +4703,60 @@ fuzzy_insert_result(struct fuzzy_client_session *session,
 				timebuf);
 		}
 
-		rspamd_snprintf(buf,
-						sizeof(buf),
-						"%d:%*s:%.2f:%s",
-						rep->v1.flag,
-						(int) MIN(rspamd_fuzzy_hash_len * 2, sizeof(rep->digest) * 2), hexbuf,
-						rep->v1.prob,
-						type);
+		if (is_fuzzy) {
+			/* Non-exact match: append the queried hash to make the option self-contained */
+			rspamd_snprintf(buf,
+							sizeof(buf),
+							"%d:%*s:%.2f:%s:%*s",
+							rep->v1.flag,
+							(int) MIN(rspamd_fuzzy_hash_len * 2, sizeof(rep->digest) * 2), hexbuf,
+							rep->v1.prob,
+							type,
+							(int) MIN(rspamd_fuzzy_hash_len * 2, sizeof(cmd->digest) * 2), qhexbuf);
+		}
+		else {
+			rspamd_snprintf(buf,
+							sizeof(buf),
+							"%d:%*s:%.2f:%s",
+							rep->v1.flag,
+							(int) MIN(rspamd_fuzzy_hash_len * 2, sizeof(rep->digest) * 2), hexbuf,
+							rep->v1.prob,
+							type);
+		}
 		res->option = rspamd_mempool_strdup(task->task_pool, buf);
 		g_ptr_array_add(session->results, res);
+
+		/* Store a structured match record for log/export consumers */
+		{
+			ucl_object_t *matches = (ucl_object_t *) rspamd_mempool_get_variable(
+				task->task_pool, RSPAMD_MEMPOOL_FUZZY_MATCHES);
+
+			if (matches == NULL) {
+				matches = ucl_object_typed_new(UCL_ARRAY);
+				rspamd_mempool_set_variable(task->task_pool,
+											RSPAMD_MEMPOOL_FUZZY_MATCHES, matches,
+											(rspamd_mempool_destruct_t) ucl_object_unref);
+			}
+
+			ucl_object_t *m = ucl_object_typed_new(UCL_OBJECT);
+			ucl_object_insert_key(m, ucl_object_fromstring(session->rule->name),
+								  "rule", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromstring(symbol), "symbol", 0, false);
+			ucl_object_insert_key(m,
+								  ucl_object_fromstring(session->server ? rspamd_upstream_name(session->server) : "unknown"),
+								  "server", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromstring(hexbuf), "found", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromstring(qhexbuf), "queried", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromstring(type), "type", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromdouble(rep->v1.prob), "prob", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromdouble(nval), "score", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromint(rep->v1.flag), "flag", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromint(rep->v1.value), "value", 0, false);
+			ucl_object_insert_key(m, ucl_object_fromint(rep->ts), "added", 0, false);
+			ucl_object_insert_key(m, ucl_object_frombool(!is_fuzzy), "exact", 0, false);
+			ucl_object_insert_key(m, ucl_object_frombool(confirmed), "confirmed", 0, false);
+			ucl_array_append(matches, m);
+		}
 
 		/* Store hex string in pool variable */
 		hex_result = rspamd_mempool_alloc(task->task_pool,
@@ -5562,6 +5621,28 @@ cleanup:
 	}
 }
 
+static const char *
+fuzzy_cmd_type_string(struct fuzzy_cmd_io *io)
+{
+	if (io->flags & FUZZY_CMD_FLAG_IMAGE) {
+		return "img";
+	}
+	if (io->flags & FUZZY_CMD_FLAG_HTML_DOMAINS) {
+		return "htmld";
+	}
+	if (io->flags & FUZZY_CMD_FLAG_HTML) {
+		return "html";
+	}
+	if (io->flags & FUZZY_CMD_FLAG_CONTENT) {
+		return "content";
+	}
+	if (io->cmd.shingles_count > 0) {
+		return "txt";
+	}
+
+	return "bin";
+}
+
 static GPtrArray *
 fuzzy_generate_commands(struct rspamd_task *task, struct fuzzy_rule *rule,
 						int c, int flag, uint32_t value, unsigned int flags)
@@ -5766,6 +5847,44 @@ fuzzy_generate_commands(struct rspamd_task *task, struct fuzzy_rule *rule,
 		g_ptr_array_free(res, TRUE);
 
 		return NULL;
+	}
+
+	if (c == FUZZY_CHECK && res != NULL) {
+		/* Record all queried hashes for post-hoc correlation, misses included */
+		GList *checked_var;
+		unsigned int ck_i;
+		struct fuzzy_cmd_io *ck_io;
+
+		checked_var = rspamd_mempool_get_variable(task->task_pool,
+												  RSPAMD_MEMPOOL_FUZZY_CHECKED);
+
+		PTR_ARRAY_FOREACH(res, ck_i, ck_io)
+		{
+			char ckbuf[rspamd_cryptobox_HASHBYTES * 2 + 128];
+			rspamd_fstring_t *ck_res;
+			int r;
+
+			r = rspamd_snprintf(ckbuf, sizeof(ckbuf), "%s:%s:%*xs",
+								rule->name,
+								fuzzy_cmd_type_string(ck_io),
+								(int) sizeof(ck_io->cmd.digest), ck_io->cmd.digest);
+
+			ck_res = rspamd_mempool_alloc(task->task_pool,
+										  sizeof(rspamd_fstring_t) + r + 1);
+			memcpy(ck_res->str, ckbuf, r + 1);
+			ck_res->len = r;
+			ck_res->allocated = (gsize) -1;
+
+			if (checked_var == NULL) {
+				checked_var = g_list_prepend(NULL, ck_res);
+				rspamd_mempool_set_variable(task->task_pool,
+											RSPAMD_MEMPOOL_FUZZY_CHECKED, checked_var,
+											(rspamd_mempool_destruct_t) g_list_free);
+			}
+			else {
+				checked_var = g_list_append(checked_var, ck_res);
+			}
+		}
 	}
 
 	return res;
@@ -7038,6 +7157,11 @@ fuzzy_lua_list_storages(lua_State *L)
 	return 1;
 }
 
+enum fuzzy_lua_session_mode {
+	FUZZY_LUA_SESSION_PING = 0,
+	FUZZY_LUA_SESSION_CHECK,
+};
+
 struct fuzzy_lua_session {
 	struct rspamd_task *task;
 	lua_State *L;
@@ -7045,6 +7169,7 @@ struct fuzzy_lua_session {
 	GPtrArray *commands;
 	struct fuzzy_rule *rule;
 	struct rspamd_io_ev ev;
+	enum fuzzy_lua_session_mode mode;
 	int cbref;
 	int fd;
 };
@@ -7120,6 +7245,62 @@ fuzzy_lua_push_error(struct fuzzy_lua_session *session, const char *err_fmt, ...
 	lua_pcall(session->L, 3, 0, 0);
 }
 
+static void
+fuzzy_lua_push_check_result(struct fuzzy_lua_session *session,
+							const struct rspamd_fuzzy_reply *rep,
+							struct rspamd_fuzzy_cmd *cmd,
+							struct fuzzy_cmd_io *io)
+{
+	char hexbuf[rspamd_cryptobox_HASHBYTES * 2 + 1];
+	int r;
+
+	lua_rawgeti(session->L, LUA_REGISTRYINDEX, session->cbref);
+	lua_pushboolean(session->L, TRUE);
+	rspamd_lua_ip_push(session->L, session->addr);
+
+	lua_createtable(session->L, 0, 9);
+
+	r = rspamd_encode_hex_buf(cmd->digest, sizeof(cmd->digest),
+							  hexbuf, sizeof(hexbuf) - 1);
+	lua_pushlstring(session->L, hexbuf, r);
+	lua_setfield(session->L, -2, "queried");
+
+	lua_pushstring(session->L, fuzzy_cmd_type_string(io));
+	lua_setfield(session->L, -2, "type");
+
+	lua_pushnumber(session->L, rep->v1.prob);
+	lua_setfield(session->L, -2, "prob");
+
+	lua_pushinteger(session->L, rep->v1.value);
+	lua_setfield(session->L, -2, "value");
+
+	lua_pushinteger(session->L, rep->v1.flag);
+	lua_setfield(session->L, -2, "flag");
+
+	if (rep->v1.prob > 0.5) {
+		lua_pushboolean(session->L, TRUE);
+		lua_setfield(session->L, -2, "found");
+
+		r = rspamd_encode_hex_buf(rep->digest, sizeof(rep->digest),
+								  hexbuf, sizeof(hexbuf) - 1);
+		lua_pushlstring(session->L, hexbuf, r);
+		lua_setfield(session->L, -2, "digest");
+
+		lua_pushinteger(session->L, rep->ts);
+		lua_setfield(session->L, -2, "added");
+
+		lua_pushboolean(session->L,
+						(rep->reserved[0] & RSPAMD_FUZZY_REPLY_FLAG_MATCHED_DIGEST) != 0);
+		lua_setfield(session->L, -2, "confirmed");
+	}
+	else {
+		lua_pushboolean(session->L, FALSE);
+		lua_setfield(session->L, -2, "found");
+	}
+
+	lua_pcall(session->L, 3, 0, 0);
+}
+
 static int
 fuzzy_lua_try_read(struct fuzzy_lua_session *session)
 {
@@ -7146,7 +7327,11 @@ fuzzy_lua_try_read(struct fuzzy_lua_session *session)
 		while ((rep = fuzzy_process_reply(&p, &r,
 										  session->commands, session->rule, &cmd, &io, NULL)) != NULL) {
 
-			if (rep->v1.prob > 0.5) {
+			if (session->mode == FUZZY_LUA_SESSION_CHECK && cmd->cmd == FUZZY_CHECK) {
+				/* Misses and error codes are valid results for the check mode */
+				fuzzy_lua_push_check_result(session, rep, cmd, io);
+			}
+			else if (rep->v1.prob > 0.5) {
 				if (cmd->cmd == FUZZY_PING) {
 					fuzzy_lua_push_result(session, fuzzy_milliseconds_since_midnight() - rep->v1.value);
 				}
@@ -7351,6 +7536,164 @@ fuzzy_lua_ping_storage(lua_State *L)
 			rspamd_ev_watcher_start(session->task->event_loop, &session->ev,
 									lua_tonumber(L, 4));
 		}
+	}
+
+	lua_pushboolean(L, TRUE);
+	return 1;
+}
+
+/***
+ * @function fuzzy_check.check(task, callback, rule, timeout[, hashes][, server_override])
+ * Sends fuzzy check requests either for the hashes generated from the task
+ * message (the default) or for an explicit list of hex digests. The callback
+ * is invoked per reply as (success, server, result) where result is a table:
+ * queried, type, prob, value, flag, found; when found is true it also
+ * contains digest (the stored hash), added (timestamp) and confirmed (the
+ * storage explicitly marked the digest as the matched one).
+ */
+static int
+fuzzy_lua_check_storage(lua_State *L)
+{
+	struct rspamd_task *task = lua_check_task(L, 1);
+
+	if (task == NULL) {
+		return luaL_error(L, "invalid arguments: task");
+	}
+
+	if (lua_type(L, 2) != LUA_TFUNCTION || lua_type(L, 3) != LUA_TSTRING || lua_type(L, 4) != LUA_TNUMBER) {
+		return luaL_error(L, "invalid arguments: callback/rule/timeout argument");
+	}
+
+	struct fuzzy_ctx *fuzzy_module_ctx = fuzzy_get_context(task->cfg);
+	struct fuzzy_rule *rule, *rule_found = NULL;
+	int i;
+	const char *rule_name = lua_tostring(L, 3);
+
+	PTR_ARRAY_FOREACH(fuzzy_module_ctx->fuzzy_rules, i, rule)
+	{
+		if (strcmp(rule->name, rule_name) == 0) {
+			rule_found = rule;
+			break;
+		}
+	}
+
+	if (rule_found == NULL) {
+		return luaL_error(L, "invalid arguments: no such rule defined");
+	}
+
+	GPtrArray *commands = NULL;
+
+	if (lua_type(L, 5) == LUA_TTABLE) {
+		/* Explicit list of hex digests to query */
+		commands = g_ptr_array_new();
+
+		for (lua_pushnil(L); lua_next(L, 5); lua_pop(L, 1)) {
+			gsize hlen = 0;
+			const char *hex = lua_tolstring(L, -1, &hlen);
+			rspamd_ftok_t tok = {.begin = hex, .len = hlen};
+			struct fuzzy_cmd_io *io = fuzzy_cmd_hash(rule_found, FUZZY_CHECK, &tok,
+													 0, 0, task->task_pool);
+
+			if (io == NULL) {
+				lua_pop(L, 2);
+				g_ptr_array_free(commands, TRUE);
+				lua_pushboolean(L, FALSE);
+				lua_pushstring(L, "invalid hash in the list (must be 128 hex characters)");
+				return 2;
+			}
+
+			g_ptr_array_add(commands, io);
+		}
+
+		if (commands->len == 0) {
+			g_ptr_array_free(commands, TRUE);
+			lua_pushboolean(L, FALSE);
+			lua_pushstring(L, "empty hashes list");
+			return 2;
+		}
+	}
+	else {
+		commands = fuzzy_generate_commands(task, rule_found, FUZZY_CHECK, 0, 0, 0);
+
+		if (commands == NULL) {
+			lua_pushboolean(L, FALSE);
+			lua_pushstring(L, "cannot generate fuzzy hashes from the task message");
+			return 2;
+		}
+	}
+
+	rspamd_inet_addr_t *addr = NULL;
+
+	if (lua_type(L, 6) == LUA_TSTRING) {
+		const char *server_name = lua_tostring(L, 6);
+		enum rspamd_parse_host_port_result res;
+		GPtrArray *addrs = g_ptr_array_new();
+
+		/* We resolve address synchronously here as it is an explicit override */
+		res = rspamd_parse_host_port_priority(server_name, &addrs, 0, NULL,
+											  11335, FALSE, task->task_pool);
+
+		if (res == RSPAMD_PARSE_ADDR_FAIL) {
+			g_ptr_array_free(commands, TRUE);
+			lua_pushboolean(L, FALSE);
+			lua_pushfstring(L, "invalid arguments: cannot resolve %s", server_name);
+			return 2;
+		}
+
+		addr = rspamd_inet_address_copy(g_ptr_array_index(addrs, rspamd_random_uint64_fast() % addrs->len),
+										task->task_pool);
+		rspamd_mempool_add_destructor(task->task_pool,
+									  rspamd_ptr_array_free_hard, addrs);
+	}
+	else {
+		struct upstream *selected = rspamd_upstream_get(rule_found->read_servers,
+														RSPAMD_UPSTREAM_ROUND_ROBIN, NULL, 0);
+		if (selected == NULL) {
+			g_ptr_array_free(commands, TRUE);
+			lua_pushboolean(L, FALSE);
+			lua_pushfstring(L, "no fuzzy storage upstream available for rule %s",
+							rule_found->name);
+			return 2;
+		}
+		addr = rspamd_upstream_addr_next(selected);
+		/* The session tracks the address directly, not the upstream */
+		rspamd_upstream_release(selected);
+	}
+
+	int sock;
+
+	if ((sock = rspamd_inet_address_connect(addr, SOCK_DGRAM, TRUE)) == -1) {
+		g_ptr_array_free(commands, TRUE);
+		lua_pushboolean(L, FALSE);
+		lua_pushfstring(L, "cannot connect to %s, %s",
+						rspamd_inet_address_to_string_pretty(addr),
+						strerror(errno));
+		return 2;
+	}
+	else {
+		struct fuzzy_lua_session *session =
+			rspamd_mempool_alloc0(task->task_pool,
+								  sizeof(struct fuzzy_lua_session));
+		session->task = task;
+		session->fd = sock;
+		session->addr = addr;
+		session->commands = commands;
+		session->L = L;
+		session->rule = rule_found;
+		session->mode = FUZZY_LUA_SESSION_CHECK;
+		/* Store callback */
+		lua_pushvalue(L, 2);
+		session->cbref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+		rspamd_session_add_event_full(task->s, fuzzy_lua_session_fin, session, M,
+									  rule_found->name);
+		rspamd_ev_watcher_init(&session->ev,
+							   sock,
+							   EV_WRITE,
+							   fuzzy_lua_io_callback,
+							   session);
+		rspamd_ev_watcher_start(session->task->event_loop, &session->ev,
+								lua_tonumber(L, 4));
 	}
 
 	lua_pushboolean(L, TRUE);

--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -33,7 +33,7 @@ local nrows = 0
 local used_memory = 0
 local last_collection = 0
 local final_call = false -- If the final collection has been started
-local schema_version = 10 -- Current schema version
+local schema_version = 11 -- Current schema version
 
 local extra_tables = {}
 local extra_table_rows = {}
@@ -177,6 +177,11 @@ CREATE TABLE IF NOT EXISTS rspamd
     `Urls.Url` Array(String) COMMENT 'Full URL if `full_urls` module option enabled, host part of URL otherwise',
     `Urls.Flags` Array(UInt32) COMMENT 'Corresponding url flags, see `enum rspamd_url_flags` in libserver/url.h for details',
     Emails Array(String) COMMENT 'List of emails extracted from the message',
+    `Fuzzy.Hash` Array(String) COMMENT 'Stored fuzzy digest that matched',
+    `Fuzzy.Queried` Array(String) COMMENT 'Fuzzy digest of the message part that was queried',
+    `Fuzzy.Rule` Array(LowCardinality(String)) COMMENT 'Fuzzy rule name',
+    `Fuzzy.Prob` Array(Float32) COMMENT 'Fuzzy match probability (shingle overlap ratio)',
+    `Fuzzy.Flag` Array(UInt32) COMMENT 'Fuzzy storage flag',
     ASN UInt32 COMMENT 'BGP AS number for SMTP client IP (returned by asn.rspamd.com or asn6.rspamd.com)',
     Country FixedString(2) COMMENT 'Country for SMTP client IP (returned by asn.rspamd.com or asn6.rspamd.com)',
     IPNet String,
@@ -306,6 +311,18 @@ local migrations = {
     -- New version
     [[INSERT INTO rspamd_version (Version) Values (10)]],
   },
+  [10] = {
+    -- Add fuzzy matches information
+    [[ALTER TABLE rspamd
+      ADD COLUMN IF NOT EXISTS `Fuzzy.Hash` Array(String) AFTER Emails,
+      ADD COLUMN IF NOT EXISTS `Fuzzy.Queried` Array(String) AFTER `Fuzzy.Hash`,
+      ADD COLUMN IF NOT EXISTS `Fuzzy.Rule` Array(LowCardinality(String)) AFTER `Fuzzy.Queried`,
+      ADD COLUMN IF NOT EXISTS `Fuzzy.Prob` Array(Float32) AFTER `Fuzzy.Rule`,
+      ADD COLUMN IF NOT EXISTS `Fuzzy.Flag` Array(UInt32) AFTER `Fuzzy.Prob`
+    ]],
+    -- New version
+    [[INSERT INTO rspamd_version (Version) Values (11)]],
+  },
 }
 
 local predefined_actions = {
@@ -389,6 +406,19 @@ end
 local function clickhouse_emails_row(res)
   local fields = {
     'Emails',
+  }
+  for _, v in ipairs(fields) do
+    table.insert(res, v)
+  end
+end
+
+local function clickhouse_fuzzy_row(res)
+  local fields = {
+    'Fuzzy.Hash',
+    'Fuzzy.Queried',
+    'Fuzzy.Rule',
+    'Fuzzy.Prob',
+    'Fuzzy.Flag',
   }
   for _, v in ipairs(fields) do
     table.insert(res, v)
@@ -527,6 +557,7 @@ local function clickhouse_send_data(task, ev_base, why, gen_rows, cust_rows, ext
   clickhouse_attachments_row(fields)
   clickhouse_urls_row(fields)
   clickhouse_emails_row(fields)
+  clickhouse_fuzzy_row(fields)
   clickhouse_asn_row(fields)
 
   if settings.enable_symbols then
@@ -1046,6 +1077,27 @@ local function clickhouse_collect(task)
   else
     table.insert(row, {})
   end
+
+  -- Fuzzy matches
+  local fuzzy_hashes = {}
+  local fuzzy_queried = {}
+  local fuzzy_rules = {}
+  local fuzzy_probs = {}
+  local fuzzy_flags = {}
+
+  for _, m in ipairs(task:get_fuzzy_results() or {}) do
+    fuzzy_hashes[#fuzzy_hashes + 1] = m.found
+    fuzzy_queried[#fuzzy_queried + 1] = m.queried
+    fuzzy_rules[#fuzzy_rules + 1] = m.rule
+    fuzzy_probs[#fuzzy_probs + 1] = m.prob
+    fuzzy_flags[#fuzzy_flags + 1] = m.flag
+  end
+
+  table.insert(row, fuzzy_hashes)
+  table.insert(row, fuzzy_queried)
+  table.insert(row, fuzzy_rules)
+  table.insert(row, fuzzy_probs)
+  table.insert(row, fuzzy_flags)
 
   -- ASN information
   local asn, country, ipnet = 0, '--', '--'

--- a/src/plugins/lua/milter_headers.lua
+++ b/src/plugins/lua/milter_headers.lua
@@ -626,13 +626,33 @@ local function milter_headers(task)
   end
 
   routines['fuzzy-hashes'] = function()
-    local res = task:get_mempool():get_variable("fuzzy_hashes", "fstrings")
+    local matches = task:get_fuzzy_results()
+    local out = {}
 
-    if res and #res > 0 then
+    if matches and #matches > 0 then
+      for _, m in ipairs(matches) do
+        local ann = string.format('rule=%s; flag=%s; prob=%.2f', m.rule, m.flag, m.prob)
+
+        if not m.exact then
+          ann = ann .. string.format('; queried=%s', m.queried)
+        end
+
+        if m.added and m.added > 0 then
+          ann = ann .. string.format('; added=%s', os.date('!%Y-%m-%d %H:%M:%S', m.added))
+        end
+
+        out[#out + 1] = string.format('%s (%s)', m.found, ann)
+      end
+    else
+      -- Legacy pool variable set by external fuzzy implementations
+      out = task:get_mempool():get_variable("fuzzy_hashes", "fstrings") or {}
+    end
+
+    if #out > 0 then
       if settings.headers_modify_mode == 'compat' then
-        add_header('fuzzy-hashes', table.concat(res, ','))
+        add_header('fuzzy-hashes', table.concat(out, ','))
       else
-        for _, h in ipairs(res) do
+        for _, h in ipairs(out) do
           add_header('fuzzy-hashes', h)
         end
       end


### PR DESCRIPTION
Fuzzy hash observability, part A + B of the diagnosis plan (stacked on #6149, which contributes the first three commits shown here).

Motivated by a false positive investigation where answering "which stored hash matched, what did my message hash to, and is that hash still in the storage" required learning the message into a scratch storage, hand-rolling binary-safe redis scripts and diffing three code paths. Each of those is now a one-liner.

## Structured match results (scanner side)

Every fuzzy match produces a structured record: rule, symbol, upstream, **stored digest**, **queried digest**, hash type, probability, score multiplier, flag, value and the hash timestamp. Consumers:

- `task:get_fuzzy_results()` — new Lua API returning the records;
- the symbol option for non-exact matches now carries both hash prefixes: `1:eb2efd2e8c:0.69:txt:f7487da4c0` (found:…:queried); exact matches keep the old format;
- `X-Rspamd-Fuzzy` (milter_headers) is now annotated: `<found> (rule=...; flag=...; prob=0.69; queried=<hex>; added=2026-07-24 15:30:17)`;
- clickhouse plugin exports `Fuzzy.Hash` / `Fuzzy.Queried` / `Fuzzy.Rule` / `Fuzzy.Prob` / `Fuzzy.Flag` nested columns (schema v11), so FP hunts start from the scanner journal;
- all queried hashes (misses included) are kept in the `fuzzy_checked` mempool variable for correlation.

## Matched-digest reply flag (wire)

The storage now sets a bit in the first reserved byte of the reply when the digest field contains the digest actually resolved by the backend. The client exposes it as `confirmed`. Legacy storages leave reserved bytes zeroed, so a modern client can finally distinguish "the storage told me the matched hash" from "this could be an echo of my own query". No wire format change — the bytes were always there.

## `rspamadm fuzzy_hash`

```
# what does this message hash to, per configured rule (bit-for-bit scanner tokenization)?
rspamadm fuzzy_hash message.eml

# would it match right now, shingles included?
rspamadm fuzzy_hash -C -r rspamd.com message.eml
  f7487da4...(txt): FOUND eb2efd2e...; flag=11 value=10 prob=0.69 added=2026-07-24 15:30:17 confirmed=true

# is this exact digest in the storage? (works over the normal protocol, encryption included)
rspamadm fuzzy_hash -r rspamd.com -H 01b31792cf9c4391...
```

Backed by a new `fuzzy_check.check(task, callback, rule, timeout[, hashes][, server_override])` Lua API which reuses the ping session machinery and reports per-reply results including misses and server error codes.

## Testing

- Full C++ unit test suite passes
- Live verification against a scratch storage: exact match (prob 1.00, `confirmed=true`, option format unchanged), non-exact match (prob 0.69: option carries both hashes, `--check` reports queried→found digest pair with timestamp), direct `-H` digest query
- `rspamadm fuzzy_hash` output verified byte-identical to the digests learned by the daemon for the same message (requires `langdet` subsystem init, included)
- luacheck clean on all touched Lua files; ClickHouse schema migration follows the existing versioning machinery
