### PR TITLE
Add an untrusted UCL parser to the Lua API and use it for external input

### DIFF
--- a/contrib/libucl/lua_ucl.c
+++ b/contrib/libucl/lua_ucl.c
@@ -690,25 +690,135 @@ lua_ucl_to_string(lua_State *L, const ucl_object_t *obj, enum ucl_emitter type)
 	return 1;
 }
 
-static int
-lua_ucl_parser_init(lua_State *L)
-{
-	struct ucl_parser *parser, **pparser;
-	/*
-	 * We disable file variables and macros by default, as
-	 * the most use cases are parsing of JSON and not of the real
-	 * files. Macros in the parser are very dangerous and should be used
-	 * for trusted data only.
-	 */
-	int flags = UCL_PARSER_SAFE_FLAGS;
+/*
+ * Structural budgets for input that came from somewhere we do not control:
+ * replies from external services, fetched documents, anything crossing a
+ * network boundary. These are absolute rather than derived from the input
+ * size, because a Lua caller creates the parser before it has the text.
+ *
+ * They are deliberately generous - the point is to bound a hostile reply, not
+ * to second guess a large legitimate one - and every one of them can be
+ * overridden per call site.
+ */
+#define LUA_UCL_UNTRUSTED_MAX_DEPTH 64
+#define LUA_UCL_UNTRUSTED_MAX_NODES 1000000
+#define LUA_UCL_UNTRUSTED_MAX_ALLOC (64 * 1024 * 1024)
+#define LUA_UCL_UNTRUSTED_MAX_KEY 1024
+#define LUA_UCL_UNTRUSTED_MAX_STRING (16 * 1024 * 1024)
 
-	if (lua_gettop(L) >= 1) {
-		flags = lua_tonumber(L, 1);
+static const struct {
+	const char *name;
+	size_t offset;
+} lua_ucl_limit_fields[] = {
+	{"max_depth", offsetof(struct ucl_parser_limits, max_depth)},
+	{"max_nodes", offsetof(struct ucl_parser_limits, max_nodes)},
+	{"max_alloc", offsetof(struct ucl_parser_limits, max_alloc)},
+	{"max_key_length", offsetof(struct ucl_parser_limits, max_key_length)},
+	{"max_string_length", offsetof(struct ucl_parser_limits, max_string_length)},
+};
+
+#define LUA_UCL_NLIMITS (sizeof(lua_ucl_limit_fields) / sizeof(lua_ucl_limit_fields[0]))
+
+static uint64_t *
+lua_ucl_limit_field(struct ucl_parser_limits *limits, unsigned i)
+{
+	return (uint64_t *) ((char *) limits + lua_ucl_limit_fields[i].offset);
+}
+
+/*
+ * Overlay the limits given in the table at `idx` on top of `limits`. Absent
+ * fields keep whatever the caller put there; unknown ones are an error, so a
+ * typo cannot quietly leave a limit unset.
+ */
+static void
+lua_ucl_limits_from_table(lua_State *L, int idx, struct ucl_parser_limits *limits)
+{
+	unsigned i;
+
+	luaL_checktype(L, idx, LUA_TTABLE);
+
+	lua_pushnil(L);
+
+	while (lua_next(L, idx) != 0) {
+		bool known = false;
+
+		if (lua_type(L, -2) == LUA_TSTRING) {
+			const char *k = lua_tostring(L, -2);
+
+			for (i = 0; i < LUA_UCL_NLIMITS; i++) {
+				if (strcmp(k, lua_ucl_limit_fields[i].name) == 0) {
+					known = true;
+					break;
+				}
+			}
+
+			if (!known) {
+				luaL_error(L, "unknown parser limit: %s", k);
+				return;
+			}
+		}
+		else {
+			luaL_error(L, "parser limits must be keyed by name");
+			return;
+		}
+
+		lua_pop(L, 1);
 	}
 
+	for (i = 0; i < LUA_UCL_NLIMITS; i++) {
+		lua_getfield(L, idx, lua_ucl_limit_fields[i].name);
+
+		if (lua_isnumber(L, -1)) {
+			lua_Number v = lua_tonumber(L, -1);
+
+			if (v < 0) {
+				luaL_error(L, "%s must not be negative",
+						   lua_ucl_limit_fields[i].name);
+				return;
+			}
+
+			*lua_ucl_limit_field(limits, i) = (uint64_t) v;
+		}
+		else if (!lua_isnil(L, -1)) {
+			luaL_error(L, "%s must be a number", lua_ucl_limit_fields[i].name);
+			return;
+		}
+
+		lua_pop(L, 1);
+	}
+}
+
+static void
+lua_ucl_limits_to_table(lua_State *L, const struct ucl_parser_limits *limits)
+{
+	unsigned i;
+
+	lua_createtable(L, 0, LUA_UCL_NLIMITS);
+
+	for (i = 0; i < LUA_UCL_NLIMITS; i++) {
+		lua_pushnumber(L,
+					   (lua_Number) *lua_ucl_limit_field(
+						   (struct ucl_parser_limits *) limits, i));
+		lua_setfield(L, -2, lua_ucl_limit_fields[i].name);
+	}
+}
+
+static int
+lua_ucl_parser_push_new(lua_State *L, int flags,
+						const struct ucl_parser_limits *limits)
+{
+	struct ucl_parser *parser, **pparser;
+
 	parser = ucl_parser_new(flags);
+
 	if (parser == NULL) {
 		lua_pushnil(L);
+
+		return 1;
+	}
+
+	if (limits != NULL) {
+		ucl_parser_set_limits(parser, limits);
 	}
 
 	pparser = lua_newuserdata(L, sizeof(parser));
@@ -719,10 +829,98 @@ lua_ucl_parser_init(lua_State *L)
 	return 1;
 }
 
+static int
+lua_ucl_parser_init(lua_State *L)
+{
+	/*
+	 * We disable file variables and macros by default, as
+	 * the most use cases are parsing of JSON and not of the real
+	 * files. Macros in the parser are very dangerous and should be used
+	 * for trusted data only.
+	 */
+	int flags = UCL_PARSER_SAFE_FLAGS;
+
+	if (lua_gettop(L) >= 1 && !lua_isnil(L, 1)) {
+		flags = lua_tonumber(L, 1);
+	}
+
+	return lua_ucl_parser_push_new(L, flags, NULL);
+}
+
+/*
+ * ucl.untrusted_parser([limits])
+ *
+ * Same parser, but with the structural budgets above applied, for input that
+ * did not come from the local configuration. Pass a table to override
+ * individual limits; zero means unlimited for any of them.
+ */
+static int
+lua_ucl_untrusted_parser_init(lua_State *L)
+{
+	struct ucl_parser_limits limits;
+
+	memset(&limits, 0, sizeof(limits));
+	limits.max_depth = LUA_UCL_UNTRUSTED_MAX_DEPTH;
+	limits.max_nodes = LUA_UCL_UNTRUSTED_MAX_NODES;
+	limits.max_alloc = LUA_UCL_UNTRUSTED_MAX_ALLOC;
+	limits.max_key_length = LUA_UCL_UNTRUSTED_MAX_KEY;
+	limits.max_string_length = LUA_UCL_UNTRUSTED_MAX_STRING;
+
+	if (lua_gettop(L) >= 1 && !lua_isnil(L, 1)) {
+		lua_ucl_limits_from_table(L, 1, &limits);
+	}
+
+	return lua_ucl_parser_push_new(L, UCL_PARSER_SAFE_FLAGS, &limits);
+}
+
 static struct ucl_parser *
 lua_ucl_parser_get(lua_State *L, int index)
 {
 	return *((struct ucl_parser **) luaL_checkudata(L, index, PARSER_META));
+}
+
+/*
+ * parser:set_limits({max_depth = 16, ...})
+ *
+ * Overlays the given limits on the ones already in effect, so tightening a
+ * single field does not silently drop the rest.
+ */
+static int
+lua_ucl_parser_set_limits(lua_State *L)
+{
+	struct ucl_parser *parser = lua_ucl_parser_get(L, 1);
+	struct ucl_parser_limits limits;
+
+	if (parser == NULL) {
+		return luaL_error(L, "invalid parser");
+	}
+
+	ucl_parser_get_limits(parser, &limits);
+	lua_ucl_limits_from_table(L, 2, &limits);
+	ucl_parser_set_limits(parser, &limits);
+
+	lua_pushvalue(L, 1);
+
+	return 1;
+}
+
+/*
+ * parser:get_limits() -> table
+ */
+static int
+lua_ucl_parser_get_limits(lua_State *L)
+{
+	struct ucl_parser *parser = lua_ucl_parser_get(L, 1);
+	struct ucl_parser_limits limits;
+
+	if (parser == NULL) {
+		return luaL_error(L, "invalid parser");
+	}
+
+	ucl_parser_get_limits(parser, &limits);
+	lua_ucl_limits_to_table(L, &limits);
+
+	return 1;
 }
 
 static ucl_object_t *
@@ -1737,6 +1935,12 @@ lua_ucl_parser_mt(lua_State *L)
 	lua_pushcfunction(L, lua_ucl_parser_validate);
 	lua_setfield(L, -2, "validate");
 
+	lua_pushcfunction(L, lua_ucl_parser_set_limits);
+	lua_setfield(L, -2, "set_limits");
+
+	lua_pushcfunction(L, lua_ucl_parser_get_limits);
+	lua_setfield(L, -2, "get_limits");
+
 	lua_pop(L, 1);
 }
 
@@ -2002,6 +2206,9 @@ int luaopen_ucl(lua_State *L)
 
 	lua_pushcfunction(L, lua_ucl_parser_init);
 	lua_setfield(L, -2, "parser");
+
+	lua_pushcfunction(L, lua_ucl_untrusted_parser_init);
+	lua_setfield(L, -2, "untrusted_parser");
 
 	lua_pushcfunction(L, lua_ucl_to_json);
 	lua_setfield(L, -2, "to_json");

--- a/lualib/llm_context.lua
+++ b/lualib/llm_context.lua
@@ -158,7 +158,7 @@ local function parse_json(data)
   if type(data) ~= 'string' or data == '' then
     return nil
   end
-  local parser = ucl.parser()
+  local parser = ucl.untrusted_parser()
   local ok, err = parser:parse_text(data)
   if not ok then return nil, err end
   return parser:get_object()

--- a/lualib/llm_search_context.lua
+++ b/lualib/llm_search_context.lua
@@ -196,7 +196,7 @@ local function query_search_api(task, domain, opts, callback, debug_module)
     lua_util.debugm(Np, task, "search API success for domain '%s', url: %s", domain, full_url)
 
     -- Parse Leta Mullvad JSON response
-    local parser = ucl.parser()
+    local parser = ucl.untrusted_parser()
     local ok, parse_err = parser:parse_string(body)
     if not ok then
       rspamd_logger.errx(task, "%s: failed to parse search API response for %s: %s",

--- a/lualib/lua_dkim_tools.lua
+++ b/lualib/lua_dkim_tools.lua
@@ -659,7 +659,7 @@ exports.sign_using_vault = function(N, task, settings, selector, sign_func, err_
       err_func(task, string.format('cannot request data from the vault url: %s; %s (%s)',
         full_url, err, body))
     else
-      local parser = ucl.parser()
+      local parser = ucl.untrusted_parser()
       local res, parser_err = parser:parse_string(body)
       if not res then
         err_func(task, string.format('vault reply for %s (data=%s) cannot be parsed: %s',

--- a/lualib/lua_mime.lua
+++ b/lualib/lua_mime.lua
@@ -1820,7 +1820,7 @@ Return ONLY the response in this format without any explanations, markdown forma
       logger.debugm('lua_mime', task, 'anonymize_message: LLM response received, size: %s bytes',
           data.content and #data.content or 0)
 
-      local parser = ucl.parser()
+      local parser = ucl.untrusted_parser()
       local res, parse_err = parser:parse_string(data.content)
       if not res then
         logger.errx(task, 'anonymize_message: cannot parse LLM response: %s', parse_err)

--- a/lualib/lua_neural_external.lua
+++ b/lualib/lua_neural_external.lua
@@ -85,7 +85,7 @@ function exports.parse_model(data)
   end
 
   -- Parse msgpack
-  local parser = ucl.parser()
+  local parser = ucl.untrusted_parser()
   local ok, parse_err = parser:parse_text(decompressed, 'msgpack')
   if not ok then
     return nil, "failed to parse msgpack: " .. (parse_err or "unknown error")

--- a/lualib/lua_scanners/cloudmark.lua
+++ b/lualib/lua_scanners/cloudmark.lua
@@ -70,7 +70,7 @@ local function cloudmark_preload(rule, cfg, ev_base, _)
     if code ~= 200 then
       rspamd_logger.errx(ev_base, 'bad HTTP code when getting max message size: %s', code)
     end
-    local parser = ucl.parser()
+    local parser = ucl.untrusted_parser()
     local ret, err = parser:parse_string(body)
     if not ret then
       rspamd_logger.errx(ev_base, 'could not parse response body [%s]: %s', body, err)
@@ -203,7 +203,7 @@ assert(get_specific_symbol({ [100] = 'CLOUDMARK_SPAM' }, 100) == 'CLOUDMARK_SPAM
 assert(get_specific_symbol({ [0] = 'CLOUDMARK_SPAM' }, 0) == 'CLOUDMARK_SPAM')
 
 local function parse_cloudmark_reply(task, rule, body)
-  local parser = ucl.parser()
+  local parser = ucl.untrusted_parser()
   local ret, err = parser:parse_string(body)
   if not ret then
     rspamd_logger.errx(task, '%s: bad response body (raw): %s', N, body)

--- a/lualib/lua_scanners/expurgate.lua
+++ b/lualib/lua_scanners/expurgate.lua
@@ -241,7 +241,7 @@ local function expurgate_check(task, content, digest, rule, maybe_part)
           task:insert_result(rule.symbol_fail, 1.0, 'Bad HTTP code: ' .. code)
           return
         end
-        local parser = ucl.parser()
+        local parser = ucl.untrusted_parser()
         local ret, err = parser:parse_string(body)
         if not ret then
           rspamd_logger.errx(task, 'expurgate: bad response body (raw): %s', body)

--- a/lualib/lua_scanners/metadefender.lua
+++ b/lualib/lua_scanners/metadefender.lua
@@ -150,7 +150,7 @@ local function metadefender_check(task, content, digest, rule, maybe_part)
           end
         else
           local ucl = require "ucl"
-          local parser = ucl.parser()
+          local parser = ucl.untrusted_parser()
           local res, json_err = parser:parse_string(body)
 
           lua_util.debugm(rule.name, task, '%s: got reply data: "%s"',

--- a/lualib/lua_scanners/oletools.lua
+++ b/lualib/lua_scanners/oletools.lua
@@ -151,7 +151,7 @@ local function oletools_check(task, content, digest, rule, maybe_part)
           conn:add_read(oletools_callback)
 
         else
-          local ucl_parser = ucl.parser()
+          local ucl_parser = ucl.untrusted_parser()
           local ok, ucl_err = ucl_parser:parse_string(tostring(json_response))
           if not ok then
             rspamd_logger.errx(task, "%s: error parsing json response, retry: %s",

--- a/lualib/lua_scanners/vadesecure.lua
+++ b/lualib/lua_scanners/vadesecure.lua
@@ -277,7 +277,7 @@ local function vade_check(task, content, digest, rule, maybe_part)
           task:insert_result(rule.symbol_fail, 1.0, 'Bad HTTP code: ' .. code)
           return
         end
-        local parser = ucl.parser()
+        local parser = ucl.untrusted_parser()
         local ret, err = parser:parse_string(body)
         if not ret then
           rspamd_logger.errx(task, 'vade: bad response body (raw): %s', body)

--- a/lualib/lua_scanners/virustotal.lua
+++ b/lualib/lua_scanners/virustotal.lua
@@ -146,7 +146,7 @@ local function virustotal_check(task, content, digest, rule, maybe_part)
           end
         else
           local ucl = require "ucl"
-          local parser = ucl.parser()
+          local parser = ucl.untrusted_parser()
           local res, json_err = parser:parse_string(body)
 
           lua_util.debugm(rule.name, task, '%s: got reply data: "%s"',

--- a/lualib/plugins/neural/providers/llm.lua
+++ b/lualib/plugins/neural/providers/llm.lua
@@ -219,7 +219,7 @@ neural_common.register_provider('llm', {
         return
       end
 
-      local parser = ucl.parser()
+      local parser = ucl.untrusted_parser()
       local ok, perr = parser:parse_string(resp)
       if not ok then
         rspamd_logger.debugm(N, task, 'llm cannot parse reply: %s', perr)

--- a/src/plugins/lua/bimi.lua
+++ b/src/plugins/lua/bimi.lua
@@ -152,7 +152,7 @@ local function insert_bimi_headers(task, domain, bimi_content)
 end
 
 local function process_bimi_json(task, domain, redis_data)
-  local parser = ucl.parser()
+  local parser = ucl.untrusted_parser()
   local _, err = parser:parse_string(redis_data)
 
   if err then
@@ -187,7 +187,7 @@ local function make_helper_request(task, domain, record, redis_server)
       return
     end
     if is_sync then
-      local parser = ucl.parser()
+      local parser = ucl.untrusted_parser()
       local _, err = parser:parse_string(body)
 
       if err then

--- a/src/plugins/lua/contextal.lua
+++ b/src/plugins/lua/contextal.lua
@@ -163,7 +163,7 @@ local function action_cb(task)
       maybe_defer(task)
       return
     end
-    local parser = ucl.parser()
+    local parser = ucl.untrusted_parser()
     local _, parse_err = parser:parse_string(body)
     if parse_err then
       rspamd_logger.err(task, 'cannot parse JSON: %s', err)
@@ -202,7 +202,7 @@ local function submit(task)
       maybe_defer(task)
       return
     end
-    local parser = ucl.parser()
+    local parser = ucl.untrusted_parser()
     local _, parse_err = parser:parse_string(body)
     if parse_err then
       rspamd_logger.err(task, 'cannot parse JSON: %s', err)

--- a/src/plugins/lua/gpt.lua
+++ b/src/plugins/lua/gpt.lua
@@ -454,7 +454,7 @@ local function clean_gpt_response(text)
 end
 
 local function default_openai_json_conversion(task, input)
-  local parser = ucl.parser()
+  local parser = ucl.untrusted_parser()
   local res, err = parser:parse_string(input)
   if not res then
     rspamd_logger.errx(task, 'cannot parse reply: %s', err)
@@ -481,7 +481,7 @@ local function default_openai_json_conversion(task, input)
   -- Apply heuristic to extract JSON
   first_message = maybe_extract_json(first_message) or first_message
 
-  parser = ucl.parser()
+  parser = ucl.untrusted_parser()
   res, err = parser:parse_string(first_message)
   if not res then
     rspamd_logger.errx(task, 'cannot parse JSON gpt reply: %s', err)
@@ -526,7 +526,7 @@ end
 
 -- Assume that we have 3 lines: probability, reason, additional categories
 local function default_openai_plain_conversion(task, input)
-  local parser = ucl.parser()
+  local parser = ucl.untrusted_parser()
   local res, err = parser:parse_string(input)
   if not res then
     rspamd_logger.errx(task, 'cannot parse reply: %s', err)
@@ -602,7 +602,7 @@ local function ollama_extract_content(task, reply)
 end
 
 local function default_ollama_plain_conversion(task, input)
-  local parser = ucl.parser()
+  local parser = ucl.untrusted_parser()
   local res, err = parser:parse_string(input)
   if not res then
     rspamd_logger.errx(task, 'cannot parse reply: %s', err)
@@ -638,7 +638,7 @@ local function default_ollama_plain_conversion(task, input)
 end
 
 local function default_ollama_json_conversion(task, input)
-  local parser = ucl.parser()
+  local parser = ucl.untrusted_parser()
   local res, err = parser:parse_string(input)
   if not res then
     rspamd_logger.errx(task, 'cannot parse reply: %s', err)
@@ -659,7 +659,7 @@ local function default_ollama_json_conversion(task, input)
   -- Apply heuristic to extract JSON
   first_message = maybe_extract_json(first_message) or first_message
 
-  parser = ucl.parser()
+  parser = ucl.untrusted_parser()
   res, err = parser:parse_string(first_message)
   if not res then
     rspamd_logger.errx(task, 'cannot parse JSON gpt reply: %s', err)

--- a/src/plugins/lua/http_headers.lua
+++ b/src/plugins/lua/http_headers.lua
@@ -85,7 +85,7 @@ rspamd_config:add_condition("DKIM_CHECK", function(task)
   local hdr = task:get_request_header('DKIM')
 
   if hdr then
-    local parser = ucl.parser()
+    local parser = ucl.untrusted_parser()
     local res, err = parser:parse_string(tostring(hdr))
     if not res then
       logger.infox(task, "cannot parse DKIM header: %1", err)
@@ -132,7 +132,7 @@ rspamd_config:add_condition("SPF_CHECK", function(task)
   local hdr = task:get_request_header('SPF')
 
   if hdr then
-    local parser = ucl.parser()
+    local parser = ucl.untrusted_parser()
     local res, err = parser:parse_string(tostring(hdr))
     if not res then
       logger.infox(task, "cannot parse SPF header: %1", err)
@@ -165,7 +165,7 @@ rspamd_config:add_condition("DMARC_CALLBACK", function(task)
   local hdr = task:get_request_header('DMARC')
 
   if hdr then
-    local parser = ucl.parser()
+    local parser = ucl.untrusted_parser()
     local res, err = parser:parse_string(tostring(hdr))
     if not res then
       logger.infox(task, "cannot parse DMARC header: %1", err)

--- a/src/plugins/lua/phishing.lua
+++ b/src/plugins/lua/phishing.lua
@@ -522,7 +522,7 @@ local function openphish_json_cb(string)
 
   local function openphish_elt_parser(cap)
     if valid then
-      local parser = ucl.parser()
+      local parser = ucl.untrusted_parser()
       local res, err = parser:parse_string(cap)
       if not res then
         valid = false

--- a/src/plugins/lua/rspamd_update.lua
+++ b/src/plugins/lua/rspamd_update.lua
@@ -91,7 +91,7 @@ end
 local function gen_callback()
 
   return function(data)
-    local parser = ucl.parser()
+    local parser = ucl.untrusted_parser()
     local res, err = parser:parse_string(data)
 
     if not res then

--- a/src/plugins/lua/settings.lua
+++ b/src/plugins/lua/settings.lua
@@ -150,7 +150,8 @@ local function check_query_settings(task)
   local query_set = task:get_request_header('settings')
   if query_set then
 
-    local parser = ucl.parser()
+    -- Client supplied header, so bound what it may cost us to represent
+    local parser = ucl.untrusted_parser()
     local res, err = parser:parse_text(tostring(query_set))
     if res then
       if settings_id then
@@ -481,7 +482,7 @@ end
 local function gen_settings_external_cb(name)
   return function(result, err_or_data, code, task)
     if result then
-      local parser = ucl.parser()
+      local parser = ucl.untrusted_parser()
 
       local res, ucl_err = parser:parse_text(err_or_data)
       if not res then

--- a/test/lua/unit/ucl.lua
+++ b/test/lua/unit/ucl.lua
@@ -71,5 +71,101 @@ context("UCL manipulation", function()
     assert_equal(reply.t.test:unwrap(), 'test')
   end)
 
+  test("UCL untrusted parser: defaults are applied", function()
+    local p = ucl.untrusted_parser()
+    local limits = p:get_limits()
+
+    assert_equal(limits.max_depth, 64)
+    assert_equal(limits.max_nodes, 1000000)
+    assert_equal(limits.max_alloc, 64 * 1024 * 1024)
+    assert_equal(limits.max_key_length, 1024)
+    assert_equal(limits.max_string_length, 16 * 1024 * 1024)
+  end)
+
+  test("UCL untrusted parser: rejects deep nesting", function()
+    local p = ucl.untrusted_parser()
+    local deep = string.rep('[', 1000) .. string.rep(']', 1000)
+    local ok, err = p:parse_string(deep)
+
+    assert_false(ok)
+    assert_not_nil(err)
+  end)
+
+  test("UCL untrusted parser: accepts ordinary replies", function()
+    local p = ucl.untrusted_parser()
+    local ok = p:parse_string('{"verdict": "clean", "scores": [1, 2, 3]}')
+
+    assert_true(ok)
+
+    local obj = p:get_object()
+    assert_equal(obj.verdict, 'clean')
+    assert_equal(#obj.scores, 3)
+  end)
+
+  test("UCL untrusted parser: msgpack is bounded too", function()
+    local p = ucl.untrusted_parser({ max_depth = 8 })
+    -- 9 nested fixarrays, innermost holding int 1
+    local deep = string.rep('\145', 9) .. '\1'
+    local ok = p:parse_text(deep, 'msgpack')
+
+    assert_false(ok)
+  end)
+
+  test("UCL untrusted parser: limits can be overridden", function()
+    local p = ucl.untrusted_parser({ max_depth = 4, max_string_length = 8 })
+    local limits = p:get_limits()
+
+    -- Overridden fields change, the rest keep the untrusted defaults
+    assert_equal(limits.max_depth, 4)
+    assert_equal(limits.max_string_length, 8)
+    assert_equal(limits.max_nodes, 1000000)
+
+    assert_false(p:parse_string('[[[[[1]]]]]'))
+  end)
+
+  test("UCL untrusted parser: zero means unlimited", function()
+    local p = ucl.untrusted_parser({ max_depth = 0 })
+    local deep = string.rep('[', 2000) .. string.rep(']', 2000)
+
+    assert_true(p:parse_string(deep))
+  end)
+
+  test("UCL parser: set_limits overlays without dropping the rest", function()
+    local p = ucl.untrusted_parser()
+    p:set_limits({ max_key_length = 4 })
+
+    local limits = p:get_limits()
+    assert_equal(limits.max_key_length, 4)
+    assert_equal(limits.max_depth, 64)
+
+    assert_false(p:parse_string('{"toolongkey": 1}'))
+  end)
+
+  test("UCL parser: default parser keeps the libucl defaults", function()
+    local p = ucl.parser()
+    local limits = p:get_limits()
+
+    -- Only the depth guard is on by default, so existing callers are unchanged
+    assert_equal(limits.max_depth, 1024)
+    assert_equal(limits.max_nodes, 0)
+    assert_equal(limits.max_alloc, 0)
+  end)
+
+  test("UCL parser: bad limit names are rejected", function()
+    local p = ucl.parser()
+
+    assert_false(pcall(function()
+      p:set_limits({ max_dpeth = 4 })
+    end))
+
+    assert_false(pcall(function()
+      p:set_limits({ max_depth = -1 })
+    end))
+
+    assert_false(pcall(function()
+      p:set_limits({ max_depth = 'lots' })
+    end))
+  end)
+
   collectgarbage() -- To ensure we don't crash with asan
 end)


### PR DESCRIPTION
Follow-up to #6207, which bounded UCL parsing in C but left the Lua API with no
way to reach any of it.

## The gap

`ucl.parser()` returns the libucl defaults, which after #6207 guard nesting
depth and nothing else. Every one of the ~88 call sites in tree used it bare —
no caller has ever passed flags. That is correct for config mode, but most of
those parsers are handling JSON or msgpack that arrived from somewhere we do
not control.

## API

```lua
local p = ucl.untrusted_parser()                      -- safe profile
local p = ucl.untrusted_parser({ max_depth = 16 })    -- with overrides
p:set_limits({ max_string_length = 65536 })           -- on any parser
local limits = p:get_limits()
```

Defaults: depth 64, a million elements, 64MB of tree, 1KB keys, 16MB strings.
The caps are absolute rather than derived from input size, because a Lua caller
builds the parser before it has the text. Zero still means unlimited.

`set_limits` overlays the fields it is given on those already in effect, so
tightening one does not silently clear the rest. An unknown key is an error
rather than a quiet no-op, so a typo cannot leave a limit unset.

`ucl.parser()` is unchanged — there is a test asserting it still reads
`max_depth = 1024, max_nodes = 0, max_alloc = 0`, so the call sites left on it
are provably unaffected.

## Migrated call sites (30 across 19 files)

The most directly attacker-controlled turned out not to be the service replies
but the request headers: `http_headers.lua` parses
`task:get_request_header('DKIM'/'SPF'/'DMARC')` and `settings.lua` parses
`get_request_header('settings')`. Both are client supplied.

The rest are replies from network services: the LLM providers and `gpt.lua`,
the six `lua_scanners` backends, `bimi`, `contextal`, the updates and openphish
feeds, the external neural service, the anonymiser in `lua_mime` and the vault
lookup in `lua_dkim_tools`.

`settings.lua` is split rather than converted wholesale — the request header and
external map parsers are untrusted, while `process_settings_map` and the Redis
one stay on the ordinary parser.

## Deliberately not migrated

`clickhouse`, `elastic`, `lua_cache`, `history_redis`, the neural model paths,
and everything config mode or `rspamadm`. Those parse data we produce ourselves
and can legitimately be large enough to reach a 64MB cap — a big `SELECT` or a
model blob would start failing to parse in existing deployments. They can be
opted in individually with explicit looser limits if that is ever wanted.

## Testing

- 1227 Lua tests, 0 failed — 9 new covering the defaults, deep-nesting
  rejection, msgpack, per-site overrides, zero-means-unlimited, overlay
  semantics, the unchanged `ucl.parser()` defaults, and rejection of bad limit
  names, negative values and non-numbers
- 379/379 C++ unit tests
- 462/462 functional across `001_merged` plus both settings suites
- luacheck 0 warnings / 0 errors across 215 files, clang-format clean
