### PR TITLE
[Fix] neural: fuse over the provider slot range, not ipairs of a sparse table

### DIFF
--- a/lualib/plugins/neural.lua
+++ b/lualib/plugins/neural.lua
@@ -978,9 +978,16 @@ local function collect_features_async(task, rule, profile_or_set, phase, cb)
   local function maybe_finish()
     remaining = remaining - 1
     if remaining == 0 then
-      -- Fuse
+      -- Fuse. `vectors` is sparse — a provider that failed (or was never
+      -- registered) leaves its slot nil — so iterate the slot RANGE, never
+      -- ipairs(): ipairs stops at the first hole and would silently drop
+      -- every later provider's block (observed live: an unregistered slot-1
+      -- text provider discarded the collected structured + metatokens
+      -- vectors and inference went dark with an empty fused vector).
       local fused = {}
-      for i, v in ipairs(vectors) do
+      local nslots = #providers_cfg + 1 -- + the trailing metatokens slot
+      for i = 1, nslots do
+        local v = vectors[i]
         if v then
           local w = (metas[i] and metas[i].weight) or 1.0
           local norm_mode = (rule.fusion and rule.fusion.normalization) or 'none'


### PR DESCRIPTION
collect_features_async fills `vectors[i]` per provider slot and leaves the slot nil when a provider failed or was never registered. The fuse loop iterated `ipairs(vectors)`, which stops at the first hole: one dead provider in slot 1 silently discards every later provider's collected block.

Observed live: with the text provider unregistered (the `neural` module disabled in the configuration — the provider modules are `require`'d from this plugin's header, so module gating skips their registration), the structured (113d) and metatokens (46d) blocks were still collected and then dropped on fuse; `cb(nil)` on every scan, and downstream fusion consumers went dark with no diagnostic at all. Reproduced under an instrumented `collect_features_async`: `fused dim=0 from [2=113,3=46]`.

Iterate `1..#providers_cfg+1` (the trailing metatokens slot) instead: a missing provider now yields a partial fused vector, which downstream dimension checks can actually see and report.