### PR TITLE
[Minor] lua: fix logger format string and argument mismatches

### DIFF
--- a/lualib/lua_fuzzy.lua
+++ b/lualib/lua_fuzzy.lua
@@ -344,7 +344,8 @@ local function check_length(task, part, rule)
           bytes, adjusted_bytes, rule.min_bytes)
       length_ok = false
     else
-      lua_util.debugm(N, task, 'allow part of length %s (%s adjusted)',
+      lua_util.debugm(N, task, 'allow part of length %s (%s adjusted) ' ..
+          'as it has at least %s bytes',
           bytes, adjusted_bytes, rule.min_bytes)
     end
   else

--- a/lualib/lua_scanners/pyzor.lua
+++ b/lualib/lua_scanners/pyzor.lua
@@ -117,7 +117,7 @@ local function pyzor_check(task, content, digest, rule)
           })
         else
           rspamd_logger.errx(task, '%s: failed to scan, maximum retransmits exceed',
-              rule['symbol'], rule['type'])
+              rule.log_prefix)
           task:insert_result(rule['symbol_fail'], 0.0,
               'failed to scan and retransmits exceed')
         end

--- a/lualib/lua_scanners/razor.lua
+++ b/lualib/lua_scanners/razor.lua
@@ -144,14 +144,14 @@ local function razor_check(task, content, digest, rule)
 
         local threat_string = tostring(data)
         if threat_string == "spam" then
-          lua_util.debugm(N, task, '%s: returned result is spam', rule['symbol'], rule['type'])
+          lua_util.debugm(N, task, '%s: returned result is spam', rule.log_prefix)
           common.yield_result(task, rule, threat_string, rule.default_score)
           common.save_cache(task, digest, rule, threat_string, rule.default_score)
         elseif threat_string == "ham" then
           if rule.log_clean then
-            rspamd_logger.infox(task, '%s: returned result is ham', rule['symbol'], rule['type'])
+            rspamd_logger.infox(task, '%s: returned result is ham', rule.log_prefix)
           else
-            lua_util.debugm(N, task, '%s: returned result is ham', rule['symbol'], rule['type'])
+            lua_util.debugm(N, task, '%s: returned result is ham', rule.log_prefix)
           end
           common.save_cache(task, digest, rule, 'OK', rule.default_score)
         else

--- a/lualib/lua_stat.lua
+++ b/lualib/lua_stat.lua
@@ -130,7 +130,7 @@ end
   ret, res = conn:exec()
 
   if not ret then
-    logger.errx('error converting metadata for symbol %s', symbol_ham, res)
+    logger.errx('error converting metadata for symbol %s: %s', symbol_ham, res)
     return false
   end
 

--- a/src/plugins/lua/clustering.lua
+++ b/src/plugins/lua/clustering.lua
@@ -249,7 +249,7 @@ local function clusterting_idempotent_cb(task, rule)
           source_selector, err)
     else
       lua_util.debugm(N, task, 'set clustering key for %s: %s{%s} = %s',
-          source_selector, "unknown error")
+          rule.name, source_selector, cluster_selector, score)
     end
   end
 

--- a/src/plugins/lua/neural.lua
+++ b/src/plugins/lua/neural.lua
@@ -1754,7 +1754,7 @@ for k, r in pairs(rules) do
   end
 
   if rule_elt.max_inputs and not has_blas then
-    rspamd_logger.errx(rspamd_config, 'cannot set max inputs to %s as BLAS is not compiled in',
+    rspamd_logger.errx(rspamd_config, 'rule %s: cannot set max inputs to %s as BLAS is not compiled in',
       rule_elt.name, rule_elt.max_inputs)
     rule_elt.max_inputs = nil
   end


### PR DESCRIPTION
Fixes #6174, and seven further call sites of the same kind found while checking whether that one was isolated.

These are all logger calls whose format directives and supplied arguments disagree. Most produce `<EXTRA n ARGUMENTS>` noise, but three lose or misreport information that someone reading the logs would actually want.

## Wrong or missing information

**`src/plugins/lua/clustering.lua:251`** — the success branch of `redis_set_cb`:

```lua
lua_util.debugm(N, task, 'set clustering key for %s: %s{%s} = %s',
    source_selector, "unknown error")
```

Four directives, two arguments, and the second is the literal `"unknown error"` in the branch where nothing went wrong — it looks like it was copied from the error branch above. Restored to the values the message describes. The `%s{%s} = %s` shape matches what the script actually does (`HINCRBYFLOAT source_selector cluster_selector score`), so the reconstruction is `rule.name, source_selector, cluster_selector, score`. All four are in scope at that point. Flagging this one explicitly since it is the only place I inferred intent rather than read it off an adjacent line.

**`src/plugins/lua/neural.lua:1757`** — `'cannot set max inputs to %s as BLAS is not compiled in'` is passed `(rule_elt.name, rule_elt.max_inputs)`, so it prints the *rule name* where the max_inputs value belongs and drops the value entirely. Reworded to `'rule %s: cannot set max inputs to %s …'` so both are reported.

**`lualib/lua_stat.lua:133`** — `'error converting metadata for symbol %s'` is passed `(symbol_ham, res)`, so `res` — the actual Redis error — never reaches the log. The `symbol_spam` call eleven lines above is already correct (`'…symbol %s: %s'`); this just matches it.

## Extra arguments

**`lualib/lua_scanners/pyzor.lua:119`** (the issue) and **`lualib/lua_scanners/razor.lua:147,152,154`** pass `rule['symbol'], rule['type']` into a single-`%s` format.

Rather than adding a second directive, these now use `rule.log_prefix`, which is what every other logging call in both files uses and which already carries exactly that information (`name` or `name (type)`, set in each scanner's config handler). `razor.lua:126` logs the identical "maximum retransmits exceed" message correctly this way, so pyzor's line now matches its own sibling.

**`lualib/lua_fuzzy.lua:347`** passes `rule.min_bytes` to a two-directive format. The `skip` branch immediately above logs `'… as it has less than %s bytes'` with the same three values, so I completed the `allow` branch to mirror it (`'… as it has at least %s bytes'`) rather than dropping the argument — the condition is `rule.min_bytes > adjusted_bytes`, so the wording holds. Happy to make this a plain argument removal instead if you would rather keep the diff purely mechanical.

## How these were found, and what this does not claim

A script parsed `rspamd_logger.*x` and `lua_util.debugm` calls across `lualib/` and `src/plugins/lua/`, compared directive count (including rspamd's positional `%1`/`%2` forms) against argument count, and every hit was then confirmed by reading the code.

**This is a lower bound, not an audit.** The parser skips any call it cannot resolve unambiguously — 130 of them — and it does not strip comments, which produced one false positive (`lua_scanners/common.lua:409` is inside a commented-out debug line and is deliberately left alone). There may well be more of these in the calls it could not parse.

## Verification

`luacheck -q --no-color` on the six modified files via `pipelinecomponents/luacheck`: 0 warnings, 0 errors.

Full functional suite, both CI phases, with these changes: 779 + 101 = 880 tests, 0 failures.

No tests are added: these are log-format changes with no observable behaviour to assert against.
