### PR TITLE
[Fix] Settings: make ip_map and client_ip_map actually match

### DIFF
--- a/src/plugins/lua/settings.lua
+++ b/src/plugins/lua/settings.lua
@@ -293,8 +293,20 @@ local function check_ip_setting(expected, ip)
   return false
 end
 
-local function check_map_setting(map, input)
-  return map:get_key(input)
+-- A map cannot go through gen_check_closure: a map object is a table, and that closure reads a
+-- table as a list of expected values, so the check would be called on the map's own fields
+local function gen_map_check_closure(map)
+  return function(value)
+    if type(value) == 'function' then
+      value = value()
+    end
+
+    if not value then
+      return false
+    end
+
+    return map:get_key(value) and true or false
+  end
 end
 
 local function priority_to_string(pri)
@@ -732,7 +744,7 @@ local function process_settings_table(tbl, allow_ids, mempool, is_static)
         lua_util.debugm(N, rspamd_config, 'added ip_map condition to "%s"',
             name)
         checks.ip_map = {
-          check = gen_check_closure(ips_map, check_map_setting),
+          check = gen_map_check_closure(ips_map),
           extract = function(task)
             local ip = task:get_from_ip()
             if ip and ip:is_valid() then
@@ -762,14 +774,14 @@ local function process_settings_table(tbl, allow_ids, mempool, is_static)
       }
     end
     if elt.client_ip_map then
-      local ips_map = lua_maps.map_add_from_ucl(elt.ip_map, 'radix',
+      local ips_map = lua_maps.map_add_from_ucl(elt.client_ip_map, 'radix',
           'settings client ip map for ' .. name)
 
       if ips_map then
         lua_util.debugm(N, rspamd_config, 'added client ip_map condition to "%s"',
             name)
         checks.client_ip_map = {
-          check = gen_check_closure(ips_map, check_map_setting),
+          check = gen_map_check_closure(ips_map),
           extract = function(task)
             local ip = task:get_client_ip()
             if ip and ip:is_valid() then


### PR DESCRIPTION
`ip_map` and `client_ip_map` have never matched anything, since 3e4b62c added them.

`gen_check_closure` was handed the map object. It branches on `type(expected) == 'table'` to support a list of expected values, and a map object is a table — so it iterated the map's own fields and called `check_map_setting` on each, which died with `attempt to call method 'get_key' (a nil value)` on every message. The error is swallowed by the atom processor, so the block was skipped without a word.

A map needs its own closure rather than that branch, so `check_map_setting` is replaced by `gen_map_check_closure`, which keeps the same deferred-value handling and asks the map directly.

Separately, `client_ip_map` built its map from `elt.ip_map`, so it loaded the wrong map or none.

Verified on a stock 4.1.5 with a one-address map: before, a message from that address scored against the default limit (`0.00 / 15.00`) and logged the error; after, it gets the limit the block sets (`0.00 / 9999.00`) while a message from an address outside the map still gets `0.00 / 15.00`, and the log is clean.

Fixes #6204
