### PR TITLE
[Fix] hfilter: compare HELO addresses against the connecting IP

### DIFF
--- a/src/plugins/lua/hfilter.lua
+++ b/src/plugins/lua/hfilter.lua
@@ -225,6 +225,7 @@ end
 local function check_host(task, host, symbol_suffix, eq_ip, eq_host)
   local failed_address = 0
   local completed_address = 0
+  local address_lookup_failed = false
   local resolved_address = {}
 
   local function check_host_cb_mx(_, to_resolve, results, err)
@@ -264,9 +265,15 @@ local function check_host(task, host, symbol_suffix, eq_ip, eq_host)
       end
     end
   end
-  local function check_host_cb_a(_, _, results)
+  local function check_host_cb_a(_, to_resolve, results, err)
     if not results then
-      failed_address = failed_address + 1
+      if err and (err ~= 'requested record is not found' and
+          err ~= 'no records with this name') then
+        lua_util.debugm(N, task, 'error looking up %s: %s', to_resolve, err)
+        address_lookup_failed = true
+      else
+        failed_address = failed_address + 1
+      end
     else
       for _, result in pairs(results) do
         table.insert(resolved_address, result:to_string())
@@ -283,7 +290,7 @@ local function check_host(task, host, symbol_suffix, eq_ip, eq_host)
       return
     end
 
-    if eq_ip and eq_ip ~= '' then
+    if not address_lookup_failed and eq_ip and eq_ip ~= '' then
       local matched = false
       for _, result in pairs(resolved_address) do
         if result == eq_ip then
@@ -298,7 +305,7 @@ local function check_host(task, host, symbol_suffix, eq_ip, eq_host)
       end
     end
 
-    if failed_address >= 2 then
+    if not address_lookup_failed and failed_address >= 2 then
       -- No A or AAAA records
       task:get_resolver():resolve_mx({
         task = task,

--- a/src/plugins/lua/hfilter.lua
+++ b/src/plugins/lua/hfilter.lua
@@ -224,6 +224,7 @@ end
 -- eq_host: host for comparing or empty string
 local function check_host(task, host, symbol_suffix, eq_ip, eq_host)
   local failed_address = 0
+  local completed_address = 0
   local resolved_address = {}
 
   local function check_host_cb_mx(_, to_resolve, results, err)
@@ -272,16 +273,33 @@ local function check_host(task, host, symbol_suffix, eq_ip, eq_host)
       end
     end
 
-    if failed_address >= 2 then
-      -- No A or AAAA records
-      if eq_ip and eq_ip ~= '' then
-        for _, result in pairs(resolved_address) do
-          if result == eq_ip then
-            return true
-          end
+    -- The A and the AAAA lookups share this callback and complete in
+    -- arbitrary order, so judge only once both have returned: an address
+    -- published in the slower family is not in `resolved_address` yet, and
+    -- comparing early would flag a matching host depending on DNS timing.
+    -- This also keeps the symbol to a single insertion per host.
+    completed_address = completed_address + 1
+    if completed_address < 2 then
+      return
+    end
+
+    if eq_ip and eq_ip ~= '' then
+      local matched = false
+      for _, result in pairs(resolved_address) do
+        if result == eq_ip then
+          matched = true
+          break
         end
+      end
+      -- Also covers the no-records case, where `resolved_address` is empty
+      -- and nothing can match.
+      if not matched then
         task:insert_result('HFILTER_' .. symbol_suffix .. '_IP_A', 1.0, host)
       end
+    end
+
+    if failed_address >= 2 then
+      -- No A or AAAA records
       task:get_resolver():resolve_mx({
         task = task,
         name = host,

--- a/test/functional/cases/171_hfilter_helo.robot
+++ b/test/functional/cases/171_hfilter_helo.robot
@@ -1,0 +1,55 @@
+*** Settings ***
+Suite Setup     Rspamd Setup
+Suite Teardown  Rspamd Teardown
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/hfilter.conf
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/spam_message.eml
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+${SETTINGS}        {symbols_enabled = [HFILTER_CHECK, HFILTER_HELO_IP_A, HFILTER_HELO_NORES_A_OR_MX, HFILTER_HELO_NORESOLVE_MX, HFILTER_HELO_NOT_FQDN]}
+
+*** Test Cases ***
+# HFILTER_HELO_IP_A is documented as "Helo A IP != hostname IP", so a HELO
+# whose address records do not contain the connecting IP must be flagged.
+HELO address not matching connecting IP is flagged
+  Scan File  ${MESSAGE}  IP=5.6.7.8  Helo=mismatch.test  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HELO_IP_A  1.00
+
+# Control: the connecting IP is exactly the published A record, so the symbol
+# must stay silent. Guards against a fix that simply always inserts.
+HELO address matching connecting IP is not flagged
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=match.test  Settings=${SETTINGS}
+  Do Not Expect Symbol  HFILTER_HELO_IP_A
+
+# The A and AAAA lookups share one callback and complete in arbitrary order.
+# Here the matching address is the AAAA one, so any check that runs before
+# both lookups have returned can observe only {1.2.3.4} and flag wrongly.
+Dual-stack HELO matching on AAAA is not flagged
+  Scan File  ${MESSAGE}  IP=2001:db8::1  Helo=dual.test  Settings=${SETTINGS}
+  Do Not Expect Symbol  HFILTER_HELO_IP_A
+
+# Mirror of the above with the match in the A reply, so neither completion
+# order is quietly favoured.
+Dual-stack HELO matching on A is not flagged
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=dual.test  Settings=${SETTINGS}
+  Do Not Expect Symbol  HFILTER_HELO_IP_A
+
+# Both families resolve and neither matches: the symbol is correct here, but
+# it must be inserted once rather than once per resolver callback. The score
+# assertion is the check -- a per-callback insert scores 2.00.
+Dual-stack HELO matching neither family is flagged exactly once
+  Scan File  ${MESSAGE}  IP=9.9.9.9  Helo=dualmiss.test  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HELO_IP_A  1.00
+
+# Existing behaviour, preserved deliberately: a HELO that resolves to no
+# address records at all is still flagged. Whether that should remain
+# HFILTER_HELO_IP_A's job rather than HFILTER_HELO_NORES_A_OR_MX's is a
+# separate scoring question, so this test pins today's behaviour.
+HELO with no address records keeps being flagged
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=noaddr.test  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HELO_IP_A  1.00
+  Expect Symbol  HFILTER_HELO_NORES_A_OR_MX

--- a/test/functional/cases/171_hfilter_helo.robot
+++ b/test/functional/cases/171_hfilter_helo.robot
@@ -53,3 +53,9 @@ HELO with no address records keeps being flagged
   Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=noaddr.test  Settings=${SETTINGS}
   Expect Symbol With Score  HFILTER_HELO_IP_A  1.00
   Expect Symbol  HFILTER_HELO_NORES_A_OR_MX
+
+# A timeout is not an authoritative absence: the failed A lookup could contain
+# the connecting IP, so the nonmatching AAAA answer cannot prove a mismatch.
+HELO with one transiently failed family is not flagged
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=partialfail.test  Settings=${SETTINGS}
+  Do Not Expect Symbol  HFILTER_HELO_IP_A

--- a/test/functional/configs/hfilter-dns.conf
+++ b/test/functional/configs/hfilter-dns.conf
@@ -1,0 +1,71 @@
+options {
+  dns {
+    fake_records = [
+      {
+        # HELO resolves to a single A record that does NOT match the
+        # connecting IP -> the mismatch case HFILTER_HELO_IP_A is meant
+        # to describe ("Helo A IP != hostname IP").
+        name = "mismatch.test";
+        type = "a";
+        replies = ["1.2.3.4"];
+      },
+      {
+        name = "mismatch.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # HELO resolves to an A record that DOES match the connecting IP.
+        name = "match.test";
+        type = "a";
+        replies = ["1.2.3.4"];
+      },
+      {
+        name = "match.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # Dual-stack HELO: the matching address lives in the AAAA reply,
+        # so a check that evaluates before both lookups have returned can
+        # see only {1.2.3.4} and produce a false positive.
+        name = "dual.test";
+        type = "a";
+        replies = ["1.2.3.4"];
+      },
+      {
+        name = "dual.test";
+        type = "aaaa";
+        replies = ["2001:db8::1"];
+      },
+      {
+        # Dual-stack HELO where neither family matches: the symbol must be
+        # inserted exactly once, not once per resolver callback.
+        name = "dualmiss.test";
+        type = "a";
+        replies = ["1.2.3.4"];
+      },
+      {
+        name = "dualmiss.test";
+        type = "aaaa";
+        replies = ["2001:db8::1"];
+      },
+      {
+        # HELO with no address records at all, and no MX either.
+        name = "noaddr.test";
+        type = "a";
+        rcode = 'nxdomain';
+      },
+      {
+        name = "noaddr.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        name = "noaddr.test";
+        type = "mx";
+        rcode = 'nxdomain';
+      }
+    ]
+  }
+}

--- a/test/functional/configs/hfilter-dns.conf
+++ b/test/functional/configs/hfilter-dns.conf
@@ -65,6 +65,18 @@ options {
         name = "noaddr.test";
         type = "mx";
         rcode = 'nxdomain';
+      },
+      {
+        # A transient failure leaves this family unknown; it must not be
+        # interpreted as proof that the connecting IPv4 address mismatches.
+        name = "partialfail.test";
+        type = "a";
+        rcode = 'timeout';
+      },
+      {
+        name = "partialfail.test";
+        type = "aaaa";
+        replies = ["2001:db8::2"];
       }
     ]
   }

--- a/test/functional/configs/hfilter.conf
+++ b/test/functional/configs/hfilter.conf
@@ -1,0 +1,35 @@
+.include(duplicate=merge,priority=0) "{= env.TESTDIR =}/configs/plugins.conf"
+.include(duplicate=merge,priority=1) "{= env.TESTDIR =}/configs/hfilter-dns.conf"
+
+hfilter {
+  enabled = true;
+  # Only the HELO checks are under test; the other groups would add
+  # unrelated symbols and extra DNS traffic.
+  helo_enabled = true;
+  hostname_enabled = false;
+  from_enabled = false;
+  rcpt_enabled = false;
+  mid_enabled = false;
+  url_enabled = false;
+}
+
+# hfilter.lua registers its symbols with score 0.0 and relies on
+# conf/scores.d/hfilter_group.conf for the real weights; that file is not part
+# of the functional test configs, so mirror it here. The exact value matters:
+# a symbol inserted once per resolver callback would score 2.0 instead of 1.0.
+group "hfilter" {
+  symbols = {
+    "HFILTER_HELO_IP_A" {
+      weight = 1.0;
+    }
+    "HFILTER_HELO_NORES_A_OR_MX" {
+      weight = 0.3;
+    }
+    "HFILTER_HELO_NORESOLVE_MX" {
+      weight = 0.2;
+    }
+    "HFILTER_HELO_NOT_FQDN" {
+      weight = 2.0;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #6165, reported by @thestinger, whose diagnosis located the problem exactly.

## The defect

`HFILTER_HELO_IP_A` is described as `"Helo A IP != hostname IP"`, but in `check_host_cb_a()` the comparison that would detect a mismatch sits inside the `failed_address >= 2` branch:

```lua
if failed_address >= 2 then
  -- No A or AAAA records
  if eq_ip and eq_ip ~= '' then
    for _, result in pairs(resolved_address) do
      if result == eq_ip then
        return true
      end
    end
    task:insert_result('HFILTER_' .. symbol_suffix .. '_IP_A', 1.0, host)
  end
```

That branch is reached only when both the A and the AAAA lookup failed, and `resolved_address` is appended to only when a lookup *succeeds*. So in the one branch that reads it, the list is necessarily empty: the loop body never executes and its `return true` is unreachable.

The symbol therefore fires **if and only if the HELO host resolves to neither A nor AAAA** — a no-resolve condition already covered by `HFILTER_HELO_NORES_A_OR_MX` — and never on the address mismatch it claims to report.

## Why moving the comparison to an `else` branch is not enough

This is the part worth flagging, since it is the natural reading of the code and it is what the issue proposes.

`check_host_cb_a` is the **shared** callback for both lookups:

```lua
task:get_resolver():resolve('a',    { task = task, name = host, callback = check_host_cb_a })
task:get_resolver():resolve('aaaa', { task = task, name = host, callback = check_host_cb_a })
```

It runs twice, in arbitrary order. An `else` branch therefore executes on the *first* callback to return, when `resolved_address` holds at most one address family. I built that variant and ran it against the tests added here — 1 of 6 passed:

- **A matching host gets flagged.** With `match.test` publishing `A=1.2.3.4` and the client connecting from `1.2.3.4`, the symbol was inserted: the AAAA NXDOMAIN callback returned first, the `else` branch ran against a still-empty `resolved_address`, and the A callback matched too late to prevent it. This is the ordinary IPv4-only-HELO case. It depends on completion order, so it is a race rather than a certainty.
- **The score doubles.** On a genuine mismatch both callbacks reach the insert, so the symbol lands twice — 2.0 instead of 1.0 in the runs here. That part is order-independent; the hfilter group sets no `one_shot` and `DEFAULT_MAX_SHOTS` is 100.

## What this changes

`failed_address >= 2` was implicitly serving as a "both lookups have finished" join. This makes that explicit with a completion counter, performs the comparison once both callbacks have returned, and leaves the MX fallback on the both-failed path.

A HELO that resolves to no addresses at all is **still flagged**, exactly as today. Whether that should remain `HFILTER_HELO_IP_A`'s job rather than `HFILTER_HELO_NORES_A_OR_MX`'s is a scoring question affecting every install, so I have not changed it — a test pins the current behaviour, and it is easy to flip if you would prefer the symbol to stay silent when there is nothing to compare against.

## Tests

hfilter had no functional tests, so this adds the first ones, using `fake_records` for deterministic DNS: mismatch, match, dual-stack matching on AAAA, dual-stack matching on A, dual-stack matching neither, and the no-records case.

Two notes on how they are built:

- The dual-stack cases exist specifically to pin the callback-ordering behaviour described above; they are the ones the `else`-branch variant fails.
- `hfilter.lua` registers its symbols at score `0.0` and relies on `conf/scores.d/hfilter_group.conf` for real weights, which the functional configs do not load, so the test config mirrors the weights in a `group "hfilter"` block. Without that, the score assertions would compare `0.0` against `0.0` and the double-insertion check would be vacuous.

## Verification

Against `master` (`0a8e795a`), building and swapping only `src/plugins/lua/hfilter.lua` between runs (md5 confirmed to change each time):

| Variant | 171_hfilter_helo |
|---|---|
| unmodified `master` | 4 passed, 2 failed |
| `else`-branch variant from the issue | 1 passed, 5 failed |
| this PR | 6 passed, 0 failed |

The two failures on unmodified `master` are the mismatch cases. The no-records case *passes* there, which is what demonstrates the comparison is dead rather than merely misplaced.

Full functional suite with this change, both CI phases: **785 + 101 = 886 tests, 0 failures**. `luacheck -q --no-color` on the modified file via `pipelinecomponents/luacheck`: 0 warnings, 0 errors.

## Not addressed

`check_host_cb_mx` counts `failed_mx_address` across a shared callback in a similar way, once per MX target. I have not reproduced a defect there and have left it alone rather than change behaviour speculatively.
