### PR TITLE
[Fix] Preventing multiple scoring for the ARC_ALLOW_TRUSTED symbol

### DIFF
--- a/src/plugins/lua/arc.lua
+++ b/src/plugins/lua/arc.lua
@@ -937,6 +937,7 @@ if settings.whitelisted_signers_map then
     score = -2.0,
     group = 'policies',
     groups = { 'arc' },
+    one_shot = true,
   })
 end
 


### PR DESCRIPTION
If email contains multiple ARC signatures from domains in  the trusted forwarder list, each signature are awarded for -2 score

Example 1. Message sended to Gmail and then forwarded.

 `whitelisted_signers_map = [ "google.com" ]` in /etc/rspamd/local.d/arc.conf

Result: Google set two ARC signatures when forwarding, so  -4 scores added to email.
```
ARC_ALLOW_TRUSTED (-4) [google.com:s=arc-20260327:i=1,google.com:s=arc-20260327:i=2]
ARC_ALLOW (-1) [google.com:s=arc-20260327:i=2]
```

Example 2. Message from domain in whitelisted_signers_map sended to Gmail and then forwarded.

`whitelisted_signers_map = [ "google.com", "list.sys4.de" ]` in /etc/rspamd/local.d/arc.conf

Result:  One signature from sender and two from Google, so -6 scores.
```
ARC_ALLOW_TRUSTED (-6) [list.sys4.de:s=2023032101:i=1, google.com:s=arc-20260327:i=2,google.com:s=arc-20260327:i=3]
ARC_ALLOW (-1) [google.com:s=arc-20260327:i=3]
```

Proposed fix added one_shot attribute to the ARC_ALLOW_TRUSTED symbol to prevent multiple scoring.
With `whitelisted_signers_map = [ "google.com" ]` :
```
ARC_ALLOW_TRUSTED (-2) [google.com:s=arc-20260327:i=1, google.com:s=arc-20260327:i=2]
ARC_ALLOW (-1) [google.com:s=arc-20260327:i=2]
```
With `whitelisted_signers_map = [ "google.com", "list.sys4.de" ]`:
```
ARC_ALLOW_TRUSTED (-2) [list.sys4.de:s=2023032101:i=1,google.com:s=arc-20260327:i=2,google.com:s=arc-20260327:i=3]
ARC_ALLOW (-1) [google.com:s=arc-20260327:i=3]
```
With `whitelisted_signers_map = [ "list.sys4.de" ]` :
```
ARC_ALLOW_TRUSTED (-2) [list.sys4.de:s=2023032101:i=1]
ARC_ALLOW (-1) [google.com:s=arc-20260327:i=3]
```