### PR TITLE
[Feature] fuzzy: sender facts extension and a forward compatible extensions parser

### DIFF
--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -993,6 +993,76 @@ fuzzy_peer_send_io(EV_P_ ev_io *w, int revents)
 	fuzzy_peer_request_release(up_req);
 }
 
+/*
+ * Decodes the sender facts bit field and sets the `sender` field of the
+ * extensions table that must be on the top of the stack.
+ *
+ * Values are pushed as strings: a handler should not need to reimplement this
+ * table and the raw numbers mean nothing in a log line. Fields that the sender
+ * facts describe as absent or unknown are not set at all.
+ */
+static void
+rspamd_fuzzy_sender_facts_tolua(lua_State *L,
+								struct rspamd_fuzzy_cmd_extension *ext)
+{
+	uint32_t val;
+	unsigned int cls;
+	const char *str;
+
+	/* The parser rejects any other length, this is merely belt and braces */
+	if (ext->length < RSPAMD_FUZZY_SENDER_FACTS_LEN) {
+		return;
+	}
+
+	memcpy(&val, ext->payload, sizeof(val));
+	val = GUINT32_FROM_BE(val);
+	cls = (val >> RSPAMD_FUZZY_SENDER_FACTS_CLASS_SHIFT) &
+		  RSPAMD_FUZZY_SENDER_FACTS_CLASS_MASK;
+
+	if (cls != RSPAMD_FUZZY_SENDER_FACTS_CLASS_V0) {
+		/* Some future layout we know nothing about */
+		return;
+	}
+
+	lua_createtable(L, 0, 7);
+
+	if ((str = rspamd_fuzzy_sf_spf_str((val >> RSPAMD_FUZZY_SF_SPF_SHIFT) &
+									   RSPAMD_FUZZY_SF_SPF_MASK)) != NULL) {
+		lua_pushstring(L, str);
+		lua_setfield(L, -2, "spf");
+	}
+
+	if ((str = rspamd_fuzzy_sf_dkim_str((val >> RSPAMD_FUZZY_SF_DKIM_SHIFT) &
+										RSPAMD_FUZZY_SF_DKIM_MASK)) != NULL) {
+		lua_pushstring(L, str);
+		lua_setfield(L, -2, "dkim");
+	}
+
+	if ((str = rspamd_fuzzy_sf_dmarc_str((val >> RSPAMD_FUZZY_SF_DMARC_SHIFT) &
+										 RSPAMD_FUZZY_SF_DMARC_MASK)) != NULL) {
+		lua_pushstring(L, str);
+		lua_setfield(L, -2, "dmarc");
+	}
+
+	if ((str = rspamd_fuzzy_sf_ptr_str((val >> RSPAMD_FUZZY_SF_PTR_SHIFT) &
+									   RSPAMD_FUZZY_SF_PTR_MASK)) != NULL) {
+		lua_pushstring(L, str);
+		lua_setfield(L, -2, "ptr");
+	}
+
+	lua_pushboolean(L, (val >> RSPAMD_FUZZY_SF_PTR_GENERIC_SHIFT) & 1u);
+	lua_setfield(L, -2, "ptr_generic");
+
+	lua_pushstring(L, rspamd_fuzzy_sf_rcpts_str((val >> RSPAMD_FUZZY_SF_RCPTS_SHIFT) &
+												RSPAMD_FUZZY_SF_RCPTS_MASK));
+	lua_setfield(L, -2, "rcpts");
+
+	lua_pushboolean(L, (val >> RSPAMD_FUZZY_SF_TLS_SHIFT) & 1u);
+	lua_setfield(L, -2, "tls");
+
+	lua_setfield(L, -2, "sender");
+}
+
 static void
 rspamd_fuzzy_extensions_tolua(lua_State *L,
 							  struct fuzzy_session *session)
@@ -1020,6 +1090,9 @@ rspamd_fuzzy_extensions_tolua(lua_State *L,
 			rspamd_lua_ip_push(L, addr);
 			rspamd_inet_address_free(addr);
 			lua_setfield(L, -2, "ip");
+			break;
+		case RSPAMD_FUZZY_EXT_SENDER_FACTS:
+			rspamd_fuzzy_sender_facts_tolua(L, ext);
 			break;
 		}
 	}
@@ -1824,140 +1897,6 @@ rspamd_fuzzy_decrypt_command(struct fuzzy_session *s, unsigned char *buf, gsize 
 
 
 static gboolean
-rspamd_fuzzy_extensions_from_wire(struct fuzzy_session *s, unsigned char *buf, gsize buflen)
-{
-	struct rspamd_fuzzy_cmd_extension *ext, *prev_ext;
-	unsigned char *storage, *p = buf, *end = buf + buflen;
-	gsize st_len = 0, n_ext = 0;
-
-	/* Read number of extensions to allocate array */
-	while (p < end) {
-		unsigned char cmd = *p++;
-
-		if (p < end) {
-			if (cmd == RSPAMD_FUZZY_EXT_SOURCE_DOMAIN) {
-				/* Next byte is buf length */
-				unsigned char dom_len = *p++;
-
-				if (dom_len <= (end - p)) {
-					st_len += dom_len;
-					n_ext++;
-				}
-				else {
-					/* Truncation */
-					return FALSE;
-				}
-
-				p += dom_len;
-			}
-			else if (cmd == RSPAMD_FUZZY_EXT_SOURCE_IP4) {
-				if (end - p >= sizeof(in_addr_t)) {
-					n_ext++;
-					st_len += sizeof(in_addr_t);
-				}
-				else {
-					/* Truncation */
-					return FALSE;
-				}
-
-				p += sizeof(in_addr_t);
-			}
-			else if (cmd == RSPAMD_FUZZY_EXT_SOURCE_IP6) {
-				if (end - p >= sizeof(struct in6_addr)) {
-					n_ext++;
-					st_len += sizeof(struct in6_addr);
-				}
-				else {
-					/* Truncation */
-					return FALSE;
-				}
-
-				p += sizeof(struct in6_addr);
-			}
-			else {
-				/* Invalid command */
-				return FALSE;
-			}
-		}
-		else {
-			/* Truncated extension */
-			return FALSE;
-		}
-	}
-
-	if (n_ext > 0) {
-		p = buf;
-		/*
-		 * Memory layout: n_ext of struct rspamd_fuzzy_cmd_extension
-		 *                payload for each extension in a continuous data segment
-		 */
-		storage = g_malloc(n_ext * sizeof(struct rspamd_fuzzy_cmd_extension) +
-						   st_len);
-
-		unsigned char *data_buf = storage +
-								  n_ext * sizeof(struct rspamd_fuzzy_cmd_extension);
-		ext = (struct rspamd_fuzzy_cmd_extension *) storage;
-
-		/* All validation has been done, so we can just go further */
-		while (p < end) {
-			prev_ext = ext;
-			unsigned char cmd = *p++;
-
-			if (cmd == RSPAMD_FUZZY_EXT_SOURCE_DOMAIN) {
-				/* Next byte is buf length */
-				unsigned char dom_len = *p++;
-				unsigned char *dest = data_buf;
-
-				ext->ext = RSPAMD_FUZZY_EXT_SOURCE_DOMAIN;
-				ext->next = ext + 1;
-				ext->length = dom_len;
-				ext->payload = dest;
-				memcpy(dest, p, dom_len);
-				p += dom_len;
-				data_buf += dom_len;
-				ext = ext->next;
-			}
-			else if (cmd == RSPAMD_FUZZY_EXT_SOURCE_IP4) {
-				unsigned char *dest = data_buf;
-
-				ext->ext = RSPAMD_FUZZY_EXT_SOURCE_IP4;
-				ext->next = ext + 1;
-				ext->length = sizeof(in_addr_t);
-				ext->payload = dest;
-				memcpy(dest, p, sizeof(in_addr_t));
-				p += sizeof(in_addr_t);
-				data_buf += sizeof(in_addr_t);
-				ext = ext->next;
-			}
-			else if (cmd == RSPAMD_FUZZY_EXT_SOURCE_IP6) {
-				unsigned char *dest = data_buf;
-
-				ext->ext = RSPAMD_FUZZY_EXT_SOURCE_IP6;
-				ext->next = ext + 1;
-				ext->length = sizeof(struct in6_addr);
-				ext->payload = dest;
-				memcpy(dest, p, sizeof(struct in6_addr));
-				p += sizeof(struct in6_addr);
-				data_buf += sizeof(struct in6_addr);
-				ext = ext->next;
-			}
-			else {
-				g_assert_not_reached();
-			}
-		}
-
-		/* Last next should be NULL */
-		prev_ext->next = NULL;
-
-		/* Rewind to the begin */
-		ext = (struct rspamd_fuzzy_cmd_extension *) storage;
-		s->extensions = ext;
-	}
-
-	return TRUE;
-}
-
-static gboolean
 rspamd_fuzzy_cmd_from_wire(unsigned char *buf, unsigned int buflen, struct fuzzy_session *s)
 {
 	enum rspamd_fuzzy_epoch epoch;
@@ -2044,8 +1983,9 @@ rspamd_fuzzy_cmd_from_wire(unsigned char *buf, unsigned int buflen, struct fuzzy
 
 	if (buflen > 0) {
 		/* Process possible extensions */
-		if (!rspamd_fuzzy_extensions_from_wire(s, buf, buflen)) {
-			msg_debug("truncated fuzzy shingles command of size %d received", buflen);
+		if (!rspamd_fuzzy_extensions_from_wire(buf, buflen, &s->extensions)) {
+			msg_debug("malformed extensions in a fuzzy command of size %d received",
+					  buflen);
 			return FALSE;
 		}
 	}

--- a/src/libserver/CMakeLists.txt
+++ b/src/libserver/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(LIBRSPAMDSERVERSRC
         ${CMAKE_CURRENT_SOURCE_DIR}/fuzzy_storage_keys.c
         ${CMAKE_CURRENT_SOURCE_DIR}/fuzzy_storage_ratelimit.c
         ${CMAKE_CURRENT_SOURCE_DIR}/fuzzy_storage_stat.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/fuzzy_wire.c
         ${CMAKE_CURRENT_SOURCE_DIR}/milter.c
         ${CMAKE_CURRENT_SOURCE_DIR}/monitored.c
         ${CMAKE_CURRENT_SOURCE_DIR}/multipart_form.cxx

--- a/src/libserver/fuzzy_wire.c
+++ b/src/libserver/fuzzy_wire.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include "fuzzy_wire.h"
+
+enum rspamd_fuzzy_ext_step {
+	RSPAMD_FUZZY_EXT_STEP_KNOWN,
+	RSPAMD_FUZZY_EXT_STEP_SKIP,
+	RSPAMD_FUZZY_EXT_STEP_ERROR,
+};
+
+/*
+ * Decode a single TLV entry starting at *pp (which must be less than end) and
+ * advance *pp past it. The buffer is never modified, payload points inside it.
+ */
+static enum rspamd_fuzzy_ext_step
+rspamd_fuzzy_ext_next(const unsigned char **pp, const unsigned char *end,
+					  unsigned char *type, const unsigned char **payload,
+					  unsigned int *length)
+{
+	const unsigned char *p = *pp;
+	unsigned char t = *p++;
+	unsigned int len;
+	gboolean known;
+
+	switch (t) {
+	case RSPAMD_FUZZY_EXT_SOURCE_IP4:
+		len = sizeof(struct in_addr);
+		known = TRUE;
+		break;
+	case RSPAMD_FUZZY_EXT_SOURCE_IP6:
+		len = sizeof(struct in6_addr);
+		known = TRUE;
+		break;
+	case RSPAMD_FUZZY_EXT_SOURCE_DOMAIN:
+		if (p >= end) {
+			/* Truncated length byte */
+			return RSPAMD_FUZZY_EXT_STEP_ERROR;
+		}
+
+		len = *p++;
+		known = TRUE;
+		break;
+	default:
+		if (t < RSPAMD_FUZZY_EXT_SKIPPABLE_MIN) {
+			/*
+			 * A legacy type we do not know: its length is implied by the type,
+			 * so we cannot tell where this entry ends
+			 */
+			return RSPAMD_FUZZY_EXT_STEP_ERROR;
+		}
+
+		if (p >= end) {
+			/* Truncated length byte */
+			return RSPAMD_FUZZY_EXT_STEP_ERROR;
+		}
+
+		len = *p++;
+
+		if (t == RSPAMD_FUZZY_EXT_SENDER_FACTS) {
+			if (len != RSPAMD_FUZZY_SENDER_FACTS_LEN) {
+				/*
+				 * We do know this type and it is fixed width, so a different
+				 * length is a malformed packet rather than a dialect from the
+				 * future: anything that needs a wider payload has to take a
+				 * new type byte instead of growing this one
+				 */
+				return RSPAMD_FUZZY_EXT_STEP_ERROR;
+			}
+
+			known = TRUE;
+		}
+		else {
+			known = FALSE;
+		}
+		break;
+	}
+
+	if (len > (gsize) (end - p)) {
+		/* Truncation */
+		return RSPAMD_FUZZY_EXT_STEP_ERROR;
+	}
+
+	*type = t;
+	*payload = p;
+	*length = len;
+	*pp = p + len;
+
+	return known ? RSPAMD_FUZZY_EXT_STEP_KNOWN : RSPAMD_FUZZY_EXT_STEP_SKIP;
+}
+
+gboolean
+rspamd_fuzzy_extensions_from_wire(const unsigned char *buf, gsize buflen,
+								  struct rspamd_fuzzy_cmd_extension **res)
+{
+	const unsigned char *p, *end = buf + buflen, *payload;
+	struct rspamd_fuzzy_cmd_extension *exts;
+	unsigned char *storage, *data_buf;
+	unsigned char type;
+	unsigned int length;
+	gsize st_len = 0, n_ext = 0, i;
+
+	g_assert(res != NULL);
+	*res = NULL;
+
+	/* First pass: validate everything and count what we can store */
+	for (p = buf; p < end;) {
+		switch (rspamd_fuzzy_ext_next(&p, end, &type, &payload, &length)) {
+		case RSPAMD_FUZZY_EXT_STEP_KNOWN:
+			n_ext++;
+			st_len += length;
+			break;
+		case RSPAMD_FUZZY_EXT_STEP_SKIP:
+			break;
+		default:
+			return FALSE;
+		}
+	}
+
+	if (n_ext == 0) {
+		return TRUE;
+	}
+
+	/*
+	 * Memory layout: n_ext of struct rspamd_fuzzy_cmd_extension
+	 *                payload for each extension in a continuous data segment
+	 */
+	storage = g_malloc(n_ext * sizeof(struct rspamd_fuzzy_cmd_extension) + st_len);
+	exts = (struct rspamd_fuzzy_cmd_extension *) storage;
+	data_buf = storage + n_ext * sizeof(struct rspamd_fuzzy_cmd_extension);
+
+	/* Second pass: the buffer has been validated, so merely copy the payloads */
+	for (p = buf, i = 0; p < end && i < n_ext;) {
+		enum rspamd_fuzzy_ext_step step = rspamd_fuzzy_ext_next(&p, end, &type,
+																&payload, &length);
+
+		if (step == RSPAMD_FUZZY_EXT_STEP_SKIP) {
+			continue;
+		}
+		else if (step != RSPAMD_FUZZY_EXT_STEP_KNOWN) {
+			/* Cannot happen as the first pass has validated the buffer */
+			break;
+		}
+
+		exts[i].ext = type;
+		exts[i].length = length;
+		exts[i].payload = data_buf;
+		exts[i].next = NULL;
+		memcpy(data_buf, payload, length);
+		data_buf += length;
+
+		if (i > 0) {
+			exts[i - 1].next = &exts[i];
+		}
+
+		i++;
+	}
+
+	if (i == 0) {
+		g_free(storage);
+
+		return TRUE;
+	}
+
+	*res = exts;
+
+	return TRUE;
+}

--- a/src/libserver/fuzzy_wire.h
+++ b/src/libserver/fuzzy_wire.h
@@ -156,10 +156,30 @@ RSPAMD_PACKED(rspamd_fuzzy_encrypted_reply_v2)
 
 static const unsigned char fuzzy_encrypted_magic[4] = {'r', 's', 'f', 'e'};
 
+/*
+ * Extensions are a sequence of TLV entries appended to a fuzzy command.
+ *
+ * Framing depends on the type byte:
+ *
+ * - types below RSPAMD_FUZZY_EXT_SKIPPABLE_MIN are legacy ones where the
+ *   length is implied by the type itself. A parser that does not know such a
+ *   type cannot tell where the entry ends, so it has no choice but to reject
+ *   the whole command;
+ * - types starting from RSPAMD_FUZZY_EXT_SKIPPABLE_MIN are always followed by
+ *   a single length byte, so an unknown entry in that range can be skipped
+ *   and the remaining extensions are still parsed.
+ *
+ * Hence, all new extensions MUST use the skippable range.
+ */
+#define RSPAMD_FUZZY_EXT_SKIPPABLE_MIN 0x80
+
 enum rspamd_fuzzy_extension_type {
-	RSPAMD_FUZZY_EXT_SOURCE_DOMAIN = 'd',
-	RSPAMD_FUZZY_EXT_SOURCE_IP4 = '4',
-	RSPAMD_FUZZY_EXT_SOURCE_IP6 = '6',
+	/* Legacy types, implicit length */
+	RSPAMD_FUZZY_EXT_SOURCE_DOMAIN = 'd', /* length byte + MIME From domain */
+	RSPAMD_FUZZY_EXT_SOURCE_IP4 = '4',    /* 4 bytes */
+	RSPAMD_FUZZY_EXT_SOURCE_IP6 = '6',    /* 16 bytes */
+	/* Skippable types, explicit length byte */
+	RSPAMD_FUZZY_EXT_SENDER_FACTS = 0x80, /* 4 bytes, big endian bit field */
 };
 
 struct rspamd_fuzzy_cmd_extension {
@@ -168,6 +188,163 @@ struct rspamd_fuzzy_cmd_extension {
 	struct rspamd_fuzzy_cmd_extension *next;
 	unsigned char *payload;
 };
+
+/**
+ * Parse the wire representation of the command extensions.
+ *
+ * Unknown types in the skippable range are ignored, everything else that
+ * cannot be understood or does not fit into the buffer is an error.
+ *
+ * @param buf start of the extensions area
+ * @param buflen its length
+ * @param res on success set to the head of the extensions list or to NULL if
+ *            there were no extensions we know about; the list is a single
+ *            allocation that must be released by one g_free()
+ * @return FALSE if the extensions area is malformed
+ */
+gboolean rspamd_fuzzy_extensions_from_wire(const unsigned char *buf, gsize buflen,
+										   struct rspamd_fuzzy_cmd_extension **res);
+
+/*
+ * RSPAMD_FUZZY_EXT_SENDER_FACTS payload: a big endian uint32 describing the
+ * sender (and only the sender: never the recipient, the local users or the
+ * local policy).
+ *
+ * The top 8 bits are a class byte that allows the meaning of the remaining 24
+ * bits to be redefined later without spending another extension type. The
+ * layout below is class 0, any other class must be ignored by a reader that
+ * does not know it.
+ *
+ * The payload is exactly RSPAMD_FUZZY_SENDER_FACTS_LEN bytes and the parser
+ * rejects any other length: since the type is known, a different length is a
+ * malformed packet. Should a wider payload ever be needed it has to take a new
+ * type byte from the skippable range (which older parsers then skip) rather
+ * than grow this one (which they could not).
+ */
+#define RSPAMD_FUZZY_SENDER_FACTS_LEN 4
+#define RSPAMD_FUZZY_SENDER_FACTS_CLASS_SHIFT 24
+#define RSPAMD_FUZZY_SENDER_FACTS_CLASS_MASK 0xffu
+#define RSPAMD_FUZZY_SENDER_FACTS_CLASS_V0 0
+
+#define RSPAMD_FUZZY_SF_SPF_SHIFT 0
+#define RSPAMD_FUZZY_SF_SPF_MASK 0x7u
+#define RSPAMD_FUZZY_SF_DKIM_SHIFT 3
+#define RSPAMD_FUZZY_SF_DKIM_MASK 0x7u
+#define RSPAMD_FUZZY_SF_DMARC_SHIFT 6
+#define RSPAMD_FUZZY_SF_DMARC_MASK 0x7u
+#define RSPAMD_FUZZY_SF_PTR_SHIFT 9
+#define RSPAMD_FUZZY_SF_PTR_MASK 0x3u
+#define RSPAMD_FUZZY_SF_PTR_GENERIC_SHIFT 11
+#define RSPAMD_FUZZY_SF_RCPTS_SHIFT 12
+#define RSPAMD_FUZZY_SF_RCPTS_MASK 0x3u
+#define RSPAMD_FUZZY_SF_TLS_SHIFT 14
+/* Bits 15..23: reserved, written as zero and ignored on read */
+#define RSPAMD_FUZZY_SF_RESERVED_MASK 0xff8000u
+
+enum rspamd_fuzzy_sf_spf {
+	RSPAMD_FUZZY_SF_SPF_ABSENT = 0,
+	RSPAMD_FUZZY_SF_SPF_NONE,
+	RSPAMD_FUZZY_SF_SPF_PASS,
+	RSPAMD_FUZZY_SF_SPF_FAIL,
+	RSPAMD_FUZZY_SF_SPF_SOFTFAIL,
+	RSPAMD_FUZZY_SF_SPF_NEUTRAL,
+	RSPAMD_FUZZY_SF_SPF_PERMERROR,
+	RSPAMD_FUZZY_SF_SPF_TEMPERROR,
+};
+
+enum rspamd_fuzzy_sf_dkim {
+	RSPAMD_FUZZY_SF_DKIM_ABSENT = 0,
+	RSPAMD_FUZZY_SF_DKIM_NONE,
+	RSPAMD_FUZZY_SF_DKIM_PASS,
+	RSPAMD_FUZZY_SF_DKIM_FAIL,
+	RSPAMD_FUZZY_SF_DKIM_PERMERROR,
+	RSPAMD_FUZZY_SF_DKIM_TEMPERROR,
+};
+
+enum rspamd_fuzzy_sf_dmarc {
+	RSPAMD_FUZZY_SF_DMARC_ABSENT = 0,
+	RSPAMD_FUZZY_SF_DMARC_NO_RECORD,
+	RSPAMD_FUZZY_SF_DMARC_PASS,
+	RSPAMD_FUZZY_SF_DMARC_FAIL_NONE,
+	RSPAMD_FUZZY_SF_DMARC_FAIL_QUARANTINE,
+	RSPAMD_FUZZY_SF_DMARC_FAIL_REJECT,
+	RSPAMD_FUZZY_SF_DMARC_PERMERROR,
+	RSPAMD_FUZZY_SF_DMARC_TEMPERROR,
+};
+
+enum rspamd_fuzzy_sf_ptr {
+	RSPAMD_FUZZY_SF_PTR_UNKNOWN = 0,
+	RSPAMD_FUZZY_SF_PTR_NONE,
+	RSPAMD_FUZZY_SF_PTR_PRESENT,
+	RSPAMD_FUZZY_SF_PTR_CONFIRMED,
+};
+
+enum rspamd_fuzzy_sf_rcpts {
+	RSPAMD_FUZZY_SF_RCPTS_ONE = 0,
+	RSPAMD_FUZZY_SF_RCPTS_FEW,  /* 2..5 */
+	RSPAMD_FUZZY_SF_RCPTS_MANY, /* 6..20 */
+	RSPAMD_FUZZY_SF_RCPTS_BULK, /* 21+ */
+};
+
+static inline uint32_t
+rspamd_fuzzy_sf_pack(unsigned int spf, unsigned int dkim, unsigned int dmarc,
+					 unsigned int ptr, gboolean ptr_generic,
+					 unsigned int rcpts, gboolean tls)
+{
+	return ((spf & RSPAMD_FUZZY_SF_SPF_MASK) << RSPAMD_FUZZY_SF_SPF_SHIFT) |
+		   ((dkim & RSPAMD_FUZZY_SF_DKIM_MASK) << RSPAMD_FUZZY_SF_DKIM_SHIFT) |
+		   ((dmarc & RSPAMD_FUZZY_SF_DMARC_MASK) << RSPAMD_FUZZY_SF_DMARC_SHIFT) |
+		   ((ptr & RSPAMD_FUZZY_SF_PTR_MASK) << RSPAMD_FUZZY_SF_PTR_SHIFT) |
+		   ((ptr_generic ? 1u : 0u) << RSPAMD_FUZZY_SF_PTR_GENERIC_SHIFT) |
+		   ((rcpts & RSPAMD_FUZZY_SF_RCPTS_MASK) << RSPAMD_FUZZY_SF_RCPTS_SHIFT) |
+		   ((tls ? 1u : 0u) << RSPAMD_FUZZY_SF_TLS_SHIFT) |
+		   ((uint32_t) RSPAMD_FUZZY_SENDER_FACTS_CLASS_V0
+			<< RSPAMD_FUZZY_SENDER_FACTS_CLASS_SHIFT);
+}
+
+static inline const char *
+rspamd_fuzzy_sf_spf_str(unsigned int v)
+{
+	static const char *tbl[] = {NULL, "none", "pass", "fail", "softfail",
+								"neutral", "permerror", "temperror"};
+
+	return v < G_N_ELEMENTS(tbl) ? tbl[v] : NULL;
+}
+
+static inline const char *
+rspamd_fuzzy_sf_dkim_str(unsigned int v)
+{
+	static const char *tbl[] = {NULL, "none", "pass", "fail", "permerror",
+								"temperror"};
+
+	return v < G_N_ELEMENTS(tbl) ? tbl[v] : NULL;
+}
+
+static inline const char *
+rspamd_fuzzy_sf_dmarc_str(unsigned int v)
+{
+	static const char *tbl[] = {NULL, "no_record", "pass", "fail_none",
+								"fail_quarantine", "fail_reject", "permerror",
+								"temperror"};
+
+	return v < G_N_ELEMENTS(tbl) ? tbl[v] : NULL;
+}
+
+static inline const char *
+rspamd_fuzzy_sf_ptr_str(unsigned int v)
+{
+	static const char *tbl[] = {NULL, "none", "present", "confirmed"};
+
+	return v < G_N_ELEMENTS(tbl) ? tbl[v] : NULL;
+}
+
+static inline const char *
+rspamd_fuzzy_sf_rcpts_str(unsigned int v)
+{
+	static const char *tbl[] = {"1", "2-5", "6-20", "21+"};
+
+	return v < G_N_ELEMENTS(tbl) ? tbl[v] : NULL;
+}
 
 struct rspamd_fuzzy_stat_entry {
 	const char *name;

--- a/src/libserver/mempool_vars_internal.h
+++ b/src/libserver/mempool_vars_internal.h
@@ -38,6 +38,12 @@
  */
 #define RSPAMD_MEMPOOL_SPF_RESULT "spf_result"
 #define RSPAMD_MEMPOOL_DMARC_RESULT "dmarc_result"
+/*
+ * Set by the hfilter module to a gboolean telling whether the PTR name of the
+ * sender matches one of its generic/dynamic naming patterns. Absent when
+ * hfilter or its hostname checks are disabled, or when there is no PTR name.
+ */
+#define RSPAMD_MEMPOOL_HOSTNAME_GENERIC "hostname_generic"
 #define RSPAMD_MEMPOOL_PRINCIPAL_RECIPIENT "principal_recipient"
 #define RSPAMD_MEMPOOL_PROFILE "profile"
 #define RSPAMD_MEMPOOL_MILTER_REPLY "milter_reply"

--- a/src/libserver/mempool_vars_internal.h
+++ b/src/libserver/mempool_vars_internal.h
@@ -25,6 +25,19 @@
 #define RSPAMD_MEMPOOL_MTA_NAME "MTA-Name"
 #define RSPAMD_MEMPOOL_SPF_DOMAIN "spf_domain"
 #define RSPAMD_MEMPOOL_SPF_RECORD "spf_record"
+/*
+ * Policy results published by the spf and dmarc modules so that other modules
+ * do not have to reimplement them by matching the (configurable) symbol names.
+ *
+ * spf_result: none, pass, fail, softfail, neutral, permerror, temperror
+ * dmarc_result: no_record, pass, fail_none, fail_quarantine, fail_reject,
+ *               permerror, temperror
+ *
+ * Both are plain NUL terminated strings and are simply absent if the
+ * corresponding check has not been performed.
+ */
+#define RSPAMD_MEMPOOL_SPF_RESULT "spf_result"
+#define RSPAMD_MEMPOOL_DMARC_RESULT "dmarc_result"
 #define RSPAMD_MEMPOOL_PRINCIPAL_RECIPIENT "principal_recipient"
 #define RSPAMD_MEMPOOL_PROFILE "profile"
 #define RSPAMD_MEMPOOL_MILTER_REPLY "milter_reply"

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -39,6 +39,7 @@
 #include "libmime/images.h"
 #include "libserver/worker_util.h"
 #include "libserver/mempool_vars_internal.h"
+#include "libserver/dkim.h"
 #include "libserver/html/html_features.h"
 #include "khash.h"
 #include "fuzzy_wire.h"
@@ -3052,6 +3053,30 @@ int fuzzy_check_module_config(struct rspamd_config *cfg, bool validate)
 		/* We want that to check bad mime attachments */
 		rspamd_symcache_add_delayed_dependency(cfg->cache,
 											   "FUZZY_CALLBACK", "MIME_TYPES_CALLBACK", FALSE);
+
+		/*
+		 * If at least one rule can share the extensions then we need the
+		 * results of the authentication checks to be there by the time the
+		 * commands are built, otherwise the sender facts would always be sent
+		 * as absent. These are ordering dependencies only (hard = FALSE): a
+		 * check that is disabled or that has not concluded merely means the
+		 * corresponding field is reported as absent.
+		 */
+		struct fuzzy_rule *rule;
+		unsigned int i;
+
+		PTR_ARRAY_FOREACH(fuzzy_module_ctx->fuzzy_rules, i, rule)
+		{
+			if (!rule->no_share && fuzzy_rule_has_encryption(rule)) {
+				rspamd_symcache_add_delayed_dependency(cfg->cache,
+													   "FUZZY_CALLBACK", "SPF_CHECK", FALSE);
+				rspamd_symcache_add_delayed_dependency(cfg->cache,
+													   "FUZZY_CALLBACK", "DKIM_CHECK", FALSE);
+				rspamd_symcache_add_delayed_dependency(cfg->cache,
+													   "FUZZY_CALLBACK", "DMARC_CHECK", FALSE);
+				break;
+			}
+		}
 	}
 
 	if (fuzzy_module_ctx->fuzzy_rules == NULL) {
@@ -3589,6 +3614,168 @@ fuzzy_rule_shares_extensions(struct rspamd_task *task,
 	return TRUE;
 }
 
+/*
+ * Map a policy result published by the spf/dmarc modules back to its wire
+ * value using the very same table the storage decodes it with
+ */
+static unsigned int
+fuzzy_sf_from_str(const char *str, const char *(*to_str)(unsigned int),
+				  unsigned int max)
+{
+	if (str != NULL) {
+		for (unsigned int i = 1; i <= max; i++) {
+			const char *known = to_str(i);
+
+			if (known != NULL && strcmp(str, known) == 0) {
+				return i;
+			}
+		}
+	}
+
+	/* Absent or something we do not know about */
+	return 0;
+}
+
+static unsigned int
+fuzzy_sf_dkim(struct rspamd_task *task)
+{
+	struct rspamd_dkim_check_result **pres, **cur;
+	gboolean has_fail = FALSE, has_permerror = FALSE, has_temperror = FALSE;
+
+	pres = rspamd_mempool_get_variable(task->task_pool,
+									   RSPAMD_MEMPOOL_DKIM_CHECK_RESULTS);
+
+	if (pres == NULL) {
+		/*
+		 * Either there was nothing to check or the dkim module has not run
+		 * (or has not finished): only the former is a definite `none`
+		 */
+		if (rspamd_message_get_header_array(task, "DKIM-Signature",
+											FALSE) == NULL) {
+			return RSPAMD_FUZZY_SF_DKIM_NONE;
+		}
+
+		return RSPAMD_FUZZY_SF_DKIM_ABSENT;
+	}
+
+	for (cur = pres; *cur != NULL; cur++) {
+		switch ((*cur)->rcode) {
+		case DKIM_CONTINUE:
+			/* A single valid signature is enough */
+			return RSPAMD_FUZZY_SF_DKIM_PASS;
+		case DKIM_REJECT:
+			has_fail = TRUE;
+			break;
+		case DKIM_TRYAGAIN:
+			has_temperror = TRUE;
+			break;
+		default:
+			has_permerror = TRUE;
+			break;
+		}
+	}
+
+	/* A broken signature says more about the sender than a broken record */
+	if (has_fail) {
+		return RSPAMD_FUZZY_SF_DKIM_FAIL;
+	}
+	else if (has_permerror) {
+		return RSPAMD_FUZZY_SF_DKIM_PERMERROR;
+	}
+	else if (has_temperror) {
+		return RSPAMD_FUZZY_SF_DKIM_TEMPERROR;
+	}
+
+	return RSPAMD_FUZZY_SF_DKIM_NONE;
+}
+
+static unsigned int
+fuzzy_sf_ptr(struct rspamd_task *task)
+{
+	struct in6_addr addr_storage;
+	gsize len;
+
+	if (task->hostname == NULL || *task->hostname == '\0') {
+		/* The MTA has told us nothing about the PTR record */
+		return RSPAMD_FUZZY_SF_PTR_UNKNOWN;
+	}
+
+	len = strlen(task->hostname);
+
+	if (*task->hostname == '[' || strcmp(task->hostname, "unknown") == 0 ||
+		rspamd_parse_inet_address_ip4((const unsigned char *) task->hostname,
+									  len, &addr_storage) ||
+		rspamd_parse_inet_address_ip6((const unsigned char *) task->hostname,
+									  len, &addr_storage)) {
+		/* This is how MTAs spell out `there is no usable PTR record` */
+		return RSPAMD_FUZZY_SF_PTR_NONE;
+	}
+
+	/*
+	 * An MTA only hands us a name (Postfix client_name, Exim
+	 * sender_host_name, Sendmail connect hostname) once it has checked that
+	 * the name resolves back to the connecting address; if that check fails it
+	 * reports one of the forms handled above instead. So a plain name here
+	 * means forward confirmed.
+	 *
+	 * RSPAMD_FUZZY_SF_PTR_PRESENT is therefore not produced yet: it is for the
+	 * day rspamd resolves the PTR record on its own.
+	 */
+	return RSPAMD_FUZZY_SF_PTR_CONFIRMED;
+}
+
+static unsigned int
+fuzzy_sf_rcpts(struct rspamd_task *task)
+{
+	unsigned int nrcpt = 0;
+
+	if (task->rcpt_envelope != NULL) {
+		nrcpt = task->rcpt_envelope->len;
+	}
+
+	if (MESSAGE_FIELD_CHECK(task, rcpt_mime) != NULL &&
+		MESSAGE_FIELD(task, rcpt_mime)->len > nrcpt) {
+		nrcpt = MESSAGE_FIELD(task, rcpt_mime)->len;
+	}
+
+	/* Buckets only: an exact count would leak the size of the organisation */
+	if (nrcpt <= 1) {
+		return RSPAMD_FUZZY_SF_RCPTS_ONE;
+	}
+	else if (nrcpt <= 5) {
+		return RSPAMD_FUZZY_SF_RCPTS_FEW;
+	}
+	else if (nrcpt <= 20) {
+		return RSPAMD_FUZZY_SF_RCPTS_MANY;
+	}
+
+	return RSPAMD_FUZZY_SF_RCPTS_BULK;
+}
+
+static uint32_t
+fuzzy_cmd_sender_facts(struct rspamd_task *task)
+{
+	return rspamd_fuzzy_sf_pack(
+		fuzzy_sf_from_str(rspamd_mempool_get_variable(task->task_pool,
+													  RSPAMD_MEMPOOL_SPF_RESULT),
+						  rspamd_fuzzy_sf_spf_str,
+						  RSPAMD_FUZZY_SF_SPF_TEMPERROR),
+		fuzzy_sf_dkim(task),
+		fuzzy_sf_from_str(rspamd_mempool_get_variable(task->task_pool,
+													  RSPAMD_MEMPOOL_DMARC_RESULT),
+						  rspamd_fuzzy_sf_dmarc_str,
+						  RSPAMD_FUZZY_SF_DMARC_TEMPERROR),
+		fuzzy_sf_ptr(task),
+		/*
+		 * The generic/dynamic name heuristic needs the pattern set that
+		 * currently lives as an inline map inside hfilter.lua, so the bit is
+		 * written as zero until that set is shared
+		 */
+		FALSE,
+		fuzzy_sf_rcpts(task),
+		(task->flags & RSPAMD_TASK_FLAG_SSL) != 0);
+}
+
 static unsigned int
 fuzzy_cmd_extension_length(struct rspamd_task *task,
 						   struct fuzzy_rule *rule)
@@ -3617,6 +3804,9 @@ fuzzy_cmd_extension_length(struct rspamd_task *task,
 	else if (task->from_addr && rspamd_inet_address_get_af(task->from_addr) == AF_INET6) {
 		total += sizeof(struct in6_addr) + 1;
 	}
+
+	/* Sender facts: type + length + payload */
+	total += 2 + RSPAMD_FUZZY_SENDER_FACTS_LEN;
 
 	return total;
 }
@@ -3691,6 +3881,18 @@ fuzzy_cmd_write_extensions(struct rspamd_task *task,
 			available -= klen + 1;
 			written += klen + 1;
 		}
+	}
+
+	if (available >= 2 + RSPAMD_FUZZY_SENDER_FACTS_LEN) {
+		uint32_t facts = GUINT32_TO_BE(fuzzy_cmd_sender_facts(task));
+
+		*dest++ = RSPAMD_FUZZY_EXT_SENDER_FACTS;
+		*dest++ = RSPAMD_FUZZY_SENDER_FACTS_LEN;
+		memcpy(dest, &facts, sizeof(facts));
+		dest += sizeof(facts);
+
+		available -= 2 + RSPAMD_FUZZY_SENDER_FACTS_LEN;
+		written += 2 + RSPAMD_FUZZY_SENDER_FACTS_LEN;
 	}
 
 	return written;

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -3074,6 +3074,8 @@ int fuzzy_check_module_config(struct rspamd_config *cfg, bool validate)
 													   "FUZZY_CALLBACK", "DKIM_CHECK", FALSE);
 				rspamd_symcache_add_delayed_dependency(cfg->cache,
 													   "FUZZY_CALLBACK", "DMARC_CHECK", FALSE);
+				rspamd_symcache_add_delayed_dependency(cfg->cache,
+													   "FUZZY_CALLBACK", "HFILTER_CHECK", FALSE);
 				break;
 			}
 		}
@@ -3724,6 +3726,19 @@ fuzzy_sf_ptr(struct rspamd_task *task)
 	return RSPAMD_FUZZY_SF_PTR_CONFIRMED;
 }
 
+/*
+ * hfilter owns the generic/dynamic naming pattern set and publishes its
+ * verdict, so we do not have to carry a second copy of those patterns here
+ */
+static gboolean
+fuzzy_sf_ptr_generic(struct rspamd_task *task)
+{
+	gboolean *generic = rspamd_mempool_get_variable(task->task_pool,
+													RSPAMD_MEMPOOL_HOSTNAME_GENERIC);
+
+	return generic != NULL && *generic;
+}
+
 static unsigned int
 fuzzy_sf_rcpts(struct rspamd_task *task)
 {
@@ -3766,12 +3781,7 @@ fuzzy_cmd_sender_facts(struct rspamd_task *task)
 						  rspamd_fuzzy_sf_dmarc_str,
 						  RSPAMD_FUZZY_SF_DMARC_TEMPERROR),
 		fuzzy_sf_ptr(task),
-		/*
-		 * The generic/dynamic name heuristic needs the pattern set that
-		 * currently lives as an inline map inside hfilter.lua, so the bit is
-		 * written as zero until that set is shared
-		 */
-		FALSE,
+		fuzzy_sf_ptr_generic(task),
 		fuzzy_sf_rcpts(task),
 		(task->flags & RSPAMD_TASK_FLAG_SSL) != 0);
 }

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -3553,13 +3553,49 @@ fuzzy_rule_check_mimepart(struct rspamd_task *task,
 
 #define MAX_FUZZY_DOMAIN 64
 
+/*
+ * Extensions describe the sender: a third party that has chosen to send mail
+ * into the world. They must never describe the recipient, our own users or our
+ * own policy, hence they are omitted when:
+ *
+ * - the rule opts out of sharing;
+ * - the storage is talked to in plain text, as the extensions would then
+ *   travel in the clear (for sanity + privacy);
+ * - the message has been submitted by an authenticated user or comes from one
+ *   of our own networks. On outbound or submission traffic the source address
+ *   is our own user rather than a third party; such addresses are also noise
+ *   in an IP reputation model, so nothing of value is lost;
+ * - we have no source address at all, which makes the rest of the telemetry
+ *   useless anyway (e.g. a message scanned from a file).
+ */
+static gboolean
+fuzzy_rule_shares_extensions(struct rspamd_task *task,
+							 struct fuzzy_rule *rule)
+{
+	if (rule->no_share || !fuzzy_rule_has_encryption(rule)) {
+		return FALSE;
+	}
+
+	if (task->auth_user != NULL) {
+		return FALSE;
+	}
+
+	if (task->from_addr == NULL ||
+		rspamd_inet_address_get_af(task->from_addr) == AF_UNIX ||
+		rspamd_ip_is_local_cfg(task->cfg, task->from_addr)) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 static unsigned int
 fuzzy_cmd_extension_length(struct rspamd_task *task,
 						   struct fuzzy_rule *rule)
 {
 	unsigned int total = 0;
 
-	if (rule->no_share) {
+	if (!fuzzy_rule_shares_extensions(task, rule)) {
 		return 0;
 	}
 
@@ -3593,7 +3629,7 @@ fuzzy_cmd_write_extensions(struct rspamd_task *task,
 {
 	unsigned int written = 0;
 
-	if (rule->no_share) {
+	if (!fuzzy_rule_shares_extensions(task, rule)) {
 		return 0;
 	}
 

--- a/src/plugins/lua/dmarc.lua
+++ b/src/plugins/lua/dmarc.lua
@@ -57,6 +57,17 @@ redis.call('ZREMRANGEBYRANK', report_key, 0, max_entries)
 redis.call('EXPIRE', report_key, 172800)
 ]]
 
+-- Publish the policy evaluation result so that other modules (e.g. fuzzy_check)
+-- can use it without matching our symbol names, which are configurable.
+-- Note that we report the *published* policy rather than the disposition we
+-- ended up applying: sampling (pct=) and local overrides describe us, not the
+-- sender.
+local function publish_result(task, result)
+  if result then
+    task:get_mempool():set_variable('dmarc_result', result)
+  end
+end
+
 local function maybe_force_action(task, disposition)
   if disposition then
     local force_action = settings.actions[disposition]
@@ -235,6 +246,7 @@ local function dmarc_validate_policy(task, policy, hdrfromdom, dmarc_esld)
     ]] --
     task:insert_result(settings.symbols['allow'], 1.0, policy.domain,
       policy.dmarc_policy)
+    publish_result(task, 'pass')
   else
     --[[
     https://tools.ietf.org/html/rfc7489#section-6.6.2
@@ -247,9 +259,16 @@ local function dmarc_validate_policy(task, policy, hdrfromdom, dmarc_esld)
     if spf_tmpfail or dkim_tmpfail then
       task:insert_result(settings.symbols['dnsfail'], 1.0, policy.domain ..
         ' : ' .. 'SPF/DKIM temp error', policy.dmarc_policy)
+      publish_result(task, 'temperror')
     else
       -- We can now check the failed policy and maybe send report data elt
       local reason_str = table.concat(reason, ', ')
+
+      if policy.dmarc_policy == 'quarantine' or policy.dmarc_policy == 'reject' then
+        publish_result(task, 'fail_' .. policy.dmarc_policy)
+      else
+        publish_result(task, 'fail_none')
+      end
 
       if policy.dmarc_policy == 'quarantine' then
         handle_dmarc_failure('quarantine', reason_str)
@@ -479,12 +498,15 @@ local function dmarc_callback(task)
     dmarc_domain = rspamd_util.get_tld(hfromdom)
   elseif (from or E)[2] then
     task:insert_result(settings.symbols['na'], 1.0, 'Duplicate From header')
+    publish_result(task, 'no_record')
     return maybe_force_action(task, 'na')
   elseif (from or E)[1] then
     task:insert_result(settings.symbols['na'], 1.0, 'No domain in From header')
+    publish_result(task, 'no_record')
     return maybe_force_action(task, 'na')
   else
     task:insert_result(settings.symbols['na'], 1.0, 'No From header')
+    publish_result(task, 'no_record')
     return maybe_force_action(task, 'na')
   end
 
@@ -500,6 +522,7 @@ local function dmarc_callback(task)
       -- insert result
       if final or policy.fatal then
         task:insert_result(policy.symbol, 1.0, policy.err)
+        publish_result(task, policy.result)
         maybe_force_action(task, policy.disposition)
 
         return true
@@ -530,9 +553,11 @@ local function dmarc_callback(task)
                 err ~= 'no records with this name') then
             policy_target.err = lookup_domain .. ' : ' .. err
             policy_target.symbol = settings.symbols['dnsfail']
+            policy_target.result = 'temperror'
           else
             policy_target.err = lookup_domain
             policy_target.symbol = settings.symbols['na']
+            policy_target.result = 'no_record'
           end
         else
           local has_valid_policy = false
@@ -545,6 +570,7 @@ local function dmarc_callback(task)
                 -- We have a fatal parsing error, give up
                 policy_target.err = lookup_domain .. ' : ' .. results_or_err
                 policy_target.symbol = settings.symbols['badpolicy']
+                policy_target.result = 'permerror'
                 policy_target.fatal = true
                 seen_invalid = true
               end
@@ -553,6 +579,7 @@ local function dmarc_callback(task)
                 policy_target.err = lookup_domain .. ' : ' ..
                     'Multiple policies defined in DNS'
                 policy_target.symbol = settings.symbols['badpolicy']
+                policy_target.result = 'permerror'
                 policy_target.fatal = true
                 seen_invalid = true
               end
@@ -567,6 +594,7 @@ local function dmarc_callback(task)
           if not has_valid_policy and not seen_invalid then
             policy_target.err = lookup_domain .. ':' .. ' no valid DMARC record'
             policy_target.symbol = settings.symbols['na']
+            policy_target.result = 'no_record'
           end
         end
       end

--- a/src/plugins/lua/hfilter.lua
+++ b/src/plugins/lua/hfilter.lua
@@ -445,6 +445,14 @@ local function hfilter_callback(task)
           weight_hostname = weight
         end
       end
+
+      -- Publish whether the PTR name follows a generic/dynamic naming pattern
+      -- so that other modules (e.g. fuzzy_check) can use this pattern set
+      -- without duplicating it. Only the `hard` and `very hard` tiers count:
+      -- those are the dynamic, dsl, pppoe and address-in-the-name families,
+      -- whereas the lower weights match ambiguous words such as `user`,
+      -- `peer` or `host`
+      task:get_mempool():set_variable('hostname_generic', weight_hostname >= 4)
     else
       task:insert_result('HFILTER_HOSTNAME_UNKNOWN', 1.00)
     end

--- a/src/plugins/lua/spf.lua
+++ b/src/plugins/lua/spf.lua
@@ -120,14 +120,26 @@ local function spf_check_callback(task)
     ip = task:get_from_ip()
   end
 
+  -- Publish the policy result so that other modules (e.g. fuzzy_check) can use
+  -- it without matching our symbol names, which are configurable
+  local function publish_result(res)
+    if res then
+      task:get_mempool():set_variable('spf_result', res)
+    end
+  end
+
   local function flag_to_symbol(fl)
     if bit.band(fl, rspamd_spf.flags.temp_fail) ~= 0 then
+      publish_result('temperror')
       return local_config.symbols.dnsfail
     elseif bit.band(fl, rspamd_spf.flags.plusall) ~= 0 then
+      publish_result('pass')
       return local_config.symbols.plusall
     elseif bit.band(fl, rspamd_spf.flags.perm_fail) ~= 0 then
+      publish_result('permerror')
       return local_config.symbols.permfail
     elseif bit.band(fl, rspamd_spf.flags.na) ~= 0 then
+      publish_result('none')
       return local_config.symbols.na
     end
 
@@ -136,12 +148,16 @@ local function spf_check_callback(task)
 
   local function policy_decode(res)
     if res == rspamd_spf.policy.fail then
+      publish_result('fail')
       return local_config.symbols.fail, '-'
     elseif res == rspamd_spf.policy.pass then
+      publish_result('pass')
       return local_config.symbols.allow, '+'
     elseif res == rspamd_spf.policy.soft_fail then
+      publish_result('softfail')
       return local_config.symbols.softfail, '~'
     elseif res == rspamd_spf.policy.neutral then
+      publish_result('neutral')
       return local_config.symbols.neutral, '?'
     end
 

--- a/test/functional/cases/120_fuzzy/sender-facts-plain.robot
+++ b/test/functional/cases/120_fuzzy/sender-facts-plain.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Suite Setup     Fuzzy Setup Plain Siphash
+Suite Teardown  Rspamd Redis Teardown
+Resource        lib.robot
+
+*** Variables ***
+${MESSAGE}                      ${RSPAMD_TESTDIR}/messages/spam_message.eml
+
+*** Test Cases ***
+Extensions Are Suppressed Over An Unencrypted Connection
+  # Same remote sender that gets the full set of extensions over an encrypted
+  # rule: without encryption they would travel in the clear, so none are sent
+  Remove File  ${RSPAMD_TMPDIR}/fuzzy_extensions.log
+  Scan File  ${MESSAGE}  IP=8.8.8.8  From=foo@example.com
+  Wait Until Created  ${RSPAMD_TMPDIR}/fuzzy_extensions.log  timeout=10s
+  ${extensions} =  Get File  ${RSPAMD_TMPDIR}/fuzzy_extensions.log
+  Log  ${extensions}
+  Should Contain  ${extensions}  extensions=none

--- a/test/functional/cases/120_fuzzy/sender-facts.robot
+++ b/test/functional/cases/120_fuzzy/sender-facts.robot
@@ -14,6 +14,18 @@ Sender Facts Are Sent For A Remote Sender
   Should Contain  ${extensions}  tls=false
   Should Contain  ${extensions}  ptr_generic=false
 
+Generic PTR Name Is Reported From The Hfilter Pattern Set
+  ${extensions} =  Scan And Read Fuzzy Extensions  IP=8.8.8.8  From=foo@example.com
+  ...  Hostname=dsl-pool-8-8-8-8.example.com
+  Should Contain  ${extensions}  ptr=confirmed
+  Should Contain  ${extensions}  ptr_generic=true
+
+Regular PTR Name Is Not Reported As Generic
+  ${extensions} =  Scan And Read Fuzzy Extensions  IP=8.8.8.8  From=foo@example.com
+  ...  Hostname=mail.example.com
+  Should Contain  ${extensions}  ptr=confirmed
+  Should Contain  ${extensions}  ptr_generic=false
+
 Extensions Are Suppressed For A Local Sender
   ${extensions} =  Scan And Read Fuzzy Extensions  IP=127.0.0.1  From=foo@example.com
   Should Contain  ${extensions}  extensions=none

--- a/test/functional/cases/120_fuzzy/sender-facts.robot
+++ b/test/functional/cases/120_fuzzy/sender-facts.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Suite Setup     Fuzzy Setup Encrypted Siphash
+Suite Teardown  Rspamd Redis Teardown
+Resource        lib.robot
+
+*** Variables ***
+${MESSAGE}                      ${RSPAMD_TESTDIR}/messages/spam_message.eml
+
+*** Test Cases ***
+Sender Facts Are Sent For A Remote Sender
+  ${extensions} =  Scan And Read Fuzzy Extensions  IP=8.8.8.8  From=foo@example.com
+  Should Contain  ${extensions}  ip=8.8.8.8
+  Should Contain  ${extensions}  rcpts=1
+  Should Contain  ${extensions}  tls=false
+  Should Contain  ${extensions}  ptr_generic=false
+
+Extensions Are Suppressed For A Local Sender
+  ${extensions} =  Scan And Read Fuzzy Extensions  IP=127.0.0.1  From=foo@example.com
+  Should Contain  ${extensions}  extensions=none
+
+Extensions Are Suppressed For An Authenticated Sender
+  ${extensions} =  Scan And Read Fuzzy Extensions  IP=8.8.8.8  From=foo@example.com
+  ...  User=foo@example.com
+  Should Contain  ${extensions}  extensions=none
+
+*** Keywords ***
+Scan And Read Fuzzy Extensions
+  [Arguments]  &{headers}
+  Remove File  ${RSPAMD_TMPDIR}/fuzzy_extensions.log
+  Scan File  ${MESSAGE}  &{headers}
+  Wait Until Created  ${RSPAMD_TMPDIR}/fuzzy_extensions.log  timeout=10s
+  ${extensions} =  Get File  ${RSPAMD_TMPDIR}/fuzzy_extensions.log
+  Log  ${extensions}
+  RETURN  ${extensions}

--- a/test/functional/configs/fuzzy.conf
+++ b/test/functional/configs/fuzzy.conf
@@ -65,6 +65,22 @@ worker {
 	{= env.SETTINGS_FUZZY_WORKER =}
 }
 
+# hfilter owns the generic/dynamic PTR name pattern set that feeds the
+# corresponding bit of the fuzzy sender facts, so load just that plugin
+modules {
+	path = "{= env.TESTDIR =}/../../src/plugins/lua/hfilter.lua"
+}
+
+# Only the hostname checks: unlike the other hfilter checks they need no DNS
+hfilter {
+	helo_enabled = false;
+	hostname_enabled = true;
+	url_enabled = false;
+	from_enabled = false;
+	rcpt_enabled = false;
+	mid_enabled = false;
+}
+
 fuzzy_check {
 	min_bytes = 100;
 	timeout = 1s;

--- a/test/functional/configs/fuzzy.conf
+++ b/test/functional/configs/fuzzy.conf
@@ -2,6 +2,7 @@ redis {
   servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
 }
 lua = "{= env.TESTDIR =}/lua/test_coverage.lua";
+lua = "{= env.TESTDIR =}/lua/fuzzy_extensions.lua";
 options = {
 	filters = "fuzzy_check";
 	pidfile = "{= env.TMPDIR =}/rspamd.pid";

--- a/test/functional/lua/fuzzy_extensions.lua
+++ b/test/functional/lua/fuzzy_extensions.lua
@@ -1,0 +1,58 @@
+--[[
+Records what the fuzzy storage has actually received in the command extensions
+so that the functional tests can assert on what the scanner has, or has not,
+sent. Only check commands are recorded and the file always holds the last one.
+]] --
+
+local FUZZY_CHECK = 0
+
+rspamd_config:add_on_load(function(_, _, worker)
+  if not worker or worker:get_name() ~= 'fuzzy' then
+    return
+  end
+
+  local tmpdir = os.getenv('RSPAMD_TMPDIR')
+
+  if not tmpdir then
+    return
+  end
+
+  local path = tmpdir .. '/fuzzy_extensions.log'
+
+  worker:add_fuzzy_pre_handler(function(_, cmd, _, _, ext)
+    if cmd ~= FUZZY_CHECK then
+      return
+    end
+
+    local out = {}
+
+    if ext.ip then
+      table.insert(out, 'ip=' .. tostring(ext.ip))
+    end
+
+    if ext.domain then
+      table.insert(out, 'domain=' .. ext.domain)
+    end
+
+    if ext.sender then
+      for _, k in ipairs({ 'spf', 'dkim', 'dmarc', 'ptr', 'rcpts' }) do
+        table.insert(out, string.format('%s=%s', k, ext.sender[k] or 'absent'))
+      end
+
+      table.insert(out, 'ptr_generic=' .. tostring(ext.sender.ptr_generic))
+      table.insert(out, 'tls=' .. tostring(ext.sender.tls))
+    end
+
+    local f = io.open(path, 'w')
+
+    if f then
+      if #out == 0 then
+        f:write('extensions=none\n')
+      else
+        f:write(table.concat(out, ' ') .. '\n')
+      end
+
+      f:close()
+    end
+  end)
+end)

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -25,6 +25,7 @@
 #include "rspamd_cxx_unit_maps.hxx"
 #include "rspamd_cxx_local_ptr.hxx"
 #include "rspamd_cxx_unit_dkim.hxx"
+#include "rspamd_cxx_unit_fuzzy_wire.hxx"
 #include "rspamd_cxx_unit_cryptobox.hxx"
 #include "rspamd_cxx_unit_rfc2047.hxx"
 #include "rspamd_cxx_unit_html_url_rewrite.hxx"

--- a/test/rspamd_cxx_unit_fuzzy_wire.hxx
+++ b/test/rspamd_cxx_unit_fuzzy_wire.hxx
@@ -1,0 +1,506 @@
+/*
+ * Copyright 2025 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Detached unit tests for the fuzzy wire extensions */
+
+#ifndef RSPAMD_RSPAMD_CXX_UNIT_FUZZY_WIRE_HXX
+#define RSPAMD_RSPAMD_CXX_UNIT_FUZZY_WIRE_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+#include "libserver/fuzzy_wire.h"
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace rspamd::test::fuzzy_wire {
+
+using ext_ptr = std::unique_ptr<struct rspamd_fuzzy_cmd_extension, decltype(&g_free)>;
+
+static auto parse(const std::vector<unsigned char> &buf) -> std::pair<bool, ext_ptr>
+{
+	struct rspamd_fuzzy_cmd_extension *res = nullptr;
+	auto ok = rspamd_fuzzy_extensions_from_wire(buf.data(), buf.size(), &res);
+
+	return {ok != FALSE, ext_ptr{res, g_free}};
+}
+
+static auto count(const struct rspamd_fuzzy_cmd_extension *head) -> unsigned int
+{
+	unsigned int n = 0;
+
+	for (auto *cur = head; cur != nullptr; cur = cur->next) {
+		n++;
+	}
+
+	return n;
+}
+
+static auto find(const struct rspamd_fuzzy_cmd_extension *head, int type)
+	-> const struct rspamd_fuzzy_cmd_extension *
+{
+	for (auto *cur = head; cur != nullptr; cur = cur->next) {
+		if ((int) cur->ext == type) {
+			return cur;
+		}
+	}
+
+	return nullptr;
+}
+
+static auto append_facts(std::vector<unsigned char> &buf, uint32_t facts) -> void
+{
+	buf.push_back(RSPAMD_FUZZY_EXT_SENDER_FACTS);
+	buf.push_back(RSPAMD_FUZZY_SENDER_FACTS_LEN);
+	buf.push_back((facts >> 24) & 0xff);
+	buf.push_back((facts >> 16) & 0xff);
+	buf.push_back((facts >> 8) & 0xff);
+	buf.push_back(facts & 0xff);
+}
+
+/* The three extensions every client has been sending since forever */
+static auto legacy_extensions() -> std::vector<unsigned char>
+{
+	std::vector<unsigned char> buf = {RSPAMD_FUZZY_EXT_SOURCE_DOMAIN, 11};
+
+	for (auto c: std::string("example.com")) {
+		buf.push_back((unsigned char) c);
+	}
+
+	buf.push_back(RSPAMD_FUZZY_EXT_SOURCE_IP4);
+	buf.insert(buf.end(), {192, 0, 2, 1});
+
+	return buf;
+}
+
+static auto decode_facts(const struct rspamd_fuzzy_cmd_extension *ext) -> uint32_t
+{
+	uint32_t v;
+
+	memcpy(&v, ext->payload, sizeof(v));
+
+	return GUINT32_FROM_BE(v);
+}
+
+}// namespace rspamd::test::fuzzy_wire
+
+TEST_SUITE("rspamd_fuzzy_wire")
+{
+	using namespace rspamd::test::fuzzy_wire;
+
+	TEST_CASE("legacy extensions still parse")
+	{
+		auto [ok, exts] = parse(legacy_extensions());
+
+		REQUIRE(ok);
+		REQUIRE(exts != nullptr);
+		CHECK(count(exts.get()) == 2);
+
+		auto *dom = find(exts.get(), RSPAMD_FUZZY_EXT_SOURCE_DOMAIN);
+		REQUIRE(dom != nullptr);
+		CHECK(std::string((const char *) dom->payload, dom->length) == "example.com");
+
+		auto *ip = find(exts.get(), RSPAMD_FUZZY_EXT_SOURCE_IP4);
+		REQUIRE(ip != nullptr);
+		CHECK(ip->length == 4);
+		CHECK(ip->payload[0] == 192);
+		CHECK(ip->payload[3] == 1);
+	}
+
+	TEST_CASE("empty extensions area")
+	{
+		auto [ok, exts] = parse({});
+
+		CHECK(ok);
+		CHECK(exts == nullptr);
+	}
+
+	TEST_CASE("ipv6 source")
+	{
+		std::vector<unsigned char> buf = {RSPAMD_FUZZY_EXT_SOURCE_IP6};
+		buf.insert(buf.end(), 16, 0xaa);
+
+		auto [ok, exts] = parse(buf);
+
+		REQUIRE(ok);
+		REQUIRE(exts != nullptr);
+		CHECK(exts->ext == RSPAMD_FUZZY_EXT_SOURCE_IP6);
+		CHECK(exts->length == 16);
+	}
+
+	TEST_CASE("sender facts round trip")
+	{
+		struct test_case {
+			unsigned int spf, dkim, dmarc, ptr, rcpts;
+			bool ptr_generic, tls;
+		};
+
+		std::vector<test_case> cases = {
+			{RSPAMD_FUZZY_SF_SPF_ABSENT, RSPAMD_FUZZY_SF_DKIM_ABSENT,
+			 RSPAMD_FUZZY_SF_DMARC_ABSENT, RSPAMD_FUZZY_SF_PTR_UNKNOWN,
+			 RSPAMD_FUZZY_SF_RCPTS_ONE, false, false},
+			{RSPAMD_FUZZY_SF_SPF_PASS, RSPAMD_FUZZY_SF_DKIM_PASS,
+			 RSPAMD_FUZZY_SF_DMARC_PASS, RSPAMD_FUZZY_SF_PTR_CONFIRMED,
+			 RSPAMD_FUZZY_SF_RCPTS_FEW, false, true},
+			{RSPAMD_FUZZY_SF_SPF_TEMPERROR, RSPAMD_FUZZY_SF_DKIM_TEMPERROR,
+			 RSPAMD_FUZZY_SF_DMARC_TEMPERROR, RSPAMD_FUZZY_SF_PTR_NONE,
+			 RSPAMD_FUZZY_SF_RCPTS_BULK, true, true},
+			{RSPAMD_FUZZY_SF_SPF_SOFTFAIL, RSPAMD_FUZZY_SF_DKIM_FAIL,
+			 RSPAMD_FUZZY_SF_DMARC_FAIL_REJECT, RSPAMD_FUZZY_SF_PTR_PRESENT,
+			 RSPAMD_FUZZY_SF_RCPTS_MANY, true, false},
+		};
+
+		/* Every enumerated value of every field must survive the round trip */
+		for (unsigned int spf = 0; spf <= RSPAMD_FUZZY_SF_SPF_TEMPERROR; spf++) {
+			cases.push_back({spf, RSPAMD_FUZZY_SF_DKIM_NONE,
+							 RSPAMD_FUZZY_SF_DMARC_NO_RECORD,
+							 RSPAMD_FUZZY_SF_PTR_NONE, RSPAMD_FUZZY_SF_RCPTS_ONE,
+							 false, false});
+		}
+
+		for (unsigned int dkim = 0; dkim <= RSPAMD_FUZZY_SF_DKIM_TEMPERROR; dkim++) {
+			cases.push_back({RSPAMD_FUZZY_SF_SPF_NONE, dkim,
+							 RSPAMD_FUZZY_SF_DMARC_NO_RECORD,
+							 RSPAMD_FUZZY_SF_PTR_NONE, RSPAMD_FUZZY_SF_RCPTS_ONE,
+							 false, false});
+		}
+
+		for (unsigned int dmarc = 0; dmarc <= RSPAMD_FUZZY_SF_DMARC_TEMPERROR; dmarc++) {
+			cases.push_back({RSPAMD_FUZZY_SF_SPF_NONE, RSPAMD_FUZZY_SF_DKIM_NONE,
+							 dmarc, RSPAMD_FUZZY_SF_PTR_NONE,
+							 RSPAMD_FUZZY_SF_RCPTS_ONE, false, false});
+		}
+
+		for (unsigned int ptr = 0; ptr <= RSPAMD_FUZZY_SF_PTR_CONFIRMED; ptr++) {
+			for (unsigned int rcpts = 0; rcpts <= RSPAMD_FUZZY_SF_RCPTS_BULK; rcpts++) {
+				cases.push_back({RSPAMD_FUZZY_SF_SPF_NONE,
+								 RSPAMD_FUZZY_SF_DKIM_NONE,
+								 RSPAMD_FUZZY_SF_DMARC_NO_RECORD, ptr, rcpts,
+								 true, true});
+			}
+		}
+
+		for (const auto &c: cases) {
+			auto packed = rspamd_fuzzy_sf_pack(c.spf, c.dkim, c.dmarc, c.ptr,
+											   c.ptr_generic, c.rcpts, c.tls);
+
+			/* Reserved bits are never written */
+			CHECK((packed & RSPAMD_FUZZY_SF_RESERVED_MASK) == 0);
+			CHECK(((packed >> RSPAMD_FUZZY_SENDER_FACTS_CLASS_SHIFT) &
+				   RSPAMD_FUZZY_SENDER_FACTS_CLASS_MASK) ==
+				  RSPAMD_FUZZY_SENDER_FACTS_CLASS_V0);
+
+			std::vector<unsigned char> buf;
+			append_facts(buf, packed);
+
+			auto [ok, exts] = parse(buf);
+			REQUIRE(ok);
+			REQUIRE(exts != nullptr);
+			REQUIRE(exts->ext == RSPAMD_FUZZY_EXT_SENDER_FACTS);
+			REQUIRE(exts->length == RSPAMD_FUZZY_SENDER_FACTS_LEN);
+
+			auto val = decode_facts(exts.get());
+			CHECK(val == packed);
+			CHECK(((val >> RSPAMD_FUZZY_SF_SPF_SHIFT) & RSPAMD_FUZZY_SF_SPF_MASK) == c.spf);
+			CHECK(((val >> RSPAMD_FUZZY_SF_DKIM_SHIFT) & RSPAMD_FUZZY_SF_DKIM_MASK) == c.dkim);
+			CHECK(((val >> RSPAMD_FUZZY_SF_DMARC_SHIFT) & RSPAMD_FUZZY_SF_DMARC_MASK) == c.dmarc);
+			CHECK(((val >> RSPAMD_FUZZY_SF_PTR_SHIFT) & RSPAMD_FUZZY_SF_PTR_MASK) == c.ptr);
+			CHECK((bool) ((val >> RSPAMD_FUZZY_SF_PTR_GENERIC_SHIFT) & 1u) == c.ptr_generic);
+			CHECK(((val >> RSPAMD_FUZZY_SF_RCPTS_SHIFT) & RSPAMD_FUZZY_SF_RCPTS_MASK) == c.rcpts);
+			CHECK((bool) ((val >> RSPAMD_FUZZY_SF_TLS_SHIFT) & 1u) == c.tls);
+		}
+	}
+
+	TEST_CASE("sender facts reserved bits are ignored on read")
+	{
+		auto packed = rspamd_fuzzy_sf_pack(RSPAMD_FUZZY_SF_SPF_FAIL,
+										   RSPAMD_FUZZY_SF_DKIM_FAIL,
+										   RSPAMD_FUZZY_SF_DMARC_FAIL_QUARANTINE,
+										   RSPAMD_FUZZY_SF_PTR_CONFIRMED, true,
+										   RSPAMD_FUZZY_SF_RCPTS_MANY, true);
+
+		std::vector<unsigned char> buf;
+		/* A future version that has started using the reserved area */
+		append_facts(buf, packed | RSPAMD_FUZZY_SF_RESERVED_MASK);
+
+		auto [ok, exts] = parse(buf);
+		REQUIRE(ok);
+		REQUIRE(exts != nullptr);
+
+		auto val = decode_facts(exts.get());
+		CHECK((val & ~RSPAMD_FUZZY_SF_RESERVED_MASK) == packed);
+		CHECK(((val >> RSPAMD_FUZZY_SF_SPF_SHIFT) & RSPAMD_FUZZY_SF_SPF_MASK) ==
+			  RSPAMD_FUZZY_SF_SPF_FAIL);
+		CHECK(((val >> RSPAMD_FUZZY_SF_RCPTS_SHIFT) & RSPAMD_FUZZY_SF_RCPTS_MASK) ==
+			  RSPAMD_FUZZY_SF_RCPTS_MANY);
+	}
+
+	TEST_CASE("string tables agree with the enums")
+	{
+		CHECK(rspamd_fuzzy_sf_spf_str(RSPAMD_FUZZY_SF_SPF_ABSENT) == nullptr);
+		CHECK(std::string(rspamd_fuzzy_sf_spf_str(RSPAMD_FUZZY_SF_SPF_SOFTFAIL)) == "softfail");
+		CHECK(std::string(rspamd_fuzzy_sf_spf_str(RSPAMD_FUZZY_SF_SPF_TEMPERROR)) == "temperror");
+		CHECK(rspamd_fuzzy_sf_spf_str(RSPAMD_FUZZY_SF_SPF_TEMPERROR + 1) == nullptr);
+
+		CHECK(rspamd_fuzzy_sf_dkim_str(RSPAMD_FUZZY_SF_DKIM_ABSENT) == nullptr);
+		CHECK(std::string(rspamd_fuzzy_sf_dkim_str(RSPAMD_FUZZY_SF_DKIM_PERMERROR)) == "permerror");
+		CHECK(rspamd_fuzzy_sf_dkim_str(RSPAMD_FUZZY_SF_DKIM_TEMPERROR + 1) == nullptr);
+
+		CHECK(rspamd_fuzzy_sf_dmarc_str(RSPAMD_FUZZY_SF_DMARC_ABSENT) == nullptr);
+		CHECK(std::string(rspamd_fuzzy_sf_dmarc_str(RSPAMD_FUZZY_SF_DMARC_FAIL_REJECT)) == "fail_reject");
+		CHECK(rspamd_fuzzy_sf_dmarc_str(RSPAMD_FUZZY_SF_DMARC_TEMPERROR + 1) == nullptr);
+
+		CHECK(rspamd_fuzzy_sf_ptr_str(RSPAMD_FUZZY_SF_PTR_UNKNOWN) == nullptr);
+		CHECK(std::string(rspamd_fuzzy_sf_ptr_str(RSPAMD_FUZZY_SF_PTR_CONFIRMED)) == "confirmed");
+
+		CHECK(std::string(rspamd_fuzzy_sf_rcpts_str(RSPAMD_FUZZY_SF_RCPTS_ONE)) == "1");
+		CHECK(std::string(rspamd_fuzzy_sf_rcpts_str(RSPAMD_FUZZY_SF_RCPTS_BULK)) == "21+");
+		CHECK(rspamd_fuzzy_sf_rcpts_str(RSPAMD_FUZZY_SF_RCPTS_BULK + 1) == nullptr);
+	}
+
+	TEST_CASE("unknown skippable extension is skipped")
+	{
+		auto buf = legacy_extensions();
+
+		/* Something a future client sends and we know nothing about */
+		buf.push_back(RSPAMD_FUZZY_EXT_SKIPPABLE_MIN + 0x20);
+		buf.push_back(3);
+		buf.insert(buf.end(), {1, 2, 3});
+
+		append_facts(buf, rspamd_fuzzy_sf_pack(RSPAMD_FUZZY_SF_SPF_PASS,
+											   RSPAMD_FUZZY_SF_DKIM_NONE,
+											   RSPAMD_FUZZY_SF_DMARC_NO_RECORD,
+											   RSPAMD_FUZZY_SF_PTR_CONFIRMED,
+											   false, RSPAMD_FUZZY_SF_RCPTS_ONE,
+											   true));
+
+		/* And another one, this time at the very end and empty */
+		buf.push_back(0xff);
+		buf.push_back(0);
+
+		auto [ok, exts] = parse(buf);
+
+		REQUIRE(ok);
+		REQUIRE(exts != nullptr);
+		/* Domain, ip4 and sender facts: the two unknown ones are dropped */
+		CHECK(count(exts.get()) == 3);
+
+		auto *dom = find(exts.get(), RSPAMD_FUZZY_EXT_SOURCE_DOMAIN);
+		REQUIRE(dom != nullptr);
+		CHECK(std::string((const char *) dom->payload, dom->length) == "example.com");
+
+		auto *ip = find(exts.get(), RSPAMD_FUZZY_EXT_SOURCE_IP4);
+		REQUIRE(ip != nullptr);
+		CHECK(ip->payload[0] == 192);
+
+		auto *facts = find(exts.get(), RSPAMD_FUZZY_EXT_SENDER_FACTS);
+		REQUIRE(facts != nullptr);
+		CHECK(((decode_facts(facts) >> RSPAMD_FUZZY_SF_SPF_SHIFT) &
+			   RSPAMD_FUZZY_SF_SPF_MASK) == RSPAMD_FUZZY_SF_SPF_PASS);
+	}
+
+	TEST_CASE("sender facts of the wrong declared length are rejected")
+	{
+		/* The type is known and fixed width, so any other length is malformed */
+		for (unsigned int len: {0, 1, 2, 3, 5, 6, 8, 16, 255}) {
+			CAPTURE(len);
+
+			std::vector<unsigned char> buf = {RSPAMD_FUZZY_EXT_SENDER_FACTS,
+											  (unsigned char) len};
+			buf.insert(buf.end(), len, 0);
+
+			auto [ok, exts] = parse(buf);
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("a wrong length invalidates the whole command")
+		{
+			/* Not merely the offending entry: the legacy ones go too */
+			auto buf = legacy_extensions();
+			buf.push_back(RSPAMD_FUZZY_EXT_SENDER_FACTS);
+			buf.push_back(8);
+			buf.insert(buf.end(), 8, 0);
+
+			auto [ok, exts] = parse(buf);
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("the exact length is still accepted")
+		{
+			std::vector<unsigned char> buf;
+			append_facts(buf, rspamd_fuzzy_sf_pack(RSPAMD_FUZZY_SF_SPF_PASS,
+												   RSPAMD_FUZZY_SF_DKIM_PASS,
+												   RSPAMD_FUZZY_SF_DMARC_PASS,
+												   RSPAMD_FUZZY_SF_PTR_CONFIRMED,
+												   false,
+												   RSPAMD_FUZZY_SF_RCPTS_ONE,
+												   true));
+
+			auto [ok, exts] = parse(buf);
+			REQUIRE(ok);
+			REQUIRE(exts != nullptr);
+			CHECK(exts->length == RSPAMD_FUZZY_SENDER_FACTS_LEN);
+		}
+
+		SUBCASE("other skippable types keep accepting any length")
+		{
+			/* The strictness must not leak into types we know nothing about */
+			for (unsigned int len: {0, 1, 4, 7, 32}) {
+				CAPTURE(len);
+
+				std::vector<unsigned char> buf = {RSPAMD_FUZZY_EXT_SKIPPABLE_MIN + 3,
+												  (unsigned char) len};
+				buf.insert(buf.end(), len, 0);
+
+				auto [ok, exts] = parse(buf);
+				CHECK(ok);
+				CHECK(exts == nullptr);
+			}
+		}
+	}
+
+	TEST_CASE("a buffer of only unknown skippable extensions is accepted")
+	{
+		std::vector<unsigned char> buf = {RSPAMD_FUZZY_EXT_SKIPPABLE_MIN + 1, 2, 0, 0};
+
+		auto [ok, exts] = parse(buf);
+
+		CHECK(ok);
+		CHECK(exts == nullptr);
+	}
+
+	TEST_CASE("unknown non skippable extension is rejected")
+	{
+		auto buf = legacy_extensions();
+
+		/* Its length is implied by the type, so we cannot skip over it */
+		buf.push_back('x');
+		buf.insert(buf.end(), {1, 2, 3});
+
+		auto [ok, exts] = parse(buf);
+
+		CHECK(!ok);
+		CHECK(exts == nullptr);
+	}
+
+	TEST_CASE("truncated extensions are rejected")
+	{
+		SUBCASE("no length byte for a legacy type")
+		{
+			auto [ok, exts] = parse({RSPAMD_FUZZY_EXT_SOURCE_DOMAIN});
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("legacy domain shorter than advertised")
+		{
+			auto [ok, exts] = parse({RSPAMD_FUZZY_EXT_SOURCE_DOMAIN, 10, 'a', 'b'});
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("truncated ipv4")
+		{
+			auto [ok, exts] = parse({RSPAMD_FUZZY_EXT_SOURCE_IP4, 192, 0});
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("truncated ipv6")
+		{
+			std::vector<unsigned char> buf = {RSPAMD_FUZZY_EXT_SOURCE_IP6};
+			buf.insert(buf.end(), 15, 0xaa);
+
+			auto [ok, exts] = parse(buf);
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("no length byte for a skippable type")
+		{
+			auto [ok, exts] = parse({RSPAMD_FUZZY_EXT_SENDER_FACTS});
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("truncated sender facts")
+		{
+			auto [ok, exts] = parse({RSPAMD_FUZZY_EXT_SENDER_FACTS,
+									 RSPAMD_FUZZY_SENDER_FACTS_LEN, 0, 0});
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("truncated unknown skippable type")
+		{
+			auto [ok, exts] = parse({RSPAMD_FUZZY_EXT_SKIPPABLE_MIN + 5, 4, 0});
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+
+		SUBCASE("valid extensions followed by a truncated one")
+		{
+			auto buf = legacy_extensions();
+			buf.push_back(RSPAMD_FUZZY_EXT_SENDER_FACTS);
+			buf.push_back(RSPAMD_FUZZY_SENDER_FACTS_LEN);
+			buf.push_back(0);
+
+			auto [ok, exts] = parse(buf);
+			CHECK(!ok);
+			CHECK(exts == nullptr);
+		}
+	}
+
+	TEST_CASE("clients built before and after the sender facts")
+	{
+		/* An old client: no extension in the skippable range at all */
+		auto [old_ok, old_exts] = parse(legacy_extensions());
+
+		REQUIRE(old_ok);
+		REQUIRE(old_exts != nullptr);
+		CHECK(count(old_exts.get()) == 2);
+		CHECK(find(old_exts.get(), RSPAMD_FUZZY_EXT_SENDER_FACTS) == nullptr);
+
+		/* A new one, sending the very same legacy extensions plus the facts */
+		auto buf = legacy_extensions();
+		append_facts(buf, rspamd_fuzzy_sf_pack(RSPAMD_FUZZY_SF_SPF_FAIL,
+											   RSPAMD_FUZZY_SF_DKIM_FAIL,
+											   RSPAMD_FUZZY_SF_DMARC_FAIL_REJECT,
+											   RSPAMD_FUZZY_SF_PTR_NONE, false,
+											   RSPAMD_FUZZY_SF_RCPTS_BULK, false));
+
+		auto [new_ok, new_exts] = parse(buf);
+
+		REQUIRE(new_ok);
+		REQUIRE(new_exts != nullptr);
+		CHECK(count(new_exts.get()) == 3);
+
+		auto *dom = find(new_exts.get(), RSPAMD_FUZZY_EXT_SOURCE_DOMAIN);
+		REQUIRE(dom != nullptr);
+		CHECK(std::string((const char *) dom->payload, dom->length) == "example.com");
+
+		auto *facts = find(new_exts.get(), RSPAMD_FUZZY_EXT_SENDER_FACTS);
+		REQUIRE(facts != nullptr);
+		CHECK(((decode_facts(facts) >> RSPAMD_FUZZY_SF_DMARC_SHIFT) &
+			   RSPAMD_FUZZY_SF_DMARC_MASK) == RSPAMD_FUZZY_SF_DMARC_FAIL_REJECT);
+	}
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds a compact sender-facts extension to the fuzzy check protocol, and first makes the extensions TLV forward compatible so that adding it does not break storages that predate it.

The three commits are deliberately separable and **must be released in order** — see the sequencing note below.

## Why the extensions format had to change first

`rspamd_fuzzy_extensions_from_wire()` returned `FALSE` on any unrecognised type byte, and the caller then rejected the whole command. A client talking to an older storage therefore got **no fuzzy answer at all**, not merely a lost field.

The root cause is that the TLV is not self describing: the length of an entry is implied by its type (`'d'` carries a length byte, `'4'`/`'6'` are fixed width), so an unknown type cannot be skipped even in principle.

So the first commit establishes that type bytes from `0x80` up are always followed by a length byte and can be skipped when unknown, while types below that keep being rejected. The parser moves to a new `src/libserver/fuzzy_wire.c` where both passes share a single TLV step, which also removes the `g_assert_not_reached()` that a malformed packet from the network could otherwise reach.

Skippable does not mean unvalidated. A type we *do* know is checked against its declared length: the sender facts entry is fixed width, so any other length is a malformed packet rather than a dialect from the future and the command is rejected. The corollary is that a wider payload has to take a new type byte from the skippable range, which older parsers then skip, rather than grow this one, which they could not.

## The extension

One 32 bit big endian word. The top 8 bits are a class byte (0 for this layout) so the meaning of the low 24 can be redefined later without spending another type byte.

| bits | width | field | values |
|---|---|---|---|
| 0–2 | 3 | SPF result | absent, none, pass, fail, softfail, neutral, permerror, temperror |
| 3–5 | 3 | DKIM result | absent, none, pass, fail, permerror, temperror |
| 6–8 | 3 | DMARC result | absent, no record, pass, fail p=none, fail p=quarantine, fail p=reject, permerror, temperror |
| 9–10 | 2 | PTR state | unknown, no PTR, present, forward confirmed |
| 11 | 1 | PTR matches a generic/dynamic naming pattern | |
| 12–13 | 2 | recipient count bucket | 1, 2–5, 6–20, 21+ |
| 14 | 1 | the sending client used TLS inbound | |
| 15–23 | 9 | reserved, written as zero and ignored on read | |

Authentication results separate "this address is the source" from "this address relayed or forged", which is the distinction an IP reputation model built from this telemetry is missing today. PTR state and the generic-name flag give dynamic/residential classification. The recipient bucket is a bulk indicator, TLS is weak but free.

The storage decodes it into `ext.sender` for the lua pre/post handlers, as strings rather than raw integers:

```lua
ext.sender = { spf = "pass", dkim = "none", dmarc = "fail_reject",
               ptr = "confirmed", ptr_generic = false, rcpts = "2-5", tls = true }
```

Fields the word describes as absent or unknown are not set at all.

## Privacy

Every field describes the sender: a third party that has chosen to send mail into the world. Deliberately **not** included, and not to be added later:

- the client's own verdict, action or score — it would create a feedback loop the moment that client also consumes the reputation list built from it, and it describes the operator's configuration rather than the sender;
- recipient addresses or domains, subject, Message-ID;
- exact recipient counts, which leak organisation size — hence the buckets.

The second commit fixes a pre-existing leak in the same area. `fuzzy_cmd_write_extensions()` shipped `task->from_addr` whenever the rule did not set `no_share`; on a deployment that runs fuzzy checks on outbound or authenticated submission traffic that address is the operator's own user. Extensions are now omitted for authenticated tasks and for sources in our own networks. Nothing of value is lost — those are noise in an IP reputation model and exactly the RFC1918 and loopback values that had to be filtered downstream anyway.

## Release sequencing

We operate every fuzzy server the public and premium rules point at, so the rollout is servers first, clients after — no config flag involved.

- Commits 1 and 2 are safe to release at any time. Commit 1 is purely the storage side and understands both old and new clients.
- **Commit 3 must not be released before storages carrying commit 1 are deployed.** Extensions only travel over encrypted connections, but encrypted private fuzzy storages do exist. Anyone upgrading in order is fine, and so is anyone upgrading everything at once; only a deployment that upgrades scanners while deliberately pinning an older encrypted storage would notice, and commit 1 is what makes even that recoverable next time.

## Notes on the implementation

Three things that are worth a look during review.

**Extensions are now genuinely encrypted-only.** They were not before: `fuzzy_cmd_from_data_part()` and `fuzzy_cmd_from_text_part()` appended them regardless of encryption, contradicting the comment directly above them ("there should be no extensions in case of unencrypted connection (for sanity + privacy)").

The gate lives in `fuzzy_rule_shares_extensions()` and keys off `fuzzy_rule_has_encryption()`, which is exactly the predicate the send path uses to decide whether the command is encrypted, so the two cannot disagree. `fuzzy_parse_rule()` backfills `read_peer_key`/`write_peer_key` from one another, so that predicate is true if and only if `fuzzy_select_encryption_keys()` yields a non-NULL peer key in either direction; there is no configuration where the rule "has encryption" but a particular command still goes out in the clear. `sender-facts-plain.robot` pins this down with the same remote sender that receives the full set of extensions over an encrypted rule, and it does fail if the encryption condition is removed.

This is also load bearing for the rollout argument above: otherwise the new type byte would reach unencrypted third party storages too.

**SPF and DMARC verdicts had no source reachable from C.** Both are lua plugins and only DKIM keeps its results in the task mempool. Rather than match the (configurable) symbol names, `spf.lua` and `dmarc.lua` now publish their own policy result as `spf_result` / `dmarc_result` mempool strings, in the same spirit as the existing `dmarc_checks` variable. DMARC reports the **published** policy rather than the disposition that was applied, since `pct=` sampling and local overrides describe the receiver, not the sender. Encoder and decoder share the string tables in `fuzzy_wire.h`, so the two directions cannot drift apart.

**The generic/dynamic PTR name bit comes from hfilter.** That plugin owns the only such pattern set in the tree (`checks_hellohost`, an inline map), so rather than copy the patterns into C it now publishes its verdict for the PTR name into the task mempool and `fuzzy_check` reads it. Only the map's "hard" and "very hard" tiers count as generic: those are the dynamic, dsl, pppoe and address-in-the-name families, while the lower weights match ambiguous words such as `user`, `peer` or `host`. The bit stays zero when hfilter or its hostname checks are disabled, exactly as the other fields are absent when their check does not run.

**PTR forward confirmation needs no extra DNS.** Postfix `client_name`, Exim `sender_host_name` and the Sendmail connect hostname are only handed over once the MTA has checked that the name resolves back to the connecting address; when that fails they report `unknown` or a bracketed address literal instead. So a plain name in `task->hostname` means forward confirmed. The consequence is that state 2 (present but unconfirmed) is unreachable until rspamd resolves the PTR record itself; that is documented at the call site.

**`FUZZY_CALLBACK` now has ordering dependencies** on `SPF_CHECK`, `DKIM_CHECK` and `DMARC_CHECK`, registered only when at least one rule can actually share extensions. Without them the three auth fields would be reported as absent on essentially every message, since the checks have not concluded by the time the fuzzy commands are built. They are ordering only (`hard = FALSE`): a disabled check just means the field is absent. The cost is that fuzzy no longer overlaps the auth DNS chain, which is a deliberate trade and the part of this PR most worth arguing about.

## Tests

- 12 new doctest cases (732 assertions) in `test/rspamd_cxx_unit_fuzzy_wire.hxx`: per-field encode/decode round trip over every enumerated value, reserved bits written as zero and ignored on read, an unknown skippable extension being skipped while the known ones still parse, an unknown non-skippable type still rejected, seven truncation cases, sender facts rejected at nine wrong declared lengths (short and oversized) while other skippable types still accept any length, and a client built before the change and one built after both parsing correctly against the new parser.
- New `120_fuzzy/sender-facts.robot` driving the real encrypted client/storage path and asserting on what the storage actually received: facts present for a remote sender, a generic PTR name reported as such and a regular one not, and no extensions at all for a local or an authenticated one.
- New `120_fuzzy/sender-facts-plain.robot` for the encryption gate: nothing is shared over an unencrypted rule.
- Full C++ suite 342/342, lua suite 1205/1205, `120_fuzzy` and `001_merged` otherwise unchanged.

