### PR TITLE
[Fix] misc: verify FCrDNS before adopting a resolved PTR name as hostname

### DIFF
--- a/conf/scores.d/hfilter_group.conf
+++ b/conf/scores.d/hfilter_group.conf
@@ -82,6 +82,10 @@ symbols = {
         weight = 2.0;
         description = "Helo not FQDN";
     }
+    "HFILTER_HELO_DNSFAIL" {
+        weight = 0.0;
+        description = "Helo address lookup DNS error";
+    }
     "HFILTER_FROMHOST_NORESOLVE_MX" {
         weight = 0.5;
         description = "MX found in FROM host and no resolve";
@@ -93,6 +97,10 @@ symbols = {
     "HFILTER_FROMHOST_NOT_FQDN" {
         weight = 3.0;
         description = "FROM host not FQDN";
+    }
+    "HFILTER_FROMHOST_DNSFAIL" {
+        weight = 0.0;
+        description = "FROM host address lookup DNS error";
     }
     "HFILTER_FROM_BOUNCE" {
         weight = 0.0;
@@ -112,6 +120,10 @@ symbols = {
     "HFILTER_MID_NOT_FQDN" {
         weight = 0.5;
         description = "Message-id host not FQDN";
+    }
+    "HFILTER_MID_DNSFAIL" {
+        weight = 0.0;
+        description = "Message-id host address lookup DNS error";
     }
 */
     "HFILTER_HOSTNAME_UNKNOWN" {

--- a/conf/scores.d/hfilter_group.conf
+++ b/conf/scores.d/hfilter_group.conf
@@ -138,4 +138,12 @@ symbols = {
         weight = 0.0;
         description = "PTR verification DNS error";
     }
+    "RDNS_FCRDNS_FAIL" {
+        weight = 0.0;
+        description = "PTR name does not resolve back to the sender's IP";
+    }
+    "RDNS_FCRDNS_DNSFAIL" {
+        weight = 0.0;
+        description = "FCrDNS verification DNS error";
+    }
 }

--- a/rules/misc.lua
+++ b/rules/misc.lua
@@ -807,6 +807,74 @@ rspamd_config.COMPLETELY_EMPTY = {
 -- Preserve compatibility
 local rdns_auth_and_local_conf = lua_util.config_check_local_or_authed(rspamd_config, 'once_received',
   false, false)
+
+-- An MTA is expected to publish a client hostname only after forward
+-- confirmed reverse DNS: per the milter interface a name that fails that
+-- check is reported as the bare IP in square brackets instead, which
+-- `task:get_hostname()` deliberately reports as nil. When Rspamd resolves the
+-- PTR itself it has to perform the same verification, otherwise an
+-- unverified name silently replaces the MTA's verdict and
+-- HFILTER_HOSTNAME_UNKNOWN, documented as covering exactly this ("PTR or
+-- FCrDNS verification failed"), can never be inserted.
+local function rdns_verify_forward(task, task_ip, ptr_name)
+  local ip_str = task_ip:to_string()
+  local completed = 0
+  local matched = false
+  local tempfail = false
+
+  local function forward_dns_cb(_, to_resolve, results, err)
+    if err and (err ~= 'requested record is not found' and
+          err ~= 'no records with this name') then
+      rspamd_logger.infox(task, 'error verifying PTR name %s: %s', to_resolve, err)
+      tempfail = true
+    elseif results then
+      for _, addr in ipairs(results) do
+        -- Compare printed forms: `ip:equal()` compares ports as well, and
+        -- the client address carries one whereas a resolved address does not
+        if addr:to_string() == ip_str then
+          matched = true
+        end
+      end
+    end
+
+    -- The A and the AAAA lookups share this callback and complete in
+    -- arbitrary order, so judge only once both have returned: an address
+    -- published in the slower family is not visible yet and a host that does
+    -- confirm would be rejected depending on DNS timing
+    completed = completed + 1
+    if completed < 2 then
+      return
+    end
+
+    if matched then
+      rspamd_logger.infox(task, 'source hostname has not been passed to Rspamd from MTA, ' ..
+        'but we could resolve source IP address PTR as "%s"', ptr_name)
+      task:set_hostname(ptr_name)
+    elseif tempfail then
+      -- Verification could not be completed, which is not evidence against
+      -- the client, so keep trusting the PTR as before. The symbol lets a
+      -- deployment that enforces HFILTER_HOSTNAME_UNKNOWN soft reject these
+      -- rather than treat a resolver failure as a pass
+      task:insert_result('RDNS_FCRDNS_DNSFAIL', 1.0, ptr_name)
+      task:set_hostname(ptr_name)
+    else
+      -- The name provably does not belong to this client, so it is not set:
+      -- this is the same state the task would be in had the MTA done the
+      -- verification itself
+      task:insert_result('RDNS_FCRDNS_FAIL', 1.0, ptr_name)
+    end
+  end
+
+  for _, rr in ipairs({ 'a', 'aaaa' }) do
+    task:get_resolver():resolve(rr, {
+      task = task,
+      name = ptr_name,
+      callback = forward_dns_cb,
+      forced = true
+    })
+  end
+end
+
 -- Check for the hostname if it was not set
 local rnds_check_id = rspamd_config:register_symbol {
   name = 'RDNS_CHECK',
@@ -824,10 +892,7 @@ local rnds_check_id = rspamd_config:register_symbol {
           if not results then
             task:insert_result('RDNS_NONE', 1.0)
           else
-            rspamd_logger.infox(task, 'source hostname has not been passed to Rspamd from MTA, ' ..
-              'but we could resolve source IP address PTR %s as "%s"',
-              to_resolve, results[1])
-            task:set_hostname(results[1])
+            rdns_verify_forward(task, task_ip, results[1])
           end
         end
         task:get_resolver():resolve_ptr({
@@ -868,6 +933,25 @@ rspamd_config:register_symbol {
   name = 'RDNS_NONE',
   score = 2.0,
   description = 'DNS failure resolving RDNS',
+  group = 'hfilter',
+  parent = rnds_check_id,
+}
+-- Informational: the weight for an unverified client already comes from
+-- HFILTER_HOSTNAME_UNKNOWN, which now fires for these, so scoring here too
+-- would count the same fact twice
+rspamd_config:register_symbol {
+  type = 'virtual',
+  name = 'RDNS_FCRDNS_FAIL',
+  score = 0.0,
+  description = 'PTR name does not resolve back to the client IP (FCrDNS verification failed)',
+  group = 'hfilter',
+  parent = rnds_check_id,
+}
+rspamd_config:register_symbol {
+  type = 'virtual',
+  name = 'RDNS_FCRDNS_DNSFAIL',
+  score = 0.0,
+  description = 'DNS failure verifying that the PTR name resolves back to the client IP',
   group = 'hfilter',
   parent = rnds_check_id,
 }

--- a/src/plugins/lua/hfilter.lua
+++ b/src/plugins/lua/hfilter.lua
@@ -290,6 +290,16 @@ local function check_host(task, host, symbol_suffix, eq_ip, eq_host)
       return
     end
 
+    -- Every check below is suppressed when a lookup failed transiently,
+    -- which is correct but indistinguishable from a clean pass. Publish the
+    -- failure so that a deployment enforcing these symbols can soft reject
+    -- what it could not verify instead of letting it through as verified.
+    -- NXDOMAIN does not count: that is an answer, already reported as
+    -- HFILTER_<suffix>_NORES_A_OR_MX.
+    if address_lookup_failed then
+      task:insert_result('HFILTER_' .. symbol_suffix .. '_DNSFAIL', 1.0, host)
+    end
+
     if not address_lookup_failed and eq_ip and eq_ip ~= '' then
       local matched = false
       for _, result in pairs(resolved_address) do
@@ -554,7 +564,8 @@ local symbols_helo = {
   "HFILTER_HELO_NORESOLVE_MX",
   "HFILTER_HELO_NORES_A_OR_MX",
   "HFILTER_HELO_IP_A",
-  "HFILTER_HELO_NOT_FQDN"
+  "HFILTER_HELO_NOT_FQDN",
+  "HFILTER_HELO_DNSFAIL"
 }
 local symbols_hostname = {
   "HFILTER_HOSTNAME_1",
@@ -570,7 +581,8 @@ local symbols_rcpt = {
 local symbols_mid = {
   "HFILTER_MID_NORESOLVE_MX",
   "HFILTER_MID_NORES_A_OR_MX",
-  "HFILTER_MID_NOT_FQDN"
+  "HFILTER_MID_NOT_FQDN",
+  "HFILTER_MID_DNSFAIL"
 }
 local symbols_url = {
   "HFILTER_URL_ONLY",
@@ -580,6 +592,7 @@ local symbols_from = {
   "HFILTER_FROMHOST_NORESOLVE_MX",
   "HFILTER_FROMHOST_NORES_A_OR_MX",
   "HFILTER_FROMHOST_NOT_FQDN",
+  "HFILTER_FROMHOST_DNSFAIL",
   "HFILTER_FROM_BOUNCE"
 }
 

--- a/test/functional/cases/171_hfilter_helo.robot
+++ b/test/functional/cases/171_hfilter_helo.robot
@@ -10,7 +10,7 @@ ${CONFIG}          ${RSPAMD_TESTDIR}/configs/hfilter.conf
 ${MESSAGE}         ${RSPAMD_TESTDIR}/messages/spam_message.eml
 ${RSPAMD_SCOPE}    Suite
 ${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
-${SETTINGS}        {symbols_enabled = [HFILTER_CHECK, HFILTER_HELO_IP_A, HFILTER_HELO_NORES_A_OR_MX, HFILTER_HELO_NORESOLVE_MX, HFILTER_HELO_NOT_FQDN]}
+${SETTINGS}        {symbols_enabled = [HFILTER_CHECK, HFILTER_HELO_IP_A, HFILTER_HELO_NORES_A_OR_MX, HFILTER_HELO_NORESOLVE_MX, HFILTER_HELO_NOT_FQDN, HFILTER_HELO_DNSFAIL]}
 
 *** Test Cases ***
 # HFILTER_HELO_IP_A is documented as "Helo A IP != hostname IP", so a HELO
@@ -59,3 +59,31 @@ HELO with no address records keeps being flagged
 HELO with one transiently failed family is not flagged
   Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=partialfail.test  Settings=${SETTINGS}
   Do Not Expect Symbol  HFILTER_HELO_IP_A
+
+# Staying silent is right, but silence is indistinguishable from a clean
+# pass. A deployment that enforces HFILTER_HELO_IP_A needs to be able to tell
+# "verified, no mismatch" from "could not verify", so the transient failure
+# is published as its own symbol to soft reject on.
+HELO with a transiently failed family reports the DNS failure
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=partialfail.test  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HELO_DNSFAIL
+
+# Both families time out. The two lookups share one callback, so the symbol
+# must be inserted once rather than once per callback; a per-callback insert
+# scores 2.00.
+HELO with both families transiently failed reports the DNS failure once
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=bothfail.test  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HELO_DNSFAIL  1.00
+
+# Control: a HELO that resolves cleanly must not be reported as unverifiable.
+HELO that resolves cleanly reports no DNS failure
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=match.test  Settings=${SETTINGS}
+  Do Not Expect Symbol  HFILTER_HELO_DNSFAIL
+
+# Control: NXDOMAIN is an authoritative answer, not a failure to obtain one.
+# It is already reported as HFILTER_HELO_NORES_A_OR_MX and must not also be
+# reported as a DNS failure, or the soft-reject signal becomes useless.
+HELO with no address records reports no DNS failure
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=noaddr.test  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HELO_NORES_A_OR_MX
+  Do Not Expect Symbol  HFILTER_HELO_DNSFAIL

--- a/test/functional/cases/172_rdns_fcrdns.robot
+++ b/test/functional/cases/172_rdns_fcrdns.robot
@@ -1,0 +1,91 @@
+*** Settings ***
+Suite Setup     Rspamd Setup
+Suite Teardown  Rspamd Teardown
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/rdns.conf
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/spam_message.eml
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+${SETTINGS}        {symbols_enabled = [RDNS_CHECK, RDNS_NONE, RDNS_DNSFAIL, RDNS_FCRDNS_FAIL, RDNS_FCRDNS_DNSFAIL, HFILTER_CHECK, HFILTER_HOSTNAME_UNKNOWN, HFILTER_HOSTNAME_1, HFILTER_HOSTNAME_2, HFILTER_HOSTNAME_3, HFILTER_HOSTNAME_4, HFILTER_HOSTNAME_5]}
+
+*** Test Cases ***
+# Harness control rather than a behaviour under test: RDNS_CHECK is a
+# prefilter, so if it did not run in this suite every other case here would
+# green for the wrong reason. A client with no PTR at all must reach the
+# pre-existing RDNS_NONE path and be reported as an unknown hostname.
+Client without a PTR record is reported unknown
+  Scan File  ${MESSAGE}  IP=23.45.67.89  Settings=${SETTINGS}
+  Expect Symbol  RDNS_NONE
+  Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# The bug. The PTR resolves, so the fallback in rules/misc.lua adopts the
+# name, but that name publishes a different address: forward-confirmed
+# reverse DNS fails. HFILTER_HOSTNAME_UNKNOWN documents itself as covering
+# exactly this ("PTR or FCrDNS verification failed") and must fire.
+Client whose PTR fails forward confirmation is reported unknown
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HOSTNAME_UNKNOWN  2.50
+  Expect Symbol  RDNS_FCRDNS_FAIL
+
+# The same client as seen from a real MTA. Per the milter interface a
+# hostname that failed the MTA's own FCrDNS check arrives as the bracketed
+# IP literal, which get_hostname() reports as nil; the fallback then runs and
+# must not overwrite that verdict with an unverified name.
+Bracketed IP literal from the MTA does not become a verified hostname
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Hostname=[1.2.3.4]  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+  Expect Symbol  RDNS_FCRDNS_FAIL
+
+# Control: the PTR name publishes exactly the connecting address, so the
+# hostname is verified and neither symbol may be inserted. Guards against a
+# fix that simply stops trusting the fallback altogether.
+Client whose PTR forward-confirms is not reported unknown
+  Scan File  ${MESSAGE}  IP=5.6.7.8  Settings=${SETTINGS}
+  Do Not Expect Symbol  RDNS_FCRDNS_FAIL
+  Do Not Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# The A and AAAA lookups of the PTR name share one callback and complete in
+# arbitrary order. Here the connecting address is in the A reply while the
+# AAAA reply holds a different one, so a check that judges before both have
+# returned can reject a correctly configured host.
+Dual-stack PTR confirming on A is not reported unknown
+  Scan File  ${MESSAGE}  IP=34.56.78.90  Settings=${SETTINGS}
+  Do Not Expect Symbol  RDNS_FCRDNS_FAIL
+  Do Not Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# Authoritative absence of address records is a failed verification, not a
+# deferred one: the name provably does not confirm the client.
+Client whose PTR name has no address records is reported unknown
+  Scan File  ${MESSAGE}  IP=45.67.89.101  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+  Expect Symbol  RDNS_FCRDNS_FAIL
+
+# A resolver timeout proves nothing either way. The verification result is
+# unknown, so the default must not be to accuse the client; instead a
+# dedicated symbol is published so a deployment enforcing
+# HFILTER_HOSTNAME_UNKNOWN can soft-reject the temporary failures.
+Client whose forward lookup times out is reported as a temporary failure
+  Scan File  ${MESSAGE}  IP=9.9.9.9  Settings=${SETTINGS}
+  Expect Symbol  RDNS_FCRDNS_DNSFAIL
+  Do Not Expect Symbol  RDNS_FCRDNS_FAIL
+  Do Not Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# Hostname pattern scoring must keep working for clients that verify: a
+# generic/dynamic-looking PTR name still earns its weight.
+Generic PTR name that forward-confirms is still scored by pattern
+  Scan File  ${MESSAGE}  IP=67.89.101.23  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HOSTNAME_5  3.00
+  Do Not Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# The deliberate consequence of the fix, pinned so it cannot change by
+# accident: a name that fails verification is not used for pattern scoring
+# either. This matches what already happens when the MTA does the check
+# itself and passes the bracketed IP literal instead of the name.
+Generic PTR name that fails forward confirmation is not scored by pattern
+  Scan File  ${MESSAGE}  IP=56.78.90.12  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+  Do Not Expect Symbol  HFILTER_HOSTNAME_5

--- a/test/functional/configs/hfilter-dns.conf
+++ b/test/functional/configs/hfilter-dns.conf
@@ -77,6 +77,19 @@ options {
         name = "partialfail.test";
         type = "aaaa";
         replies = ["2001:db8::2"];
+      },
+      {
+        # Neither family answers. Both lookups share one callback, so a
+        # failure reported from inside that callback would be inserted
+        # twice; the score assertion is what catches that.
+        name = "bothfail.test";
+        type = "a";
+        rcode = 'timeout';
+      },
+      {
+        name = "bothfail.test";
+        type = "aaaa";
+        rcode = 'timeout';
       }
     ]
   }

--- a/test/functional/configs/hfilter.conf
+++ b/test/functional/configs/hfilter.conf
@@ -31,5 +31,10 @@ group "hfilter" {
     "HFILTER_HELO_NOT_FQDN" {
       weight = 2.0;
     }
+    # Shipped as informational (0.0); pinned here only so that a symbol
+    # inserted once per resolver callback shows as 2.0 rather than 1.0.
+    "HFILTER_HELO_DNSFAIL" {
+      weight = 1.0;
+    }
   }
 }

--- a/test/functional/configs/rdns-dns.conf
+++ b/test/functional/configs/rdns-dns.conf
@@ -1,0 +1,139 @@
+options {
+  dns {
+    fake_records = [
+      {
+        # The PTR resolves, but the name it yields publishes a different
+        # address: forward-confirmed reverse DNS fails. This is the case
+        # HFILTER_HOSTNAME_UNKNOWN is documented to cover ("PTR or FCrDNS
+        # verification failed") and the one an MTA reports as `[ip]`.
+        name = "4.3.2.1.in-addr.arpa";
+        type = "ptr";
+        replies = ["nofcrdns.test"];
+      },
+      {
+        name = "nofcrdns.test";
+        type = "a";
+        replies = ["99.99.99.99"];
+      },
+      {
+        name = "nofcrdns.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # Fully forward-confirmed: the PTR name publishes exactly the
+        # connecting address, so the hostname is trustworthy and no symbol
+        # may be inserted.
+        name = "8.7.6.5.in-addr.arpa";
+        type = "ptr";
+        replies = ["goodfcrdns.test"];
+      },
+      {
+        name = "goodfcrdns.test";
+        type = "a";
+        replies = ["5.6.7.8"];
+      },
+      {
+        name = "goodfcrdns.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # Both forward lookups time out. Absence of an answer is not proof
+        # of a mismatch, so this must be reported as a temporary failure
+        # rather than silently treated as either outcome.
+        name = "9.9.9.9.in-addr.arpa";
+        type = "ptr";
+        replies = ["tempfcrdns.test"];
+      },
+      {
+        name = "tempfcrdns.test";
+        type = "a";
+        rcode = 'timeout';
+      },
+      {
+        name = "tempfcrdns.test";
+        type = "aaaa";
+        rcode = 'timeout';
+      },
+      {
+        # No PTR at all: the pre-existing RDNS_NONE path, kept here as a
+        # harness control proving RDNS_CHECK actually runs in this suite.
+        name = "89.67.45.23.in-addr.arpa";
+        type = "ptr";
+        rcode = 'nxdomain';
+      },
+      {
+        # Dual-stack PTR name where the match lives in the A reply and the
+        # AAAA reply holds a different address. The two forward lookups
+        # share one callback and complete in arbitrary order, so a check
+        # that judges before both have returned can see only the AAAA
+        # answer and reject a correctly configured host.
+        name = "90.78.56.34.in-addr.arpa";
+        type = "ptr";
+        replies = ["dualfcrdns.test"];
+      },
+      {
+        name = "dualfcrdns.test";
+        type = "a";
+        replies = ["34.56.78.90"];
+      },
+      {
+        name = "dualfcrdns.test";
+        type = "aaaa";
+        replies = ["2001:db8::9"];
+      },
+      {
+        # PTR name with no address records at all. Authoritative absence,
+        # so verification fails rather than being deferred.
+        name = "101.89.67.45.in-addr.arpa";
+        type = "ptr";
+        replies = ["noaddrfcrdns.test"];
+      },
+      {
+        name = "noaddrfcrdns.test";
+        type = "a";
+        rcode = 'nxdomain';
+      },
+      {
+        name = "noaddrfcrdns.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # A generic/dynamic-looking PTR name (matches the `nat[.-][0-9]`
+        # pattern, weight 5) that does NOT forward-confirm.
+        name = "12.90.78.56.in-addr.arpa";
+        type = "ptr";
+        replies = ["nat-1.dyn.example.test"];
+      },
+      {
+        name = "nat-1.dyn.example.test";
+        type = "a";
+        replies = ["99.99.99.99"];
+      },
+      {
+        name = "nat-1.dyn.example.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # The same generic name shape, but forward-confirmed. The pattern
+        # scoring must keep working for hosts that verify.
+        name = "23.101.89.67.in-addr.arpa";
+        type = "ptr";
+        replies = ["nat-2.dyn.example.test"];
+      },
+      {
+        name = "nat-2.dyn.example.test";
+        type = "a";
+        replies = ["67.89.101.23"];
+      },
+      {
+        name = "nat-2.dyn.example.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      }
+    ]
+  }
+}

--- a/test/functional/configs/rdns.conf
+++ b/test/functional/configs/rdns.conf
@@ -1,0 +1,29 @@
+.include(duplicate=merge,priority=0) "{= env.TESTDIR =}/configs/plugins.conf"
+.include(duplicate=merge,priority=1) "{= env.TESTDIR =}/configs/rdns-dns.conf"
+
+hfilter {
+  enabled = true;
+  # Only the hostname checks are under test here; the other groups would
+  # add unrelated symbols and extra DNS traffic.
+  helo_enabled = false;
+  hostname_enabled = true;
+  from_enabled = false;
+  rcpt_enabled = false;
+  mid_enabled = false;
+  url_enabled = false;
+}
+
+# hfilter.lua registers its symbols with score 0.0 and relies on
+# conf/scores.d/hfilter_group.conf for the real weights; that file is not
+# part of the functional test configs, so mirror the ones asserted on here.
+# The RDNS_* symbols carry their scores in rules/misc.lua itself.
+group "hfilter" {
+  symbols = {
+    "HFILTER_HOSTNAME_UNKNOWN" {
+      weight = 2.5;
+    }
+    "HFILTER_HOSTNAME_5" {
+      weight = 3.0;
+    }
+  }
+}


### PR DESCRIPTION
Fixes the bug reported in #6190, and adds the temporary-failure symbol asked for in the same thread as a follow-up to #6165.

## The bug

`RDNS_CHECK` in `rules/misc.lua` fills in the hostname when the MTA passed none, straight from the PTR answer and with no forward confirmation:

```lua
task:set_hostname(results[1])
```

An MTA publishes a client hostname only once it has confirmed that the name resolves back to the connecting address. Per the milter interface a name that fails that check arrives as the bare IP in square brackets instead, which `lua_task_get_hostname()` deliberately reports as `nil` — the comment in `src/lua/lua_task.c` quotes the milter documentation for exactly this. So the fallback runs on precisely the clients the MTA has just judged unverifiable, and replaces that verdict with an unverified name.

Two consumers depend on the contract it breaks:

* **`HFILTER_HOSTNAME_UNKNOWN`**, described as *"Unknown client hostname (PTR or FCrDNS verification failed)"*, is inserted only in the `else` branch of `if hostname` in `hfilter.lua`. Once the fallback has installed a name, the symbol can never fire for the FCrDNS half of what it documents.
* **`fuzzy_sf_ptr()`** in `src/plugins/fuzzy_check.c` reasons that *"a plain name here means forward confirmed"* when producing `RSPAMD_FUZZY_SF_PTR_CONFIRMED`, and notes that `RSPAMD_FUZZY_SF_PTR_PRESENT` is reserved *"for the day rspamd resolves the PTR record on its own"*. That day has already arrived in `misc.lua`, without the verification, so the shingle feature is currently told "confirmed" about names nobody checked.

## The fix

Resolve `A` and `AAAA` for the PTR name and compare against the client address before calling `set_hostname()`.

The two lookups share a callback and complete in arbitrary order, so the verdict is taken only once both have returned — otherwise an address published in the slower family is not visible yet and a host that *does* confirm gets rejected depending on DNS timing. This is the same hazard as in `check_host_cb_a`. The comparison is on the printed forms because `ip:equal()` compares ports as well, and the client address carries one whereas a resolved address does not.

* **Verified** — hostname is installed, exactly as before.
* **Provably not confirmed** (mismatch, or no address records) — the name is not installed, leaving the task in the state it would have been in had the MTA done the check itself, plus `RDNS_FCRDNS_FAIL` for visibility.
* **Resolver failure** — not evidence against the client, so the PTR keeps being trusted as before and `RDNS_FCRDNS_DNSFAIL` is published instead. This is what gives a deployment enforcing `HFILTER_HOSTNAME_UNKNOWN` something to soft reject on rather than treating a timeout as a pass.

Both new symbols are scored 0.0: the weight for an unverified client already comes from `HFILTER_HOSTNAME_UNKNOWN`, and scoring here too would count the same fact twice.

## One deliberate behaviour change — worth your ruling

A name that fails verification is not installed, so hfilter's generic/dynamic **hostname pattern checks no longer score it either**. On the shipped weights, a dynamic-pool client with a generic PTR that fails FCrDNS loses `HFILTER_HOSTNAME_5` (3.0) and gains `HFILTER_HOSTNAME_UNKNOWN` (2.5) — a net −0.5.

I chose this because it is identical to what already happens whenever the MTA performs the check itself and sends the bracketed literal: in that case rspamd never sees the name and never pattern-scores it. The fallback path was the inconsistent one. Both halves are pinned by tests so the behaviour cannot drift by accident.

The alternative would be to install the name anyway for pattern scoring and carry the FCrDNS verdict separately, which nets +2.5 instead. That is a scoring decision for you rather than something to change unilaterally, so I have left it as the consistent option — happy to rework it if you prefer the other.

## Second commit: transient DNS failures in `check_host()`

`check_host()` suppresses every verdict when an address lookup fails transiently — `HFILTER_<suffix>_IP_A` is not inserted, and the MX fallback behind `NORES_A_OR_MX` / `NORESOLVE_MX` is not attempted. That is correct, but it leaves silence as the only outcome, and silence is indistinguishable from a clean pass. A deployment enforcing those symbols cannot tell "verified, no problem" from "could not verify", so a resolver outage quietly degrades into accepting everything.

`HFILTER_<suffix>_DNSFAIL` is published for that case, inserted after the both-callbacks join so a host whose `A` and `AAAA` both fail is reported once rather than once per callback. NXDOMAIN does not qualify — that is an answer, already reported as `HFILTER_<suffix>_NORES_A_OR_MX`. Scored 0.0.

This is the follow-up @thestinger asked for in #6190 against #6165. It is a separate commit and can be dropped or split out if you would rather keep this PR to the hostname fix alone.

## Verification

Built and run against current master (`6d84be9ab`, reports 4.1.6).

**New suite `172_rdns_fcrdns.robot`, covering `RDNS_CHECK`, which had no functional tests at all — 4 pass / 5 fail on stock master, 9/9 with the fix.** Four of the five stock failures are literally `Symbol HFILTER_HOSTNAME_UNKNOWN wasn't found in result`, i.e. the reported bug, reproduced through the mismatch case, the bracketed-IP-literal case an MTA actually sends, the no-address-records case, and the pattern-scoring case.

The suite deliberately opens with a control — a client with no PTR at all must still reach `RDNS_NONE` — which passes on stock, proving the prefilter really runs and the other cases are not green for free. The other controls (forward-confirmed client, dual-stack confirming on the slower family, generic name that *does* confirm) also pass on stock, so the fix is not simply always inserting.

| | stock master | with fix |
|---|---|---|
| `172_rdns_fcrdns` (new) | 4 / 9 | **9 / 9** |
| `171_hfilter_helo` (+4 new cases) | 9 / 11 | **11 / 11** |
| full functional, pabot + serial | — | **907 / 907, 0 failed** |
| `ninja test` | — | **8 / 8** |
| luacheck (`pipelinecomponents/luacheck`, `-q --no-color .`) | — | **0 warnings / 0 errors**, 262 files |

The both-families-fail case asserts on the *score* rather than presence, so an insertion made once per resolver callback shows as 2.00 and fails.

Issue: #6190
