### PR TITLE
Bound UCL parsing of untrusted input and free trees iteratively

### DIFF
--- a/contrib/libucl/ucl.h
+++ b/contrib/libucl/ucl.h
@@ -138,7 +138,8 @@ typedef enum ucl_error {
 	UCL_EMACRO,    /**< Error processing a macro */
 	UCL_EINTERNAL, /**< Internal unclassified error */
 	UCL_ESSL,      /**< SSL error */
-	UCL_EMERGE     /**< A merge error occurred */
+	UCL_EMERGE,    /**< A merge error occurred */
+	UCL_ELIMIT     /**< Input exceeds one of the configured parser limits */
 } ucl_error_t;
 
 /**
@@ -1026,6 +1027,42 @@ UCL_EXTERN bool ucl_parser_set_default_priority(struct ucl_parser *parser,
  * @return true default priority (0 .. 16), -1 for failure
  */
 UCL_EXTERN int ucl_parser_get_default_priority(struct ucl_parser *parser);
+
+/**
+ * Structural and allocation budgets applied while parsing.
+ *
+ * The input size alone is a poor proxy for the cost of parsing it: a small
+ * document can describe a very deep or very fragmented tree, and every
+ * element of that tree costs an object, a copied key/value and hash
+ * bookkeeping. These limits bound that amplification and should be set
+ * whenever the input is untrusted.
+ *
+ * A zero value means "no limit" for that particular field. Exceeding a limit
+ * aborts the parse with #UCL_ELIMIT (or #UCL_ENESTED for the depth limit).
+ */
+struct ucl_parser_limits {
+	uint64_t max_depth;         /**< Maximum nesting depth of objects and arrays */
+	uint64_t max_nodes;         /**< Maximum number of elements in the parsed tree */
+	uint64_t max_alloc;         /**< Maximum aggregate bytes attributed to the parsed tree */
+	uint64_t max_key_length;    /**< Maximum length of a single key */
+	uint64_t max_string_length; /**< Maximum length of a single string value */
+};
+
+/**
+ * Sets the parser limits, replacing all of them at once
+ * @param parser parser object
+ * @param limits limits to apply, NULL restores the defaults
+ */
+UCL_EXTERN void ucl_parser_set_limits(struct ucl_parser *parser,
+									  const struct ucl_parser_limits *limits);
+
+/**
+ * Gets the limits currently in effect for a parser
+ * @param parser parser object
+ * @param limits output, filled with the current limits
+ */
+UCL_EXTERN void ucl_parser_get_limits(struct ucl_parser *parser,
+									  struct ucl_parser_limits *limits);
 
 /**
  * Register new handler for a macro

--- a/contrib/libucl/ucl_hash.c
+++ b/contrib/libucl/ucl_hash.c
@@ -165,7 +165,7 @@ ucl_hash_create(bool ignore_case)
 	return new;
 }
 
-void ucl_hash_destroy(ucl_hash_t *hashlin, ucl_hash_free_func func)
+void ucl_hash_destroy(ucl_hash_t *hashlin, ucl_hash_free_func func, void *ud)
 {
 
 	if (hashlin == NULL) {
@@ -184,7 +184,7 @@ void ucl_hash_destroy(ucl_hash_t *hashlin, ucl_hash_free_func func)
 				cur = (kh_value(h, k))->obj;
 				while (cur != NULL) {
 					tmp = cur->next;
-					func(__DECONST(ucl_object_t *, cur));
+					func(__DECONST(ucl_object_t *, cur), ud);
 					cur = tmp;
 				}
 			}

--- a/contrib/libucl/ucl_hash.h
+++ b/contrib/libucl/ucl_hash.h
@@ -32,7 +32,7 @@ struct ucl_hash_node_s;
 typedef struct ucl_hash_node_s ucl_hash_node_t;
 
 typedef int (*ucl_hash_cmp_func) (const void* void_a, const void* void_b);
-typedef void (*ucl_hash_free_func) (void *ptr);
+typedef void (*ucl_hash_free_func) (void *ptr, void *ud);
 typedef void* ucl_hash_iter_t;
 
 
@@ -50,8 +50,12 @@ ucl_hash_t* ucl_hash_create (bool ignore_case);
 
 /**
  * Deinitializes the hashtable.
+ * @param func called for every stored object (and every element of its
+ *   implicit-array chain) before the table itself is released; NULL leaves
+ *   the stored objects alone and only frees the table
+ * @param ud opaque context handed to `func`
  */
-void ucl_hash_destroy (ucl_hash_t* hashlin, ucl_hash_free_func func);
+void ucl_hash_destroy (ucl_hash_t* hashlin, ucl_hash_free_func func, void *ud);
 
 /**
  * Inserts an element in the the hashtable.

--- a/contrib/libucl/ucl_internal.h
+++ b/contrib/libucl/ucl_internal.h
@@ -141,6 +141,14 @@ typedef SSIZE_T ssize_t;
 
 #define UCL_MAX_RECURSION 16
 #define UCL_MAX_NESTING 1024
+
+/*
+ * Bookkeeping that a single tree element is assumed to cost on top of the
+ * object itself: a hash element, a khash slot and the usual allocator
+ * overhead. It is deliberately a rough estimate - it only has to make
+ * `max_alloc` track the real footprint closely enough to be a useful budget.
+ */
+#define UCL_NODE_OVERHEAD 64
 #define UCL_TRASH_KEY 0
 #define UCL_TRASH_VALUE 1
 
@@ -272,6 +280,10 @@ struct ucl_parser {
 	void *var_data;
 	ucl_object_t *comments;
 	ucl_object_t *last_comment;
+	struct ucl_parser_limits limits;
+	uint64_t cur_nodes;
+	uint64_t cur_alloc;
+	uint32_t cur_depth;
 	UT_string *err;
 };
 
@@ -293,6 +305,36 @@ size_t ucl_unescape_json_string (char *str, size_t len);
  * @param str
  */
 size_t ucl_unescape_squoted_string (char *str, size_t len);
+
+/**
+ * Pop the head frame off the parser stack, keeping the nesting depth counter
+ * in sync
+ * @param parser parser object
+ * @param st frame to pop, must be the current head of parser->stack
+ */
+void ucl_parser_pop_container (struct ucl_parser *parser, struct ucl_stack *st);
+
+/**
+ * Empty an array without releasing the objects it holds. Used to unwind a
+ * partially built array whose elements are still owned by somebody else.
+ * @param ar array object
+ */
+void ucl_array_detach_elements (ucl_object_t *ar);
+
+/**
+ * Account for one more element in the resulting tree
+ * @param parser parser object
+ * @return false if either the node or the allocation budget is exhausted
+ */
+bool ucl_parser_account_node (struct ucl_parser *parser);
+
+/**
+ * Charge `bytes` against the parser's allocation budget
+ * @param parser parser object
+ * @param bytes amount of memory the tree is about to grow by
+ * @return false if the budget is exhausted (parser error is set)
+ */
+bool ucl_parser_account_alloc (struct ucl_parser *parser, uint64_t bytes);
 
 /**
  * Handle include macro
@@ -486,7 +528,7 @@ ucl_hash_insert_object (ucl_hash_t *hashlin,
 	}
 	if (!ucl_hash_insert (nhp, obj, obj->key, obj->keylen)) {
 		if (nhp != hashlin) {
-			ucl_hash_destroy(nhp, NULL);
+			ucl_hash_destroy(nhp, NULL, NULL);
 		}
 		return NULL;
 	}

--- a/contrib/libucl/ucl_msgpack.c
+++ b/contrib/libucl/ucl_msgpack.c
@@ -758,6 +758,30 @@ ucl_msgpack_get_parser_from_type (unsigned char t)
 	return NULL;
 }
 
+/*
+ * Create an object for a msgpack element, charging it against the parser
+ * budgets first. MessagePack is far denser than JSON - a whole container costs
+ * a single byte - so it amplifies harder than text input and needs the same
+ * accounting.
+ */
+static inline ucl_object_t *
+ucl_msgpack_new_object (struct ucl_parser *parser, ucl_type_t type)
+{
+	ucl_object_t *obj;
+
+	if (!ucl_parser_account_node (parser)) {
+		return NULL;
+	}
+
+	obj = ucl_object_new_full (type, parser->chunks->priority);
+
+	if (obj == NULL) {
+		ucl_create_err (&parser->err, "no memory for a msgpack object");
+	}
+
+	return obj;
+}
+
 static inline struct ucl_stack *
 ucl_msgpack_get_container (struct ucl_parser *parser,
 		struct ucl_msgpack_parser *obj_parser, uint64_t len)
@@ -770,15 +794,13 @@ ucl_msgpack_get_container (struct ucl_parser *parser,
 		/*
 		 * Insert new container to the stack
 		 */
-		unsigned int depth = 0;
-		struct ucl_stack *sp;
-		for (sp = parser->stack; sp != NULL; sp = sp->next) {
-			depth++;
-		}
-		if (depth >= UCL_MAX_NESTING) {
+		if (parser->limits.max_depth > 0 &&
+			(uint64_t) parser->cur_depth >= parser->limits.max_depth) {
 			ucl_create_err(&parser->err,
-						   "msgpack containers are nested too deep (over %d)",
-						   UCL_MAX_NESTING);
+						   "msgpack containers are nested too deep (over %ju)",
+						   (uintmax_t) parser->limits.max_depth);
+			parser->err_code = UCL_ENESTED;
+
 			return NULL;
 		}
 
@@ -805,6 +827,7 @@ ucl_msgpack_get_container (struct ucl_parser *parser,
 			parser->stack = stack;
 		}
 
+		parser->cur_depth ++;
 		parser->stack->e.len = len;
 
 #ifdef MSGPACK_DEBUG_PARSER
@@ -893,19 +916,27 @@ ucl_msgpack_get_next_container (struct ucl_parser *parser)
 	struct ucl_stack *cur = NULL;
 	uint64_t len;
 
-	cur = parser->stack;
+	/*
+	 * Iterative rather than tail recursive: closing a deeply nested document
+	 * unwinds every finished container in one go, and doing that on the C
+	 * stack would make parse depth a stack-depth problem again.
+	 */
+	for (;;) {
+		cur = parser->stack;
 
-	if (cur == NULL) {
-		return NULL;
-	}
+		if (cur == NULL) {
+			return NULL;
+		}
 
-	len = cur->e.len;
+		len = cur->e.len;
 
-	if (len == 0) {
+		if (len != 0) {
+			break;
+		}
+
 		/* We need to switch to the previous container */
-		parser->stack = cur->next;
 		parser->cur_obj = cur->obj;
-		free (cur);
+		ucl_parser_pop_container (parser, cur);
 
 #ifdef MSGPACK_DEBUG_PARSER
 		cur = parser->stack;
@@ -915,8 +946,6 @@ ucl_msgpack_get_next_container (struct ucl_parser *parser)
 			}
 			fprintf(stderr, "-%s -> %d\n", parser->cur_obj->type == UCL_OBJECT ? "object" : "array", (int)parser->cur_obj->len);
 #endif
-
-		return ucl_msgpack_get_next_container (parser);
 	}
 
 	/*
@@ -937,10 +966,13 @@ ucl_msgpack_get_next_container (struct ucl_parser *parser)
 		assert (remain >= 0);								\
 	}														\
 	else {													\
-		ucl_create_err (&parser->err,						\
-			"cannot parse type %d of len %u",				\
-			(int)obj_parser->fmt,							\
-			(unsigned)len);									\
+		/* Keep a more specific reason if one was recorded */\
+		if (parser->err_code == UCL_EOK) {					\
+			ucl_create_err (&parser->err,					\
+				"cannot parse type %d of len %u",			\
+				(int)obj_parser->fmt,						\
+				(unsigned)len);								\
+		}													\
 		return false;										\
 	}														\
 } while(0)
@@ -1089,8 +1121,12 @@ ucl_msgpack_consume (struct ucl_parser *parser)
 
 			break;
 		case start_assoc:
-			parser->cur_obj = ucl_object_new_full (UCL_OBJECT,
-					parser->chunks->priority);
+			parser->cur_obj = ucl_msgpack_new_object (parser, UCL_OBJECT);
+
+			if (parser->cur_obj == NULL) {
+				return false;
+			}
+
 			/* Insert to the previous level container */
 			if (parser->stack && !ucl_msgpack_insert_object (parser,
 					key, keylen, parser->cur_obj)) {
@@ -1120,8 +1156,12 @@ ucl_msgpack_consume (struct ucl_parser *parser)
 			break;
 
 		case start_array:
-			parser->cur_obj = ucl_object_new_full (UCL_ARRAY,
-					parser->chunks->priority);
+			parser->cur_obj = ucl_msgpack_new_object (parser, UCL_ARRAY);
+
+			if (parser->cur_obj == NULL) {
+				return false;
+			}
+
 			/* Insert to the previous level container */
 			if (parser->stack && !ucl_msgpack_insert_object (parser,
 					key, keylen, parser->cur_obj)) {
@@ -1206,6 +1246,15 @@ ucl_msgpack_consume (struct ucl_parser *parser)
 				return false;
 			}
 
+			if (parser->limits.max_key_length > 0 &&
+				(uint64_t) len > parser->limits.max_key_length) {
+				ucl_create_err (&parser->err, "msgpack key is too long: %ju",
+						(uintmax_t) len);
+				parser->err_code = UCL_ELIMIT;
+
+				return false;
+			}
+
 			keylen = len;
 			p += len;
 			remain -= len;
@@ -1280,9 +1329,12 @@ ucl_msgpack_consume (struct ucl_parser *parser)
 			return false;
 		}
 
-		parser->cur_obj = ucl_object_new_full (
-				state == start_array ? UCL_ARRAY : UCL_OBJECT,
-				parser->chunks->priority);
+		parser->cur_obj = ucl_msgpack_new_object (parser,
+				state == start_array ? UCL_ARRAY : UCL_OBJECT);
+
+		if (parser->cur_obj == NULL) {
+			return false;
+		}
 
 		if (parser->stack == NULL) {
 			ucl_create_err (&parser->err,
@@ -1429,7 +1481,21 @@ ucl_msgpack_parse_string (struct ucl_parser *parser,
 		return -1;
 	}
 
-	obj = ucl_object_new_full (UCL_STRING, parser->chunks->priority);
+	if (parser->limits.max_string_length > 0 &&
+		(uint64_t) len > parser->limits.max_string_length) {
+		ucl_create_err (&parser->err, "msgpack string is too long: %ju",
+				(uintmax_t) len);
+		parser->err_code = UCL_ELIMIT;
+
+		return -1;
+	}
+
+	obj = ucl_msgpack_new_object (parser, UCL_STRING);
+
+	if (obj == NULL) {
+		return -1;
+	}
+
 	obj->value.sv = pos;
 	obj->len = len;
 
@@ -1438,6 +1504,13 @@ ucl_msgpack_parse_string (struct ucl_parser *parser,
 	}
 
 	if (!(parser->flags & UCL_PARSER_ZEROCOPY)) {
+		/* The contents are about to be copied, so they cost us memory too */
+		if (!ucl_parser_account_alloc (parser, (uint64_t) len + 1)) {
+			ucl_object_unref (obj);
+
+			return -1;
+		}
+
 		if (obj->flags & UCL_OBJECT_BINARY) {
 			obj->trash_stack[UCL_TRASH_VALUE] = malloc (len);
 
@@ -1474,7 +1547,12 @@ ucl_msgpack_parse_int (struct ucl_parser *parser,
 		return -1;
 	}
 
-	obj = ucl_object_new_full (UCL_INT, parser->chunks->priority);
+	obj = ucl_msgpack_new_object (parser, UCL_INT);
+
+	if (obj == NULL) {
+		return -1;
+	}
+
 
 	switch (fmt) {
 	case msgpack_positive_fixint:
@@ -1556,7 +1634,12 @@ ucl_msgpack_parse_float (struct ucl_parser *parser,
 		return -1;
 	}
 
-	obj = ucl_object_new_full (UCL_FLOAT, parser->chunks->priority);
+	obj = ucl_msgpack_new_object (parser, UCL_FLOAT);
+
+	if (obj == NULL) {
+		return -1;
+	}
+
 
 	switch (fmt) {
 	case msgpack_float32:
@@ -1593,7 +1676,12 @@ ucl_msgpack_parse_bool (struct ucl_parser *parser,
 		return -1;
 	}
 
-	obj = ucl_object_new_full (UCL_BOOLEAN, parser->chunks->priority);
+	obj = ucl_msgpack_new_object (parser, UCL_BOOLEAN);
+
+	if (obj == NULL) {
+		return -1;
+	}
+
 
 	switch (fmt) {
 	case msgpack_true:
@@ -1623,7 +1711,12 @@ ucl_msgpack_parse_null (struct ucl_parser *parser,
 		return -1;
 	}
 
-	obj = ucl_object_new_full (UCL_NULL, parser->chunks->priority);
+	obj = ucl_msgpack_new_object (parser, UCL_NULL);
+
+	if (obj == NULL) {
+		return -1;
+	}
+
 	parser->cur_obj = obj;
 
 	return 1;

--- a/contrib/libucl/ucl_parser.c
+++ b/contrib/libucl/ucl_parser.c
@@ -96,6 +96,23 @@ ucl_set_err(struct ucl_parser *parser, int code, const char *str, UT_string **er
 	parser->state = UCL_STATE_ERROR;
 }
 
+/**
+ * Record a generic failure, but only if nothing more specific was recorded
+ * already. Used where a helper returning NULL means "syntax error" in the
+ * common case yet may also have failed for a reason of its own, such as a
+ * parser limit being hit.
+ */
+static void
+ucl_set_err_fallback(struct ucl_parser *parser, int code, const char *str)
+{
+	if (parser->err_code == UCL_EOK) {
+		ucl_set_err(parser, code, str, &parser->err);
+	}
+	else {
+		parser->state = UCL_STATE_ERROR;
+	}
+}
+
 static void
 ucl_save_comment(struct ucl_parser *parser, const char *begin, size_t len)
 {
@@ -579,6 +596,38 @@ ucl_expand_variable(struct ucl_parser *parser, unsigned char **dst,
 	return out_len;
 }
 
+bool ucl_parser_account_alloc(struct ucl_parser *parser, uint64_t bytes)
+{
+	parser->cur_alloc += bytes;
+
+	if (parser->limits.max_alloc > 0 &&
+		parser->cur_alloc > parser->limits.max_alloc) {
+		ucl_set_err(parser, UCL_ELIMIT,
+					"input requires too much memory to represent",
+					&parser->err);
+
+		return false;
+	}
+
+	return true;
+}
+
+bool ucl_parser_account_node(struct ucl_parser *parser)
+{
+	parser->cur_nodes++;
+
+	if (parser->limits.max_nodes > 0 &&
+		parser->cur_nodes > parser->limits.max_nodes) {
+		ucl_set_err(parser, UCL_ELIMIT, "input has too many elements",
+					&parser->err);
+
+		return false;
+	}
+
+	return ucl_parser_account_alloc(parser,
+									sizeof(ucl_object_t) + UCL_NODE_OVERHEAD);
+}
+
 /**
  * Store or copy pointer to the trash stack
  * @param parser parser object
@@ -586,6 +635,7 @@ ucl_expand_variable(struct ucl_parser *parser, unsigned char **dst,
  * @param dst destination buffer (trash stack pointer)
  * @param dst_const const destination pointer (e.g. value of object)
  * @param in_len input length
+ * @param max_len maximum accepted length, 0 for unlimited
  * @param need_unescape need to unescape source (and copy it)
  * @param need_lowercase need to lowercase value (and copy)
  * @param need_expand need to expand variables (and copy as well)
@@ -595,12 +645,23 @@ ucl_expand_variable(struct ucl_parser *parser, unsigned char **dst,
 static inline ssize_t
 ucl_copy_or_store_ptr(struct ucl_parser *parser,
 					  const unsigned char *src, unsigned char **dst,
-					  const char **dst_const, size_t in_len,
+					  const char **dst_const, size_t in_len, uint64_t max_len,
 					  bool need_unescape, bool need_lowercase, bool need_expand,
 					  bool unescape_squote)
 {
 	ssize_t ret = -1, tret;
 	unsigned char *tmp;
+
+	/*
+	 * Checked before allocating: `in_len` comes straight from the input and
+	 * is an upper bound on the result, as neither unescaping nor lowercasing
+	 * can make a string longer.
+	 */
+	if (max_len > 0 && (uint64_t) in_len > max_len) {
+		ucl_set_err(parser, UCL_ELIMIT, "string is too long", &parser->err);
+
+		return -1;
+	}
 
 	if (need_unescape || need_lowercase ||
 		(need_expand && parser->variables != NULL) ||
@@ -610,8 +671,19 @@ ucl_copy_or_store_ptr(struct ucl_parser *parser,
 		if (*dst == NULL) {
 			ucl_set_err(parser, UCL_EINTERNAL, "cannot allocate memory for a string",
 						&parser->err);
-			return false;
+			return -1;
 		}
+
+		/*
+		 * Charge what was actually allocated, not what the decoded string ends
+		 * up being: unescaping shrinks the contents but keeps the buffer, so
+		 * charging the decoded length would let escape-heavy input claim more
+		 * memory than the budget accounts for.
+		 */
+		if (!ucl_parser_account_alloc(parser, (uint64_t) in_len + 1)) {
+			return -1;
+		}
+
 		if (need_lowercase) {
 			ret = ucl_strlcpy_tolower(*dst, src, in_len + 1);
 		}
@@ -641,6 +713,22 @@ ucl_copy_or_store_ptr(struct ucl_parser *parser,
 				/* Free unexpanded value */
 				UCL_FREE(in_len + 1, tmp);
 			}
+
+			/* Expansion is the one transform that can grow a string */
+			if (max_len > 0 && ret > 0 && (uint64_t) ret > max_len) {
+				ucl_set_err(parser, UCL_ELIMIT,
+							"string is too long after variables expansion",
+							&parser->err);
+
+				return -1;
+			}
+
+			/* Charge whatever expansion added on top of the original buffer */
+			if (ret > 0 && (uint64_t) ret > (uint64_t) in_len &&
+				!ucl_parser_account_alloc(parser,
+										  (uint64_t) ret - (uint64_t) in_len)) {
+				return -1;
+			}
 		}
 		*dst_const = *dst;
 	}
@@ -666,10 +754,31 @@ ucl_parser_add_container(ucl_object_t *obj, struct ucl_parser *parser,
 	struct ucl_stack *st;
 	ucl_object_t *nobj;
 
+	/*
+	 * `level` below is the UCL dotted-key nesting level, which says nothing
+	 * about how deep the containers actually are; the stack depth does, and
+	 * that is what every recursive walk over the resulting tree (emitting,
+	 * copying, and destruction itself) is proportional to. Checked before
+	 * anything is allocated.
+	 */
+	if (parser->limits.max_depth > 0 &&
+		(uint64_t) parser->cur_depth >= parser->limits.max_depth) {
+		ucl_set_err(parser, UCL_ENESTED, "data is nested too deep",
+					&parser->err);
+
+		return NULL;
+	}
+
 	if (obj == NULL) {
 		nobj = ucl_object_new_full(is_array ? UCL_ARRAY : UCL_OBJECT, parser->chunks->priority);
 		if (nobj == NULL) {
 			goto enomem0;
+		}
+
+		if (!ucl_parser_account_node(parser)) {
+			ucl_object_unref(nobj);
+
+			return NULL;
 		}
 	}
 	else {
@@ -732,6 +841,7 @@ ucl_parser_add_container(ucl_object_t *obj, struct ucl_parser *parser,
 	}
 
 	LL_PREPEND(parser->stack, st);
+	parser->cur_depth++;
 	parser->cur_obj = nobj;
 
 	return nobj;
@@ -742,6 +852,22 @@ enomem0:
 	ucl_set_err(parser, UCL_EINTERNAL, "cannot allocate memory for an object",
 				&parser->err);
 	return NULL;
+}
+
+/**
+ * Pop the head frame off the parser stack, keeping the depth counter in sync
+ * @param parser parser object
+ * @param st frame to pop, must be the current head of parser->stack
+ */
+void ucl_parser_pop_container(struct ucl_parser *parser, struct ucl_stack *st)
+{
+	parser->stack = st->next;
+
+	if (parser->cur_depth > 0) {
+		parser->cur_depth--;
+	}
+
+	UCL_FREE(sizeof(struct ucl_stack), st);
 }
 
 int ucl_maybe_parse_number(ucl_object_t *obj,
@@ -1208,7 +1334,7 @@ ucl_lex_squoted_string(struct ucl_parser *parser,
 	return false;
 }
 
-static void
+static bool
 ucl_parser_append_elt(struct ucl_parser *parser, ucl_hash_t *cont,
 					  ucl_object_t *top,
 					  ucl_object_t *elt)
@@ -1224,19 +1350,58 @@ ucl_parser_append_elt(struct ucl_parser *parser, ucl_hash_t *cont,
 	else {
 		if ((top->flags & UCL_OBJECT_MULTIVALUE) != 0) {
 			/* Just add to the explicit array */
-			ucl_array_append(top, elt);
+			if (!ucl_array_append(top, elt)) {
+				ucl_set_err(parser, UCL_EINTERNAL,
+							"cannot allocate memory for an array",
+							&parser->err);
+
+				return false;
+			}
 		}
 		else {
-			/* Convert to an array */
+			/*
+			 * Converting to an explicit array costs one more element, so it has
+			 * to be charged as well: otherwise a run of duplicate keys grows the
+			 * tree without ever touching the budget.
+			 */
+			if (!ucl_parser_account_node(parser)) {
+				return false;
+			}
+
 			nobj = ucl_object_typed_new(UCL_ARRAY);
+
+			if (nobj == NULL) {
+				ucl_set_err(parser, UCL_EINTERNAL,
+							"cannot allocate memory for an object",
+							&parser->err);
+
+				return false;
+			}
+
 			nobj->key = top->key;
 			nobj->keylen = top->keylen;
 			nobj->flags |= UCL_OBJECT_MULTIVALUE;
-			ucl_array_append(nobj, top);
-			ucl_array_append(nobj, elt);
+
+			if (!ucl_array_append(nobj, top) ||
+				!ucl_array_append(nobj, elt)) {
+				/*
+				 * `top` is still owned by the container, so the half-built
+				 * array must be dropped without releasing what it holds.
+				 */
+				ucl_array_detach_elements(nobj);
+				ucl_object_unref(nobj);
+				ucl_set_err(parser, UCL_EINTERNAL,
+							"cannot allocate memory for an array",
+							&parser->err);
+
+				return false;
+			}
+
 			ucl_hash_replace(cont, top, nobj);
 		}
 	}
+
+	return true;
 }
 
 bool ucl_parser_process_object_element(struct ucl_parser *parser, ucl_object_t *nobj)
@@ -1298,7 +1463,9 @@ bool ucl_parser_process_object_element(struct ucl_parser *parser, ucl_object_t *
 			}
 
 			if (priold == prinew) {
-				ucl_parser_append_elt(parser, container, tobj, nobj);
+				if (!ucl_parser_append_elt(parser, container, tobj, nobj)) {
+					return false;
+				}
 			}
 			else if (priold > prinew) {
 				/*
@@ -1339,7 +1506,9 @@ bool ucl_parser_process_object_element(struct ucl_parser *parser, ucl_object_t *
 				nobj = tobj;
 			}
 			else if (priold == prinew) {
-				ucl_parser_append_elt(parser, container, tobj, nobj);
+				if (!ucl_parser_append_elt(parser, container, tobj, nobj)) {
+					return false;
+				}
 			}
 			else if (priold > prinew) {
 				/*
@@ -1564,8 +1733,15 @@ ucl_parse_key(struct ucl_parser *parser, struct ucl_chunk *chunk,
 	if (nobj == NULL) {
 		return false;
 	}
+
+	if (!ucl_parser_account_node(parser)) {
+		ucl_object_unref(nobj);
+		return false;
+	}
+
 	keylen = ucl_copy_or_store_ptr(parser, c, &nobj->trash_stack[UCL_TRASH_KEY],
-								   &key, end - c, need_unescape, parser->flags & UCL_PARSER_KEY_LOWERCASE,
+								   &key, end - c, parser->limits.max_key_length,
+								   need_unescape, parser->flags & UCL_PARSER_KEY_LOWERCASE,
 								   false, false);
 	if (keylen == -1) {
 		ucl_object_unref(nobj);
@@ -1734,6 +1910,11 @@ ucl_parser_get_container(struct ucl_parser *parser)
 		obj = ucl_object_new_full(UCL_NULL, parser->chunks->priority);
 		t = parser->stack->obj;
 
+		if (!ucl_parser_account_node(parser)) {
+			ucl_object_unref(obj);
+			return NULL;
+		}
+
 		if (!ucl_array_append(t, obj)) {
 			ucl_object_unref(obj);
 			return NULL;
@@ -1800,7 +1981,9 @@ ucl_parse_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 			obj->type = UCL_STRING;
 			if ((str_len = ucl_copy_or_store_ptr(parser, c + 1,
 												 &obj->trash_stack[UCL_TRASH_VALUE],
-												 &obj->value.sv, str_len, need_unescape, false,
+												 &obj->value.sv, str_len,
+												 parser->limits.max_string_length,
+												 need_unescape, false,
 												 var_expand, false)) == -1) {
 				return false;
 			}
@@ -1828,7 +2011,9 @@ ucl_parse_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 
 			if ((str_len = ucl_copy_or_store_ptr(parser, c + 1,
 												 &obj->trash_stack[UCL_TRASH_VALUE],
-												 &obj->value.sv, str_len, need_unescape, false,
+												 &obj->value.sv, str_len,
+												 parser->limits.max_string_length,
+												 need_unescape, false,
 												 var_expand, true)) == -1) {
 				return false;
 			}
@@ -1842,9 +2027,8 @@ ucl_parse_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 		case '{':
 			obj = ucl_parser_get_container(parser);
 			if (obj == NULL) {
-				parser->state = UCL_STATE_ERROR;
-				ucl_set_err(parser, UCL_ESYNTAX, "object value must be a part of an object",
-							&parser->err);
+				ucl_set_err_fallback(parser, UCL_ESYNTAX,
+									 "object value must be a part of an object");
 				return false;
 			}
 			/* We have a new object */
@@ -1866,9 +2050,8 @@ ucl_parse_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 		case '[':
 			obj = ucl_parser_get_container(parser);
 			if (obj == NULL) {
-				parser->state = UCL_STATE_ERROR;
-				ucl_set_err(parser, UCL_ESYNTAX, "array value must be a part of an object",
-							&parser->err);
+				ucl_set_err_fallback(parser, UCL_ESYNTAX,
+									 "array value must be a part of an object");
 				return false;
 			}
 			/* We have a new array */
@@ -1901,9 +2084,8 @@ ucl_parse_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 		case '<':
 			obj = ucl_parser_get_container(parser);
 			if (obj == NULL) {
-				parser->state = UCL_STATE_ERROR;
-				ucl_set_err(parser, UCL_ESYNTAX, "multiline value must be a part of an object",
-							&parser->err);
+				ucl_set_err_fallback(parser, UCL_ESYNTAX,
+									 "multiline value must be a part of an object");
 				return false;
 			}
 			/* We have something like multiline value, which must be <<[A-Z]+\n */
@@ -1937,7 +2119,9 @@ ucl_parse_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 						obj->flags |= UCL_OBJECT_MULTILINE;
 						if ((str_len = ucl_copy_or_store_ptr(parser, c,
 															 &obj->trash_stack[UCL_TRASH_VALUE],
-															 &obj->value.sv, str_len - 1, false,
+															 &obj->value.sv, str_len - 1,
+															 parser->limits.max_string_length,
+															 false,
 															 false, var_expand, false)) == -1) {
 							return false;
 						}
@@ -1958,9 +2142,8 @@ ucl_parse_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 			}
 
 			if (obj == NULL) {
-				parser->state = UCL_STATE_ERROR;
-				ucl_set_err(parser, UCL_ESYNTAX, "value must be a part of an object",
-							&parser->err);
+				ucl_set_err_fallback(parser, UCL_ESYNTAX,
+									 "value must be a part of an object");
 				return false;
 			}
 
@@ -2012,7 +2195,9 @@ ucl_parse_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 				obj->type = UCL_STRING;
 				if ((str_len = ucl_copy_or_store_ptr(parser, c,
 													 &obj->trash_stack[UCL_TRASH_VALUE],
-													 &obj->value.sv, str_len, need_unescape,
+													 &obj->value.sv, str_len,
+													 parser->limits.max_string_length,
+													 need_unescape,
 													 false, var_expand, false)) == -1) {
 					return false;
 				}
@@ -2086,8 +2271,7 @@ ucl_parse_after_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 						st->e.params.flags = 0;
 					}
 					else {
-						parser->stack = st->next;
-						UCL_FREE(sizeof(struct ucl_stack), st);
+						ucl_parser_pop_container(parser, st);
 					}
 
 					if (parser->cur_obj) {
@@ -2105,9 +2289,8 @@ ucl_parse_after_value(struct ucl_parser *parser, struct ucl_chunk *chunk)
 						}
 
 
-						parser->stack = st->next;
 						parser->cur_obj = st->obj;
-						UCL_FREE(sizeof(struct ucl_stack), st);
+						ucl_parser_pop_container(parser, st);
 					}
 				}
 				else {
@@ -2844,6 +3027,16 @@ ucl_parser_new(int flags)
 	parser->flags = flags;
 	parser->includepaths = NULL;
 
+	/*
+	 * Only the depth limit is on by default: it is the one that protects
+	 * against stack growth in the recursive walks over the resulting tree,
+	 * and 1024 levels is far beyond any legitimate configuration. The
+	 * remaining budgets would break large but perfectly valid inputs (maps,
+	 * language models, big JSON replies), so callers that deal with
+	 * untrusted data opt into them explicitly via ucl_parser_set_limits().
+	 */
+	parser->limits.max_depth = UCL_MAX_NESTING;
+
 	if (flags & UCL_PARSER_SAVE_COMMENTS) {
 		parser->comments = ucl_object_typed_new(UCL_OBJECT);
 	}
@@ -2877,6 +3070,32 @@ int ucl_parser_get_default_priority(struct ucl_parser *parser)
 	}
 
 	return parser->default_priority;
+}
+
+void ucl_parser_set_limits(struct ucl_parser *parser,
+						   const struct ucl_parser_limits *limits)
+{
+	if (parser == NULL) {
+		return;
+	}
+
+	if (limits == NULL) {
+		memset(&parser->limits, 0, sizeof(parser->limits));
+		parser->limits.max_depth = UCL_MAX_NESTING;
+	}
+	else {
+		memcpy(&parser->limits, limits, sizeof(parser->limits));
+	}
+}
+
+void ucl_parser_get_limits(struct ucl_parser *parser,
+						   struct ucl_parser_limits *limits)
+{
+	if (parser == NULL || limits == NULL) {
+		return;
+	}
+
+	memcpy(limits, &parser->limits, sizeof(*limits));
 }
 
 bool ucl_parser_register_macro(struct ucl_parser *parser, const char *macro,

--- a/contrib/libucl/ucl_util.c
+++ b/contrib/libucl/ucl_util.c
@@ -188,10 +188,14 @@ char *basename(char *path)
 #define ucl_realpath realpath
 #endif
 
-typedef void (*ucl_object_dtor) (ucl_object_t *obj);
-static void ucl_object_free_internal (ucl_object_t *obj, bool allow_rec,
-		ucl_object_dtor dtor);
-static void ucl_object_dtor_unref (ucl_object_t *obj);
+static void ucl_object_dtor_free (ucl_object_t *obj);
+
+static void
+ucl_object_dtor_free_ud (void *obj, void *ud)
+{
+	(void) ud;
+	ucl_object_dtor_free ((ucl_object_t *) obj);
+}
 
 static void
 ucl_object_dtor_free (ucl_object_t *obj)
@@ -218,84 +222,209 @@ ucl_object_dtor_free (ucl_object_t *obj)
 }
 
 /*
- * This is a helper function that performs exactly the same as
- * `ucl_object_unref` but it doesn't iterate over elements allowing
- * to use it for individual elements of arrays and multiple values
+ * Destroying a UCL tree is a graph traversal: releasing a container releases
+ * its children, which may be containers themselves. Doing that on the C stack
+ * makes cleanup depth proportional to the nesting depth of the document, so a
+ * deeply nested (and possibly attacker supplied) input could exhaust the stack
+ * while being freed - long after the parser had returned successfully.
+ *
+ * So the traversal is explicit instead. An object only reaches the worklist
+ * once its last reference is gone, which means it is already detached from the
+ * tree and nothing else can observe it; its `next` pointer is therefore free
+ * for us to reuse as the worklist link. That keeps destruction allocation free
+ * and its stack usage constant.
+ */
+struct ucl_dtor_worklist {
+	ucl_object_t *head;
+};
+
+static inline void
+ucl_dtor_worklist_push (struct ucl_dtor_worklist *wl, ucl_object_t *obj)
+{
+	obj->next = wl->head;
+	wl->head = obj;
+}
+
+static inline ucl_object_t *
+ucl_dtor_worklist_pop (struct ucl_dtor_worklist *wl)
+{
+	ucl_object_t *obj = wl->head;
+
+	if (obj != NULL) {
+		wl->head = obj->next;
+		obj->next = NULL;
+	}
+
+	return obj;
+}
+
+/*
+ * Drop one reference to `obj` and queue it for destruction if that was the
+ * last one. `obj` must already be unlinked from whatever contained it.
  */
 static void
-ucl_object_dtor_unref_single (ucl_object_t *obj)
+ucl_dtor_worklist_unref (void *ptr, void *ud)
 {
-	if (obj != NULL) {
+	ucl_object_t *obj = (ucl_object_t *) ptr;
+	struct ucl_dtor_worklist *wl = (struct ucl_dtor_worklist *) ud;
+
+	if (obj == NULL) {
+		return;
+	}
+
 #ifdef HAVE_ATOMIC_BUILTINS
-		unsigned int rc = __sync_sub_and_fetch (&obj->ref, 1);
-		if (rc == 0) {
+	if (__sync_sub_and_fetch (&obj->ref, 1) == 0) {
 #else
-		if (--obj->ref == 0) {
+	if (--obj->ref == 0) {
 #endif
-			ucl_object_free_internal (obj, false, ucl_object_dtor_unref);
-		}
+		ucl_dtor_worklist_push (wl, obj);
 	}
 }
 
-static void
-ucl_object_dtor_unref (ucl_object_t *obj)
+/*
+ * Queue every element of an implicit-array chain starting at `obj`. The chain
+ * links are read before each element is unreffed, since unreffing may reuse
+ * them for the worklist.
+ */
+static inline void
+ucl_dtor_worklist_unref_chain (struct ucl_dtor_worklist *wl, ucl_object_t *obj)
 {
-	if (obj->ref == 0) {
-		ucl_object_dtor_free (obj);
-	}
-	else {
-		/* This may cause dtor unref being called one more time */
-		ucl_object_dtor_unref_single (obj);
-	}
-}
-
-static void
-ucl_object_free_internal (ucl_object_t *obj, bool allow_rec, ucl_object_dtor dtor)
-{
-	ucl_object_t *tmp, *sub;
+	ucl_object_t *tmp;
 
 	while (obj != NULL) {
-		if (obj->type == UCL_ARRAY) {
-			UCL_ARRAY_GET (vec, obj);
-			unsigned int i;
+		tmp = obj->next;
+		ucl_dtor_worklist_unref (obj, wl);
+		obj = tmp;
+	}
+}
+
+/*
+ * Release a whole subtree. `obj` must have already reached zero references;
+ * with `allow_rec` its implicit-array siblings are released as well.
+ */
+static void
+ucl_object_free_internal (ucl_object_t *obj, bool allow_rec)
+{
+	struct ucl_dtor_worklist wl = {NULL};
+	ucl_object_t *cur, *sub, *tmp;
+
+	if (obj == NULL) {
+		return;
+	}
+
+	/*
+	 * The head is dead already, so it goes straight onto the worklist; its
+	 * siblings still hold a reference each and have to be unreffed properly.
+	 * Save the link first, pushing overwrites it.
+	 */
+	tmp = obj->next;
+	ucl_dtor_worklist_push (&wl, obj);
+
+	if (allow_rec) {
+		ucl_dtor_worklist_unref_chain (&wl, tmp);
+	}
+
+	while ((cur = ucl_dtor_worklist_pop (&wl)) != NULL) {
+		if (cur->type == UCL_ARRAY) {
+			UCL_ARRAY_GET (vec, cur);
 
 			if (vec != NULL) {
+				unsigned int i;
+
 				for (i = 0; i < vec->n; i ++) {
 					sub = kv_A (*vec, i);
-					if (sub != NULL) {
-						tmp = sub;
-						while (sub) {
-							tmp = sub->next;
-							dtor (sub);
-							sub = tmp;
-						}
-					}
+					ucl_dtor_worklist_unref_chain (&wl, sub);
 				}
+
 				kv_destroy (*vec);
 				UCL_FREE (sizeof (*vec), vec);
 			}
-			obj->value.av = NULL;
-		}
-		else if (obj->type == UCL_OBJECT) {
-			if (obj->value.ov != NULL) {
-				ucl_hash_destroy (obj->value.ov, (ucl_hash_free_func)dtor);
-			}
-			obj->value.ov = NULL;
-		}
-		tmp = obj->next;
-		dtor (obj);
-		obj = tmp;
 
-		if (!allow_rec) {
-			break;
+			cur->value.av = NULL;
 		}
+		else if (cur->type == UCL_OBJECT) {
+			if (cur->value.ov != NULL) {
+				ucl_hash_destroy (cur->value.ov, ucl_dtor_worklist_unref, &wl);
+			}
+
+			cur->value.ov = NULL;
+		}
+
+		ucl_object_dtor_free (cur);
 	}
+}
+
+/*
+ * Release `obj` along with the objects it directly holds, without descending
+ * into them and without touching reference counts. Only valid for objects
+ * that are known not to be shared - parser trash and the deprecated
+ * ucl_object_free() below.
+ */
+static void
+ucl_object_free_shallow (ucl_object_t *obj)
+{
+	ucl_object_t *sub, *tmp;
+
+	if (obj->type == UCL_ARRAY) {
+		UCL_ARRAY_GET (vec, obj);
+
+		if (vec != NULL) {
+			unsigned int i;
+
+			for (i = 0; i < vec->n; i ++) {
+				sub = kv_A (*vec, i);
+
+				while (sub != NULL) {
+					tmp = sub->next;
+					ucl_object_dtor_free (sub);
+					sub = tmp;
+				}
+			}
+
+			kv_destroy (*vec);
+			UCL_FREE (sizeof (*vec), vec);
+		}
+
+		obj->value.av = NULL;
+	}
+	else if (obj->type == UCL_OBJECT) {
+		if (obj->value.ov != NULL) {
+			ucl_hash_destroy (obj->value.ov, ucl_object_dtor_free_ud, NULL);
+		}
+
+		obj->value.ov = NULL;
+	}
+
+	ucl_object_dtor_free (obj);
+}
+
+void
+ucl_array_detach_elements (ucl_object_t *ar)
+{
+	if (ar == NULL || ar->type != UCL_ARRAY) {
+		return;
+	}
+
+	UCL_ARRAY_GET (vec, ar);
+
+	if (vec != NULL) {
+		vec->n = 0;
+	}
+
+	ar->len = 0;
 }
 
 void
 ucl_object_free (ucl_object_t *obj)
 {
-	ucl_object_free_internal (obj, true, ucl_object_dtor_free);
+	ucl_object_t *tmp;
+
+	/* Deprecated: shallow and refcount blind, use ucl_object_unref() instead */
+	while (obj != NULL) {
+		tmp = obj->next;
+		ucl_object_free_shallow (obj);
+		obj = tmp;
+	}
 }
 
 size_t
@@ -641,7 +770,7 @@ ucl_parser_free (struct ucl_parser *parser)
 		UCL_FREE (sizeof (struct ucl_variable), var);
 	}
 	LL_FOREACH_SAFE (parser->trash_objs, tr, trtmp) {
-		ucl_object_free_internal (tr, false, ucl_object_dtor_free);
+		ucl_object_free_shallow (tr);
 	}
 
 	if (parser->err != NULL) {
@@ -1360,6 +1489,7 @@ ucl_include_file_single (const unsigned char *data, size_t len,
 		st->e.params.line = parser->stack->e.params.line;
 		st->chunk = parser->chunks;
 		LL_PREPEND (parser->stack, st);
+		parser->cur_depth ++;
 		parser->cur_obj = nest_obj;
 	}
 
@@ -1369,8 +1499,7 @@ ucl_include_file_single (const unsigned char *data, size_t len,
 	if (res) {
 		/* Stop nesting the include, take 1 level off the stack */
 		if (params->prefix != NULL && nest_obj != NULL) {
-			parser->stack = st->next;
-			UCL_FREE (sizeof (struct ucl_stack), st);
+			ucl_parser_pop_container (parser, st);
 		}
 
 		/* Remove chunk from the stack */
@@ -3741,7 +3870,7 @@ ucl_object_unref (ucl_object_t *obj)
 #else
 		if (--obj->ref == 0) {
 #endif
-			ucl_object_free_internal (obj, true, ucl_object_dtor_unref);
+			ucl_object_free_internal (obj, true);
 		}
 	}
 }

--- a/src/controller.c
+++ b/src/controller.c
@@ -2698,7 +2698,7 @@ rspamd_controller_handle_saveactions(
 		return 0;
 	}
 
-	parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+	parser = rspamd_ucl_parser_new_untrusted(msg->body_buf.len);
 	if (!ucl_parser_add_chunk(parser, msg->body_buf.begin, msg->body_buf.len)) {
 		if ((error = ucl_parser_get_error(parser)) != NULL) {
 			msg_err_session("cannot parse input: %s", error);
@@ -2821,7 +2821,7 @@ rspamd_controller_handle_savesymbols(
 		return 0;
 	}
 
-	parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+	parser = rspamd_ucl_parser_new_untrusted(msg->body_buf.len);
 	if (!ucl_parser_add_chunk(parser, msg->body_buf.begin, msg->body_buf.len)) {
 		if ((error = ucl_parser_get_error(parser)) != NULL) {
 			msg_err_session("cannot parse input: %s", error);

--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -63,6 +63,55 @@ rspamd_protocol_quark(void)
 }
 
 /*
+ * Budgets for UCL/JSON that arrived from the network.
+ *
+ * A tree element costs roughly 128 bytes (the object itself plus hash
+ * bookkeeping), while the densest legitimate JSON that can describe one is two
+ * bytes - "1," inside an array. Parsing therefore amplifies by up to ~64x, so
+ * the proportional budget sits above that and never rejects real input; it
+ * only stops a small request from claiming a large tree. The absolute cap is
+ * what matters for big bodies: without it, max_message worth of "[1,1,1,...]"
+ * turns into gigabytes of objects.
+ *
+ * Depth is kept far tighter than libucl's own default because every recursive
+ * walk over the result - emitting it, copying it, handing it to Lua - is
+ * proportional to it, and nothing legitimate comes close.
+ */
+#define RSPAMD_UNTRUSTED_UCL_MAX_DEPTH 64
+#define RSPAMD_UNTRUSTED_UCL_MAX_NODES 1000000
+#define RSPAMD_UNTRUSTED_UCL_MAX_KEY 1024
+#define RSPAMD_UNTRUSTED_UCL_MAX_STRING (16 * 1024 * 1024)
+#define RSPAMD_UNTRUSTED_UCL_ALLOC_FACTOR 96
+#define RSPAMD_UNTRUSTED_UCL_ALLOC_FLOOR (256 * 1024)
+#define RSPAMD_UNTRUSTED_UCL_MAX_ALLOC (64 * 1024 * 1024)
+
+struct ucl_parser *
+rspamd_ucl_parser_new_untrusted(gsize inlen)
+{
+	struct ucl_parser *parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+	struct ucl_parser_limits limits;
+	uint64_t proportional;
+
+	if (parser == NULL) {
+		return NULL;
+	}
+
+	proportional = (uint64_t) inlen * RSPAMD_UNTRUSTED_UCL_ALLOC_FACTOR +
+				   RSPAMD_UNTRUSTED_UCL_ALLOC_FLOOR;
+
+	memset(&limits, 0, sizeof(limits));
+	limits.max_depth = RSPAMD_UNTRUSTED_UCL_MAX_DEPTH;
+	limits.max_nodes = RSPAMD_UNTRUSTED_UCL_MAX_NODES;
+	limits.max_key_length = RSPAMD_UNTRUSTED_UCL_MAX_KEY;
+	limits.max_string_length = RSPAMD_UNTRUSTED_UCL_MAX_STRING;
+	limits.max_alloc = MIN(proportional, RSPAMD_UNTRUSTED_UCL_MAX_ALLOC);
+
+	ucl_parser_set_limits(parser, &limits);
+
+	return parser;
+}
+
+/*
  * Remove <> from the fixed string and copy it to the pool
  */
 static char *
@@ -2948,7 +2997,7 @@ rspamd_protocol_handle_v3_request(struct rspamd_task *task,
 										 sizeof("msgpack") - 1) != -1) {
 		/* Remember the input serialization so the reply can mirror it */
 		task->protocol_flags |= RSPAMD_TASK_PROTOCOL_FLAG_V3_MSGPACK;
-		parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+		parser = rspamd_ucl_parser_new_untrusted(metadata_part->data_len);
 		ucl_parser_add_chunk_full(parser, (const unsigned char *) metadata_part->data,
 								  metadata_part->data_len,
 								  ucl_parser_get_default_priority(parser),
@@ -2957,7 +3006,7 @@ rspamd_protocol_handle_v3_request(struct rspamd_task *task,
 	}
 	else {
 		/* Strict mode: disable UCL macros/includes, treat as plain JSON */
-		parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+		parser = rspamd_ucl_parser_new_untrusted(metadata_part->data_len);
 		ucl_parser_add_chunk(parser, (const unsigned char *) metadata_part->data,
 							 metadata_part->data_len);
 	}

--- a/src/libserver/protocol.h
+++ b/src/libserver/protocol.h
@@ -54,6 +54,22 @@ struct rspamd_protocol_log_message_sum {
 struct rspamd_main;
 
 /**
+ * Create a UCL parser for input that arrived over the network.
+ *
+ * On top of UCL_PARSER_SAFE_FLAGS this bounds what a request may cost us to
+ * represent: nesting depth, element count, key and string lengths, and the
+ * total memory the resulting tree may occupy. Without those, a request that
+ * fits comfortably under max_message can still describe a tree orders of
+ * magnitude larger than its wire size, and one nested deeply enough to
+ * exhaust the stack in any recursive walk over it.
+ *
+ * @param inlen length of the input about to be parsed; the memory budget is
+ *   derived from it, so that a small request cannot claim a large tree
+ * @return a new parser, or NULL on allocation failure
+ */
+struct ucl_parser *rspamd_ucl_parser_new_untrusted(gsize inlen);
+
+/**
  * Process headers into HTTP message and set appropriate task fields
  * @param task
  * @param msg

--- a/src/rspamd_proxy.c
+++ b/src/rspamd_proxy.c
@@ -1387,7 +1387,7 @@ proxy_backend_parse_results(struct rspamd_proxy_session *session,
 		}
 
 		/* Parse UCL from result part */
-		parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+		parser = rspamd_ucl_parser_new_untrusted(result_len);
 
 		if (result_part->content_type &&
 			rspamd_substring_search_caseless(result_part->content_type,
@@ -1467,7 +1467,7 @@ proxy_backend_parse_results(struct rspamd_proxy_session *session,
 		RSPAMD_FTOK_ASSIGN(&json_ct, "application/json");
 
 		if (ct && rspamd_ftok_casecmp(ct, &json_ct) == 0) {
-			parser = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+			parser = rspamd_ucl_parser_new_untrusted(inlen);
 
 			if (!ucl_parser_add_chunk(parser, in, inlen)) {
 				char *encoded;

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -53,6 +53,7 @@
 #include "rspamd_cxx_unit_tokenizer.hxx"
 #include "rspamd_cxx_unit_http_timeout.hxx"
 #include "rspamd_cxx_unit_task_input.hxx"
+#include "rspamd_cxx_unit_ucl_limits.hxx"
 
 static gboolean verbose = false;
 static const GOptionEntry entries[] =

--- a/test/rspamd_cxx_unit_ucl_limits.hxx
+++ b/test/rspamd_cxx_unit_ucl_limits.hxx
@@ -1,0 +1,582 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_RSPAMD_CXX_UNIT_UCL_LIMITS_HXX
+#define RSPAMD_RSPAMD_CXX_UNIT_UCL_LIMITS_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+#include "ucl.h"
+
+#include <memory>
+#include <string>
+
+/*
+ * Structural budgets for untrusted UCL/JSON input, plus the destruction path
+ * they protect: freeing a tree used to recurse once per nesting level, so a
+ * document that parsed fine could still take the process down on cleanup.
+ */
+TEST_SUITE("ucl limits")
+{
+	using ucl_parser_t = struct ucl_parser;
+	using ucl_limits_t = struct ucl_parser_limits;
+
+	struct parser_deleter {
+		void operator()(ucl_parser_t *p) const
+		{
+			ucl_parser_free(p);
+		}
+	};
+
+	using parser_ptr = std::unique_ptr<ucl_parser_t, parser_deleter>;
+
+	static parser_ptr make_parser(const ucl_limits_t *limits = nullptr)
+	{
+		parser_ptr p{ucl_parser_new(UCL_PARSER_SAFE_FLAGS)};
+
+		REQUIRE(p != nullptr);
+
+		if (limits != nullptr) {
+			ucl_parser_set_limits(p.get(), limits);
+		}
+
+		return p;
+	}
+
+	/* `depth` nested arrays: [[[...]]] */
+	static std::string nested_arrays(unsigned depth)
+	{
+		return std::string(depth, '[') + std::string(depth, ']');
+	}
+
+	/* `depth` nested objects: {"a":{"a":{...}}} */
+	static std::string nested_objects(unsigned depth)
+	{
+		std::string res;
+
+		for (unsigned i = 0; i < depth; i++) {
+			res += "{\"a\":";
+		}
+
+		res += "1";
+
+		for (unsigned i = 0; i < depth; i++) {
+			res += "}";
+		}
+
+		return res;
+	}
+
+	static bool parse(ucl_parser_t * p, const std::string &input)
+	{
+		return ucl_parser_add_chunk(p, (const unsigned char *) input.data(),
+									input.size());
+	}
+
+	TEST_CASE("default limits reject unbounded nesting")
+	{
+		auto p = make_parser();
+		auto input = nested_arrays(100000);
+
+		CHECK(parse(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ENESTED);
+	}
+
+	TEST_CASE("default depth limit is enforced for objects too")
+	{
+		auto p = make_parser();
+		auto input = nested_objects(100000);
+
+		CHECK(parse(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ENESTED);
+	}
+
+	TEST_CASE("input just under the depth limit still parses and frees")
+	{
+		ucl_limits_t limits = {};
+		limits.max_depth = 64;
+
+		auto p = make_parser(&limits);
+
+		REQUIRE(parse(p.get(), nested_arrays(63)) == true);
+
+		ucl_object_t *top = ucl_parser_get_object(p.get());
+		REQUIRE(top != nullptr);
+		CHECK(ucl_object_type(top) == UCL_ARRAY);
+
+		/* The interesting part: this must not recurse 63 levels deep */
+		ucl_object_unref(top);
+	}
+
+	TEST_CASE("a custom depth limit overrides the default")
+	{
+		ucl_limits_t limits = {};
+		limits.max_depth = 8;
+
+		auto p = make_parser(&limits);
+
+		CHECK(parse(p.get(), nested_arrays(9)) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ENESTED);
+	}
+
+	TEST_CASE("depth is measured per container, not per document")
+	{
+		ucl_limits_t limits = {};
+		limits.max_depth = 4;
+
+		auto p = make_parser(&limits);
+
+		/* Many shallow siblings must not accumulate against the limit */
+		std::string input = "[";
+
+		for (int i = 0; i < 1000; i++) {
+			if (i > 0) {
+				input += ",";
+			}
+
+			input += "[1,2]";
+		}
+
+		input += "]";
+
+		CHECK(parse(p.get(), input) == true);
+	}
+
+	TEST_CASE("max_nodes bounds the element count")
+	{
+		ucl_limits_t limits = {};
+		limits.max_nodes = 16;
+
+		auto p = make_parser(&limits);
+
+		std::string input = "[";
+
+		for (int i = 0; i < 1000; i++) {
+			if (i > 0) {
+				input += ",";
+			}
+
+			input += "1";
+		}
+
+		input += "]";
+
+		CHECK(parse(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("max_nodes leaves conforming input alone")
+	{
+		ucl_limits_t limits = {};
+		limits.max_nodes = 1000;
+
+		auto p = make_parser(&limits);
+
+		CHECK(parse(p.get(), "{\"a\": 1, \"b\": [1, 2, 3]}") == true);
+	}
+
+	TEST_CASE("max_alloc bounds the memory a small input can claim")
+	{
+		ucl_limits_t limits = {};
+		limits.max_alloc = 4096;
+
+		auto p = make_parser(&limits);
+
+		std::string input = "{";
+
+		for (int i = 0; i < 10000; i++) {
+			if (i > 0) {
+				input += ",";
+			}
+
+			input += "\"k" + std::to_string(i) + "\": \"v\"";
+		}
+
+		input += "}";
+
+		CHECK(parse(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("max_key_length rejects oversized keys")
+	{
+		ucl_limits_t limits = {};
+		limits.max_key_length = 32;
+
+		auto p = make_parser(&limits);
+
+		std::string input = "{\"" + std::string(64, 'k') + "\": 1}";
+
+		CHECK(parse(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("max_key_length accepts keys at the limit")
+	{
+		ucl_limits_t limits = {};
+		limits.max_key_length = 32;
+
+		auto p = make_parser(&limits);
+
+		std::string input = "{\"" + std::string(32, 'k') + "\": 1}";
+
+		CHECK(parse(p.get(), input) == true);
+	}
+
+	TEST_CASE("max_string_length rejects oversized values")
+	{
+		ucl_limits_t limits = {};
+		limits.max_string_length = 32;
+
+		auto p = make_parser(&limits);
+
+		std::string input = "{\"a\": \"" + std::string(64, 'v') + "\"}";
+
+		CHECK(parse(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("max_string_length accepts values at the limit")
+	{
+		ucl_limits_t limits = {};
+		limits.max_string_length = 32;
+
+		auto p = make_parser(&limits);
+
+		std::string input = "{\"a\": \"" + std::string(32, 'v') + "\"}";
+
+		CHECK(parse(p.get(), input) == true);
+	}
+
+	TEST_CASE("limits round trip through the getter")
+	{
+		ucl_limits_t limits = {};
+		limits.max_depth = 11;
+		limits.max_nodes = 22;
+		limits.max_alloc = 33;
+		limits.max_key_length = 44;
+		limits.max_string_length = 55;
+
+		auto p = make_parser(&limits);
+
+		ucl_limits_t got = {};
+		ucl_parser_get_limits(p.get(), &got);
+
+		CHECK(got.max_depth == 11);
+		CHECK(got.max_nodes == 22);
+		CHECK(got.max_alloc == 33);
+		CHECK(got.max_key_length == 44);
+		CHECK(got.max_string_length == 55);
+
+		/* NULL restores the defaults */
+		ucl_parser_set_limits(p.get(), nullptr);
+		ucl_parser_get_limits(p.get(), &got);
+
+		CHECK(got.max_depth == 1024);
+		CHECK(got.max_nodes == 0);
+	}
+
+	TEST_CASE("zero means unlimited")
+	{
+		ucl_limits_t limits = {};
+
+		/* Everything zeroed: depth included, so deep input is accepted */
+		auto p = make_parser(&limits);
+
+		REQUIRE(parse(p.get(), nested_arrays(20000)) == true);
+
+		ucl_object_t *top = ucl_parser_get_object(p.get());
+		REQUIRE(top != nullptr);
+
+		/*
+		 * 20k levels: the old recursive destructor would blow the stack right
+		 * here, which is the whole point of the iterative one.
+		 */
+		ucl_object_unref(top);
+	}
+
+	TEST_CASE("deeply nested objects are destroyed without recursion")
+	{
+		ucl_limits_t limits = {};
+
+		auto p = make_parser(&limits);
+
+		REQUIRE(parse(p.get(), nested_objects(20000)) == true);
+
+		ucl_object_t *top = ucl_parser_get_object(p.get());
+		REQUIRE(top != nullptr);
+
+		ucl_object_unref(top);
+	}
+
+	TEST_CASE("shared subtrees survive their container")
+	{
+		ucl_object_t *kept;
+
+		{
+			auto p = make_parser();
+
+			REQUIRE(parse(p.get(), "{\"a\": {\"b\": [1, 2, 3]}}") == true);
+
+			ucl_object_t *top = ucl_parser_get_object(p.get());
+			REQUIRE(top != nullptr);
+
+			const ucl_object_t *inner = ucl_object_lookup(top, "a");
+			REQUIRE(inner != nullptr);
+
+			/* Take our own reference on the subtree */
+			kept = ucl_object_ref(inner);
+
+			/*
+			 * The tree has to actually die for this to test anything:
+			 * ucl_parser_get_object() hands out a second reference, so
+			 * releasing `top` alone leaves the parser owning everything.
+			 * Dropping ours and then freeing the parser is what runs the
+			 * destructor over the container while `kept` is still live.
+			 */
+			ucl_object_unref(top);
+		}
+
+		const ucl_object_t *arr = ucl_object_lookup(kept, "b");
+		REQUIRE(arr != nullptr);
+		CHECK(ucl_object_type(arr) == UCL_ARRAY);
+		CHECK(ucl_array_size(arr) == 3);
+		CHECK(ucl_object_toint(ucl_array_find_index(arr, 0)) == 1);
+		CHECK(ucl_object_toint(ucl_array_find_index(arr, 2)) == 3);
+
+		ucl_object_unref(kept);
+	}
+
+	/*
+	 * MessagePack reaches the same parsers over the network (checkv3 metadata
+	 * and proxy replies) and is far denser than JSON - a container costs one
+	 * byte - so the budgets have to hold there too.
+	 */
+	static bool parse_msgpack(ucl_parser_t * p, const std::string &input)
+	{
+		return ucl_parser_add_chunk_full(p, (const unsigned char *) input.data(),
+										 input.size(),
+										 ucl_parser_get_default_priority(p),
+										 UCL_DUPLICATE_APPEND, UCL_PARSE_MSGPACK);
+	}
+
+	/* `depth` fixarrays each holding one element, innermost being int 1 */
+	static std::string msgpack_nested_arrays(unsigned depth)
+	{
+		return std::string(depth, '\x91') + std::string(1, '\x01');
+	}
+
+	/* One array16 holding `n` ints */
+	static std::string msgpack_flat_array(uint16_t n)
+	{
+		std::string res;
+
+		res += '\xdc';
+		res += (char) (n >> 8);
+		res += (char) (n & 0xff);
+		res += std::string(n, '\x01');
+
+		return res;
+	}
+
+	TEST_CASE("msgpack nesting is bounded by default")
+	{
+		auto p = make_parser();
+
+		/* 100k levels in 100k bytes - JSON would need twice that */
+		CHECK(parse_msgpack(p.get(), msgpack_nested_arrays(100000)) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ENESTED);
+	}
+
+	TEST_CASE("msgpack honours a custom depth limit")
+	{
+		ucl_limits_t limits = {};
+		limits.max_depth = 8;
+
+		auto p = make_parser(&limits);
+
+		CHECK(parse_msgpack(p.get(), msgpack_nested_arrays(9)) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ENESTED);
+	}
+
+	TEST_CASE("msgpack within the depth limit parses and frees")
+	{
+		ucl_limits_t limits = {};
+		limits.max_depth = 64;
+
+		auto p = make_parser(&limits);
+
+		REQUIRE(parse_msgpack(p.get(), msgpack_nested_arrays(60)) == true);
+
+		ucl_object_t *top = ucl_parser_get_object(p.get());
+		REQUIRE(top != nullptr);
+		CHECK(ucl_object_type(top) == UCL_ARRAY);
+
+		ucl_object_unref(top);
+	}
+
+	TEST_CASE("msgpack respects max_nodes")
+	{
+		ucl_limits_t limits = {};
+		limits.max_nodes = 16;
+
+		auto p = make_parser(&limits);
+
+		CHECK(parse_msgpack(p.get(), msgpack_flat_array(1000)) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("msgpack respects max_alloc")
+	{
+		ucl_limits_t limits = {};
+		limits.max_alloc = 4096;
+
+		auto p = make_parser(&limits);
+
+		CHECK(parse_msgpack(p.get(), msgpack_flat_array(1000)) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("msgpack respects max_string_length")
+	{
+		ucl_limits_t limits = {};
+		limits.max_string_length = 32;
+
+		auto p = make_parser(&limits);
+
+		/* fixarray of one str8 of 64 bytes; msgpack has no top level scalars */
+		std::string input;
+		input += '\x91';
+		input += '\xd9';
+		input += (char) 64;
+		input += std::string(64, 'v');
+
+		CHECK(parse_msgpack(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("msgpack respects max_key_length")
+	{
+		ucl_limits_t limits = {};
+		limits.max_key_length = 32;
+
+		auto p = make_parser(&limits);
+
+		/* fixmap with one entry whose key is a 64 byte str8 */
+		std::string input;
+		input += '\x81';
+		input += '\xd9';
+		input += (char) 64;
+		input += std::string(64, 'k');
+		input += '\x01';
+
+		CHECK(parse_msgpack(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("conforming msgpack is unaffected by the budgets")
+	{
+		ucl_limits_t limits = {};
+		limits.max_depth = 16;
+		limits.max_nodes = 1000;
+		limits.max_alloc = 1024 * 1024;
+		limits.max_key_length = 64;
+		limits.max_string_length = 1024;
+
+		auto p = make_parser(&limits);
+
+		/* fixmap{"ab": [1,1,1]} */
+		std::string input;
+		input += '\x81';
+		input += '\xa2';
+		input += "ab";
+		input += '\x93';
+		input += std::string(3, '\x01');
+
+		REQUIRE(parse_msgpack(p.get(), input) == true);
+
+		ucl_object_t *top = ucl_parser_get_object(p.get());
+		REQUIRE(top != nullptr);
+
+		const ucl_object_t *arr = ucl_object_lookup(top, "ab");
+		REQUIRE(arr != nullptr);
+		CHECK(ucl_array_size(arr) == 3);
+
+		ucl_object_unref(top);
+	}
+
+	TEST_CASE("duplicate keys are charged against max_nodes")
+	{
+		/*
+		 * SAFE_FLAGS implies NO_IMPLICIT_ARRAYS, so each repeated key converts
+		 * the value into an explicit array - an extra element that has to be
+		 * paid for like any other.
+		 */
+		ucl_limits_t limits = {};
+		limits.max_nodes = 8;
+
+		auto p = make_parser(&limits);
+
+		std::string input;
+
+		for (int i = 0; i < 100; i++) {
+			input += "a = 1\n";
+		}
+
+		CHECK(parse(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("escape-heavy strings are charged for what they allocate")
+	{
+		/*
+		 * Unescaping shrinks the contents but not the buffer, so the budget has
+		 * to track the allocation rather than the decoded length.
+		 */
+		ucl_limits_t limits = {};
+		limits.max_alloc = 8 * 1024;
+
+		auto p = make_parser(&limits);
+
+		/* ~60k of input decoding to ~10k of text */
+		std::string input = "{\"a\": \"";
+
+		for (int i = 0; i < 10000; i++) {
+			input += "\\u0041";
+		}
+
+		input += "\"}";
+
+		CHECK(parse(p.get(), input) == false);
+		CHECK(ucl_parser_get_error_code(p.get()) == UCL_ELIMIT);
+	}
+
+	TEST_CASE("implicit array chains are fully released")
+	{
+		/* Duplicate keys build a `next` chain, which the worklist reuses */
+		auto p = make_parser();
+
+		REQUIRE(parse(p.get(), "a = 1\na = 2\na = 3\na = 4\n") == true);
+
+		ucl_object_t *top = ucl_parser_get_object(p.get());
+		REQUIRE(top != nullptr);
+
+		ucl_object_unref(top);
+	}
+}
+
+#endif


### PR DESCRIPTION
Hardens UCL parsing of untrusted input. Two problems: freeing a parsed tree
was recursive, and nothing bounded how much tree a request could ask for.

## Stack exhaustion while freeing

`ucl_object_free_internal` descended into every child, so cleanup depth was
proportional to the nesting depth of the document. A deeply nested document
could therefore take the process down *during destruction* — after the parser
had already returned success.

Destruction now walks an explicit worklist threaded through the dying objects'
`next` pointers. That is safe because an object only reaches the worklist once
its refcount hits zero, meaning it is already detached and unobservable, so the
link field is free to reuse. Allocation free, constant stack.

Verified rather than assumed: with the old recursive destructor restored behind
a temporary flag, freeing a 20 000-level tree is a hard `SIGSEGV`; with the
worklist it frees cleanly. That case is now a test.

## Nesting was unbounded

`UCL_MAX_NESTING` existed but was only ever consulted by the msgpack and csexp
parsers — brace containers passed the dotted-key `level` through untouched and
were never depth-checked. Container depth is now tracked separately from
`level` and checked before anything is allocated, so the 1024 default applies
to every parse type.

## Parser budgets

New `ucl_parser_set_limits()` / `ucl_parser_get_limits()`:

| field | bounds |
| --- | --- |
| `max_depth` | nesting depth of objects and arrays |
| `max_nodes` | elements in the parsed tree |
| `max_alloc` | aggregate bytes attributed to the tree |
| `max_key_length` | length of a single key |
| `max_string_length` | length of a single string value |

Zero means unlimited, and only `max_depth` is on by default — the others would
reject large but perfectly valid inputs (maps, language models, big replies),
so callers handling untrusted data opt in.

Both the UCL and the MessagePack parser charge every element they create.
MessagePack matters here: a container costs one byte, so it amplifies harder
than JSON — 100 000 nesting levels fit in 100 KB.

## Applying it in rspamd

`rspamd_ucl_parser_new_untrusted(inlen)` sets depth 64, 1M elements, 1KB keys,
16MB strings and `min(96 * inlen + 256KB, 64MB)` of tree. The factor is derived,
not guessed: an element costs ~128 bytes and the densest JSON describing one is
two bytes (`1,`), so real input tops out near 64x. The absolute cap is what does
the work — today 50MB of `[1,1,1,...]` builds gigabytes of objects.

Wired into checkv3 metadata (JSON and msgpack), both controller body parsers and
both proxy parsers.

## Bugs fixed on the way

- `ucl_copy_or_store_ptr()` returned `false` instead of `-1` on allocation
  failure, leaving a value object with a stale union pointer and `len == 0`.
- The sibling-chain loop released a sibling's children *before* checking its
  refcount, so a shared object could have its children freed underneath it.
- `ucl_parser_append_elt()` dereferenced an unchecked allocation and ignored
  both `ucl_array_append()` results. It is also the `NO_IMPLICIT_ARRAYS` path
  that `SAFE_FLAGS` selects, so its wrapper node now counts against the budget.
- A NULL container was unconditionally reported as a syntax error, masking the
  real cause; msgpack's `CONSUME_RET` did the same to every `-1`.
- `ucl_msgpack_get_next_container()` unwound finished containers by tail
  recursion, making parse depth a stack-depth problem of its own.

## Testing

- 379/379 C++ unit tests, 27 of them new in `rspamd_cxx_unit_ucl_limits.hxx`
  covering each limit for both JSON and msgpack, deep-tree destruction, and
  shared subtrees outliving their container
- 1218 Lua tests, 0 failures
- 440/440 functional across `001_merged` (which carries `430_checkv3` and
  `420_content_negotiation`, the msgpack protocol tests), `121_json`,
  `140_proxy`, `220`/`221_http`, `560_metadata_exporter`
- `rspamadm configtest` on a full production config: `syntax OK`, so the 1024
  default does not disturb real configs
- Everything runs under ASAN

## Known gap

`ucl_sexp.c` still has its own hardcoded `UCL_MAX_NESTING` and manipulates
`parser->stack` directly without touching the depth counter. It is internally
consistent (it neither increments nor decrements, so nothing desyncs) and CSEXP
is not reachable from any of the network paths wired here, which only use
`UCL_PARSE_UCL` and `UCL_PARSE_MSGPACK`. Worth unifying if that ever changes.
