### PR TITLE
[Fix] spf: return permerror when a domain has multiple SPF records

### DIFF
--- a/src/libserver/spf.c
+++ b/src/libserver/spf.c
@@ -885,6 +885,7 @@ spf_process_txt_record(struct spf_record *rec, struct spf_resolved_element *reso
 {
 	struct rdns_reply_entry *elt, *selected = NULL;
 	gboolean ret = FALSE;
+	unsigned int nspf1 = 0;
 
 	/*
 	 * We prefer spf version 1 as other records are mostly likely garbage
@@ -894,15 +895,39 @@ spf_process_txt_record(struct spf_record *rec, struct spf_resolved_element *reso
 	{
 		if (elt->type == RDNS_REQUEST_TXT) {
 			if (strncmp(elt->content.txt.data, "v=spf1", sizeof("v=spf1") - 1) == 0) {
-				selected = elt;
+				nspf1++;
 
-				if (pselected != NULL) {
-					*pselected = selected;
+				if (selected == NULL) {
+					selected = elt;
+
+					if (pselected != NULL) {
+						*pselected = selected;
+					}
 				}
-
-				break;
 			}
 		}
+	}
+
+	/*
+	 * RFC 7208 4.5: if the DNS lookup returns more than one SPF record, then
+	 * check_host() produces the permerror result. An RRset carries no order,
+	 * so evaluating any single one of them would tie the verdict to the order
+	 * the resolver happened to answer in - the same message could pass here
+	 * and permerror at the next receiver.
+	 */
+	if (nspf1 > 1) {
+		msg_warn_spf("spf record is not unique: %ud records found, domain: %s",
+					 nspf1, resolved->cur_domain);
+		rec->permfail = true;
+
+		/*
+		 * Report the record as handled so that the caller does not fall back to
+		 * na: the resolved element is left without elements on purpose, which
+		 * together with the permfail flag is what the consumers read as
+		 * permerror. Signalling failure here instead would add an na element,
+		 * and na is checked first when the result is dispatched.
+		 */
+		return TRUE;
 	}
 
 	if (!selected) {

--- a/src/libserver/spf.c
+++ b/src/libserver/spf.c
@@ -879,6 +879,25 @@ spf_record_addr_set(struct spf_addr *addr, gboolean allow_any)
 	}
 }
 
+/*
+ * RFC 7208 4.5: the version section is the literal `v=spf1` matched without
+ * regard to case and terminated by SP or the end of the record. `v=spf10` is
+ * explicitly not an SPF1 record, so it must neither be selected nor counted
+ * towards the one-record limit. g_ascii_strncasecmp stops at the terminator,
+ * which a TXT string as short as "" needs.
+ */
+static inline gboolean
+spf_is_spf1_record(const char *txt)
+{
+	if (g_ascii_strncasecmp(txt, SPF_VER1_STR, sizeof(SPF_VER1_STR) - 1) != 0) {
+		return FALSE;
+	}
+
+	const char terminator = txt[sizeof(SPF_VER1_STR) - 1];
+
+	return terminator == '\0' || terminator == ' ';
+}
+
 static gboolean
 spf_process_txt_record(struct spf_record *rec, struct spf_resolved_element *resolved,
 					   struct rdns_reply *reply, struct rdns_reply_entry **pselected)
@@ -894,7 +913,7 @@ spf_process_txt_record(struct spf_record *rec, struct spf_resolved_element *reso
 	LL_FOREACH(reply->entries, elt)
 	{
 		if (elt->type == RDNS_REQUEST_TXT) {
-			if (strncmp(elt->content.txt.data, "v=spf1", sizeof("v=spf1") - 1) == 0) {
+			if (spf_is_spf1_record(elt->content.txt.data)) {
 				nspf1++;
 
 				if (selected == NULL) {

--- a/test/functional/cases/001_merged/117_spf.robot
+++ b/test/functional/cases/001_merged/117_spf.robot
@@ -170,6 +170,28 @@ SPF PLUSALL
   ...  Settings=${SETTINGS_SPF}
   Expect Symbol  R_SPF_PLUSALL
 
+SPF PERMFAIL MULTIPLE RECORDS
+  [Documentation]  RFC 7208 4.5: more than one SPF record yields permerror. An
+  ...  RRset has no order, so evaluating either of them would tie the verdict to
+  ...  the order the resolver answered in, even though 8.8.8.8 is authorised by
+  ...  the first one
+  Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@twospf.org.org.za
+  ...  Settings=${SETTINGS_SPF}
+  Expect Symbol  R_SPF_PERMFAIL
+  Do Not Expect Symbol  R_SPF_ALLOW
+  Do Not Expect Symbol  R_SPF_FAIL
+
+SPF ALLOW ONE RECORD AMONG OTHER TXT
+  [Documentation]  Only records starting with the v=spf1 version string count
+  ...  towards that limit, an unrelated TXT record alongside one SPF record is
+  ...  the common case and must still be evaluated
+  Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@onespf.org.org.za
+  ...  Settings=${SETTINGS_SPF}
+  Expect Symbol  R_SPF_ALLOW
+  Do Not Expect Symbol  R_SPF_PERMFAIL
+
 SPF ALLOW MX
   [Documentation]  A normal mx element is expanded to the addresses of its names
   Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/bad_dkim1.eml

--- a/test/functional/cases/001_merged/117_spf.robot
+++ b/test/functional/cases/001_merged/117_spf.robot
@@ -192,6 +192,35 @@ SPF ALLOW ONE RECORD AMONG OTHER TXT
   Expect Symbol  R_SPF_ALLOW
   Do Not Expect Symbol  R_SPF_PERMFAIL
 
+SPF ALLOW MIXED CASE VERSION
+  [Documentation]  RFC 7208 4.5 matches the version section without regard to
+  ...  case, so a record announcing itself as V=SPF1 is an SPF record like any
+  ...  other
+  Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@mixedcasespf.org.org.za
+  ...  Settings=${SETTINGS_SPF}
+  Expect Symbol  R_SPF_ALLOW
+  Do Not Expect Symbol  R_SPF_NA
+
+SPF PERMFAIL MULTIPLE RECORDS MIXED CASE
+  [Documentation]  A caseless match is what makes the one-record limit hold: a
+  ...  duplicate spelled V=SPF1 must not escape permerror by its case
+  Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@twomixedcasespf.org.org.za
+  ...  Settings=${SETTINGS_SPF}
+  Expect Symbol  R_SPF_PERMFAIL
+  Do Not Expect Symbol  R_SPF_ALLOW
+
+SPF ALLOW ONE RECORD BESIDE A LATER VERSION
+  [Documentation]  RFC 7208 4.5 terminates the version section with SP or the
+  ...  end of the record and says v=spf10 is discarded, so it is not a second
+  ...  SPF1 record and must not cause permerror
+  Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/bad_dkim1.eml
+  ...  IP=8.8.8.8  From=x@spf10.org.org.za
+  ...  Settings=${SETTINGS_SPF}
+  Expect Symbol  R_SPF_ALLOW
+  Do Not Expect Symbol  R_SPF_PERMFAIL
+
 SPF ALLOW MX
   [Documentation]  A normal mx element is expanded to the addresses of its names
   Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/bad_dkim1.eml

--- a/test/functional/configs/merged-local.conf
+++ b/test/functional/configs/merged-local.conf
@@ -278,6 +278,16 @@ options = {
           replies = ["v=spf1 +all"];
         },
         {
+          name = "twospf.org.org.za",
+          type = "txt";
+          replies = ["v=spf1 ip4:8.8.8.8 -all", "v=spf1 ip4:9.9.9.9 -all"];
+        },
+        {
+          name = "onespf.org.org.za",
+          type = "txt";
+          replies = ["some-vendor-verification=abcdef", "v=spf1 ip4:8.8.8.8 -all"];
+        },
+        {
           name = "fail4.org.org.za",
           type = "txt";
           replies = ["v=spf1 redirect=asdfsfewewrredfs"];

--- a/test/functional/configs/merged-local.conf
+++ b/test/functional/configs/merged-local.conf
@@ -288,6 +288,21 @@ options = {
           replies = ["some-vendor-verification=abcdef", "v=spf1 ip4:8.8.8.8 -all"];
         },
         {
+          name = "mixedcasespf.org.org.za",
+          type = "txt";
+          replies = ["V=SPF1 ip4:8.8.8.8 -all"];
+        },
+        {
+          name = "twomixedcasespf.org.org.za",
+          type = "txt";
+          replies = ["V=SPF1 ip4:8.8.8.8 -all", "v=spf1 ip4:9.9.9.9 -all"];
+        },
+        {
+          name = "spf10.org.org.za",
+          type = "txt";
+          replies = ["v=spf10 ip4:9.9.9.9 -all", "v=spf1 ip4:8.8.8.8 -all"];
+        },
+        {
           name = "fail4.org.org.za",
           type = "txt";
           replies = ["v=spf1 redirect=asdfsfewewrredfs"];


### PR DESCRIPTION
Only the first record starting with the version string was taken and the rest of the answer ignored, so a domain publishing two SPF records was evaluated as if it published one. RFC 7208 4.5 requires permerror instead. An RRset carries no order, so which record won depended on the order the resolver happened to answer in: the same message could pass here and permerror at the next receiver.

Count the records rather than breaking out on the first one and set `permfail`, as is already done for the DNS limits. The duplicate branch reports the record as handled so that the caller does not fall back to `na`: an na element added there would mask the error, since na is checked before permerror when the result is dispatched.

Only records starting with the version string count, so a domain publishing one SPF record next to unrelated TXT records - vendor verification tokens and the like - is unaffected, which the second test added here guards.