### PR TITLE
[Fix] lua_mime: unwind every boundary level when returning from nested parts

### DIFF
--- a/lualib/lua_mime.lua
+++ b/lualib/lua_mime.lua
@@ -430,6 +430,46 @@ local function do_append_footer(task, part, footer, is_multipart, out, state)
 
 end
 
+-- Emit closing delimiters for every boundary we are leaving behind, stopping once
+-- the top of the stack is `target` -- the boundary that is about to be re-entered.
+--
+-- The number of levels to unwind is a property of the message structure, so it
+-- cannot be a fixed count. Popping one entry (or two, as the previous
+-- multipart/related special case did) desynchronises the stack as soon as the part
+-- walk returns from a nested part to a shallower one; `boundaries[#boundaries]`
+-- then names an unrelated boundary and a closing delimiter for it -- in practice
+-- the top-level one -- is emitted into the middle of the body.
+--
+-- When `target` is not on the stack at all, which happens when a nested
+-- message/rfc822 opens a boundary of its own, close exactly one level so the
+-- behaviour for that case is unchanged.
+local function close_boundaries_until(out, boundaries, target, newline_s)
+  local found = false
+
+  for i = 1, #boundaries do
+    if boundaries[i].boundary == target then
+      found = true
+      break
+    end
+  end
+
+  if not found then
+    if #boundaries > 0 then
+      out[#out + 1] = string.format('--%s--%s',
+          boundaries[#boundaries].boundary, newline_s)
+      table.remove(boundaries)
+    end
+
+    return
+  end
+
+  while #boundaries > 0 and boundaries[#boundaries].boundary ~= target do
+    out[#out + 1] = string.format('--%s--%s',
+        boundaries[#boundaries].boundary, newline_s)
+    table.remove(boundaries)
+  end
+end
+
 --[[[
 -- @function lua_mime.add_text_footer(task, html_footer, text_footer)
 -- Adds a footer to all text parts in a message. It returns a table with the following
@@ -523,10 +563,8 @@ exports.add_text_footer = function(task, html_footer, text_footer)
     elseif part:is_message() then
       if boundary then
         if cur_boundary and boundary ~= cur_boundary then
-          -- Need to close boundary
-          out[#out + 1] = string.format('--%s--%s',
-              boundaries[#boundaries].boundary, newline_s)
-          table.remove(boundaries)
+          -- Need to close every boundary we are leaving behind
+          close_boundaries_until(out, boundaries, boundary, newline_s)
           cur_boundary = nil
         end
         out[#out + 1] = string.format('--%s',
@@ -565,16 +603,10 @@ exports.add_text_footer = function(task, html_footer, text_footer)
 
       if boundary then
         if cur_boundary and boundary ~= cur_boundary then
-          -- Need to close boundary
-          out[#out + 1] = string.format('--%s--%s',
-              boundaries[#boundaries].boundary, newline_s)
-          -- Need to close previous boundary, if ct_subtype is related
-          if #boundaries > 1 and boundaries[#boundaries].ct_type == "multipart" and boundaries[#boundaries].ct_subtype == "related" then
-            out[#out + 1] = string.format('--%s--%s',
-                boundaries[#boundaries - 1].boundary, newline_s)
-            table.remove(boundaries)
-          end
-          table.remove(boundaries)
+          -- Need to close every boundary we are leaving behind. This subsumes the
+          -- former multipart/related special case: that shape is simply one
+          -- instance of "more than one level to close".
+          close_boundaries_until(out, boundaries, boundary, newline_s)
           cur_boundary = boundary
         end
         out[#out + 1] = string.format('--%s',

--- a/test/lua/unit/lua_mime.add_text_footer.lua
+++ b/test/lua/unit/lua_mime.add_text_footer.lua
@@ -1,0 +1,306 @@
+--[[
+Boundary handling in lua_mime.add_text_footer.
+
+Regression coverage for the boundary stack desynchronising when the part walk
+returns from a nested part to a shallower one: the walk closed a fixed number of
+boundaries (one, or two in the former multipart/related special case) rather than
+every level it had actually left behind. Once the stack drifted,
+`boundaries[#boundaries]` named an unrelated boundary and a closing delimiter for
+the top-level one was emitted into the middle of the body. Everything after that
+point is epilogue per RFC 2046, so attachments were still in the byte stream but
+unreachable to any strict parser -- silently, with the message growing rather
+than shrinking.
+
+Each case asserts the same three invariants rather than exact bytes, so the tests
+stay meaningful if footer placement or encoding changes:
+  * exactly one top-level closing delimiter
+  * every part appears before it
+  * the footer is still applied
+
+Assertions live in the test bodies rather than in the helpers: telescope injects
+assert_* into the environment of the test function only, so a helper defined at
+context scope would see them as nil.
+]]
+
+context("lua_mime.add_text_footer", function()
+  local rspamd_task = require "rspamd_task"
+  local rspamd_util = require "rspamd_util"
+  local rspamd_test_helper = require "rspamd_test_helper"
+  local lua_mime = require "lua_mime"
+
+  rspamd_test_helper.init_url_parser()
+  local cfg = rspamd_util.config_from_ucl(rspamd_test_helper.default_config(),
+      "INIT_URL,INIT_LIBS,INIT_SYMCACHE,INIT_VALIDATE,INIT_PRELOAD_MAPS")
+
+  local html_footer = '<p>FOOTERMARKER</p>'
+  local text_footer = 'FOOTERMARKER'
+
+  -- Reassemble the body the same way rspamadm mime does: bare strings get a
+  -- newline appended, table entries carry an explicit "add a newline" flag.
+  local function body_to_string(rewrite)
+    local buf = {}
+
+    for _, o in ipairs(rewrite.out) do
+      if type(o) == 'string' then
+        buf[#buf + 1] = o
+        buf[#buf + 1] = rewrite.newline_s
+      elseif type(o) == 'table' then
+        buf[#buf + 1] = tostring(o[1])
+
+        if o[2] then
+          buf[#buf + 1] = rewrite.newline_s
+        end
+      else
+        buf[#buf + 1] = tostring(o)
+      end
+    end
+
+    return table.concat(buf)
+  end
+
+  local function count_substr(haystack, needle)
+    local n = 0
+    local pos = 1
+
+    while true do
+      local s, e = string.find(haystack, needle, pos, true)
+
+      if not s then
+        break
+      end
+
+      n = n + 1
+      pos = e + 1
+    end
+
+    return n
+  end
+
+  -- Apply the footer and return a list of everything wrong with the result, so
+  -- the test body can assert on it. Empty list means the message is intact.
+  local function footer_problems(message, markers)
+    local res, task = rspamd_task.load_from_string(message, cfg)
+
+    if not res or not task then
+      return { 'failed to load message' }
+    end
+
+    task:process_message()
+
+    local rewrite = lua_mime.add_text_footer(task, html_footer, text_footer)
+
+    if not rewrite or not rewrite.out then
+      task:destroy()
+      return { 'add_text_footer did not rewrite the message' }
+    end
+
+    local body = body_to_string(rewrite)
+    task:destroy()
+
+    local problems = {}
+    local n_close = count_substr(body, '--outerbnd--')
+
+    if n_close ~= 1 then
+      problems[#problems + 1] = string.format(
+          'expected exactly one top-level closing delimiter, got %d', n_close)
+    end
+
+    local close = string.find(body, '--outerbnd--', 1, true)
+
+    if not close then
+      problems[#problems + 1] = 'top-level boundary is never closed'
+    else
+      for _, marker in ipairs(markers) do
+        local pos = string.find(body, marker, 1, true)
+
+        if not pos then
+          problems[#problems + 1] = string.format('part %s is missing entirely',
+              marker)
+        elseif pos > close then
+          problems[#problems + 1] = string.format(
+              'part %s lands after the top-level closing delimiter at %d/%d, ' ..
+                  'so it is RFC 2046 epilogue and unreachable',
+              marker, close, #body)
+        end
+      end
+    end
+
+    if not string.find(body, 'FOOTERMARKER', 1, true) then
+      problems[#problems + 1] = 'footer was not applied'
+    end
+
+    return problems
+  end
+
+  -- multipart/related sitting directly under the top-level multipart/mixed, with
+  -- an attachment after it. Three parts, no message/rfc822 nesting -- the
+  -- smallest shape that desynchronises the stack.
+  local msg_mixed_related = [[
+From: sender@example.com
+To: rcpt@example.com
+Subject: mixed over related with a trailing attachment
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outerbnd"
+
+--outerbnd
+Content-Type: multipart/related; boundary="relbnd"
+
+--relbnd
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body><p>Hello</p><img src="cid:img@example.com"></body></html>
+
+--relbnd
+Content-Type: image/png
+Content-Transfer-Encoding: base64
+Content-ID: <img@example.com>
+
+iVBORw0KGgo=
+
+--relbnd--
+
+--outerbnd
+Content-Type: application/pdf
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="ATTACHMENTMARKER.pdf"
+
+cGF5bG9hZCBkYXRhCg==
+
+--outerbnd--
+]]
+
+  -- The same message with a text/plain alternative pushing multipart/related one
+  -- level down. This is the shape addressed by the earlier multipart/related
+  -- special case, and it must keep working now that the special case is gone.
+  local msg_mixed_alt_related = [[
+From: sender@example.com
+To: rcpt@example.com
+Subject: mixed over alternative over related with a trailing attachment
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outerbnd"
+
+--outerbnd
+Content-Type: multipart/alternative; boundary="altbnd"
+
+--altbnd
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+PLAINMARKER
+
+--altbnd
+Content-Type: multipart/related; boundary="relbnd"
+
+--relbnd
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body><p>Hello</p><img src="cid:img@example.com"></body></html>
+
+--relbnd
+Content-Type: image/png
+Content-Transfer-Encoding: base64
+Content-ID: <img@example.com>
+
+iVBORw0KGgo=
+
+--relbnd--
+
+--altbnd--
+
+--outerbnd
+Content-Type: application/pdf
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="ATTACHMENTMARKER.pdf"
+
+cGF5bG9hZCBkYXRhCg==
+
+--outerbnd--
+]]
+
+  -- A forwarded message whose body nests multipart/related one level deeper,
+  -- followed by a further top-level attachment. Two levels are left behind when
+  -- the walk returns to the outer container.
+  local msg_nested_rfc822 = [[
+From: forwarder@example.com
+To: rcpt@example.com
+Subject: forwarded bundle
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outerbnd"
+
+--outerbnd
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+INTROMARKER
+
+--outerbnd
+Content-Type: message/rfc822
+Content-Transfer-Encoding: 8bit
+Content-Disposition: attachment; filename="nested.eml"
+MIME-Version: 1.0
+
+From: inner@example.com
+To: rcpt@example.com
+Subject: nested message
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="innerbnd"
+
+--innerbnd
+Content-Type: multipart/related; boundary="relbnd"
+
+--relbnd
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body><p>Nested</p><img src="cid:img@example.com"></body></html>
+
+--relbnd
+Content-Type: image/png
+Content-Transfer-Encoding: base64
+Content-ID: <img@example.com>
+
+iVBORw0KGgo=
+
+--relbnd--
+
+--innerbnd
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="INNERMARKER.txt"
+
+cGF5bG9hZCBkYXRhCg==
+
+--innerbnd--
+
+--outerbnd
+Content-Type: application/pdf
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="ATTACHMENTMARKER.pdf"
+
+cGF5bG9hZCBkYXRhCg==
+
+--outerbnd--
+]]
+
+  test("multipart/mixed over multipart/related keeps a trailing attachment reachable",
+      function()
+        local problems = footer_problems(msg_mixed_related, { 'ATTACHMENTMARKER' })
+        assert_equal(0, #problems, table.concat(problems, '; '))
+      end)
+
+  test("multipart/alternative between mixed and related is not regressed",
+      function()
+        local problems = footer_problems(msg_mixed_alt_related,
+            { 'PLAINMARKER', 'ATTACHMENTMARKER' })
+        assert_equal(0, #problems, table.concat(problems, '; '))
+      end)
+
+  test("nested message/rfc822 unwinds every level it leaves behind",
+      function()
+        local problems = footer_problems(msg_nested_rfc822,
+            { 'INTROMARKER', 'INNERMARKER', 'ATTACHMENTMARKER' })
+        assert_equal(0, #problems, table.concat(problems, '; '))
+      end)
+end)


### PR DESCRIPTION
Fixes #6170.

### The defect

`lua_mime.add_text_footer()` closes a fixed number of boundaries when the part walk returns from a nested part to a shallower one — one in the `is_message` branch, or two in the `multipart/related` special case added by #5334. The number of levels to close is a property of the message structure, so a constant cannot be right. Once the stack drifts, `boundaries[#boundaries]` names an unrelated boundary and a closing delimiter for the **top-level** one is emitted into the middle of the body.

Everything after that delimiter is epilogue per RFC 2046, so attachments are still in the byte stream but unreachable to any strict parser. The failure is silent: no error, no log line, and the message *grows* rather than shrinks, so size checks do not catch it.

One point worth drawing out, because it changes how the special case should be read: for `multipart/mixed > multipart/related` with a trailing attachment, the two-pop branch is what *emits* the premature top-level delimiter. Without it that shape already worked. So #5334 did not merely under-fix the stack handling — it broke an adjacent shape while fixing its own. That is the argument for replacing the special case rather than extending it.

### The fix

`close_boundaries_until()` unwinds to the boundary being re-entered instead of popping a fixed count. When the target is not on the stack at all — a nested `message/rfc822` that opens a boundary of its own — it closes exactly one level, so that path behaves as before. This subsumes the `multipart/related` special case, which is simply one instance of "more than one level to close".

The approach is @Viktort-t's, proposed in #6170; I have packaged it with tests and an A/B.

### Two independent reproductions

This was reproduced twice, by different people, with different methods, before any patch was written — worth recording since the two routes fail in different directions.

**@Viktort-t** hit it in production via mailcow's domain-wide footer feature and reported it downstream as mailcow/mailcow-dockerized#7399: a forwarded bundle of 18 messages delivered as 5. On a 4.4 MB production message the stack went empty 14 times in a single walk, with the closing delimiter landing ~700 KB before the end. Because that host is production they could not swap `lua_mime.lua` for a side-by-side control, so they loaded each version by path with `dofile` and called `add_text_footer` directly, md5-verifying the live file was untouched throughout.

**I** reproduced it independently on a disposable stand, driving Rspamd 4.1.4 (`ghcr.io/mailcow/rspamd:4.1.4-1`) through `rspamc -m` and `rspamadm mime modify` so that only Rspamd was in the path. That established the defect is live on 4.1.4 as well as 4.1.0 — the original report cited only 4.1.0, so upgrading is not a workaround — and it narrowed the trigger: an 18-part `mixed > alternative > related` bundle did **not** corrupt, which is what pointed at `related` sitting *directly* under the inner `mixed` rather than at nesting depth as such.

Two method notes that cost us time and may save someone else's:

- Shadowing the module via `LUA_PATH` does **not** work. `rspamadm` resolves `lua_mime` to the compiled-in `/usr/share/rspamd/lualib/` path regardless, so both arms of an A/B silently load the same file and produce byte-identical output — it fails in the direction that looks like a passing test. The module has to be replaced outright and the md5 of the loaded file confirmed to have changed.
- The smaller trigger below needs no `message/rfc822` nesting at all, and is the easier one to reason about.

### Verification

A/B on Rspamd 4.1.4 with only `add_text_footer` patched — `multipattern_text_replace` and `remove_attachments` contain the same "Need to close boundary" code and were deliberately left untouched, so the change under test is isolated. `lualib/lua_mime.lua` on current `master` is md5-identical to the one shipped in 4.1.4 (`b11ccc51…`), so these numbers carry over to `master` unchanged.

Reachability measured by raw byte offset of the top-level delimiter *and* independently by Python's `email` parser under `policy.default`:

| structure | build | top-level close at | leaf parts reachable |
|---|---|---|---|
| `mixed > related` + attachment | stock | 75.2% — mid-body | 2 |
| | patched | 98.2% — end | **3** |
| `mixed > alternative > related` + attachment | stock | 98.6% | 4 |
| | patched | 98.6% | 4 — **byte-identical to stock** |
| nested `message/rfc822` + attachment | stock | 86.2% — mid-body | 4 |
| | patched | 99.0% — end | **6** |

Exactly one closing delimiter in every build, so this is a premature close rather than a duplicate. The `mixed > alternative > related` row is byte-identical before and after, so the shape #5334 addressed is not regressed — @Viktort-t independently confirmed that same control on their side.

On @Viktort-t's original 8-part reproducer, reachable `message/rfc822` parts go from 3/8 (stock 4.1.0 and 4.1.4 alike) to 8/8.

### Tests

`test/lua/unit/lua_mime.add_text_footer.lua` covers the three shapes that distinguish the behaviours: the three-part `mixed > related` trigger, the `mixed > alternative > related` shape from #5334, and a nested `message/rfc822` bundle. Each asserts invariants — exactly one top-level closing delimiter, every part before it, footer still applied — rather than exact bytes, so they stay meaningful if footer placement or encoding changes.

The tests were checked against the unpatched module as well, so they are known to actually catch this:

```
                                                    unpatched   patched
mixed > related + attachment                          FAIL        PASS
mixed > alternative > related + attachment (#5334)    PASS        PASS
nested message/rfc822 + attachment                    FAIL        PASS
```

The two failures report the defect directly, e.g. `part ATTACHMENTMARKER lands after the top-level closing delimiter at 361/537, so it is RFC 2046 epilogue and unreachable`. Full Lua unit suite with the patch applied: 1194 tests, 1191 passed, 0 failed, 0 errors (3 pre-existing unassertive).

### Notes for review

- `ct_type` / `ct_subtype` are now written into the `boundaries` entries but never read, since the special case that consumed them is gone. I left them, and the `part_ct` parse that feeds them, in place to keep the diff to the actual behaviour change — happy to strip both if you would prefer.
- The same fixed-count close pattern appears in `multipattern_text_replace` and `remove_attachments`. Those are plausibly affected by the same class of bug, but I have not reproduced it there and have not touched them; that felt like it should be its own change rather than an unverified drive-by.
