### PR TITLE
[Fix] lua_mime: unwind every boundary level in the remaining rewriters

### DIFF
--- a/lualib/lua_mime.lua
+++ b/lualib/lua_mime.lua
@@ -470,6 +470,35 @@ local function close_boundaries_until(out, boundaries, target, newline_s)
   end
 end
 
+-- The same unwind for the two rewriters that keep a stack of plain boundary
+-- strings and emit {text, is_raw} pairs, rather than the {boundary = ...}
+-- records and plain strings used above. Sharing a single helper across both
+-- shapes would need an accessor and an emitter callback for no real gain.
+local function close_raw_boundaries_until(out, boundaries, target)
+  local found = false
+
+  for i = 1, #boundaries do
+    if boundaries[i] == target then
+      found = true
+      break
+    end
+  end
+
+  if not found then
+    if #boundaries > 0 then
+      out[#out + 1] = { string.format('--%s--', boundaries[#boundaries]), true }
+      table.remove(boundaries)
+    end
+
+    return
+  end
+
+  while #boundaries > 0 and boundaries[#boundaries] ~= target do
+    out[#out + 1] = { string.format('--%s--', boundaries[#boundaries]), true }
+    table.remove(boundaries)
+  end
+end
+
 --[[[
 -- @function lua_mime.add_text_footer(task, html_footer, text_footer)
 -- Adds a footer to all text parts in a message. It returns a table with the following
@@ -836,10 +865,8 @@ exports.multipattern_text_replace = function(task, mp, replacements)
     elseif part:is_message() then
       if boundary then
         if cur_boundary and boundary ~= cur_boundary then
-          -- Need to close boundary
-          out[#out + 1] = { string.format('--%s--',
-              boundaries[#boundaries]), true }
-          table.remove(boundaries)
+          -- Need to close every boundary we are leaving behind
+          close_raw_boundaries_until(out, boundaries, boundary)
           cur_boundary = nil
         end
         out[#out + 1] = { string.format('--%s',
@@ -865,10 +892,8 @@ exports.multipattern_text_replace = function(task, mp, replacements)
 
       if boundary then
         if cur_boundary and boundary ~= cur_boundary then
-          -- Need to close boundary
-          out[#out + 1] = { string.format('--%s--',
-              boundaries[#boundaries]), true }
-          table.remove(boundaries)
+          -- Need to close every boundary we are leaving behind
+          close_raw_boundaries_until(out, boundaries, boundary)
           cur_boundary = boundary
         end
         out[#out + 1] = { string.format('--%s',
@@ -1277,10 +1302,8 @@ exports.remove_attachments = function(task, settings)
     elseif part:is_message() then
       if boundary then
         if cur_boundary and boundary ~= cur_boundary then
-          -- Need to close boundary
-          out[#out + 1] = { string.format('--%s--',
-              boundaries[#boundaries]), true }
-          table.remove(boundaries)
+          -- Need to close every boundary we are leaving behind
+          close_raw_boundaries_until(out, boundaries, boundary)
           cur_boundary = nil
         end
         out[#out + 1] = { string.format('--%s',
@@ -1292,10 +1315,8 @@ exports.remove_attachments = function(task, settings)
       if parts_indexes_to_keep[i] then
         if boundary then
           if cur_boundary and boundary ~= cur_boundary then
-            -- Need to close previous boundary
-            out[#out + 1] = { string.format('--%s--',
-                boundaries[#boundaries]), true }
-            table.remove(boundaries)
+            -- Need to close every boundary we are leaving behind
+            close_raw_boundaries_until(out, boundaries, boundary)
             cur_boundary = boundary
           end
           out[#out + 1] = { string.format('--%s',

--- a/test/lua/unit/lua_mime.remove_attachments.lua
+++ b/test/lua/unit/lua_mime.remove_attachments.lua
@@ -1,0 +1,298 @@
+--[[
+Boundary handling in lua_mime.remove_attachments.
+
+Regression coverage for the same defect fixed in add_text_footer: the part walk
+closed a single boundary when returning from a nested part to a shallower one,
+rather than every level it had actually left behind. One level is enough for a
+return of depth 2 -> 1, which is why the flat and single-nesting shapes always
+worked, but a return of depth 3 -> 1 leaves the intermediate boundary on the
+stack. Its closing delimiter is then emitted by the final unwind loop, after the
+part that follows -- so it lands inside that part's body as literal text.
+
+Reachable in production through `rspamadm mime strip`.
+
+Each case asserts structural invariants rather than exact bytes:
+  * every boundary is closed exactly once
+  * every inner boundary closes before the trailing top-level part begins
+  * kept text survives and the attachment is gone
+
+Assertions live in the test bodies rather than in the helpers: telescope injects
+assert_* into the environment of the test function only, so a helper defined at
+context scope would see them as nil.
+]]
+
+context("lua_mime.remove_attachments", function()
+  local rspamd_task = require "rspamd_task"
+  local rspamd_util = require "rspamd_util"
+  local rspamd_test_helper = require "rspamd_test_helper"
+  local lua_mime = require "lua_mime"
+
+  rspamd_test_helper.init_url_parser()
+  local cfg = rspamd_util.config_from_ucl(rspamd_test_helper.default_config(),
+      "INIT_URL,INIT_LIBS,INIT_SYMCACHE,INIT_VALIDATE,INIT_PRELOAD_MAPS")
+
+  -- Reassemble the body the way rspamadm mime strip does.
+  local function body_to_string(rewrite)
+    local buf = {}
+
+    for _, o in ipairs(rewrite.out) do
+      if type(o) == 'string' then
+        buf[#buf + 1] = o
+        buf[#buf + 1] = rewrite.newline_s
+      elseif type(o) == 'table' then
+        buf[#buf + 1] = tostring(o[1])
+
+        if o[2] then
+          buf[#buf + 1] = rewrite.newline_s
+        end
+      else
+        buf[#buf + 1] = tostring(o)
+      end
+    end
+
+    return table.concat(buf)
+  end
+
+  local function count_substr(haystack, needle)
+    local n = 0
+    local pos = 1
+
+    while true do
+      local s, e = string.find(haystack, needle, pos, true)
+
+      if not s then
+        break
+      end
+
+      n = n + 1
+      pos = e + 1
+    end
+
+    return n
+  end
+
+  -- Strip attachments and return everything wrong with the result. `inner` is
+  -- the list of boundaries nested below the top level; each must be closed
+  -- before TRAILINGMARKER, the kept part that follows the nested subtree.
+  local function strip_problems(message, inner)
+    local res, task = rspamd_task.load_from_string(message, cfg)
+
+    if not res or not task then
+      return { 'failed to load message' }
+    end
+
+    task:process_message()
+
+    local rewrite = lua_mime.remove_attachments(task, {})
+
+    if not rewrite or not rewrite.out then
+      task:destroy()
+      return { 'remove_attachments did not rewrite the message' }
+    end
+
+    local body = body_to_string(rewrite)
+    task:destroy()
+
+    local problems = {}
+
+    if not string.find(body, 'TRAILINGMARKER', 1, true) then
+      problems[#problems + 1] = 'the trailing text part is missing entirely'
+      return problems
+    end
+
+    if string.find(body, 'application/pdf', 1, true) then
+      problems[#problems + 1] = 'the attachment was not removed'
+    end
+
+    local trailing = string.find(body, 'TRAILINGMARKER', 1, true)
+
+    for _, b in ipairs(inner) do
+      local close = '--' .. b .. '--'
+      local n = count_substr(body, close)
+
+      if n ~= 1 then
+        problems[#problems + 1] = string.format(
+            'expected exactly one closing delimiter for %s, got %d', b, n)
+      end
+
+      local pos = string.find(body, close, 1, true)
+
+      if pos and pos > trailing then
+        problems[#problems + 1] = string.format(
+            'closing delimiter for %s lands at %d, after the trailing part at ' ..
+                '%d, so it is literal text inside that part rather than a delimiter',
+            b, pos, trailing)
+      end
+    end
+
+    if count_substr(body, '--outerbnd--') ~= 1 then
+      problems[#problems + 1] = 'expected exactly one top-level closing delimiter'
+    end
+
+    return problems
+  end
+
+  -- Control: nothing nested, so there is never more than one level to unwind.
+  local msg_flat = [[
+From: sender@example.com
+To: rcpt@example.com
+Subject: flat mixed
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outerbnd"
+
+--outerbnd
+Content-Type: text/plain; charset=us-ascii
+
+TRAILINGMARKER
+
+--outerbnd
+Content-Type: application/pdf
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="doc.pdf"
+
+JVBERi0xLjQKJcOkw7zDtsOfCg==
+
+--outerbnd--
+]]
+
+  -- Return of depth 2 -> 1: a single pop is still sufficient here, so this
+  -- shape passed both before and after the fix.
+  local msg_one_level = [[
+From: sender@example.com
+To: rcpt@example.com
+Subject: related then trailing text
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outerbnd"
+
+--outerbnd
+Content-Type: multipart/related; boundary="relbnd"
+
+--relbnd
+Content-Type: text/html; charset=us-ascii
+
+<html><body>html body</body></html>
+
+--relbnd--
+--outerbnd
+Content-Type: text/plain; charset=us-ascii
+
+TRAILINGMARKER
+
+--outerbnd
+Content-Type: application/pdf
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="doc.pdf"
+
+JVBERi0xLjQKJcOkw7zDtsOfCg==
+
+--outerbnd--
+]]
+
+  -- Return of depth 3 -> 1: the smallest shape that leaves a boundary behind.
+  local msg_two_levels = [[
+From: sender@example.com
+To: rcpt@example.com
+Subject: alternative over related then trailing text
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outerbnd"
+
+--outerbnd
+Content-Type: multipart/alternative; boundary="altbnd"
+
+--altbnd
+Content-Type: text/plain; charset=us-ascii
+
+alternative plain
+
+--altbnd
+Content-Type: multipart/related; boundary="relbnd"
+
+--relbnd
+Content-Type: text/html; charset=us-ascii
+
+<html><body>html body</body></html>
+
+--relbnd--
+--altbnd--
+--outerbnd
+Content-Type: text/plain; charset=us-ascii
+
+TRAILINGMARKER
+
+--outerbnd
+Content-Type: application/pdf
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="doc.pdf"
+
+JVBERi0xLjQKJcOkw7zDtsOfCg==
+
+--outerbnd--
+]]
+
+  -- Return of depth 4 -> 1: the number of boundaries left behind grows with
+  -- nesting depth, so both altbnd and midbnd leak here.
+  local msg_three_levels = [[
+From: sender@example.com
+To: rcpt@example.com
+Subject: three levels then trailing text
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outerbnd"
+
+--outerbnd
+Content-Type: multipart/mixed; boundary="midbnd"
+
+--midbnd
+Content-Type: multipart/alternative; boundary="altbnd"
+
+--altbnd
+Content-Type: text/plain; charset=us-ascii
+
+alternative plain
+
+--altbnd
+Content-Type: multipart/related; boundary="relbnd"
+
+--relbnd
+Content-Type: text/html; charset=us-ascii
+
+<html><body>html body</body></html>
+
+--relbnd--
+--altbnd--
+--midbnd--
+--outerbnd
+Content-Type: text/plain; charset=us-ascii
+
+TRAILINGMARKER
+
+--outerbnd
+Content-Type: application/pdf
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="doc.pdf"
+
+JVBERi0xLjQKJcOkw7zDtsOfCg==
+
+--outerbnd--
+]]
+
+  test("flat multipart/mixed is unaffected", function()
+    local problems = strip_problems(msg_flat, {})
+    assert_equal(#problems, 0, table.concat(problems, '; '))
+  end)
+
+  test("single level of nesting closes cleanly", function()
+    local problems = strip_problems(msg_one_level, { 'relbnd' })
+    assert_equal(#problems, 0, table.concat(problems, '; '))
+  end)
+
+  test("two levels of nesting unwind before the trailing part", function()
+    local problems = strip_problems(msg_two_levels, { 'relbnd', 'altbnd' })
+    assert_equal(#problems, 0, table.concat(problems, '; '))
+  end)
+
+  test("three levels of nesting unwind before the trailing part", function()
+    local problems = strip_problems(msg_three_levels,
+        { 'relbnd', 'altbnd', 'midbnd' })
+    assert_equal(#problems, 0, table.concat(problems, '; '))
+  end)
+end)


### PR DESCRIPTION
Follow-up to #6173. That PR fixed the fixed-count boundary close in `add_text_footer` and noted that `multipattern_text_replace` and `remove_attachments` still had the same pattern, left alone because nothing had been reproduced there. This reproduces it for `remove_attachments`.

## The defect

When the part walk returns from a nested part to a shallower one, both functions emit one closing delimiter and pop one stack entry, however many levels they actually left behind:

```lua
if cur_boundary and boundary ~= cur_boundary then
  -- Need to close boundary
  out[#out + 1] = { string.format('--%s--', boundaries[#boundaries]), true }
  table.remove(boundaries)
  cur_boundary = boundary
end
```

A return of depth 2 → 1 needs exactly one pop, which is why flat and singly-nested messages have always been fine. A return of depth 3 → 1 leaves the intermediate boundary on the stack; the final unwind loop then emits its closing delimiter *after* the part that follows, so it lands inside that part's body as literal text. The number of delimiters that leak grows with nesting depth.

Unlike the `add_text_footer` case, **no parts are lost** — the output still parses and the leaf count is unchanged. The damage is delimiter text appearing inside message content.

## Reproduction

`rspamadm mime strip` is the one in-tree caller of `remove_attachments`. Running it over `multipart/mixed > multipart/alternative > multipart/related` followed by a kept text part, on unmodified `master`:

```
--BBB--
--AAA
Content-Type: text/plain; charset=us-ascii

trailing outer text

--CCC--          <-- multipart/alternative's delimiter, now body text
--AAA--
```

`--CCC--` should have been emitted immediately after `--BBB--`. Adding a fourth level leaks `--DDD--` as well.

Across five fixtures, on `master`:

| fixture | verdict |
|---|---|
| flat `multipart/mixed` | OK |
| `related` then outer text (depth 2 → 1) | OK |
| `alternative > related` then outer text (depth 3 → 1) | **stray `CCC` in text/plain** |
| one level deeper (depth 4 → 1) | **stray `CCC` and `DDD` in text/plain** |
| nested `message/rfc822` | OK |

With this change all five are clean, and the fixed output closes `--BBB-- --CCC-- --DDD--` in order before `--AAA`.

## The change

These two functions keep a stack of plain boundary strings and emit `{text, is_raw}` pairs, whereas `add_text_footer` keeps `{boundary = ...}` records and emits strings. `close_boundaries_until` therefore cannot be called from them directly, so this adds the same unwind for that shape — including its "target is not on the stack" fallback of closing exactly one level, which is what keeps `message/rfc822` handling unchanged.

Generalising one helper across both shapes would need an accessor plus an emitter callback; that seemed worse than a second small function, but I'll happily fold them together if you prefer.

**`multipattern_text_replace` has no callers anywhere in the tree.** The same change is applied there by symmetry with its reproduced twin, but it is not exercised by the tests and I could not construct a reproduction for it. Say the word if you would rather it were left untouched, or removed.

## Tests

`test/lua/unit/lua_mime.remove_attachments.lua` covers flat, one-, two- and three-level nesting, asserting structural invariants (each boundary closed exactly once, every inner boundary closed before the trailing part begins, kept text present and attachment gone) rather than exact bytes.

They discriminate rather than merely pass:

* unmodified module — **2 passed, 2 failed**, the two nested cases, e.g. `closing delimiter for altbnd lands at 372, after the trailing part at 356`
* with this change — **4 passed**

The two flat cases pass either way; they are there to show the fix does not disturb shapes that already worked.

## Verification

* Full Lua unit suite: 1212 tests, 1209 passed, 0 failed, 0 errors (3 pre-existing unassertive).
* `lua_mime.add_text_footer` suite from #6173: 3/3, so that behaviour is unchanged.
* Full functional suite, both CI phases: 779 + 101 = 880 tests, 0 failures.
* `luacheck -q --no-color lualib/lua_mime.lua` via `pipelinecomponents/luacheck`: 0 warnings, 0 errors.
