### PR TITLE
[Fix] url_suspect: restrict html_entities obfuscation pattern to ASCII

### DIFF
--- a/src/plugins/lua/url_suspect.lua
+++ b/src/plugins/lua/url_suspect.lua
@@ -824,7 +824,15 @@ if settings.enabled and settings.checks.obfuscated_text and settings.checks.obfu
   end
 
   if is_pattern_enabled('html_entities') then
-    table.insert(pattern_list, [=[&#\d{2,3};[^&]{0,20}&#\d{2,3};]=])
+    -- Only ASCII code points (< 128). Entity obfuscation spells out the
+    -- characters of a URL, which are ASCII ("&#104;&#116;&#116;&#112;" for
+    -- "http"). Ordinary prose in many languages entity-encodes accented
+    -- letters instead -- Danish/Norwegian ae-o-aa, German umlauts and
+    -- sharp s, French accents -- all of which live at 192-255 and cluster
+    -- naturally within a few characters of each other. Matching those made
+    -- URL_OBFUSCATED_TEXT fire on routine non-English newsletters.
+    table.insert(pattern_list,
+      [=[&#(?:\d{2}|1[01]\d|12[0-7]);[^&]{0,20}&#(?:\d{2}|1[01]\d|12[0-7]);]=])
     pattern_meta[#pattern_list] = { name = 'html_entity' }
   end
 


### PR DESCRIPTION
### The problem

`url_suspect`'s `html_entities` obfuscation pattern is:

```
&#\d{2,3};[^&]{0,20}&#\d{2,3};
```

"Two numeric HTML entities within 20 characters of each other."

The premise — clustered numeric entities mean someone is hiding a URL — holds for **ASCII**, where the technique spells out the characters of the URL itself: `&#104;&#116;&#116;&#112;` for `http`.

It does not hold for prose. Many languages routinely entity-encode accented letters, and those cluster naturally within a few characters:

| text | language |
|---|---|
| `v&#230;r s&#248;d` | Danish / Norwegian |
| `Gr&#252;&#223;e aus M&#252;nchen` | German |
| `r&#233;serv&#233; aux clients` | French |

All three match the current pattern, so `URL_OBFUSCATED_TEXT` fires on ordinary non-English newsletters. Because the symbol carries real weight and is shared with four other patterns, the only local workaround is turning the whole `html_entities` pattern off — which also gives up genuine ASCII-entity obfuscation detection.

### The fix

Latin-1 letters live at 192–255, well clear of the ASCII range the obfuscation technique actually uses. Restricting the pattern to code points below 128 keeps the detection and drops the false positives:

```
&#(?:\d{2}|1[01]\d|12[0-7]);[^&]{0,20}&#(?:\d{2}|1[01]\d|12[0-7]);
```

### Verification

Checked against the pattern directly:

| case | before | after |
|---|---|---|
| `&#104;&#116;&#116;&#112;://…` (obfuscated `http`) | match | match |
| `&#119;&#119;&#119;.…` (obfuscated `www`) | match | match |
| `v&#230;r s&#248;d` (Danish) | match | no match |
| `Gr&#252;&#223;e aus M&#252;nchen` (German) | match | no match |
| `r&#233;serv&#233; aux clients` (French) | match | no match |

Multi-byte entities such as `&#8203;` were already outside `\d{2,3}` and are unaffected. The other four obfuscation patterns (`hxxp`, bracket dots, spaced protocol, word-dot) are untouched.

### Note

I have not added a functional test. `test/functional/cases/001_merged/400_url_suspect.robot` looks like the natural home for one — happy to add cases there (an ASCII-obfuscated positive and a Latin-1 negative) if you would like them in this PR.
