### PR TITLE
[Fix] symcache: stamp slow-rule start under the same condition it is measured

### DIFF
--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -569,7 +569,18 @@ auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache,
 		msg_debug_cache_task("execute %s, %d; symbol type = %s", item->symbol.data(),
 							 item->id, item_type_to_str(item->type));
 
-		if (profile) {
+		/*
+		 * Stamp the start under the SAME condition finalize_item measures
+		 * with (profile || bit_slow). Stamping under `profile` alone left
+		 * start_msec at 0 on every non-profiled task once an item had been
+		 * flagged slow: finalize then computed diff from the TASK start, so
+		 * any DNS-bound or deadline-hitting scan was logged as a multi-second
+		 * "slow synchronous rule" against that item — phantom slowness that
+		 * also shifted pending items' start corrections by whole-scan
+		 * amounts. One genuinely slow profiled call was enough to make the
+		 * flagged rule blamed for every slow scan thereafter.
+		 */
+		if (profile || (item->flags & cache_item::bit_slow)) {
 			ev_now_update_if_cheap(task->event_loop);
 			dyn_item->start_msec = (ev_now(task->event_loop) -
 									profile_start) *

--- a/src/lua/lua_url.c
+++ b/src/lua/lua_url.c
@@ -1221,7 +1221,13 @@ void lua_tree_url_callback(gpointer key, gpointer value, gpointer ud)
 			if ((url->flags & cb->flags_exclude_mask) != 0) {
 				return;
 			}
-			if ((url->flags & cb->flags_mask) == 0) {
+			/*
+			 * `flags_mask` is set to ~0U when no include list has been given,
+			 * meaning "include everything". A plain bitwise test would still
+			 * drop urls that carry no flags at all (e.g. urls found in html
+			 * parts), so only apply the include filter when one was requested.
+			 */
+			if (cb->flags_mask != ~0U && (url->flags & cb->flags_mask) == 0) {
 				return;
 			}
 			break;

--- a/test/lua/unit/task_urls_filtered.lua
+++ b/test/lua/unit/task_urls_filtered.lua
@@ -1,0 +1,100 @@
+context("task:get_urls_filtered", function()
+  local rspamd_task = require("rspamd_task")
+  local logger = require("rspamd_logger")
+  local test_helper = require("rspamd_test_helper")
+
+  -- Initialises the tld list; without it every url carries the `no_tld` flag
+  -- and the missing-flags case below cannot be reproduced.
+  test_helper.init_url_parser()
+
+  local html_msg = [[
+From: test@example.com
+To: nobody@example.com
+Subject: test
+Content-Type: text/html
+
+<html><body><a href="https://example.com/test">Click here</a></body></html>
+]]
+
+  local text_msg = [[
+From: test@example.com
+To: nobody@example.com
+Subject: test
+Content-Type: text/plain
+
+visit https://example.com/test now
+]]
+
+  -- assertions are only injected into test() bodies, so this helper returns
+  -- nil instead of asserting and every caller checks the result itself
+  local function load(msg)
+    local res, task = rspamd_task.load_from_string(msg, rspamd_config)
+    if not res then
+      return nil
+    end
+    task:process_message()
+    return task
+  end
+
+  -- Urls extracted from html parts carry no flags at all. The no-argument
+  -- form means "include everything", so they must not be filtered out.
+  test("no arguments returns urls from an html part", function()
+    local task = load(html_msg)
+    assert_not_nil(task, "failed to load message")
+    local urls = task:get_urls_filtered()
+
+    assert_equal(1, #urls,
+        logger.slog('expected 1 url from the html part, got %s', #urls))
+    assert_equal("https://example.com/test", urls[1]:get_text())
+  end)
+
+  test("no arguments returns urls from a text part", function()
+    local task = load(text_msg)
+    assert_not_nil(task, "failed to load message")
+    local urls = task:get_urls_filtered()
+
+    assert_equal(1, #urls,
+        logger.slog('expected 1 url from the text part, got %s', #urls))
+  end)
+
+  -- get_urls() has never applied the include filter, so the two must agree
+  -- when no filtering has been asked for.
+  test("no arguments agrees with get_urls", function()
+    for _, msg in ipairs({ html_msg, text_msg }) do
+      local task = load(msg)
+      assert_not_nil(task, "failed to load message")
+      assert_equal(#task:get_urls(), #task:get_urls_filtered(),
+          "get_urls and unfiltered get_urls_filtered must agree")
+    end
+  end)
+
+  -- An explicit exclude list still has to work, and must not resurrect the
+  -- bug by way of the include mask staying at ~0U.
+  test("exclude list still filters", function()
+    -- the html part url carries no flags, so no exclude list can match it
+    local html_task = load(html_msg)
+    assert_not_nil(html_task, "failed to load message")
+    assert_equal(1, #html_task:get_urls_filtered(nil, { 'subject' }),
+        "excluding an unrelated flag must keep the url")
+
+    -- the text part url carries `text`, so excluding it must drop the url
+    local task = load(text_msg)
+    assert_not_nil(task, "failed to load message")
+    assert_equal(1, #task:get_urls_filtered(nil, { 'subject' }),
+        "excluding an unrelated flag must keep the url")
+    assert_equal(0, #task:get_urls_filtered(nil, { 'text' }),
+        "excluding the url's own flag must drop it")
+  end)
+
+  -- An explicit include list keeps its original meaning: only urls carrying
+  -- at least one of the requested flags come back.
+  test("explicit include list only returns matching urls", function()
+    local task = load(text_msg)
+    assert_not_nil(task, "failed to load message")
+
+    assert_equal(1, #task:get_urls_filtered({ 'text' }),
+        "the text part url carries the `text` flag")
+    assert_equal(0, #task:get_urls_filtered({ 'obscured' }),
+        "no url carries the `obscured` flag")
+  end)
+end)


### PR DESCRIPTION
`start_msec` was stamped only on profiled tasks, but `finalize_item` measures elapsed when `(profile || bit_slow)`. Once an item had been flagged slow ONCE on a profiled task, every subsequent non-profiled task measured it against `start_msec = 0` — i.e. from the task start — so any DNS-bound or deadline-hitting scan was logged as a multi-second `slow synchronous rule` against that item, and the pending-item start corrections were shifted by whole-scan amounts.

Observed in production: ~1200 phantom 5–8 s warnings/day attributed to a Lua postfilter whose callback measured sub-millisecond; the logged diff matched the total scan time to the millisecond on 7 KB messages (4.2 s ≈ the DNS-bound scans, 8 s ≈ the task deadline). The one genuinely slow profiled call that set `bit_slow` was a separate issue (#6187); after fixing it the phantom warnings continued unchanged, which is what exposed this.

Stamp under `(profile || bit_slow)`, mirroring the measurement condition. Third companion in the series #6186 / #6187.