### PR TITLE
[Minor] Expose Errors history to read-only mode

### DIFF
--- a/interface/index.html
+++ b/interface/index.html
@@ -741,7 +741,7 @@
 						</div>
 					</div>
 				</div>
-				<div class="card shadow my-3 ro-hide" id="errors-history">
+				<div class="card shadow my-3" id="errors-history">
 					<div class="card-header text-secondary py-1 d-flex align-items-center">
 						<span class="icon me-3"><i class="fas fa-exclamation-triangle"></i></span>
 						<span class="h6 fw-bolder my-auto ms-0">Errors</span>

--- a/interface/js/app/history.js
+++ b/interface/js/app/history.js
@@ -293,8 +293,6 @@ define(["app/common", "app/libft", "app/tab-utils", "tabulator"],
         }
 
         ui.getErrors = function () {
-            if (common.read_only) return;
-
             common.query("errors", {
                 success: function (data) {
                     const neighbours_data = data

--- a/src/controller.c
+++ b/src/controller.c
@@ -1767,7 +1767,7 @@ rspamd_controller_handle_errors(struct rspamd_http_connection_entry *conn_ent,
 
 	ctx = session->ctx;
 
-	if (!rspamd_controller_check_password(conn_ent, session, msg, TRUE)) {
+	if (!rspamd_controller_check_password(conn_ent, session, msg, FALSE)) {
 		return 0;
 	}
 


### PR DESCRIPTION
The /errors endpoint and its WebUI table were gated behind the enable (privileged) password. Lower the privilege check so any authenticated user can view them.

This is safe: the endpoint returns only Rspamd's internal operational error log (timestamp, pid, level, module, message) — no email content, PII, or secrets — and read-only users already see strictly more sensitive data in the History tab (sender/ recipient IPs, scores, symbols). Authentication remains required and the endpoint is purely informational (no mutation).