### PR TITLE
Fuzzy storage: persistent shingle index, per-hash introspection, unkeyed client stats

### DIFF
--- a/lualib/redis_scripts/fuzzy_update.lua
+++ b/lualib/redis_scripts/fuzzy_update.lua
@@ -144,12 +144,41 @@ if op == "add" then
   redis.call('EXPIRE', key, expire)
   redis.call('INCR', count_key)
 
-  -- Handle shingles: SETEX each shingle key with expire and digest as value
-  for i = 3, #KEYS do
-    redis.call('SETEX', KEYS[i], expire, digest)
+  -- Handle shingles: SETEX each shingle key with expire and digest as value.
+  -- Also persist the shingle set in the 'S' field of the digest hash
+  -- ("idx_value" suffixes, comma separated), so digest-only deletes and
+  -- refreshes can locate the slots without knowing the source message.
+  if #KEYS > 2 then
+    local suffixes = {}
+
+    for i = 3, #KEYS do
+      local suf = string.match(KEYS[i], '(%d+_%d+)$')
+      if suf then
+        suffixes[#suffixes + 1] = suf
+      end
+      redis.call('SETEX', KEYS[i], expire, digest)
+    end
+
+    if #suffixes > 0 then
+      redis.call('HSET', key, 'S', table.concat(suffixes, ','))
+    end
   end
 
 elseif op == "del" then
+  -- Reconstruct this digest's own shingle slots from the persisted set and
+  -- delete those still owned by it: digest-only deletes (e.g. deletions by
+  -- a hash list) carry no shingle keys, which used to leave orphaned slots
+  local stored = redis.call('HGET', key, 'S')
+  if stored then
+    local prefix = string.sub(key, 1, #key - #digest)
+    for suf in string.gmatch(stored, '[^,]+') do
+      local skey = prefix .. '_' .. suf
+      if redis.call('GET', skey) == digest then
+        redis.call('DEL', skey)
+      end
+    end
+  end
+
   redis.call('DEL', key)
   redis.call('DECR', count_key)
 
@@ -160,8 +189,25 @@ elseif op == "del" then
 elseif op == "refresh" then
   redis.call('EXPIRE', key, expire)
 
-  for i = 3, #KEYS do
-    redis.call('EXPIRE', KEYS[i], expire)
+  -- Prefer the persisted shingle set: refresh the slots this digest still
+  -- owns and reclaim expired ones, instead of touching the slots of the
+  -- message that merely triggered the refresh
+  local stored = redis.call('HGET', key, 'S')
+  if stored then
+    local prefix = string.sub(key, 1, #key - #digest)
+    for suf in string.gmatch(stored, '[^,]+') do
+      local skey = prefix .. '_' .. suf
+      local owner = redis.call('GET', skey)
+      if owner == digest then
+        redis.call('EXPIRE', skey, expire)
+      elseif not owner then
+        redis.call('SETEX', skey, expire, digest)
+      end
+    end
+  else
+    for i = 3, #KEYS do
+      redis.call('EXPIRE', KEYS[i], expire)
+    end
   end
 end
 

--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -572,6 +572,11 @@ rspamd_fuzzy_update_stats(struct rspamd_fuzzy_storage_ctx *ctx,
 		ctx->stat.delayed_hashes++;
 	}
 
+	if (key == NULL && ip_stat != NULL && ctx->unkeyed_stat != NULL) {
+		/* Unkeyed client: update the aggregate bucket */
+		rspamd_fuzzy_update_key_stat(matched, ctx->unkeyed_stat, cmd, res, timestamp);
+	}
+
 	if (key) {
 		rspamd_fuzzy_update_key_stat(matched, key->stat, cmd, res, timestamp);
 
@@ -1360,6 +1365,37 @@ rspamd_fuzzy_process_command(struct fuzzy_session *session)
 			ip_stat = g_malloc0(sizeof(*ip_stat));
 			REF_INIT_RETAIN(ip_stat, fuzzy_key_stat_dtor);
 			rspamd_lru_hash_insert(session->key->stat->last_ips,
+								   naddr, ip_stat, -1, 0);
+		}
+
+		REF_RETAIN(ip_stat);
+		session->ip_stat = ip_stat;
+	}
+	else if (session->addr) {
+		/*
+		 * Unkeyed client (e.g. allowed by IP): track its traffic under the
+		 * dedicated bucket, otherwise such writers are invisible in the stats
+		 */
+		if (session->ctx->unkeyed_stat == NULL) {
+			struct fuzzy_key_stat *unkeyed = g_malloc0(sizeof(*unkeyed));
+
+			REF_INIT_RETAIN(unkeyed, fuzzy_key_stat_dtor);
+			unkeyed->last_ips = rspamd_lru_hash_new_full(1024,
+														 (GDestroyNotify) rspamd_inet_address_free,
+														 fuzzy_key_stat_unref,
+														 rspamd_inet_address_hash,
+														 rspamd_inet_address_equal);
+			session->ctx->unkeyed_stat = unkeyed;
+		}
+
+		ip_stat = rspamd_lru_hash_lookup(session->ctx->unkeyed_stat->last_ips,
+										 session->addr, -1);
+
+		if (ip_stat == NULL) {
+			naddr = rspamd_inet_address_copy(session->addr, NULL);
+			ip_stat = g_malloc0(sizeof(*ip_stat));
+			REF_INIT_RETAIN(ip_stat, fuzzy_key_stat_dtor);
+			rspamd_lru_hash_insert(session->ctx->unkeyed_stat->last_ips,
 								   naddr, ip_stat, -1, 0);
 		}
 
@@ -3276,6 +3312,8 @@ start_fuzzy(struct rspamd_worker *worker)
 										  rspamd_fuzzy_storage_reload, ctx);
 	rspamd_control_worker_add_cmd_handler(worker, RSPAMD_CONTROL_FUZZY_STAT,
 										  rspamd_fuzzy_storage_stat, ctx);
+	rspamd_control_worker_add_cmd_handler(worker, RSPAMD_CONTROL_FUZZY_HASH,
+										  rspamd_fuzzy_storage_hash_info, ctx);
 	rspamd_control_worker_add_cmd_handler(worker, RSPAMD_CONTROL_FUZZY_SYNC,
 										  rspamd_fuzzy_storage_sync, ctx);
 	rspamd_control_worker_add_cmd_handler(worker, RSPAMD_CONTROL_FUZZY_BLOCKED,

--- a/src/libserver/fuzzy_backend/fuzzy_backend.c
+++ b/src/libserver/fuzzy_backend/fuzzy_backend.c
@@ -49,6 +49,10 @@ static void rspamd_fuzzy_backend_version_sqlite(struct rspamd_fuzzy_backend *bk,
 												void *subr_ud);
 static const char *rspamd_fuzzy_backend_id_sqlite(struct rspamd_fuzzy_backend *bk,
 												  void *subr_ud);
+static void rspamd_fuzzy_backend_inspect_sqlite_wrapper(struct rspamd_fuzzy_backend *bk,
+														const unsigned char *digest,
+														rspamd_fuzzy_inspect_cb cb, void *ud,
+														void *subr_ud);
 static void rspamd_fuzzy_backend_expire_sqlite(struct rspamd_fuzzy_backend *bk,
 											   void *subr_ud);
 static void rspamd_fuzzy_backend_close_sqlite(struct rspamd_fuzzy_backend *bk,
@@ -69,6 +73,10 @@ struct rspamd_fuzzy_backend_subr {
 	void (*count)(struct rspamd_fuzzy_backend *bk,
 				  rspamd_fuzzy_count_cb cb, void *ud,
 				  void *subr_ud);
+	void (*inspect)(struct rspamd_fuzzy_backend *bk,
+					const unsigned char *digest,
+					rspamd_fuzzy_inspect_cb cb, void *ud,
+					void *subr_ud);
 	void (*version)(struct rspamd_fuzzy_backend *bk,
 					const char *src,
 					rspamd_fuzzy_version_cb cb, void *ud,
@@ -84,6 +92,7 @@ static const struct rspamd_fuzzy_backend_subr fuzzy_subrs[] = {
 		.check = rspamd_fuzzy_backend_check_sqlite,
 		.update = rspamd_fuzzy_backend_update_sqlite,
 		.count = rspamd_fuzzy_backend_count_sqlite,
+		.inspect = rspamd_fuzzy_backend_inspect_sqlite_wrapper,
 		.version = rspamd_fuzzy_backend_version_sqlite,
 		.id = rspamd_fuzzy_backend_id_sqlite,
 		.periodic = rspamd_fuzzy_backend_expire_sqlite,
@@ -94,6 +103,7 @@ static const struct rspamd_fuzzy_backend_subr fuzzy_subrs[] = {
 		.check = rspamd_fuzzy_backend_check_redis,
 		.update = rspamd_fuzzy_backend_update_redis,
 		.count = rspamd_fuzzy_backend_count_redis,
+		.inspect = rspamd_fuzzy_backend_inspect_redis,
 		.version = rspamd_fuzzy_backend_version_redis,
 		.id = rspamd_fuzzy_backend_id_redis,
 		.periodic = rspamd_fuzzy_backend_expire_redis,
@@ -466,6 +476,33 @@ void rspamd_fuzzy_backend_count(struct rspamd_fuzzy_backend *bk,
 	g_assert(bk != NULL);
 
 	bk->subr->count(bk, cb, ud, bk->subr_ud);
+}
+
+void rspamd_fuzzy_backend_inspect(struct rspamd_fuzzy_backend *bk,
+								  const unsigned char *digest,
+								  rspamd_fuzzy_inspect_cb cb, void *ud)
+{
+	g_assert(bk != NULL);
+
+	if (bk->subr->inspect) {
+		bk->subr->inspect(bk, digest, cb, ud, bk->subr_ud);
+	}
+	else if (cb) {
+		cb(NULL, ud);
+	}
+}
+
+static void
+rspamd_fuzzy_backend_inspect_sqlite_wrapper(struct rspamd_fuzzy_backend *bk,
+											const unsigned char *digest,
+											rspamd_fuzzy_inspect_cb cb, void *ud,
+											void *subr_ud)
+{
+	struct rspamd_fuzzy_backend_sqlite *sq = subr_ud;
+
+	if (cb) {
+		cb(rspamd_fuzzy_backend_sqlite_inspect(sq, digest), ud);
+	}
 }
 
 

--- a/src/libserver/fuzzy_backend/fuzzy_backend.h
+++ b/src/libserver/fuzzy_backend/fuzzy_backend.h
@@ -51,6 +51,8 @@ typedef void (*rspamd_fuzzy_update_cb)(gboolean success,
 typedef void (*rspamd_fuzzy_version_cb)(uint64_t rev, void *ud);
 
 typedef void (*rspamd_fuzzy_count_cb)(uint64_t count, void *ud);
+/* Called with an ucl object describing the hash (ownership transferred) or NULL */
+typedef void (*rspamd_fuzzy_inspect_cb)(ucl_object_t *res, void *ud);
 
 typedef gboolean (*rspamd_fuzzy_periodic_cb)(void *ud);
 
@@ -93,6 +95,14 @@ void rspamd_fuzzy_backend_process_updates(struct rspamd_fuzzy_backend *bk,
  * @param cb
  * @param ud
  */
+/**
+ * Get diagnostic information about a specific hash: flags, values, creation
+ * time, ttl and shingle slot ownership (where the backend supports it)
+ */
+void rspamd_fuzzy_backend_inspect(struct rspamd_fuzzy_backend *bk,
+								  const unsigned char *digest,
+								  rspamd_fuzzy_inspect_cb cb, void *ud);
+
 void rspamd_fuzzy_backend_count(struct rspamd_fuzzy_backend *bk,
 								rspamd_fuzzy_count_cb cb, void *ud);
 

--- a/src/libserver/fuzzy_backend/fuzzy_backend_redis.c
+++ b/src/libserver/fuzzy_backend/fuzzy_backend_redis.c
@@ -67,7 +67,8 @@ struct rspamd_fuzzy_backend_redis {
 enum rspamd_fuzzy_redis_command {
 	RSPAMD_FUZZY_REDIS_COMMAND_COUNT,
 	RSPAMD_FUZZY_REDIS_COMMAND_VERSION,
-	RSPAMD_FUZZY_REDIS_COMMAND_CHECK
+	RSPAMD_FUZZY_REDIS_COMMAND_CHECK,
+	RSPAMD_FUZZY_REDIS_COMMAND_INSPECT
 };
 
 struct rspamd_fuzzy_redis_session {
@@ -86,6 +87,7 @@ struct rspamd_fuzzy_redis_session {
 		rspamd_fuzzy_check_cb cb_check;
 		rspamd_fuzzy_version_cb cb_version;
 		rspamd_fuzzy_count_cb cb_count;
+		rspamd_fuzzy_inspect_cb cb_inspect;
 	} callback;
 	void *cbdata;
 
@@ -853,6 +855,196 @@ rspamd_fuzzy_redis_count_callback(redisAsyncContext *c, gpointer r,
 	}
 
 	rspamd_fuzzy_redis_session_dtor(session, FALSE);
+}
+
+/*
+ * Runs entirely on the redis side to gather per-hash diagnostics in a single
+ * round trip: flag slots, ttl and shingle slot ownership computed from the
+ * persisted 'S' field (see fuzzy_update.lua)
+ */
+static const char *rspamd_fuzzy_redis_inspect_script =
+	"local key = KEYS[1]\n"
+	"if redis.call('EXISTS', key) == 0 then return cjson.encode({found=false}) end\n"
+	"local o = {found=true, ttl=redis.call('TTL', key)}\n"
+	"local data = redis.call('HGETALL', key)\n"
+	"local fields = {}\n"
+	"for i=1,#data,2 do fields[data[i]] = data[i+1] end\n"
+	"o.flag = tonumber(fields['F'])\n"
+	"o.value = tonumber(fields['V'])\n"
+	"o.created = tonumber(fields['C'])\n"
+	"local extra = {}\n"
+	"for i=1,7 do\n"
+	"  if fields['F'..i] and fields['V'..i] then\n"
+	"    extra[#extra+1] = {flag=tonumber(fields['F'..i]), value=tonumber(fields['V'..i])}\n"
+	"  end\n"
+	"end\n"
+	"if #extra > 0 then o.extra_flags = extra end\n"
+	"if fields['S'] then\n"
+	"  local owned, total, vacant = 0, 0, 0\n"
+	"  local prefix = string.sub(key, 1, #key - #ARGV[1])\n"
+	"  for suf in string.gmatch(fields['S'], '[^,]+') do\n"
+	"    total = total + 1\n"
+	"    local owner = redis.call('GET', prefix .. '_' .. suf)\n"
+	"    if owner == ARGV[1] then owned = owned + 1\n"
+	"    elseif owner == false then vacant = vacant + 1 end\n"
+	"  end\n"
+	"  o.shingles = {total=total, owned=owned, vacant=vacant, foreign=total-owned-vacant}\n"
+	"end\n"
+	"return cjson.encode(o)\n";
+
+static void
+rspamd_fuzzy_redis_inspect_callback(redisAsyncContext *c, gpointer r,
+									gpointer priv)
+{
+	struct rspamd_fuzzy_redis_session *session = priv;
+	redisReply *reply = r;
+	ucl_object_t *res = NULL;
+
+	ev_timer_stop(session->event_loop, &session->timeout);
+
+	if (c->err == 0 && reply != NULL) {
+		rspamd_upstream_ok(session->up);
+
+		if (reply->type == REDIS_REPLY_STRING) {
+			struct ucl_parser *parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+
+			if (ucl_parser_add_chunk(parser, reply->str, reply->len)) {
+				res = ucl_parser_get_object(parser);
+			}
+			else {
+				msg_err_redis_session("cannot parse inspect reply: %s",
+									  ucl_parser_get_error(parser));
+			}
+
+			ucl_parser_free(parser);
+		}
+		else if (reply->type == REDIS_REPLY_ERROR) {
+			msg_err_redis_session("fuzzy backend redis error: \"%s\"",
+								  reply->str);
+		}
+	}
+	else {
+		if (c->errstr) {
+			msg_err_redis_session("error inspecting hash on %s: %s",
+								  rspamd_inet_address_to_string_pretty(rspamd_upstream_addr_cur(session->up)),
+								  c->errstr);
+			rspamd_upstream_fail(session->up, FALSE, c->errstr);
+		}
+	}
+
+	if (session->callback.cb_inspect) {
+		session->callback.cb_inspect(res, session->cbdata);
+	}
+	else if (res) {
+		ucl_object_unref(res);
+	}
+
+	rspamd_fuzzy_redis_session_dtor(session, FALSE);
+}
+
+void rspamd_fuzzy_backend_inspect_redis(struct rspamd_fuzzy_backend *bk,
+										const unsigned char *digest,
+										rspamd_fuzzy_inspect_cb cb, void *ud,
+										void *subr_ud)
+{
+	struct rspamd_fuzzy_backend_redis *backend = subr_ud;
+	struct rspamd_fuzzy_redis_session *session;
+	struct upstream *up;
+	struct upstream_list *ups;
+	rspamd_inet_addr_t *addr;
+	GString *key;
+
+	g_assert(backend != NULL);
+
+	ups = rspamd_redis_get_servers(backend, "read_servers");
+	if (!ups) {
+		if (cb) {
+			cb(NULL, ud);
+		}
+
+		return;
+	}
+
+	session = g_malloc0(sizeof(*session));
+	session->backend = backend;
+	REF_RETAIN(session->backend);
+
+	session->callback.cb_inspect = cb;
+	session->cbdata = ud;
+	session->command = RSPAMD_FUZZY_REDIS_COMMAND_INSPECT;
+	session->event_loop = rspamd_fuzzy_backend_event_base(bk);
+
+	/* EVAL script 1 <hash key> <raw digest> */
+	session->nargs = 5;
+	session->argv = g_malloc0(sizeof(char *) * session->nargs);
+	session->argv_lens = g_malloc0(sizeof(gsize) * session->nargs);
+	session->argv[0] = g_strdup("EVAL");
+	session->argv_lens[0] = 4;
+	session->argv[1] = g_strdup(rspamd_fuzzy_redis_inspect_script);
+	session->argv_lens[1] = strlen(rspamd_fuzzy_redis_inspect_script);
+	session->argv[2] = g_strdup("1");
+	session->argv_lens[2] = 1;
+	key = g_string_new(backend->redis_object);
+	g_string_append_len(key, digest, rspamd_cryptobox_HASHBYTES);
+	session->argv[3] = key->str;
+	session->argv_lens[3] = key->len;
+	g_string_free(key, FALSE); /* Do not free underlying array */
+	session->argv[4] = g_malloc(rspamd_cryptobox_HASHBYTES);
+	memcpy(session->argv[4], digest, rspamd_cryptobox_HASHBYTES);
+	session->argv_lens[4] = rspamd_cryptobox_HASHBYTES;
+
+	up = rspamd_upstream_get(ups,
+							 RSPAMD_UPSTREAM_ROUND_ROBIN,
+							 NULL,
+							 0);
+
+	if (up == NULL) {
+		msg_err_redis_session("cannot select fuzzy redis upstream for inspect: "
+							  "all backends are dead or pending DNS resolution");
+		rspamd_fuzzy_redis_session_dtor(session, TRUE);
+		if (cb) {
+			cb(NULL, ud);
+		}
+		return;
+	}
+
+	session->up = rspamd_upstream_ref(up);
+	addr = rspamd_upstream_addr_next(up);
+	g_assert(addr != NULL);
+	session->ctx = rspamd_redis_pool_connect(backend->pool,
+											 backend->dbname,
+											 backend->username, backend->password,
+											 rspamd_inet_address_to_string(addr),
+											 rspamd_inet_address_get_port(addr));
+
+	if (session->ctx == NULL) {
+		rspamd_upstream_fail(up, TRUE, strerror(errno));
+		rspamd_fuzzy_redis_session_dtor(session, TRUE);
+
+		if (cb) {
+			cb(NULL, ud);
+		}
+	}
+	else {
+		if (redisAsyncCommandArgv(session->ctx, rspamd_fuzzy_redis_inspect_callback,
+								  session, session->nargs,
+								  (const char **) session->argv, session->argv_lens) != REDIS_OK) {
+			rspamd_fuzzy_redis_session_dtor(session, TRUE);
+
+			if (cb) {
+				cb(NULL, ud);
+			}
+		}
+		else {
+			/* Add timeout */
+			session->timeout.data = session;
+			ev_now_update_if_cheap((struct ev_loop *) session->event_loop);
+			ev_timer_init(&session->timeout,
+						  rspamd_fuzzy_redis_timeout,
+						  session->backend->timeout, 0.0);
+			ev_timer_start(session->event_loop, &session->timeout);
+		}
+	}
 }
 
 void rspamd_fuzzy_backend_count_redis(struct rspamd_fuzzy_backend *bk,

--- a/src/libserver/fuzzy_backend/fuzzy_backend_redis.h
+++ b/src/libserver/fuzzy_backend/fuzzy_backend_redis.h
@@ -41,6 +41,10 @@ void rspamd_fuzzy_backend_update_redis(struct rspamd_fuzzy_backend *bk,
 									   rspamd_fuzzy_update_cb cb, void *ud,
 									   void *subr_ud);
 
+void rspamd_fuzzy_backend_inspect_redis(struct rspamd_fuzzy_backend *bk,
+										const unsigned char *digest,
+										rspamd_fuzzy_inspect_cb cb, void *ud,
+										void *subr_ud);
 void rspamd_fuzzy_backend_count_redis(struct rspamd_fuzzy_backend *bk,
 									  rspamd_fuzzy_count_cb cb, void *ud,
 									  void *subr_ud);

--- a/src/libserver/fuzzy_backend/fuzzy_backend_sqlite.c
+++ b/src/libserver/fuzzy_backend/fuzzy_backend_sqlite.c
@@ -97,6 +97,8 @@ enum rspamd_fuzzy_statement_idx {
 	RSPAMD_FUZZY_BACKEND_GET_DIGEST_BY_ID,
 	RSPAMD_FUZZY_BACKEND_DELETE,
 	RSPAMD_FUZZY_BACKEND_COUNT,
+	RSPAMD_FUZZY_BACKEND_INSPECT,
+	RSPAMD_FUZZY_BACKEND_SHINGLES_COUNT,
 	RSPAMD_FUZZY_BACKEND_EXPIRE,
 	RSPAMD_FUZZY_BACKEND_VACUUM,
 	RSPAMD_FUZZY_BACKEND_DELETE_ORPHANED,
@@ -175,6 +177,16 @@ static struct rspamd_fuzzy_stmts {
 		{.idx = RSPAMD_FUZZY_BACKEND_COUNT,
 		 .sql = "SELECT COUNT(*) FROM digests;",
 		 .args = "",
+		 .stmt = NULL,
+		 .result = SQLITE_ROW},
+		{.idx = RSPAMD_FUZZY_BACKEND_INSPECT,
+		 .sql = "SELECT id, value, time, flag FROM digests WHERE digest==?1;",
+		 .args = "D",
+		 .stmt = NULL,
+		 .result = SQLITE_ROW},
+		{.idx = RSPAMD_FUZZY_BACKEND_SHINGLES_COUNT,
+		 .sql = "SELECT COUNT(*) FROM shingles WHERE digest_id=?1;",
+		 .args = "I",
 		 .stmt = NULL,
 		 .result = SQLITE_ROW},
 		{.idx = RSPAMD_FUZZY_BACKEND_EXPIRE,
@@ -997,6 +1009,63 @@ gsize rspamd_fuzzy_backend_sqlite_count(struct rspamd_fuzzy_backend_sqlite *back
 	}
 
 	return 0;
+}
+
+ucl_object_t *
+rspamd_fuzzy_backend_sqlite_inspect(struct rspamd_fuzzy_backend_sqlite *backend,
+									const unsigned char *digest)
+{
+	ucl_object_t *res;
+	int rc;
+
+	if (backend == NULL) {
+		return NULL;
+	}
+
+	res = ucl_object_typed_new(UCL_OBJECT);
+
+	rc = rspamd_fuzzy_backend_sqlite_run_stmt(backend, FALSE,
+											  RSPAMD_FUZZY_BACKEND_INSPECT, digest);
+
+	if (rc == SQLITE_OK) {
+		int64_t id = sqlite3_column_int64(
+			prepared_stmts[RSPAMD_FUZZY_BACKEND_INSPECT].stmt, 0);
+
+		ucl_object_insert_key(res, ucl_object_frombool(true), "found", 0, false);
+		ucl_object_insert_key(res,
+							  ucl_object_fromint(sqlite3_column_int64(
+								  prepared_stmts[RSPAMD_FUZZY_BACKEND_INSPECT].stmt, 1)),
+							  "value", 0, false);
+		ucl_object_insert_key(res,
+							  ucl_object_fromint(sqlite3_column_int64(
+								  prepared_stmts[RSPAMD_FUZZY_BACKEND_INSPECT].stmt, 2)),
+							  "created", 0, false);
+		ucl_object_insert_key(res,
+							  ucl_object_fromint(sqlite3_column_int(
+								  prepared_stmts[RSPAMD_FUZZY_BACKEND_INSPECT].stmt, 3)),
+							  "flag", 0, false);
+		rspamd_fuzzy_backend_sqlite_cleanup_stmt(backend, RSPAMD_FUZZY_BACKEND_INSPECT);
+
+		if (rspamd_fuzzy_backend_sqlite_run_stmt(backend, FALSE,
+												 RSPAMD_FUZZY_BACKEND_SHINGLES_COUNT, id) == SQLITE_OK) {
+			int64_t nshingles = sqlite3_column_int64(
+				prepared_stmts[RSPAMD_FUZZY_BACKEND_SHINGLES_COUNT].stmt, 0);
+			ucl_object_t *sgl = ucl_object_typed_new(UCL_OBJECT);
+
+			/* Shingles are bound to the digest id in sqlite, so all are owned */
+			ucl_object_insert_key(sgl, ucl_object_fromint(nshingles), "total", 0, false);
+			ucl_object_insert_key(sgl, ucl_object_fromint(nshingles), "owned", 0, false);
+			ucl_object_insert_key(res, sgl, "shingles", 0, false);
+		}
+
+		rspamd_fuzzy_backend_sqlite_cleanup_stmt(backend, RSPAMD_FUZZY_BACKEND_SHINGLES_COUNT);
+	}
+	else {
+		ucl_object_insert_key(res, ucl_object_frombool(false), "found", 0, false);
+		rspamd_fuzzy_backend_sqlite_cleanup_stmt(backend, RSPAMD_FUZZY_BACKEND_INSPECT);
+	}
+
+	return res;
 }
 
 int rspamd_fuzzy_backend_sqlite_version(struct rspamd_fuzzy_backend_sqlite *backend,

--- a/src/libserver/fuzzy_backend/fuzzy_backend_sqlite.h
+++ b/src/libserver/fuzzy_backend/fuzzy_backend_sqlite.h
@@ -94,6 +94,13 @@ void rspamd_fuzzy_backend_sqlite_close(struct rspamd_fuzzy_backend_sqlite *backe
 
 gsize rspamd_fuzzy_backend_sqlite_count(struct rspamd_fuzzy_backend_sqlite *backend);
 
+/**
+ * Get diagnostic info for a specific digest (or NULL if the backend is not available):
+ * flags, values, creation time and the number of shingles stored for the digest
+ */
+ucl_object_t *rspamd_fuzzy_backend_sqlite_inspect(struct rspamd_fuzzy_backend_sqlite *backend,
+												  const unsigned char *digest);
+
 int rspamd_fuzzy_backend_sqlite_version(struct rspamd_fuzzy_backend_sqlite *backend, const char *source);
 
 gsize rspamd_fuzzy_backend_sqlite_expired(struct rspamd_fuzzy_backend_sqlite *backend);

--- a/src/libserver/fuzzy_storage_internal.h
+++ b/src/libserver/fuzzy_storage_internal.h
@@ -82,7 +82,7 @@ struct rspamd_leaky_bucket_elt {
 };
 
 struct rspamd_fuzzy_dynamic_ban {
-	double expire_ts; /* monotonic clock; 0.0 = never expires */
+	double expire_ts;      /* monotonic clock; 0.0 = never expires */
 	int32_t response_code; /* fuzzy reply code; 0 = use default (503) */
 	char reason[64];
 };
@@ -182,6 +182,8 @@ struct rspamd_fuzzy_storage_ctx {
 	struct rspamd_http_context *http_ctx;
 	rspamd_lru_hash_t *errors_ips;
 	rspamd_lru_hash_t *ratelimit_buckets;
+	/* Aggregate + per-IP stats for unkeyed clients (allowed by allow_update etc) */
+	struct fuzzy_key_stat *unkeyed_stat;
 	struct rspamd_fuzzy_backend *backend;
 	GArray *updates_pending;
 	unsigned int updates_failed;
@@ -222,7 +224,7 @@ struct fuzzy_session {
 	rspamd_inet_addr_t *addr;
 	struct rspamd_fuzzy_storage_ctx *ctx;
 
-	struct rspamd_fuzzy_shingle_cmd cmd;       /* Can handle both shingles and non-shingles */
+	struct rspamd_fuzzy_shingle_cmd cmd; /* Can handle both shingles and non-shingles */
 	union {
 		struct rspamd_fuzzy_encrypted_reply v1;
 		struct rspamd_fuzzy_encrypted_reply_v2 v2;
@@ -348,5 +350,11 @@ gboolean rspamd_fuzzy_storage_stat(struct rspamd_main *rspamd_main,
 								   int attached_fd,
 								   struct rspamd_control_command *cmd,
 								   gpointer ud);
+
+gboolean rspamd_fuzzy_storage_hash_info(struct rspamd_main *rspamd_main,
+										struct rspamd_worker *worker, int fd,
+										int attached_fd,
+										struct rspamd_control_command *cmd,
+										gpointer ud);
 
 #endif

--- a/src/libserver/fuzzy_storage_stat.c
+++ b/src/libserver/fuzzy_storage_stat.c
@@ -135,6 +135,29 @@ rspamd_fuzzy_stat_to_ucl(struct rspamd_fuzzy_storage_ctx *ctx, gboolean ip_stat)
 		});
 	}
 
+	if (ctx->unkeyed_stat) {
+		/* Pseudo-key entry for unkeyed clients (e.g. allowed by IP) */
+		elt = rspamd_fuzzy_storage_stat_key(ctx->unkeyed_stat);
+
+		if (ctx->unkeyed_stat->last_ips && ip_stat) {
+			int i = 0;
+			gpointer k, v;
+
+			ip_elt = ucl_object_typed_new(UCL_OBJECT);
+
+			while ((i = rspamd_lru_hash_foreach(ctx->unkeyed_stat->last_ips,
+												i, &k, &v)) != -1) {
+				ucl_object_insert_key(ip_elt,
+									  rspamd_fuzzy_storage_stat_key(v),
+									  rspamd_inet_address_to_string(k), 0, true);
+			}
+
+			ucl_object_insert_key(elt, ip_elt, "ips", 0, false);
+		}
+
+		ucl_object_insert_key(keys_obj, elt, "unkeyed", 0, false);
+	}
+
 	ucl_object_insert_key(obj, keys_obj, "keys", 0, false);
 
 	/* Now generic stats */
@@ -295,6 +318,127 @@ rspamd_fuzzy_storage_stat(struct rspamd_main *rspamd_main,
 	if (outfd != -1) {
 		close(outfd);
 	}
+
+	return TRUE;
+}
+
+struct rspamd_fuzzy_hash_info_cbdata {
+	struct rspamd_main *rspamd_main;
+	struct rspamd_fuzzy_storage_ctx *ctx;
+	uint64_t id;
+	int fd;
+};
+
+static void
+rspamd_fuzzy_hash_info_cb(ucl_object_t *res, void *ud)
+{
+	struct rspamd_fuzzy_hash_info_cbdata *cbd = ud;
+	struct rspamd_main *rspamd_main = cbd->rspamd_main;
+	struct rspamd_control_reply rep;
+	struct ucl_emitter_functions *emit_subr;
+	unsigned char fdspace[CMSG_SPACE(sizeof(int))];
+	struct iovec iov;
+	struct msghdr msg;
+	struct cmsghdr *cmsg;
+	int outfd = -1;
+	char tmppath[PATH_MAX];
+
+	memset(&rep, 0, sizeof(rep));
+	rep.type = RSPAMD_CONTROL_FUZZY_HASH;
+	rep.id = cbd->id;
+
+	if (res == NULL) {
+		rep.reply.fuzzy_hash.status = ENOENT;
+	}
+	else {
+		const char *backend_id = rspamd_fuzzy_backend_id(cbd->ctx->backend);
+
+		if (backend_id) {
+			memcpy(rep.reply.fuzzy_hash.storage_id,
+				   backend_id,
+				   sizeof(rep.reply.fuzzy_hash.storage_id));
+		}
+
+		rspamd_snprintf(tmppath, sizeof(tmppath), "%s%c%s-XXXXXXXXXX",
+						rspamd_main->cfg->temp_dir, G_DIR_SEPARATOR, "fuzzy-hash");
+
+		if ((outfd = mkstemp(tmppath)) == -1) {
+			rep.reply.fuzzy_hash.status = errno;
+			msg_info_main("cannot make temporary file for fuzzy hash info: %s",
+						  strerror(errno));
+		}
+		else {
+			rep.reply.fuzzy_hash.status = 0;
+			emit_subr = ucl_object_emit_fd_funcs(outfd);
+			ucl_object_emit_full(res, UCL_EMIT_JSON_COMPACT, emit_subr, NULL);
+			ucl_object_emit_funcs_free(emit_subr);
+			/* Rewind output file */
+			close(outfd);
+			outfd = open(tmppath, O_RDONLY);
+			unlink(tmppath);
+		}
+
+		ucl_object_unref(res);
+	}
+
+	memset(&msg, 0, sizeof(msg));
+
+	if (outfd != -1) {
+		memset(fdspace, 0, sizeof(fdspace));
+		msg.msg_control = fdspace;
+		msg.msg_controllen = sizeof(fdspace);
+		cmsg = CMSG_FIRSTHDR(&msg);
+
+		if (cmsg) {
+			cmsg->cmsg_level = SOL_SOCKET;
+			cmsg->cmsg_type = SCM_RIGHTS;
+			cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+			memcpy(CMSG_DATA(cmsg), &outfd, sizeof(int));
+		}
+	}
+
+	iov.iov_base = &rep;
+	iov.iov_len = sizeof(rep);
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	if (sendmsg(cbd->fd, &msg, 0) == -1) {
+		msg_err_main("cannot send fuzzy hash info: %s", strerror(errno));
+	}
+
+	if (outfd != -1) {
+		close(outfd);
+	}
+
+	g_free(cbd);
+}
+
+gboolean
+rspamd_fuzzy_storage_hash_info(struct rspamd_main *rspamd_main,
+							   struct rspamd_worker *worker, int fd,
+							   int attached_fd,
+							   struct rspamd_control_command *cmd,
+							   gpointer ud)
+{
+	struct rspamd_fuzzy_storage_ctx *ctx = ud;
+	struct rspamd_fuzzy_hash_info_cbdata *cbd;
+
+	if (attached_fd != -1) {
+		close(attached_fd);
+	}
+
+	cbd = g_malloc0(sizeof(*cbd));
+	cbd->rspamd_main = rspamd_main;
+	cbd->ctx = ctx;
+	cbd->id = cmd->id;
+	cbd->fd = fd;
+
+	/*
+	 * The reply is sent from the backend callback: the control pipe is
+	 * persistent, so a deferred reply is safe here
+	 */
+	rspamd_fuzzy_backend_inspect(ctx->backend, cmd->cmd.fuzzy_hash.digest,
+								 rspamd_fuzzy_hash_info_cb, cbd);
 
 	return TRUE;
 }

--- a/src/libserver/rspamd_control.c
+++ b/src/libserver/rspamd_control.c
@@ -84,6 +84,7 @@ static const struct rspamd_control_cmd_match {
 	{.name = {.begin = "/recompile", .len = sizeof("/recompile") - 1}, .type = RSPAMD_CONTROL_RECOMPILE},
 	{.name = {.begin = "/fuzzystat", .len = sizeof("/fuzzystat") - 1}, .type = RSPAMD_CONTROL_FUZZY_STAT},
 	{.name = {.begin = "/fuzzysync", .len = sizeof("/fuzzysync") - 1}, .type = RSPAMD_CONTROL_FUZZY_SYNC},
+	{.name = {.begin = "/fuzzyhash", .len = sizeof("/fuzzyhash") - 1}, .type = RSPAMD_CONTROL_FUZZY_HASH},
 	{.name = {.begin = "/compositesstats", .len = sizeof("/compositesstats") - 1}, .type = RSPAMD_CONTROL_COMPOSITES_STATS},
 	{.name = {.begin = "/memstat", .len = sizeof("/memstat") - 1}, .type = RSPAMD_CONTROL_MEMORY_STAT},
 };
@@ -198,7 +199,8 @@ rspamd_control_write_reply(struct rspamd_control_session *session)
 	{
 		/* Skip incompatible worker for fuzzy_stat */
 		if ((session->cmd.type == RSPAMD_CONTROL_FUZZY_STAT ||
-			 session->cmd.type == RSPAMD_CONTROL_FUZZY_SYNC) &&
+			 session->cmd.type == RSPAMD_CONTROL_FUZZY_SYNC ||
+			 session->cmd.type == RSPAMD_CONTROL_FUZZY_HASH) &&
 			elt->wrk_type != g_quark_from_static_string("fuzzy")) {
 			continue;
 		}
@@ -278,6 +280,34 @@ rspamd_control_write_reply(struct rspamd_control_session *session)
 			break;
 		case RSPAMD_CONTROL_FUZZY_SYNC:
 			ucl_object_insert_key(cur, ucl_object_fromint(elt->reply.reply.fuzzy_sync.status), "status", 0, false);
+			break;
+		case RSPAMD_CONTROL_FUZZY_HASH:
+			ucl_object_insert_key(cur,
+								  ucl_object_fromint(elt->reply.reply.fuzzy_hash.status),
+								  "status", 0, false);
+
+			if (elt->attached_fd != -1) {
+				parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+
+				if (ucl_parser_add_fd(parser, elt->attached_fd)) {
+					ucl_object_insert_key(cur, ucl_parser_get_object(parser),
+										  "data", 0, false);
+				}
+				else {
+					ucl_object_insert_key(cur,
+										  ucl_object_fromstring(ucl_parser_get_error(parser)),
+										  "error", 0, false);
+				}
+
+				ucl_parser_free(parser);
+				ucl_object_insert_key(cur,
+									  ucl_object_fromlstring(
+										  elt->reply.reply.fuzzy_hash.storage_id,
+										  MEMPOOL_UID_LEN - 1),
+									  "id",
+									  0,
+									  false);
+			}
 			break;
 		case RSPAMD_CONTROL_COMPOSITES_STATS:
 			ucl_object_insert_key(cur, ucl_object_fromint(elt->reply.reply.composites_stats.checked_slow),
@@ -741,6 +771,16 @@ rspamd_control_finish_handler(struct rspamd_http_connection *conn,
 		srch.begin = msg->url->str;
 		srch.len = msg->url->len;
 
+		/* Some commands carry arguments in the query string */
+		const char *qpos = memchr(msg->url->str, '?', msg->url->len);
+		rspamd_ftok_t query = {.begin = NULL, .len = 0};
+
+		if (qpos != NULL) {
+			query.begin = qpos + 1;
+			query.len = msg->url->len - (qpos - msg->url->str) - 1;
+			srch.len = qpos - msg->url->str;
+		}
+
 		session->is_reply = TRUE;
 
 		for (i = 0; i < G_N_ELEMENTS(cmd_matches); i++) {
@@ -748,6 +788,25 @@ rspamd_control_finish_handler(struct rspamd_http_connection *conn,
 				session->cmd.type = cmd_matches[i].type;
 				found = TRUE;
 				break;
+			}
+		}
+
+		if (found && session->cmd.type == RSPAMD_CONTROL_FUZZY_HASH) {
+			/* Parse digest=<128 hex chars> */
+			static const char digest_pfx[] = "digest=";
+			gsize hexlen = sizeof(session->cmd.cmd.fuzzy_hash.digest) * 2;
+
+			if (query.len == sizeof(digest_pfx) - 1 + hexlen &&
+				memcmp(query.begin, digest_pfx, sizeof(digest_pfx) - 1) == 0 &&
+				rspamd_decode_hex_buf(query.begin + sizeof(digest_pfx) - 1, hexlen,
+									  session->cmd.cmd.fuzzy_hash.digest,
+									  sizeof(session->cmd.cmd.fuzzy_hash.digest)) != -1) {
+				/* Parsed fine */
+			}
+			else {
+				rspamd_control_send_error(session, 400,
+										  "fuzzyhash requires ?digest=<%z hex characters>", hexlen);
+				return 0;
 			}
 		}
 
@@ -857,6 +916,7 @@ rspamd_control_default_cmd_handler(int fd,
 	case RSPAMD_CONTROL_MONITORED_CHANGE:
 	case RSPAMD_CONTROL_FUZZY_STAT:
 	case RSPAMD_CONTROL_FUZZY_SYNC:
+	case RSPAMD_CONTROL_FUZZY_HASH:
 	case RSPAMD_CONTROL_LOG_PIPE:
 	case RSPAMD_CONTROL_CHILD_CHANGE:
 	case RSPAMD_CONTROL_FUZZY_BLOCKED:
@@ -1803,6 +1863,9 @@ rspamd_control_command_from_string(const char *str)
 	else if (g_ascii_strcasecmp(str, "fuzzy_sync") == 0) {
 		ret = RSPAMD_CONTROL_FUZZY_SYNC;
 	}
+	else if (g_ascii_strcasecmp(str, "fuzzy_hash") == 0) {
+		ret = RSPAMD_CONTROL_FUZZY_HASH;
+	}
 	else if (g_ascii_strcasecmp(str, "monitored_change") == 0) {
 		ret = RSPAMD_CONTROL_MONITORED_CHANGE;
 	}
@@ -1848,6 +1911,9 @@ rspamd_control_command_to_string(enum rspamd_control_type cmd)
 		break;
 	case RSPAMD_CONTROL_FUZZY_SYNC:
 		reply = "fuzzy_sync";
+		break;
+	case RSPAMD_CONTROL_FUZZY_HASH:
+		reply = "fuzzy_hash";
 		break;
 	case RSPAMD_CONTROL_MONITORED_CHANGE:
 		reply = "monitored_change";

--- a/src/libserver/rspamd_control.h
+++ b/src/libserver/rspamd_control.h
@@ -42,6 +42,7 @@ enum rspamd_control_type {
 	RSPAMD_CONTROL_MULTIPATTERN_LOADED,
 	RSPAMD_CONTROL_REGEXP_MAP_LOADED,
 	RSPAMD_CONTROL_MEMORY_STAT,
+	RSPAMD_CONTROL_FUZZY_HASH,
 	RSPAMD_CONTROL_MAX
 };
 
@@ -107,6 +108,9 @@ struct rspamd_control_command {
 			unsigned int unused;
 		} fuzzy_sync;
 		struct {
+			unsigned char digest[64];
+		} fuzzy_hash;
+		struct {
 			enum {
 				rspamd_child_offline,
 				rspamd_child_online,
@@ -168,6 +172,10 @@ struct rspamd_control_reply {
 			unsigned int status;
 			char storage_id[MEMPOOL_UID_LEN];
 		} fuzzy_stat;
+		struct {
+			unsigned int status;
+			char storage_id[MEMPOOL_UID_LEN];
+		} fuzzy_hash;
 		struct {
 			unsigned int status;
 		} fuzzy_sync;

--- a/src/rspamadm/control.c
+++ b/src/rspamadm/control.c
@@ -63,15 +63,16 @@ static GOptionEntry entries[] = {
 	 "Set IO timeout (1s by default)", NULL},
 	{NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
 
-#define RSPAMADM_CONTROL_COMMAND_LIST                                  \
-	"Supported commands:\n"                                            \
-	"  stat            - show statistics\n"                            \
-	"  reload          - reload workers dynamic data\n"                \
-	"  reresolve       - resolve upstreams addresses\n"                \
-	"  recompile       - recompile hyperscan regexes\n"                \
-	"  fuzzystat       - show fuzzy statistics\n"                      \
-	"  fuzzysync       - immediately sync fuzzy database to storage\n" \
-	"  compositesstats - show composites processing statistics\n"      \
+#define RSPAMADM_CONTROL_COMMAND_LIST                                          \
+	"Supported commands:\n"                                                    \
+	"  stat            - show statistics\n"                                    \
+	"  reload          - reload workers dynamic data\n"                        \
+	"  reresolve       - resolve upstreams addresses\n"                        \
+	"  recompile       - recompile hyperscan regexes\n"                        \
+	"  fuzzystat       - show fuzzy statistics\n"                              \
+	"  fuzzysync       - immediately sync fuzzy database to storage\n"         \
+	"  fuzzyhash <hex> - show storage info for a fuzzy hash (128 hex chars)\n" \
+	"  compositesstats - show composites processing statistics\n"              \
 	"  memstat         - show memory usage statistics across all workers\n"
 
 static const char *
@@ -231,6 +232,20 @@ rspamadm_control(int argc, char **argv, const struct rspamadm_command *_cmd)
 	else if (g_ascii_strcasecmp(cmd, "fuzzysync") == 0 ||
 			 g_ascii_strcasecmp(cmd, "fuzzy_sync") == 0) {
 		path = "/fuzzysync";
+	}
+	else if (g_ascii_strcasecmp(cmd, "fuzzyhash") == 0 ||
+			 g_ascii_strcasecmp(cmd, "fuzzy_hash") == 0) {
+		static char hash_path_buf[256];
+
+		if (argc < 3 || strlen(argv[2]) != 128) {
+			rspamd_fprintf(stderr,
+						   "fuzzyhash requires a 128 characters hex digest argument\n");
+			exit(EXIT_FAILURE);
+		}
+
+		rspamd_snprintf(hash_path_buf, sizeof(hash_path_buf),
+						"/fuzzyhash?digest=%s", argv[2]);
+		path = hash_path_buf;
 	}
 	else if (g_ascii_strcasecmp(cmd, "compositesstats") == 0 ||
 			 g_ascii_strcasecmp(cmd, "composites_stats") == 0) {


### PR DESCRIPTION
Storage-side fuzzy observability (layer C of the fuzzy diagnosis plan; follows #6149/#6150). Motivated by a false positive investigation where the shingle index turned out to be write-only state: nothing recorded which slots a digest owns, digest-only deletions orphaned slots, and unkeyed writers were invisible in statistics.

## Persist the shingle set with the digest (redis)

Every ADD now stores the shingle key suffixes in the `S` field of the digest hash (~700 bytes of ASCII per hash, no schema migration: old entries simply lack the field). This makes each digest self-describing and fixes two long-standing behaviors:

- **DEL**: digest-only deletions (deletions by hash list, `/fuzzydelhash`) used to leave the digest's shingle slots orphaned — there was no way to find them. Now they are reconstructed from the persisted set and removed if still owned by the deleted digest (slots since taken over by other hashes are left alone).
- **REFRESH**: a refresh used to touch the shingle slots of the *checking* message (a different message by definition, since refresh fires on strong matches). Now it refreshes the slots the digest still owns and reclaims vacant ones, so a hash that keeps matching keeps its full shingle anchor instead of decaying.

sqlite needs no changes (shingles reference digests with enforced `ON DELETE CASCADE`).

## `rspamadm control fuzzyhash <hex>`

Per-hash storage diagnostics from all fuzzy workers, over the existing control socket:

```
$ rspamadm control fuzzyhash eb2efd2e8cf7...
workers { ... data {
    found = true; flag = 11; value = 10;
    created = 1784916924; ttl = 1707;
    shingles { total = 32; owned = 9; foreign = 23; vacant = 0; }
} }
```

`shingles.owned` directly answers the FP-triage question "can this hash still produce fuzzy matches, or has its anchor decayed?". Implemented as a new `inspect` backend API: redis gathers everything in one server-side script round trip; sqlite queries its tables synchronously. The worker replies asynchronously from the backend callback using the same fd-attachment mechanism as `fuzzy_stat`.

## Unkeyed clients in `fuzzystat`

Traffic allowed by `allow_update` (no key) was invisible in key statistics — writers to a storage could not be identified from stats at all. Such clients are now tracked under an `unkeyed` pseudo-key with the same aggregate and per-IP counters as regular keys:

```
Key id: unkeyed
	Checked: 1 ... Added: 1  Deleted: 1
	IPs stat:
	127.0.0.1 ...
```

## Testing

Full C++ unit suite passes; live end-to-end against a redis-backed scratch storage:

1. learn → `S` field persisted (32 suffixes), `fuzzyhash` reports `owned = 32/32`, correct flag/value/ttl
2. learn an overlapping message → ownership decay visible: `owned = 9, foreign = 23`
3. `rspamc fuzzy_delhash` of the second hash → its digest **and** its 23 slots removed (`foreign = 23` → `vacant = 23`), the first hash's 9 slots untouched — no orphans
4. exact-match scan triggers refresh → the first hash re-anchors to `owned = 32/32`
5. `fuzzystat` shows the `unkeyed` pseudo-key with per-IP breakdown

Note: the DEL/REFRESH script paths access reconstructed keys not declared in KEYS[]; this is fine for standalone/sentinel deployments (fuzzy prefix+digest and shingle keys never hash to one cluster slot anyway, so Redis Cluster was not supported by this schema before either).
