### PR TITLE
[Fix] rbl: honour no_ip for helo and selector lookups

### DIFF
--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -397,6 +397,21 @@ local function gen_rbl_callback(rule)
       req_str = tostring(req)
     end
 
+    -- `no_ip` must cover textual sources as well: helo and selectors (e.g. the
+    -- `mid` one in DBL) can yield a bare IP literal, rejected by domain zones
+    if rule.no_ip and not is_ip and type(req_str) == 'string' then
+      -- Literals are bracketed in helo: [192.0.2.1], [IPv6:2001:db8::1]
+      local bare = req_str:match('^%[IPv6:(.+)%]$') or
+          req_str:match('^%[(.+)%]$') or req_str
+      local maybe_ip = rspamd_ip.from_string(bare)
+
+      if maybe_ip and maybe_ip:is_valid() then
+        lua_util.debugm(N, task, 'skip ip %s from %s: no_ip for rbl %s',
+            req_str, label, rule.symbol)
+        return
+      end
+    end
+
     if whitelist and is_whitelisted(task, req, req_str, whitelist, label) then
       return
     end


### PR DESCRIPTION
While tracking down a steady trickle of `DBL_PROHIBIT`.

### The problem

`no_ip` is documented as *"Disable IP-based lookups for this RBL"* (`lualib/plugins/rbl.lua`), but in `rbl.lua` it is only ever consulted in two places: the monitored-zone logic, and `ignore_ip` in the URL-extraction params. It never reaches the other sources of a lookup key, which are textual and can perfectly well yield a bare IP literal:

* a HELO of `[192.0.2.1]`, or a device HELOing as a bare address
* selectors — including DBL's own `mid` selector:
  `header(Message-Id).regexp('@([^\.]+\.[^>]+)').last`
  which returns `192.0.2.1` for `<...@192.0.2.1>`

So a rule with `no_ip = true` still submits IP literals to the zone.

Domain-only zones reject them. Spamhaus DBL replies `127.0.1.255`, which the stock `DBL` rule maps to `DBL_PROHIBIT` — its own `returncodes` comment reads `# error - IP queries prohibited!`. The symbol carries no score, so nothing is mis-scored; the cost is a query that can never succeed. Illustrative of the shape seen in logs:

```
DBL_PROHIBIT(0.00){192.0.2.1:mid;}
DBL_PROHIBIT(0.00){192.0.2.55:helo;}
```

Multifunction printers and similar appliances stamp a private address into `Message-Id` or HELO constantly, so on a busy MX this is a continuous stream of queries that can only ever fail, aimed at a zone whose operator explicitly prohibits them.

### The fix

Filter in `add_dns_request()` — the single funnel every non-`is_ip` lookup passes through — so one check covers `helo`, selectors, and any future textual source. RFC 5321 bracketed literals (`[192.0.2.1]`, `[IPv6:2001:db8::1]`) are unwrapped before the test, and the existing `rspamd_ip.from_string(...)` / `:is_valid()` idiom already used in this file does the detection.

### Compatibility

No configuration change and no new option. Rules that do not set `no_ip` are unaffected. For rules that do set it — DBL among them, in the shipped config — this simply makes the option behave as documented.