### PR TITLE
[Test] Don't cancel Playwright CI runs on master

### DIFF
--- a/.github/workflows/ci_webui_e2e_playwright.yml
+++ b/.github/workflows/ci_webui_e2e_playwright.yml
@@ -102,11 +102,28 @@ jobs:
         with:
           node-version: ${{ matrix.node-version || 'lts/*' }}
 
+      - name: Determine browser cache key
+        id: browsers-key
+        run: |
+          # 'latest' is a moving target: roll the key weekly (ISO year-week) so the
+          # newest Playwright/browser revisions are re-fetched regularly, while still
+          # benefiting from the cache within a week. 'legacy' is pinned => stable key.
+          if [ "${{ matrix.label }}" = "latest" ]; then
+            echo "key=browsers-latest-${{ runner.os }}-$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+          else
+            echo "key=browsers-legacy-${{ matrix.version }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: .cache/ms-playwright-${{ matrix.label }}
-          key: browsers-${{ matrix.label }}-${{ runner.os }}
+          key: ${{ steps.browsers-key.outputs.key }}
+          # Warm-restore the most recent matching cache when the key rolls (esp. 'latest'
+          # across weeks), so only changed browser revisions are re-downloaded.
+          restore-keys: |
+            browsers-${{ matrix.label }}-${{ runner.os }}-
 
       - id: run-playwright
         name: Run Playwright tests (${{ matrix.label }})

--- a/.github/workflows/ci_webui_e2e_playwright.yml
+++ b/.github/workflows/ci_webui_e2e_playwright.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: webui-e2e-playwright-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   e2e:

--- a/test/playwright/tests/charts.spec.mjs
+++ b/test/playwright/tests/charts.spec.mjs
@@ -1,0 +1,118 @@
+import {expect, test} from "@playwright/test";
+import {login} from "../helpers/auth.mjs";
+
+// Status / Throughput / History rendering. The existing scan.spec only reads the
+// numeric #rrd-total-value; the D3Pie/D3Evolution charts, graph controls, the
+// client-side history search and the column-options dropdown are untested.
+//
+// Shares one logged-in page across the serial tests (like scan.spec) to amortise
+// login. No test waits on the 60 s RRD row boundary — only rendering & controls.
+test.describe.serial("WebUI Status / Throughput / History rendering", () => {
+    let page = null;
+
+    test.beforeAll(async ({browser}, testInfo) => {
+        const context = await browser.newContext();
+        page = await context.newPage();
+        const {enablePassword} = testInfo.project.use.rspamdPasswords;
+        await login(page, enablePassword);
+        await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    });
+
+    test.afterAll(async () => {
+        if (page) await page.close();
+    });
+
+    test("Status tab renders stat widgets and the pie chart", async () => {
+        await page.locator("#status_nav").click();
+        await page.waitForResponse((r) => r.url().includes("/stat") && r.ok());
+        await expect(page.locator("#statWidgets")).toBeVisible();
+        await expect(page.locator("#statWidgets .widget").first()).toBeVisible();
+        // D3Pie draws an <svg> inside #chart.
+        await expect.poll(async () => await page.locator("#chart svg").count()).toBeGreaterThan(0);
+    });
+
+    test("Throughput tab renders the graph and reloads on dataset change", async () => {
+        // Track every /graph response. The listener is attached before navigating
+        // so there is no race (localhost responses can beat a waitForResponse
+        // registered after the triggering click).
+        const graphUrls = [];
+        page.on("response", (r) => {
+            if (r.url().includes("/graph")) graphUrls.push(r.url());
+        });
+
+        await page.locator("#throughput_nav").click();
+        await expect.poll(() => graphUrls.length).toBeGreaterThan(0);
+        await expect.poll(async () => await page.locator("#graph svg").count()).toBeGreaterThan(0);
+        await expect(page.locator("#rrd-total-value")).toBeVisible();
+
+        // tabClick() disables navbar controls (incl. #throughput_nav) for 1s after
+        // activating the tab. The #selData change handler routes through tabClick,
+        // which short-circuits while a control is disabled — so wait for the
+        // controls to re-enable before changing the dataset.
+        await expect(page.locator("#throughput_nav")).not.toHaveClass(/\bdisabled\b/);
+
+        // Switching dataset fires a fresh /graph?type=week request and redraws.
+        const before = graphUrls.length;
+        await page.locator("#selData").selectOption("week");
+        await expect.poll(() => graphUrls.slice(before).some((u) => u.includes("type=week"))).toBe(true);
+    });
+
+    test("History global search filters rows client-side", async () => {
+        // Seed two messages with distinct subjects.
+        await page.locator("#scan_nav").click();
+        const scanBtn = page.locator('#scan button[data-upload="checkv2"]');
+        const subjects = [`charts-A-${Date.now()}`, `charts-B-${Date.now()}`];
+        for (const subject of subjects) {
+            await page.locator("#scanMsgSource").fill(
+                `Message-Id: <${subject}@e2e>\nFrom: test@example.com\nSubject: ${subject}\n\nbody`
+            );
+            await Promise.all([
+                page.waitForResponse((r) => r.url().includes("checkv2") && r.ok()),
+                scanBtn.click(),
+            ]);
+            await expect(page.locator(".alert-success, .alert-modal.alert-success").last())
+                .toContainText("Data successfully scanned", {timeout: 10000});
+        }
+
+        await page.locator("#history_nav").click();
+        await page.waitForResponse((r) => r.url().includes("/history") && r.ok());
+        await expect(page.locator("#historyTable_history .tabulator-row").first())
+            .toBeVisible({timeout: 10000});
+        const baseline = await page.locator("#historyTable_history .tabulator-row").count();
+
+        // The filter is debounced (250 ms) and applied client-side via Tabulator.
+        await page.locator("#filter_history").fill(subjects[0]);
+        await expect.poll(async () => await page.locator("#historyTable_history .tabulator-row").count())
+            .toBeLessThan(baseline);
+
+        // Clearing restores the rows.
+        await page.locator("#filter_history").fill("");
+        await expect.poll(async () => await page.locator("#historyTable_history .tabulator-row").count())
+            .toBe(baseline);
+    });
+
+    test("History column-options dropdown hides and resets a column", async () => {
+        // History table is already loaded from the preceding serial test.
+        const colBtn = page.locator("#history .tab-columns-btn");
+        await expect(colBtn).toBeEnabled();
+
+        await colBtn.click();
+        const dropdown = page.locator("#history .tab-columns-dropdown");
+        await expect(dropdown).toBeVisible();
+        await expect(dropdown.locator("button", {hasText: "Reset to default"})).toBeVisible();
+        await expect(dropdown.locator("input[data-option='visible']")).not.toHaveCount(0);
+
+        // Hide the Subject column and persist (dropdown stays open: auto-close=outside).
+        const subjectVisible = dropdown.locator("input[data-name='subject'][data-option='visible']");
+        test.skip((await subjectVisible.count()) === 0, "Subject column checkbox not present");
+        await subjectVisible.check();
+        await dropdown.locator("button", {hasText: "Save"}).click();
+        await expect.poll(() => page.evaluate(() => localStorage.getItem("columns") || ""))
+            .toContain("subject");
+
+        // Reset to default clears the customisation.
+        await dropdown.locator("button", {hasText: "Reset to default"}).click();
+        await expect.poll(() => page.evaluate(() => localStorage.getItem("columns") || ""))
+            .not.toContain("subject");
+    });
+});

--- a/test/playwright/tests/global.spec.mjs
+++ b/test/playwright/tests/global.spec.mjs
@@ -1,0 +1,94 @@
+import {expect, test} from "@playwright/test";
+import {login} from "../helpers/auth.mjs";
+
+// Global widgets not tied to a single tab: theme toggle, settings popover, the
+// backend-API-errors badge/modal, and sticky-tab (URL hash) navigation.
+test.describe("WebUI global widgets", () => {
+    test.beforeEach(async ({page}, testInfo) => {
+        const {enablePassword} = testInfo.project.use.rspamdPasswords;
+        await login(page, enablePassword);
+        await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    });
+
+    // #theme-toggle cycles the stored preference light → dark → auto → light
+    // (rspamd.js themeMap) and applies it via data-bs-theme on <html>.
+    test("theme toggle cycles light → dark → auto and persists to localStorage", async ({page}) => {
+        const html = page.locator("html");
+        // A fresh context has no stored theme => treated as "auto".
+        await page.locator("#theme-toggle").click();
+        await expect(html).toHaveAttribute("data-bs-theme", "light");
+        expect(await page.evaluate(() => localStorage.getItem("theme"))).toBe("light");
+
+        await page.locator("#theme-toggle").click();
+        await expect(html).toHaveAttribute("data-bs-theme", "dark");
+        expect(await page.evaluate(() => localStorage.getItem("theme"))).toBe("dark");
+
+        await page.locator("#theme-toggle").click();
+        expect(await page.evaluate(() => localStorage.getItem("theme"))).toBe("auto");
+    });
+
+    test("settings popover validates locale and restores the ajax timeout", async ({page}) => {
+        await page.locator("#settings").click();
+        // The popover clones #settings-popover into a .popover container.
+        const popover = page.locator(".popover #settings-popover");
+        await expect(popover).toBeVisible();
+
+        // Custom locale: valid value → is-valid and a rendered date example.
+        await popover.locator('input[name="locale"][value="custom"]').check();
+        const localeInput = popover.locator("#locale");
+        await localeInput.fill("de-DE");
+        await expect(localeInput).toHaveClass(/\bis-valid\b/, {timeout: 10000});
+        await expect(popover.locator("#date-example")).not.toBeEmpty();
+
+        // Invalid value → is-invalid. Use a value toLocaleString() actually
+        // rejects: ICU accepts "not-a-locale"-shaped tags, but "1" is never a
+        // valid language subtag → RangeError → is-invalid.
+        await localeInput.fill("1");
+        await expect(localeInput).toHaveClass(/\bis-invalid\b/, {timeout: 10000});
+
+        // HTTP timeout: set then restore to the default (20000 ms).
+        await popover.locator("#ajax-timeout").fill("30000");
+        await expect.poll(async () => await page.evaluate(() => localStorage.getItem("ajax_timeout"))).toBe("30000");
+        await popover.locator("#ajax-timeout-restore").click();
+        await expect.poll(async () => await page.evaluate(() => localStorage.getItem("ajax_timeout"))).toBe("20000");
+    });
+
+    test("backend API error surfaces the error badge and errors modal", async ({page}) => {
+        // Force /symbols to fail so opening the Symbols tab logs an API error.
+        await page.route("**/symbols", (route) => route.fulfill({status: 500, body: "server error"}));
+
+        const badge = page.locator("#error-log-badge");
+        await expect(badge).toHaveClass(/\bd-none\b/);
+
+        await page.locator("#symbols_nav").click();
+        await page.waitForResponse((r) => r.url().includes("/symbols") && r.status() === 500);
+
+        // A failed request is logged → badge + unseen counter appear.
+        await expect(badge).not.toHaveClass(/\bd-none\b/);
+        await expect(page.locator("#error-count")).not.toHaveClass(/\bd-none\b/);
+
+        // Open the modal → table populated, action buttons enabled.
+        await page.locator("#error-log-badge button").click();
+        await expect(page.locator("#errorLogModal")).toBeVisible();
+        await expect(page.locator("#errorLogTable tbody tr")).not.toHaveCount(0);
+        await expect(page.locator("#clearErrorLog")).toBeEnabled();
+        await expect(page.locator("#copyErrorLog")).toBeEnabled();
+
+        // Clear → badge hides again.
+        await page.locator("#clearErrorLog").click();
+        await expect(badge).toHaveClass(/\bd-none\b/);
+    });
+
+    test("sticky tabs switch the active pane on URL hash change", async ({page}) => {
+        // Status is the initial tab after login.
+        await expect(page.locator("#status")).toHaveClass(/\bactive\b/);
+
+        // initStickyTabs binds hashchange → activates the matching tab.
+        await page.evaluate(() => {
+            history.pushState(null, "", "#selectors");
+            window.dispatchEvent(new Event("hashchange"));
+        });
+
+        await expect(page.locator("#selectors")).toHaveClass(/\bactive\b/);
+    });
+});

--- a/test/playwright/tests/maps.spec.mjs
+++ b/test/playwright/tests/maps.spec.mjs
@@ -1,0 +1,67 @@
+import {expect, test} from "@playwright/test";
+import {login} from "../helpers/auth.mjs";
+
+// Configuration → Maps editor. The existing config.spec only covers the Actions
+// thresholds; the Maps card, modal editor and read-only handling are untested.
+// Map rows: the clickable cell is span.map-link; a "Writable" badge
+// (span.badge.text-bg-success) marks editable maps.
+test.describe("WebUI Configuration → Maps editor", () => {
+    test.beforeEach(async ({page}, testInfo) => {
+        const {enablePassword} = testInfo.project.use.rspamdPasswords;
+        await login(page, enablePassword);
+        await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+
+        await page.locator("#configuration_nav").click();
+        await page.waitForResponse((r) => r.url().endsWith("/maps") && r.ok());
+        await expect(page.locator("#listMaps tbody tr").first()).toBeVisible();
+    });
+
+    test("maps list renders rows with flag badges and a map link", async ({page}) => {
+        const firstRow = page.locator("#listMaps tbody tr").first();
+        await expect(firstRow).toBeVisible();
+        // Flags cell carries at least one badge; URL cell has the clickable .map-link.
+        await expect(firstRow.locator("span.badge")).not.toHaveCount(0);
+        await expect(firstRow.locator("span.map-link")).not.toHaveCount(0);
+    });
+
+    test("opening a writable map shows the editor with Save enabled", async ({page}) => {
+        const writableLink = page.locator(
+            "#listMaps tbody tr:has(span.badge.text-bg-success) span.map-link"
+        );
+        test.skip((await writableLink.count()) === 0, "no writable map present in this configuration");
+
+        // Register the response listener before the click: getmap on localhost is
+        // faster than a sequentially-registered waitForResponse, which would miss it.
+        await Promise.all([
+            page.waitForResponse((r) => r.url().includes("getmap")),
+            writableLink.first().click(),
+        ]);
+
+        await expect(page.locator("#modalDialog")).toBeVisible();
+        await expect(page.locator("#modalTitle")).not.toBeEmpty();
+        await expect(page.locator("#editor")).toBeVisible();
+        // Writable branch: Save group is shown (no d-none).
+        await expect(page.locator("#modalSaveGroup")).not.toHaveClass(/\bd-none\b/);
+        await expect(page.locator("#modalSave")).toBeVisible();
+    });
+
+    test("opening a read-only map hides Save", async ({page}) => {
+        // A loaded, non-writable row lacks the Writable badge (and isn't unloaded).
+        const readOnlyRow = page.locator(
+            "#listMaps tbody tr:not(:has(span.badge.text-bg-success)):not(.table-active)"
+        );
+        const count = await readOnlyRow.count();
+        test.skip(count === 0, "no read-only map present in this configuration");
+
+        // Listener before click (see writable test): localhost getmap beats a
+        // sequentially-registered waitForResponse.
+        await Promise.all([
+            page.waitForResponse((r) => r.url().includes("getmap")),
+            readOnlyRow.locator("span.map-link").first().click(),
+        ]);
+
+        await expect(page.locator("#modalDialog")).toBeVisible();
+        // Read-only branch: the whole Save group is hidden.
+        await expect(page.locator("#modalSaveGroup")).toHaveClass(/\bd-none\b/);
+    });
+});

--- a/test/playwright/tests/ro.spec.mjs
+++ b/test/playwright/tests/ro.spec.mjs
@@ -1,0 +1,35 @@
+import {expect, test} from "@playwright/test";
+import {login} from "../helpers/auth.mjs";
+
+// Read-only permission gating. NOTE: this works without any CI change — the
+// controller already authenticates (secure_ip="0" matches only 0.0.0.0, never
+// localhost), so a read-only password yields a real read-only session and
+// displayUI() applies .ro-hide / .ro-disable / .ro-show accordingly.
+//
+// The assertions use elements that exist in the DOM regardless of the active
+// tab: the Scan nav "/Learn" label (span.ro-hide, always rendered) and the
+// Actions fieldset (.ro-disable), so they reflect the global RO state set on
+// login rather than the visibility of the active pane.
+test.describe("WebUI read-only permission gating", () => {
+    test("read-only login hides write controls and disables inputs", async ({page}, testInfo) => {
+        const {readOnlyPassword} = testInfo.project.use.rspamdPasswords;
+        await login(page, readOnlyPassword);
+        await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+
+        // .ro-hide hidden: the "/Learn" label on the Scan tab is hidden.
+        await expect(page.locator("#scan_nav span.ro-hide")).toHaveClass(/\bd-none\b/);
+        // .ro-disable disabled: the Actions fieldset is locked. Assert the property
+        // directly — Playwright's toBeDisabled() does not treat a disabled
+        // <fieldset> (which locks its descendants) as a disabled element itself.
+        await expect(page.locator("#actionsFormField")).toHaveJSProperty("disabled", true);
+    });
+
+    test("enable login exposes write controls", async ({page}, testInfo) => {
+        const {enablePassword} = testInfo.project.use.rspamdPasswords;
+        await login(page, enablePassword);
+        await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+
+        await expect(page.locator("#scan_nav span.ro-hide")).not.toHaveClass(/\bd-none\b/);
+        await expect(page.locator("#actionsFormField")).toHaveJSProperty("disabled", false);
+    });
+});

--- a/test/playwright/tests/selectors.spec.mjs
+++ b/test/playwright/tests/selectors.spec.mjs
@@ -1,0 +1,76 @@
+import {expect, test} from "@playwright/test";
+import {login} from "../helpers/auth.mjs";
+
+// The "Test selectors" tab — previously the only tab with zero E2E coverage.
+// displayUI() (selectors.js) fires list_extractors/list_transforms on first
+// open and disables #selectorsChkMsgBtn while the selector textarea is empty.
+test.describe("WebUI Selectors tab", () => {
+    test.beforeEach(async ({page}, testInfo) => {
+        const {enablePassword} = testInfo.project.use.rspamdPasswords;
+        await login(page, enablePassword);
+        await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+
+        // displayUI() fires list_extractors and list_transforms together, right
+        // from the click handler. Register both listeners before the click — on
+        // localhost they can beat a sequentially-registered waitForResponse,
+        // especially on older Playwright.
+        await Promise.all([
+            page.waitForResponse((r) => r.url().includes("list_extractors") && r.ok()),
+            page.waitForResponse((r) => r.url().includes("list_transforms") && r.ok()),
+            page.locator("#selectors_nav").click(),
+        ]);
+        await expect(page.locator("#selectorsTable-extractors tbody tr").first()).toBeVisible();
+    });
+
+    // check_selector toggles is-valid/is-invalid on #selectorsSelArea; the Check
+    // button is enabled only when the selector is valid AND a message is present.
+    test("selector textarea live-validates and gates the Check button", async ({page}) => {
+        const selArea = page.locator("#selectorsSelArea");
+        const checkBtn = page.locator("#selectorsChkMsgBtn");
+
+        // Empty selector on a fresh tab → button disabled.
+        await expect(checkBtn).toBeDisabled();
+
+        // Invalid selector → is-invalid, button still disabled.
+        await selArea.fill("from(unclosed");
+        await expect(selArea).toHaveClass(/\bis-invalid\b/, {timeout: 10000});
+        await expect(checkBtn).toBeDisabled();
+
+        // A valid selector (plus a non-empty message) enables the button.
+        await page.locator("#selectorsMsgArea").fill("From: test@example.com\n\nBody");
+        await selArea.fill("from");
+        await expect(selArea).toHaveClass(/\bis-valid\b/, {timeout: 10000});
+        await expect(checkBtn).toBeEnabled();
+    });
+
+    test("Check message evaluates the selector and fills the result", async ({page}) => {
+        await page.locator("#selectorsMsgArea").fill("From: test@example.com\nSubject: hi\n\nBody text");
+        await page.locator("#selectorsSelArea").fill("from");
+        await expect(page.locator("#selectorsSelArea")).toHaveClass(/\bis-valid\b/);
+
+        // Listener before click: check_message fires synchronously from the click
+        // handler and can beat a post-click waitForResponse on localhost.
+        await Promise.all([
+            page.waitForResponse((r) => r.url().includes("check_message") && r.ok()),
+            page.locator("#selectorsChkMsgBtn").click(),
+        ]);
+
+        // The result textarea (disabled/readonly) is populated with the extraction.
+        await expect(page.locator("#selectorsResArea")).not.toHaveValue("");
+    });
+
+    test("extractors/transforms tables populate and sidebars collapse", async ({page}) => {
+        await expect(page.locator("#selectorsTable-extractors tbody tr")).not.toHaveCount(0);
+        await expect(page.locator("#selectorsTable-transforms tbody tr")).not.toHaveCount(0);
+
+        // Collapsing the left sidebar toggles a `collapsed` class and regrids #content.
+        await expect(page.locator("#sidebar-left")).not.toHaveClass(/\bcollapsed\b/);
+        await page.locator("#sidebar-tab-left > a").click();
+        await expect(page.locator("#sidebar-left")).toHaveClass(/\bcollapsed\b/);
+        await expect(page.locator("#content")).toHaveClass(/\bcol-lg-9\b/);
+
+        // Expand back.
+        await page.locator("#sidebar-tab-left > a").click();
+        await expect(page.locator("#sidebar-left")).not.toHaveClass(/\bcollapsed\b/);
+    });
+});


### PR DESCRIPTION
Concurrency cancel-in-progress on ci_webui_e2e_playwright keyed by github.ref cancels the previous master commit's Playwright run when two merges land close together. GitHub's binary commit-status model then shows a red X on that commit even though nothing failed.

Only cancel for PR/fork refs; on refs/heads/master let runs queue and complete so master commit history stays green, while preserving resource-saving cancellation during PR iteration.