### PR TITLE
Rework public suffix matching: suffix hash lookup and two-pass URL discovery

### DIFF
--- a/lualib/lua_urls_compose.lua
+++ b/lualib/lua_urls_compose.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (c) 2022, Vsevolod Stakhov <vsevolod@rspamd.com>
+Copyright (c) 2026, Vsevolod Stakhov <vsevolod@rspamd.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,208 +22,86 @@ limitations under the License.
 
 local N = "lua_urls_compose"
 local lua_util = require "lua_util"
-local rspamd_util = require "rspamd_util"
+local rspamd_tld_lookup = require "rspamd_tld_lookup"
 local bit = require "bit"
-local rspamd_trie = require "rspamd_trie"
-local fun = require "fun"
-local rspamd_regexp = require "rspamd_regexp"
 
 local maps_cache = {}
 
 local exports = {}
 
+-- Composition map rules use the public suffix list syntax with slightly
+-- different semantics:
+--  * `foo.bar` composes to the rule plus one preceding label (like a
+--    public suffix)
+--  * `*.foo.bar` composes to the whole host under the rule
+--  * `!baz.foo.bar` cancels composition, the default eSLD is used
 local function process_url(self, log_obj, url_tld, url_host)
-  local tld_elt = self.tlds[url_tld]
-
-  if tld_elt then
-    lua_util.debugm(N, log_obj, 'found compose tld for %s (host = %s)',
-        url_tld, url_host)
-
-    for _, excl in ipairs(tld_elt.except_rules) do
-      local matched, ret = excl[2](url_tld, url_host)
-      if matched then
-        lua_util.debugm(N, log_obj, 'found compose exclusion for %s (%s) -> %s',
-            url_host, excl[1], ret)
-
-        return ret
-      end
-    end
-
-    if tld_elt.multipattern_compose_rules then
-      local matches = tld_elt.multipattern_compose_rules:match(url_host)
-
-      if matches then
-        local lua_pat_idx = math.huge
-
-        for m, _ in pairs(matches) do
-          if m < lua_pat_idx then
-            lua_pat_idx = m
-          end
-        end
-
-        if #tld_elt.compose_rules >= lua_pat_idx then
-          local lua_pat = tld_elt.compose_rules[lua_pat_idx]
-          local matched, ret = lua_pat[2](url_tld, url_host)
-
-          if not matched then
-            lua_util.debugm(N, log_obj, 'NOT found compose inclusion for %s (%s) -> %s',
-                url_host, lua_pat[1], url_tld)
-
-            return url_tld
-          else
-            lua_util.debugm(N, log_obj, 'found compose inclusion for %s (%s) -> %s',
-                url_host, lua_pat[1], ret)
-
-            return ret
-          end
-        else
-          lua_util.debugm(N, log_obj, 'NOT found compose inclusion for %s (%s) -> %s',
-              url_host, lua_pat_idx, url_tld)
-
-          return url_tld
-        end
-      end
-    else
-      -- Match one by one
-      for _, lua_pat in ipairs(tld_elt.compose_rules) do
-        local matched, ret = lua_pat[2](url_tld, url_host)
-        if matched then
-          lua_util.debugm(N, log_obj, 'found compose inclusion for %s (%s) -> %s',
-              url_host, lua_pat[1], ret)
-
-          return ret
-        end
-      end
-    end
-
-    lua_util.debugm(N, log_obj, 'not found compose inclusion for %s in %s -> %s',
-        url_host, url_tld, url_tld)
-  else
-    lua_util.debugm(N, log_obj, 'not found compose tld for %s in %s -> %s',
-        url_host, url_tld, url_tld)
+  if not self.suffix_set then
+    -- Map is not loaded yet
+    return url_tld
   end
 
-  return url_tld
-end
+  local domain, flags = self.suffix_set:registrable(url_host)
 
-local function tld_pattern_transform(tld_pat)
-  -- Convert tld like pattern to a lua match pattern
-  -- blah -> %.blah
-  -- *.blah -> .*%.blah
-  local ret
-  if tld_pat:sub(1, 2) == '*.' then
-    ret = string.format('^((?:[^.]+\\.)*%s)$', tld_pat:sub(3))
-  else
-    ret = string.format('(?:^|\\.)((?:[^.]+\\.)?%s)$', tld_pat)
+  if not domain then
+    lua_util.debugm(N, log_obj, 'not found compose rule for %s -> %s',
+        url_host, url_tld)
+
+    return url_tld
   end
 
-  lua_util.debugm(N, nil, 'added pattern %s -> %s',
-      tld_pat, ret)
+  if bit.band(flags, rspamd_tld_lookup.flags.exception) ~= 0 then
+    lua_util.debugm(N, log_obj, 'found compose exclusion for %s -> %s',
+        url_host, url_tld)
 
-  return ret
-end
-
-local function include_elt_gen(pat)
-  pat = rspamd_regexp.create(tld_pattern_transform(pat), 'i')
-  return function(_, host)
-    local matches = pat:search(host, false, true)
-    if matches then
-      return true, matches[1][2]
-    end
-
-    return false
+    return url_tld
   end
-end
 
-local function exclude_elt_gen(pat)
-  pat = rspamd_regexp.create(tld_pattern_transform(pat))
-  return function(tld, host)
-    if pat:search(host) then
-      return true, tld
-    end
+  if bit.band(flags, rspamd_tld_lookup.flags.wildcard) ~= 0 then
+    -- Wildcard compose rules are greedy: keep the whole host
+    lua_util.debugm(N, log_obj, 'found compose wildcard for %s -> %s',
+        url_host, url_host)
 
-    return false
+    return url_host
   end
+
+  lua_util.debugm(N, log_obj, 'found compose inclusion for %s -> %s',
+      url_host, domain)
+
+  return domain
 end
 
 local function compose_map_cb(self, map_text)
-  local lpeg = require "lpeg"
-
-  local singleline_comment = lpeg.P '#' * (1 - lpeg.S '\r\n\f') ^ 0
-  local comments_strip_grammar = lpeg.C((1 - lpeg.P '#') ^ 1) * lpeg.S(' \t') ^ 0 * singleline_comment ^ 0
-
-  local function process_tld_rule(tld_elt, l)
-    if l:sub(1, 1) == '!' then
-      -- Exclusion elt
-      table.insert(tld_elt.except_rules, { l, exclude_elt_gen(l:sub(2)) })
-    else
-      table.insert(tld_elt.compose_rules, { l, include_elt_gen(l) })
-    end
-  end
+  local suffix_set = rspamd_tld_lookup.create()
+  local nrules = 0
 
   local function process_map_line(l)
-    -- Skip empty lines and comments
+    -- Strip comments and surrounding spaces
+    l = l:gsub('#.*$', '')
+    l = l:match('^%s*(.-)%s*$')
+
     if #l == 0 then
       return
     end
-    l = comments_strip_grammar:match(l)
-    if not l or #l == 0 then
-      return
-    end
 
-    -- Get TLD
-    local tld = rspamd_util.get_tld(l)
-
-    if tld then
-      local tld_elt = self.tlds[tld]
-
-      if not tld_elt then
-        tld_elt = {
-          compose_rules = {},
-          except_rules = {},
-          multipattern_compose_rules = nil
-        }
-
-        lua_util.debugm(N, rspamd_config, 'processed new tld rule for %s', tld)
-        self.tlds[tld] = tld_elt
-      end
-
-      process_tld_rule(tld_elt, l)
+    if l:sub(1, 2) == '*.' then
+      -- Compose wildcards match zero or more labels, whilst suffix
+      -- wildcards require exactly one, so add the bare parent as well
+      suffix_set:add_rule(l)
+      suffix_set:add_rule(l:sub(3))
     else
-      lua_util.debugm(N, rspamd_config, 'cannot read tld from compose map line: %s', l)
+      suffix_set:add_rule(l)
     end
+
+    nrules = nrules + 1
   end
 
-  for line in map_text:lines() do
+  for line in map_text:lines(true) do
     process_map_line(line)
   end
 
-  local multipattern_threshold = 1
-  for tld, tld_elt in pairs(self.tlds) do
-    -- Sort patterns to have longest labels before shortest ones,
-    -- so we can ensure that they match before
-    table.sort(tld_elt.compose_rules, function(e1, e2)
-      local _, ndots1 = string.gsub(e1[1], '(%.)', '')
-      local _, ndots2 = string.gsub(e2[1], '(%.)', '')
-
-      return ndots1 > ndots2
-    end)
-    if rspamd_trie.has_hyperscan() and #tld_elt.compose_rules >= multipattern_threshold then
-      lua_util.debugm(N, rspamd_config, 'tld %s has %s rules, apply multipattern',
-          tld, #tld_elt.compose_rules)
-      local flags = bit.bor(rspamd_trie.flags.re,
-          rspamd_trie.flags.dot_all,
-          rspamd_trie.flags.no_start,
-          rspamd_trie.flags.icase)
-
-
-      -- We now convert our internal patterns to multipattern patterns
-      local mp_table = fun.totable(fun.map(function(pat_elt)
-        return tld_pattern_transform(pat_elt[1])
-      end, tld_elt.compose_rules))
-      tld_elt.multipattern_compose_rules = rspamd_trie.create(mp_table, flags)
-    end
-  end
+  self.suffix_set = suffix_set
+  lua_util.debugm(N, rspamd_config, 'loaded %s compose rules', nrules)
 end
 
 exports.add_composition_map = function(cfg, map_obj)
@@ -238,7 +116,6 @@ exports.add_composition_map = function(cfg, map_obj)
     local ret = {
       process_url = process_url,
       hash = hash_key,
-      tlds = {},
     }
 
     map = cfg:add_map {
@@ -272,7 +149,6 @@ exports.inject_composition_rules = function(cfg, rules)
     local ret = {
       process_url = process_url,
       hash = hash_key,
-      tlds = {},
     }
 
     compose_map_cb(ret, rspamd_text.fromtable(rules, '\n'))

--- a/src/libserver/CMakeLists.txt
+++ b/src/libserver/CMakeLists.txt
@@ -35,6 +35,7 @@ SET(LIBRSPAMDSERVERSRC
         ${CMAKE_CURRENT_SOURCE_DIR}/settings_merge.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/allocator_conf.c
         ${CMAKE_CURRENT_SOURCE_DIR}/task.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/tld_lookup.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/url.c
         ${CMAKE_CURRENT_SOURCE_DIR}/worker_util.c
         ${CMAKE_CURRENT_SOURCE_DIR}/http_content_negotiation.c

--- a/src/libserver/tld_lookup.cxx
+++ b/src/libserver/tld_lookup.cxx
@@ -17,9 +17,12 @@
 #include "config.h"
 #include "tld_lookup.h"
 #include "logger.h"
+#include "libutil/str_util.h"
+#include "libutil/cxx/hash_util.hxx"
 
 #include "contrib/ankerl/unordered_dense.h"
 
+#include <array>
 #include <cstring>
 #include <optional>
 #include <string>
@@ -33,29 +36,73 @@ constexpr std::uint8_t FL_WILDCARD = 0x2;
 constexpr std::uint8_t FL_EXCEPTION = 0x4;
 constexpr std::uint8_t FL_PRIVATE = 0x8;
 
-struct sv_hash {
-	using is_transparent = void;
-	using is_avalanching = void;
-	auto operator()(std::string_view v) const noexcept -> std::uint64_t
-	{
-		return ankerl::unordered_dense::hash<std::string_view>{}(v);
-	}
-};
-
 using rules_map = ankerl::unordered_dense::map<std::string, std::uint8_t,
-											   sv_hash, std::equal_to<>>;
+											   rspamd::smart_str_hash, rspamd::smart_str_equal>;
 using labels_set = ankerl::unordered_dense::set<std::string,
-												sv_hash, std::equal_to<>>;
+												rspamd::smart_str_hash, rspamd::smart_str_equal>;
 
 /* Suffix rules never exceed 6 labels, +1 for a wildcard child */
-constexpr int max_suffix_labels = 7;
-constexpr std::size_t max_labels = 256;
+constexpr unsigned int max_suffix_labels = 7;
 
+/*
+ * A lookup result in terms of labels counted from the right: label 0 is the
+ * rightmost one. Case folding may change byte offsets but never the label
+ * structure, so labels are the safe currency between the folded copy used
+ * for probing and the original host used for the output tokens.
+ */
 struct lookup_result {
-	std::size_t suffix_off;
-	std::size_t reg_off;
+	unsigned int suffix_label;
+	unsigned int reg_label;
 	unsigned int flags;
 };
+
+/*
+ * Lowercased copy of a host for probing: rules are stored folded with
+ * rspamd_str_lc_utf8, which never grows a string (length-increasing case
+ * mappings are kept as is), so the copy always fits the original size and
+ * ordinary hosts stay on the stack.
+ */
+struct folded_host {
+	explicit folded_host(std::string_view host)
+	{
+		char *dst = stack_buf.data();
+
+		if (host.size() > stack_buf.size()) {
+			heap_buf.resize(host.size());
+			dst = heap_buf.data();
+		}
+
+		memcpy(dst, host.data(), host.size());
+		auto len = rspamd_str_lc_utf8(dst, (unsigned int) host.size());
+		folded = std::string_view{dst, len};
+	}
+
+	std::string_view folded;
+
+private:
+	std::array<char, 256> stack_buf;
+	std::string heap_buf;
+};
+
+/* Byte offset of the label `nright` positions from the right (0 = last) */
+auto right_label_offset(std::string_view host, unsigned int nright) -> std::size_t
+{
+	auto search_end = host.size();
+
+	for (unsigned int i = 0;; i++) {
+		auto dot = search_end == 0 ? std::string_view::npos
+								   : host.rfind('.', search_end - 1);
+
+		if (dot == std::string_view::npos) {
+			return 0;
+		}
+		if (i == nright) {
+			return dot + 1;
+		}
+
+		search_end = dot;
+	}
+}
 
 } /* anonymous namespace */
 
@@ -106,40 +153,49 @@ struct rspamd_tld_lookup {
 
 	auto lookup(std::string_view host) const -> std::optional<lookup_result>
 	{
-		std::size_t starts[max_labels];
-		std::size_t nl = 0;
+		/* Start offsets of the rightmost labels, rightmost first; one extra
+		 * entry past the deepest possible suffix for the registrable label */
+		std::array<std::size_t, max_suffix_labels + 2> starts;
+		unsigned int nl = 0;
+		auto search_end = host.size();
 
-		starts[nl++] = 0;
-		for (std::size_t i = 0; i < host.size() && nl < max_labels; i++) {
-			if (host[i] == '.') {
-				starts[nl++] = i + 1;
+		while (nl < starts.size()) {
+			auto dot = search_end == 0 ? std::string_view::npos
+									   : host.rfind('.', search_end - 1);
+
+			if (dot == std::string_view::npos) {
+				starts[nl++] = 0;
+				break;
 			}
+
+			starts[nl++] = dot + 1;
+			search_end = dot;
 		}
 
-		auto lo = nl > max_suffix_labels ? nl - max_suffix_labels : 0;
 		std::uint8_t prev_flags = 0;
-		int ps_i = -1, exc_i = -1;
+		int ps_r = -1, exc_r = -1;
 		unsigned int ps_flags = 0, exc_flags = 0;
+		auto nprobe = std::min(nl, max_suffix_labels);
 
-		for (auto i = (int) nl - 1; i >= (int) lo; i--) {
+		for (unsigned int r = 0; r < nprobe; r++) {
 			std::uint8_t fl = 0;
 
-			if (auto it = rules.find(host.substr(starts[i])); it != rules.end()) {
+			if (auto it = rules.find(host.substr(starts[r])); it != rules.end()) {
 				fl = it->second;
 			}
 
 			if (fl & FL_EXCEPTION) {
-				exc_i = i;
+				exc_r = r;
 				exc_flags = RSPAMD_TLD_SUFFIX_EXCEPTION |
 							((fl & FL_PRIVATE) ? RSPAMD_TLD_SUFFIX_PRIVATE : 0);
 			}
 
 			if (fl & FL_EXACT) {
-				ps_i = i;
+				ps_r = r;
 				ps_flags = (fl & FL_PRIVATE) ? RSPAMD_TLD_SUFFIX_PRIVATE : 0;
 			}
 			else if (prev_flags & FL_WILDCARD) {
-				ps_i = i;
+				ps_r = r;
 				ps_flags = RSPAMD_TLD_SUFFIX_WILDCARD |
 						   ((prev_flags & FL_PRIVATE) ? RSPAMD_TLD_SUFFIX_PRIVATE : 0);
 			}
@@ -147,18 +203,19 @@ struct rspamd_tld_lookup {
 			prev_flags = fl;
 		}
 
-		/* An exception rule prevails: the matched host part is registrable and
-		 * the public suffix is the rule minus its leftmost label */
-		if (exc_i >= 0 && (std::size_t) exc_i + 1 < nl) {
-			return lookup_result{starts[exc_i + 1], starts[exc_i], exc_flags};
+		/* An exception rule prevails: the matched host part is registrable
+		 * and the public suffix is the rule minus its leftmost label */
+		if (exc_r >= 1) {
+			return lookup_result{(unsigned int) exc_r - 1, (unsigned int) exc_r, exc_flags};
 		}
 
-		if (ps_i >= 0) {
+		if (ps_r >= 0) {
 			/* Registrable domain is one label to the left of the public
 			 * suffix; a host that is itself a public suffix is clamped to
 			 * the whole host */
-			auto reg_off = ps_i > 0 ? starts[ps_i - 1] : starts[0];
-			return lookup_result{starts[ps_i], reg_off, ps_flags};
+			auto reg_r = (unsigned int) ps_r + 1 < nl ? (unsigned int) ps_r + 1
+													  : (unsigned int) ps_r;
+			return lookup_result{(unsigned int) ps_r, reg_r, ps_flags};
 		}
 
 		return std::nullopt;
@@ -167,36 +224,21 @@ struct rspamd_tld_lookup {
 
 namespace {
 
-auto lookup_prepared(const struct rspamd_tld_lookup *lookup,
-					 const char *host, gsize len) -> std::optional<lookup_result>
+auto tld_lookup_run(const struct rspamd_tld_lookup *lookup,
+					std::string_view &host) -> std::optional<lookup_result>
 {
-	if (len == 0) {
+	/* Ignore a single trailing dot (FQDN form) */
+	if (!host.empty() && host.back() == '.') {
+		host.remove_suffix(1);
+	}
+
+	if (host.empty()) {
 		return std::nullopt;
 	}
 
-	/* Ignore a single trailing dot (FQDN form) */
-	if (host[len - 1] == '.') {
-		len--;
-		if (len == 0) {
-			return std::nullopt;
-		}
-	}
+	folded_host fh{host};
 
-	/* Rules are stored lowercase; fold the host before probing */
-	char buf[512];
-	std::string long_buf;
-	char *dst = buf;
-
-	if (len > sizeof(buf)) {
-		long_buf.resize(len);
-		dst = long_buf.data();
-	}
-
-	for (gsize i = 0; i < len; i++) {
-		dst[i] = (char) g_ascii_tolower(host[i]);
-	}
-
-	return lookup->lookup(std::string_view{dst, len});
+	return lookup->lookup(fh.folded);
 }
 
 } /* anonymous namespace */
@@ -211,45 +253,38 @@ rspamd_tld_lookup_new(const char *tld_file)
 	}
 
 	auto *lookup = new rspamd_tld_lookup;
-	char linebuf[512];
+	char *linebuf = nullptr;
+	gsize buflen = 0;
+	gssize r;
 	bool in_private = false;
 
-	while (fgets(linebuf, sizeof(linebuf), f) != nullptr) {
-		auto len = strlen(linebuf);
-		bool truncated = len > 0 && linebuf[len - 1] != '\n' && !feof(f);
+	while ((r = rspamd_getline(&linebuf, &buflen, f)) > 0) {
+		auto line = std::string_view{linebuf, (std::size_t) r};
 
-		while (len > 0 && g_ascii_isspace(linebuf[len - 1])) {
-			linebuf[--len] = '\0';
+		while (!line.empty() && g_ascii_isspace(line.back())) {
+			line.remove_suffix(1);
 		}
 
-		if (truncated) {
-			/* Drop the tail of an oversized line */
-			int c;
-			while ((c = fgetc(f)) != EOF && c != '\n') {}
+		if (line.empty() || g_ascii_isspace(line.front())) {
 			continue;
 		}
 
-		if (len == 0 || g_ascii_isspace(linebuf[0])) {
-			continue;
-		}
-
-		if (linebuf[0] == '/') {
-			if (strstr(linebuf, "===BEGIN PRIVATE DOMAINS===") != nullptr) {
+		if (line.front() == '/') {
+			if (line.find("===BEGIN PRIVATE DOMAINS===") != std::string_view::npos) {
 				in_private = true;
 			}
-			else if (strstr(linebuf, "===END PRIVATE DOMAINS===") != nullptr) {
+			else if (line.find("===END PRIVATE DOMAINS===") != std::string_view::npos) {
 				in_private = false;
 			}
 			continue;
 		}
 
-		for (gsize i = 0; i < len; i++) {
-			linebuf[i] = (char) g_ascii_tolower(linebuf[i]);
-		}
-
-		lookup->add_rule(std::string_view{linebuf, len}, in_private);
+		/* Rules are matched against folded hosts, so fold them the same way */
+		auto flen = rspamd_str_lc_utf8(linebuf, (unsigned int) line.size());
+		lookup->add_rule(std::string_view{linebuf, flen}, in_private);
 	}
 
+	rspamd_getline_free(linebuf);
 	fclose(f);
 
 	if (lookup->nrules == 0) {
@@ -279,16 +314,17 @@ rspamd_tld_lookup_registrable(const struct rspamd_tld_lookup *lookup,
 		return FALSE;
 	}
 
-	auto res = lookup_prepared(lookup, host, len);
+	auto hv = std::string_view{host, len};
+	auto res = tld_lookup_run(lookup, hv);
 
 	if (!res) {
 		return FALSE;
 	}
 
 	if (out != nullptr) {
-		gsize eff_len = (len > 0 && host[len - 1] == '.') ? len - 1 : len;
-		out->begin = host + res->reg_off;
-		out->len = eff_len - res->reg_off;
+		auto off = right_label_offset(hv, res->reg_label);
+		out->begin = hv.data() + off;
+		out->len = hv.size() - off;
 	}
 
 	return TRUE;
@@ -303,16 +339,17 @@ rspamd_tld_lookup_suffix(const struct rspamd_tld_lookup *lookup,
 		return FALSE;
 	}
 
-	auto res = lookup_prepared(lookup, host, len);
+	auto hv = std::string_view{host, len};
+	auto res = tld_lookup_run(lookup, hv);
 
 	if (!res) {
 		return FALSE;
 	}
 
 	if (out != nullptr) {
-		gsize eff_len = (len > 0 && host[len - 1] == '.') ? len - 1 : len;
-		out->begin = host + res->suffix_off;
-		out->len = eff_len - res->suffix_off;
+		auto off = right_label_offset(hv, res->suffix_label);
+		out->begin = hv.data() + off;
+		out->len = hv.size() - off;
 	}
 
 	if (flags != nullptr) {
@@ -332,9 +369,8 @@ rspamd_tld_lookup_is_final_label(const struct rspamd_tld_lookup *lookup,
 
 	char buf[64];
 
-	for (gsize i = 0; i < len; i++) {
-		buf[i] = (char) g_ascii_tolower(label[i]);
-	}
+	memcpy(buf, label, len);
+	auto flen = rspamd_str_lc_utf8(buf, (unsigned int) len);
 
-	return lookup->final_labels.contains(std::string_view{buf, len}) ? TRUE : FALSE;
+	return lookup->final_labels.contains(std::string_view{buf, flen}) ? TRUE : FALSE;
 }

--- a/src/libserver/tld_lookup.cxx
+++ b/src/libserver/tld_lookup.cxx
@@ -305,6 +305,24 @@ rspamd_tld_lookup_new(const char *tld_file)
 	return lookup;
 }
 
+struct rspamd_tld_lookup *
+rspamd_tld_lookup_new_empty(void)
+{
+	return new rspamd_tld_lookup;
+}
+
+void rspamd_tld_lookup_add_rule(struct rspamd_tld_lookup *lookup,
+								const char *rule, gsize len)
+{
+	if (lookup == nullptr || rule == nullptr || len == 0) {
+		return;
+	}
+
+	folded_host folded{std::string_view{rule, len}};
+
+	lookup->add_rule(folded.folded, false);
+}
+
 void rspamd_tld_lookup_destroy(struct rspamd_tld_lookup *lookup)
 {
 	delete lookup;

--- a/src/libserver/tld_lookup.cxx
+++ b/src/libserver/tld_lookup.cxx
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include "tld_lookup.h"
+#include "logger.h"
+
+#include "contrib/ankerl/unordered_dense.h"
+
+#include <cstring>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace {
+
+constexpr std::uint8_t FL_EXACT = 0x1;
+/* Set on the parent key `foo` of a `*.foo` rule */
+constexpr std::uint8_t FL_WILDCARD = 0x2;
+constexpr std::uint8_t FL_EXCEPTION = 0x4;
+constexpr std::uint8_t FL_PRIVATE = 0x8;
+
+struct sv_hash {
+	using is_transparent = void;
+	using is_avalanching = void;
+	auto operator()(std::string_view v) const noexcept -> std::uint64_t
+	{
+		return ankerl::unordered_dense::hash<std::string_view>{}(v);
+	}
+};
+
+using rules_map = ankerl::unordered_dense::map<std::string, std::uint8_t,
+											   sv_hash, std::equal_to<>>;
+using labels_set = ankerl::unordered_dense::set<std::string,
+												sv_hash, std::equal_to<>>;
+
+/* Suffix rules never exceed 6 labels, +1 for a wildcard child */
+constexpr int max_suffix_labels = 7;
+constexpr std::size_t max_labels = 256;
+
+struct lookup_result {
+	std::size_t suffix_off;
+	std::size_t reg_off;
+	unsigned int flags;
+};
+
+} /* anonymous namespace */
+
+struct rspamd_tld_lookup {
+	rules_map rules;
+	labels_set final_labels;
+	unsigned int nrules = 0;
+
+	auto add_rule(std::string_view rule, bool in_private) -> void
+	{
+		auto flags_of = [in_private](std::uint8_t fl) -> std::uint8_t {
+			return in_private ? (fl | FL_PRIVATE) : fl;
+		};
+
+		if (rule.empty()) {
+			return;
+		}
+
+		if (rule.front() == '!') {
+			rule.remove_prefix(1);
+			if (rule.empty()) {
+				return;
+			}
+			rules[std::string{rule}] |= flags_of(FL_EXCEPTION);
+		}
+		else if (rule.front() == '*') {
+			auto dot = rule.find('.');
+			if (dot == std::string_view::npos || dot + 1 == rule.size()) {
+				msg_err("got bad star suffix rule, skip it: %*s",
+						(int) rule.size(), rule.data());
+				return;
+			}
+			rule.remove_prefix(dot + 1);
+			rules[std::string{rule}] |= flags_of(FL_WILDCARD);
+		}
+		else {
+			rules[std::string{rule}] |= flags_of(FL_EXACT);
+		}
+
+		auto last_dot = rule.rfind('.');
+		auto label = last_dot == std::string_view::npos ? rule : rule.substr(last_dot + 1);
+		if (!label.empty()) {
+			final_labels.emplace(label);
+		}
+
+		nrules++;
+	}
+
+	auto lookup(std::string_view host) const -> std::optional<lookup_result>
+	{
+		std::size_t starts[max_labels];
+		std::size_t nl = 0;
+
+		starts[nl++] = 0;
+		for (std::size_t i = 0; i < host.size() && nl < max_labels; i++) {
+			if (host[i] == '.') {
+				starts[nl++] = i + 1;
+			}
+		}
+
+		auto lo = nl > max_suffix_labels ? nl - max_suffix_labels : 0;
+		std::uint8_t prev_flags = 0;
+		int ps_i = -1, exc_i = -1;
+		unsigned int ps_flags = 0, exc_flags = 0;
+
+		for (auto i = (int) nl - 1; i >= (int) lo; i--) {
+			std::uint8_t fl = 0;
+
+			if (auto it = rules.find(host.substr(starts[i])); it != rules.end()) {
+				fl = it->second;
+			}
+
+			if (fl & FL_EXCEPTION) {
+				exc_i = i;
+				exc_flags = RSPAMD_TLD_SUFFIX_EXCEPTION |
+							((fl & FL_PRIVATE) ? RSPAMD_TLD_SUFFIX_PRIVATE : 0);
+			}
+
+			if (fl & FL_EXACT) {
+				ps_i = i;
+				ps_flags = (fl & FL_PRIVATE) ? RSPAMD_TLD_SUFFIX_PRIVATE : 0;
+			}
+			else if (prev_flags & FL_WILDCARD) {
+				ps_i = i;
+				ps_flags = RSPAMD_TLD_SUFFIX_WILDCARD |
+						   ((prev_flags & FL_PRIVATE) ? RSPAMD_TLD_SUFFIX_PRIVATE : 0);
+			}
+
+			prev_flags = fl;
+		}
+
+		/* An exception rule prevails: the matched host part is registrable and
+		 * the public suffix is the rule minus its leftmost label */
+		if (exc_i >= 0 && (std::size_t) exc_i + 1 < nl) {
+			return lookup_result{starts[exc_i + 1], starts[exc_i], exc_flags};
+		}
+
+		if (ps_i >= 0) {
+			/* Registrable domain is one label to the left of the public
+			 * suffix; a host that is itself a public suffix is clamped to
+			 * the whole host */
+			auto reg_off = ps_i > 0 ? starts[ps_i - 1] : starts[0];
+			return lookup_result{starts[ps_i], reg_off, ps_flags};
+		}
+
+		return std::nullopt;
+	}
+};
+
+namespace {
+
+auto lookup_prepared(const struct rspamd_tld_lookup *lookup,
+					 const char *host, gsize len) -> std::optional<lookup_result>
+{
+	if (len == 0) {
+		return std::nullopt;
+	}
+
+	/* Ignore a single trailing dot (FQDN form) */
+	if (host[len - 1] == '.') {
+		len--;
+		if (len == 0) {
+			return std::nullopt;
+		}
+	}
+
+	/* Rules are stored lowercase; fold the host before probing */
+	char buf[512];
+	std::string long_buf;
+	char *dst = buf;
+
+	if (len > sizeof(buf)) {
+		long_buf.resize(len);
+		dst = long_buf.data();
+	}
+
+	for (gsize i = 0; i < len; i++) {
+		dst[i] = (char) g_ascii_tolower(host[i]);
+	}
+
+	return lookup->lookup(std::string_view{dst, len});
+}
+
+} /* anonymous namespace */
+
+struct rspamd_tld_lookup *
+rspamd_tld_lookup_new(const char *tld_file)
+{
+	FILE *f = fopen(tld_file, "r");
+
+	if (f == nullptr) {
+		return nullptr;
+	}
+
+	auto *lookup = new rspamd_tld_lookup;
+	char linebuf[512];
+	bool in_private = false;
+
+	while (fgets(linebuf, sizeof(linebuf), f) != nullptr) {
+		auto len = strlen(linebuf);
+		bool truncated = len > 0 && linebuf[len - 1] != '\n' && !feof(f);
+
+		while (len > 0 && g_ascii_isspace(linebuf[len - 1])) {
+			linebuf[--len] = '\0';
+		}
+
+		if (truncated) {
+			/* Drop the tail of an oversized line */
+			int c;
+			while ((c = fgetc(f)) != EOF && c != '\n') {}
+			continue;
+		}
+
+		if (len == 0 || g_ascii_isspace(linebuf[0])) {
+			continue;
+		}
+
+		if (linebuf[0] == '/') {
+			if (strstr(linebuf, "===BEGIN PRIVATE DOMAINS===") != nullptr) {
+				in_private = true;
+			}
+			else if (strstr(linebuf, "===END PRIVATE DOMAINS===") != nullptr) {
+				in_private = false;
+			}
+			continue;
+		}
+
+		for (gsize i = 0; i < len; i++) {
+			linebuf[i] = (char) g_ascii_tolower(linebuf[i]);
+		}
+
+		lookup->add_rule(std::string_view{linebuf, len}, in_private);
+	}
+
+	fclose(f);
+
+	if (lookup->nrules == 0) {
+		delete lookup;
+		return nullptr;
+	}
+
+	return lookup;
+}
+
+void rspamd_tld_lookup_destroy(struct rspamd_tld_lookup *lookup)
+{
+	delete lookup;
+}
+
+unsigned int rspamd_tld_lookup_nrules(const struct rspamd_tld_lookup *lookup)
+{
+	return lookup ? lookup->nrules : 0;
+}
+
+gboolean
+rspamd_tld_lookup_registrable(const struct rspamd_tld_lookup *lookup,
+							  const char *host, gsize len,
+							  rspamd_ftok_t *out)
+{
+	if (lookup == nullptr || host == nullptr) {
+		return FALSE;
+	}
+
+	auto res = lookup_prepared(lookup, host, len);
+
+	if (!res) {
+		return FALSE;
+	}
+
+	if (out != nullptr) {
+		gsize eff_len = (len > 0 && host[len - 1] == '.') ? len - 1 : len;
+		out->begin = host + res->reg_off;
+		out->len = eff_len - res->reg_off;
+	}
+
+	return TRUE;
+}
+
+gboolean
+rspamd_tld_lookup_suffix(const struct rspamd_tld_lookup *lookup,
+						 const char *host, gsize len,
+						 rspamd_ftok_t *out, unsigned int *flags)
+{
+	if (lookup == nullptr || host == nullptr) {
+		return FALSE;
+	}
+
+	auto res = lookup_prepared(lookup, host, len);
+
+	if (!res) {
+		return FALSE;
+	}
+
+	if (out != nullptr) {
+		gsize eff_len = (len > 0 && host[len - 1] == '.') ? len - 1 : len;
+		out->begin = host + res->suffix_off;
+		out->len = eff_len - res->suffix_off;
+	}
+
+	if (flags != nullptr) {
+		*flags = res->flags;
+	}
+
+	return TRUE;
+}
+
+gboolean
+rspamd_tld_lookup_is_final_label(const struct rspamd_tld_lookup *lookup,
+								 const char *label, gsize len)
+{
+	if (lookup == nullptr || label == nullptr || len == 0 || len > 63) {
+		return FALSE;
+	}
+
+	char buf[64];
+
+	for (gsize i = 0; i < len; i++) {
+		buf[i] = (char) g_ascii_tolower(label[i]);
+	}
+
+	return lookup->final_labels.contains(std::string_view{buf, len}) ? TRUE : FALSE;
+}

--- a/src/libserver/tld_lookup.cxx
+++ b/src/libserver/tld_lookup.cxx
@@ -73,7 +73,17 @@ struct folded_host {
 		}
 
 		memcpy(dst, host.data(), host.size());
-		auto len = rspamd_str_lc_utf8(dst, (unsigned int) host.size());
+
+		/* The ICU based folding costs a per-codepoint function call, so keep
+		 * the dominant all-ASCII case on the table based path */
+		unsigned int len;
+		if (!rspamd_str_has_8bit((const unsigned char *) dst, host.size())) {
+			len = rspamd_str_lc(dst, (unsigned int) host.size());
+		}
+		else {
+			len = rspamd_str_lc_utf8(dst, (unsigned int) host.size());
+		}
+
 		folded = std::string_view{dst, len};
 	}
 
@@ -368,9 +378,16 @@ rspamd_tld_lookup_is_final_label(const struct rspamd_tld_lookup *lookup,
 	}
 
 	char buf[64];
+	unsigned int flen;
 
 	memcpy(buf, label, len);
-	auto flen = rspamd_str_lc_utf8(buf, (unsigned int) len);
+
+	if (!rspamd_str_has_8bit((const unsigned char *) buf, len)) {
+		flen = rspamd_str_lc(buf, (unsigned int) len);
+	}
+	else {
+		flen = rspamd_str_lc_utf8(buf, (unsigned int) len);
+	}
 
 	return lookup->final_labels.contains(std::string_view{buf, flen}) ? TRUE : FALSE;
 }

--- a/src/libserver/tld_lookup.h
+++ b/src/libserver/tld_lookup.h
@@ -48,6 +48,19 @@ struct rspamd_tld_lookup;
  */
 struct rspamd_tld_lookup *rspamd_tld_lookup_new(const char *tld_file);
 
+/**
+ * Create an empty lookup to be filled with rspamd_tld_lookup_add_rule.
+ * Useful for custom suffix-like rule sets (e.g. URL composition maps).
+ */
+struct rspamd_tld_lookup *rspamd_tld_lookup_new_empty(void);
+
+/**
+ * Add a single rule in the public suffix list syntax: `foo.bar`,
+ * `*.foo.bar` or `!baz.foo.bar`. The rule is case-folded internally.
+ */
+void rspamd_tld_lookup_add_rule(struct rspamd_tld_lookup *lookup,
+								const char *rule, gsize len);
+
 void rspamd_tld_lookup_destroy(struct rspamd_tld_lookup *lookup);
 
 /**

--- a/src/libserver/tld_lookup.h
+++ b/src/libserver/tld_lookup.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_TLD_LOOKUP_H
+#define RSPAMD_TLD_LOOKUP_H
+
+#include "config.h"
+#include "libutil/fstring.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Public suffix list lookup: longest-suffix matching of hostnames against
+ * the effective TLDs file with full semantics (wildcard `*.foo` rules,
+ * `!exception` rules, ICANN/private sections).
+ *
+ * Matching is ASCII case-insensitive; hosts are expected in UTF-8 or
+ * punycode form (the suffix file contains both variants).
+ */
+
+struct rspamd_tld_lookup;
+
+/* The matched suffix comes from a `*.foo` wildcard rule */
+#define RSPAMD_TLD_SUFFIX_WILDCARD (1u << 0)
+/* The host is registrable due to a `!bar.foo` exception rule */
+#define RSPAMD_TLD_SUFFIX_EXCEPTION (1u << 1)
+/* The rule comes from the private domains section of the file */
+#define RSPAMD_TLD_SUFFIX_PRIVATE (1u << 2)
+
+/**
+ * Load the effective TLDs file (public suffix list format).
+ * @return new lookup object or NULL if the file cannot be read
+ */
+struct rspamd_tld_lookup *rspamd_tld_lookup_new(const char *tld_file);
+
+void rspamd_tld_lookup_destroy(struct rspamd_tld_lookup *lookup);
+
+/**
+ * Number of suffix rules loaded
+ */
+unsigned int rspamd_tld_lookup_nrules(const struct rspamd_tld_lookup *lookup);
+
+/**
+ * Find the registrable domain (eTLD+1, the "tld" in rspamd terms) of a host:
+ * the longest matching public suffix plus one preceding label. A host that is
+ * itself a public suffix resolves to the whole host. A single trailing dot is
+ * ignored. `out` points into `host`.
+ * @return TRUE if a suffix rule matched
+ */
+gboolean rspamd_tld_lookup_registrable(const struct rspamd_tld_lookup *lookup,
+									   const char *host, gsize len,
+									   rspamd_ftok_t *out);
+
+/**
+ * Find the longest matching public suffix of a host. For a host covered by an
+ * exception rule this is the exception rule minus its leftmost label.
+ * `out` points into `host`; `flags` (optional) receives RSPAMD_TLD_SUFFIX_*.
+ * @return TRUE if a suffix rule matched
+ */
+gboolean rspamd_tld_lookup_suffix(const struct rspamd_tld_lookup *lookup,
+								  const char *host, gsize len,
+								  rspamd_ftok_t *out, unsigned int *flags);
+
+/**
+ * Check whether `label` (a single DNS label, no dots) is the final label of
+ * any suffix rule. Used to anchor URL discovery in free text.
+ */
+gboolean rspamd_tld_lookup_is_final_label(const struct rspamd_tld_lookup *lookup,
+										  const char *label, gsize len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libserver/url.c
+++ b/src/libserver/url.c
@@ -58,7 +58,6 @@ typedef struct url_match_s {
 
 #define URL_MATCHER_FLAG_NOHTML (1u << 0u)
 #define URL_MATCHER_FLAG_TLD_MATCH (1u << 1u)
-#define URL_MATCHER_FLAG_STAR_MATCH (1u << 2u)
 #define URL_MATCHER_FLAG_REGEXP (1u << 3u)
 
 struct url_callback_data;
@@ -262,10 +261,8 @@ struct url_callback_data {
 };
 
 struct url_match_scanner {
-	GArray *matchers_full;
 	GArray *matchers_strict;
 	GArray *matchers_tld;
-	struct rspamd_multipattern *search_trie_full;
 	struct rspamd_multipattern *search_trie_strict;
 	struct rspamd_tld_lookup *tld_lookup;
 	bool has_tld_file;
@@ -439,73 +436,6 @@ rspamd_url_strerror(int err)
 	return NULL;
 }
 
-static gboolean
-rspamd_url_parse_tld_file(const char *fname,
-						  struct url_match_scanner *scanner)
-{
-	FILE *f;
-	struct url_matcher m;
-	char *linebuf = NULL, *p;
-	gsize buflen = 0;
-	gssize r;
-	int flags;
-
-	f = fopen(fname, "r");
-
-	if (f == NULL) {
-		msg_err("cannot open TLD file %s: %s", fname, strerror(errno));
-		return FALSE;
-	}
-
-	m.end = url_tld_end;
-	m.start = url_tld_start;
-	m.prefix = "http://";
-
-	while ((r = rspamd_getline(&linebuf, &buflen, f)) > 0) {
-		if (linebuf[0] == '/' || g_ascii_isspace(linebuf[0])) {
-			/* Skip comment or empty line */
-			continue;
-		}
-
-		g_strchomp(linebuf);
-
-		/* TODO: add support for ! patterns */
-		if (linebuf[0] == '!') {
-			msg_debug("skip '!' patterns from parsing for now: %s", linebuf);
-			continue;
-		}
-
-		flags = URL_MATCHER_FLAG_NOHTML | URL_MATCHER_FLAG_TLD_MATCH;
-
-		if (linebuf[0] == '*') {
-			flags |= URL_MATCHER_FLAG_STAR_MATCH;
-			p = strchr(linebuf, '.');
-
-			if (p == NULL) {
-				msg_err("got bad star line, skip it: %s", linebuf);
-				continue;
-			}
-			p++;
-		}
-		else {
-			p = linebuf;
-		}
-
-		m.flags = flags;
-		rspamd_multipattern_add_pattern(url_scanner->search_trie_full, p,
-										RSPAMD_MULTIPATTERN_TLD | RSPAMD_MULTIPATTERN_ICASE | RSPAMD_MULTIPATTERN_UTF8);
-		m.pattern = rspamd_multipattern_get_pattern(url_scanner->search_trie_full,
-													rspamd_multipattern_get_npatterns(url_scanner->search_trie_full) - 1);
-
-		g_array_append_val(url_scanner->matchers_full, m);
-	}
-
-	rspamd_getline_free(linebuf);
-	fclose(f);
-
-	return TRUE;
-}
-
 static void
 rspamd_url_add_static_matchers(struct url_match_scanner *sc)
 {
@@ -526,33 +456,11 @@ rspamd_url_add_static_matchers(struct url_match_scanner *sc)
 	}
 
 	g_array_append_vals(sc->matchers_strict, static_matchers, n);
-
-	if (sc->matchers_full) {
-		for (i = 0; i < n; i++) {
-			if (static_matchers[i].flags & URL_MATCHER_FLAG_REGEXP) {
-				rspamd_multipattern_add_pattern(url_scanner->search_trie_full,
-												static_matchers[i].pattern,
-												RSPAMD_MULTIPATTERN_ICASE | RSPAMD_MULTIPATTERN_UTF8 |
-													RSPAMD_MULTIPATTERN_RE);
-			}
-			else {
-				rspamd_multipattern_add_pattern(url_scanner->search_trie_full,
-												static_matchers[i].pattern,
-												RSPAMD_MULTIPATTERN_ICASE | RSPAMD_MULTIPATTERN_UTF8);
-			}
-		}
-		g_array_append_vals(sc->matchers_full, static_matchers, n);
-	}
 }
 
 void rspamd_url_deinit(void)
 {
 	if (url_scanner != NULL) {
-		if (url_scanner->search_trie_full) {
-			rspamd_multipattern_destroy(url_scanner->search_trie_full);
-			g_array_free(url_scanner->matchers_full, TRUE);
-		}
-
 		rspamd_multipattern_destroy(url_scanner->search_trie_strict);
 		g_array_free(url_scanner->matchers_strict, TRUE);
 		g_array_free(url_scanner->matchers_tld, TRUE);
@@ -566,8 +474,6 @@ void rspamd_url_deinit(void)
 void rspamd_url_init(const char *tld_file)
 {
 	GError *err = NULL;
-	gboolean ret = TRUE;
-	int mp_compile_flags = 0;
 
 	if (url_scanner != NULL) {
 		rspamd_url_deinit();
@@ -580,23 +486,7 @@ void rspamd_url_init(const char *tld_file)
 	url_scanner->search_trie_strict = rspamd_multipattern_create_sized(
 		G_N_ELEMENTS(static_matchers),
 		RSPAMD_MULTIPATTERN_ICASE | RSPAMD_MULTIPATTERN_UTF8);
-
-	if (tld_file) {
-		/* Reserve larger multipattern */
-		url_scanner->matchers_full = g_array_sized_new(FALSE, TRUE,
-													   sizeof(struct url_matcher), 13000);
-		url_scanner->search_trie_full = rspamd_multipattern_create_sized(13000,
-																		 RSPAMD_MULTIPATTERN_TLD | RSPAMD_MULTIPATTERN_ICASE | RSPAMD_MULTIPATTERN_UTF8);
-		/* Use FALLBACK mode: ACISM immediately, HS async */
-		rspamd_multipattern_set_mode(url_scanner->search_trie_full, RSPAMD_MP_MODE_FALLBACK);
-	}
-	else {
-		url_scanner->matchers_full = NULL;
-		url_scanner->search_trie_full = NULL;
-		url_scanner->has_tld_file = false;
-		mp_compile_flags |= RSPAMD_MULTIPATTERN_COMPILE_NO_FS;
-	}
-
+	url_scanner->has_tld_file = false;
 	url_scanner->tld_lookup = NULL;
 
 	/* Shared matcher template for TLD candidates anchored by the suffix probe */
@@ -616,51 +506,27 @@ void rspamd_url_init(const char *tld_file)
 	rspamd_url_add_static_matchers(url_scanner);
 
 	if (tld_file != NULL) {
-		ret = rspamd_url_parse_tld_file(tld_file, url_scanner);
-
 		url_scanner->tld_lookup = rspamd_tld_lookup_new(tld_file);
-		if (url_scanner->tld_lookup == NULL) {
-			msg_err("cannot load TLD suffixes from '%s'", tld_file);
-			ret = FALSE;
-		}
 
-		if (ret) {
+		if (url_scanner->tld_lookup != NULL) {
 			url_scanner->has_tld_file = true;
-		}
-	}
-
-	if (!rspamd_multipattern_compile(url_scanner->search_trie_strict, mp_compile_flags, &err)) {
-		msg_err("cannot compile url matcher static patterns, fatal error: %e", err);
-		abort();
-	}
-
-	if (url_scanner->search_trie_full) {
-		if (!rspamd_multipattern_compile(url_scanner->search_trie_full, mp_compile_flags, &err)) {
-			msg_err("cannot compile tld patterns, url matching will be "
-					"incomplete: %e",
-					err);
-			g_error_free(err);
-			ret = FALSE;
-		}
-		else if (rspamd_multipattern_get_state(url_scanner->search_trie_full) ==
-				 RSPAMD_MP_STATE_COMPILING) {
-			/* Add to pending queue for hs_helper to compile */
-			rspamd_multipattern_add_pending(url_scanner->search_trie_full, "tld");
-		}
-	}
-
-	if (tld_file != NULL) {
-		if (ret) {
 			msg_info("loaded %ud TLD suffixes from '%s'",
-					 url_scanner->matchers_full->len - url_scanner->matchers_strict->len,
+					 rspamd_tld_lookup_nrules(url_scanner->tld_lookup),
 					 tld_file);
 		}
 		else {
-			msg_err("failed to initialize url tld suffixes from '%s', "
+			msg_err("failed to load TLD suffixes from '%s', "
 					"use %ud internal match suffixes",
 					tld_file,
 					url_scanner->matchers_strict->len);
 		}
+	}
+
+	/* The static matcher set is small, so it is compiled in memory and never
+	 * uses the file cache or async compilation */
+	if (!rspamd_multipattern_compile(url_scanner->search_trie_strict, 0, &err)) {
+		msg_err("cannot compile url matcher static patterns, fatal error: %e", err);
+		abort();
 	}
 
 	/* Generate hashes for flags */

--- a/src/libserver/url.c
+++ b/src/libserver/url.c
@@ -2652,6 +2652,12 @@ rspamd_url_find_tld(const char *in, gsize inlen, rspamd_ftok_t *out)
 	return rspamd_tld_lookup_registrable(url_scanner->tld_lookup, in, inlen, out);
 }
 
+struct rspamd_tld_lookup *
+rspamd_url_get_tld_lookup(void)
+{
+	return url_scanner ? url_scanner->tld_lookup : NULL;
+}
+
 static const char url_braces[] = {
 	'(', ')',
 	'{', '}',

--- a/src/libserver/url.c
+++ b/src/libserver/url.c
@@ -264,6 +264,7 @@ struct url_callback_data {
 struct url_match_scanner {
 	GArray *matchers_full;
 	GArray *matchers_strict;
+	GArray *matchers_tld;
 	struct rspamd_multipattern *search_trie_full;
 	struct rspamd_multipattern *search_trie_strict;
 	struct rspamd_tld_lookup *tld_lookup;
@@ -554,6 +555,7 @@ void rspamd_url_deinit(void)
 
 		rspamd_multipattern_destroy(url_scanner->search_trie_strict);
 		g_array_free(url_scanner->matchers_strict, TRUE);
+		g_array_free(url_scanner->matchers_tld, TRUE);
 		rspamd_tld_lookup_destroy(url_scanner->tld_lookup);
 		g_free(url_scanner);
 
@@ -596,6 +598,21 @@ void rspamd_url_init(const char *tld_file)
 	}
 
 	url_scanner->tld_lookup = NULL;
+
+	/* Shared matcher template for TLD candidates anchored by the suffix probe */
+	url_scanner->matchers_tld = g_array_sized_new(FALSE, TRUE,
+												  sizeof(struct url_matcher), 1);
+	{
+		struct url_matcher tld_matcher = {
+			.pattern = "",
+			.prefix = "http://",
+			.start = url_tld_start,
+			.end = url_tld_end,
+			.flags = URL_MATCHER_FLAG_NOHTML | URL_MATCHER_FLAG_TLD_MATCH,
+		};
+		g_array_append_val(url_scanner->matchers_tld, tld_matcher);
+	}
+
 	rspamd_url_add_static_matchers(url_scanner);
 
 	if (tld_file != NULL) {
@@ -3333,6 +3350,204 @@ rspamd_url_trie_callback(struct rspamd_multipattern *mp,
 	return 0;
 }
 
+/*
+ * Two-pass full text scan: the small static-matcher multipattern provides
+ * scheme and known-prefix candidates, whilst TLD candidates are anchored on
+ * every '.<known final label>' occurrence found via the suffix lookup.
+ * Candidates must reach the processing callback in ascending match-end order,
+ * as both the cb->fin dedup and the newline cursor rely on it, so static
+ * matches are collected upfront and merged with the streamed TLD anchors.
+ */
+
+struct rspamd_url_static_match {
+	int start;
+	int end;
+	unsigned int strnum;
+};
+
+struct rspamd_url_static_matches {
+	struct rspamd_url_static_match fixed[64];
+	GArray *spill;
+	unsigned int n;
+};
+
+static int
+rspamd_url_static_collect_cb(struct rspamd_multipattern *mp,
+							 unsigned int strnum,
+							 int match_start,
+							 int match_pos,
+							 const char *text,
+							 gsize len,
+							 void *context)
+{
+	struct rspamd_url_static_matches *matches = context;
+	struct rspamd_url_static_match m = {match_start, match_pos, strnum};
+
+	if (matches->n < G_N_ELEMENTS(matches->fixed)) {
+		matches->fixed[matches->n] = m;
+	}
+	else {
+		if (matches->spill == NULL) {
+			matches->spill = g_array_new(FALSE, FALSE,
+										 sizeof(struct rspamd_url_static_match));
+		}
+		g_array_append_val(matches->spill, m);
+	}
+
+	matches->n++;
+
+	return 0;
+}
+
+static inline const struct rspamd_url_static_match *
+rspamd_url_static_match_at(const struct rspamd_url_static_matches *matches,
+						   unsigned int i)
+{
+	if (i < G_N_ELEMENTS(matches->fixed)) {
+		return &matches->fixed[i];
+	}
+
+	return &g_array_index(matches->spill, struct rspamd_url_static_match,
+						  i - G_N_ELEMENTS(matches->fixed));
+}
+
+struct rspamd_url_two_pass_state {
+	struct url_callback_data *cb;
+	rspamd_multipattern_cb_t func;
+	const char *in;
+	gsize inlen;
+	struct rspamd_url_static_matches matches;
+	unsigned int scur;
+	int ret;
+};
+
+/* Emit collected static matches with end offset up to the given bound */
+static gboolean
+rspamd_url_two_pass_flush_static(struct rspamd_url_two_pass_state *st, int bound)
+{
+	while (st->scur < st->matches.n) {
+		const struct rspamd_url_static_match *m =
+			rspamd_url_static_match_at(&st->matches, st->scur);
+
+		if (bound >= 0 && m->end > bound) {
+			break;
+		}
+
+		st->scur++;
+		st->cb->matchers = url_scanner->matchers_strict;
+		st->ret = st->func(NULL, m->strnum, m->start, m->end,
+						   st->in, st->inlen, st->cb);
+
+		if (st->ret != 0) {
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+static gboolean
+rspamd_url_two_pass_emit_tld(struct rspamd_url_two_pass_state *st,
+							 const char *lstart, gsize llen)
+{
+	if (!rspamd_tld_lookup_is_final_label(url_scanner->tld_lookup, lstart, llen)) {
+		return TRUE;
+	}
+
+	int match_pos = (lstart + llen) - st->in;
+
+	if (!rspamd_url_two_pass_flush_static(st, match_pos)) {
+		return FALSE;
+	}
+
+	st->cb->matchers = url_scanner->matchers_tld;
+	st->ret = st->func(NULL, 0, (lstart - 1) - st->in, match_pos,
+					   st->in, st->inlen, st->cb);
+
+	return st->ret == 0;
+}
+
+static int
+rspamd_url_scan_text_full(const char *in, gsize inlen,
+						  rspamd_multipattern_cb_t func,
+						  struct url_callback_data *cb)
+{
+	struct rspamd_url_two_pass_state st;
+
+	memset(&st, 0, sizeof(st));
+	st.cb = cb;
+	st.func = func;
+	st.in = in;
+	st.inlen = inlen;
+
+	/* First pass: collect the (few) static matcher candidates */
+	rspamd_multipattern_lookup(url_scanner->search_trie_strict, in, inlen,
+							   rspamd_url_static_collect_cb, &st.matches, NULL);
+
+	/* Second pass: stream TLD anchors, merging static candidates in */
+	if (url_scanner->tld_lookup != NULL) {
+		const char *p = in, *end = in + inlen;
+
+		while (p < end && (p = memchr(p, '.', end - p)) != NULL) {
+			const char *lstart = p + 1;
+			const char *q = lstart;
+			gboolean capped = FALSE;
+
+			while (q < end) {
+				unsigned char c = *q;
+
+				if (!(g_ascii_isalnum(c) || c == '-' || c >= 0x80)) {
+					break;
+				}
+
+				if (q > lstart && (c == '-' || c >= 0xC0)) {
+					/* A valid label may end here: this byte cannot continue
+					 * an alphanumeric TLD */
+					if (!rspamd_url_two_pass_emit_tld(&st, lstart, q - lstart)) {
+						goto out;
+					}
+				}
+
+				if (q - lstart >= 63) {
+					capped = TRUE;
+					break;
+				}
+
+				q++;
+			}
+
+			if (capped) {
+				/* An oversized run cannot end a valid label; skip it */
+				while (q < end) {
+					unsigned char c = *q;
+
+					if (!(g_ascii_isalnum(c) || c == '-' || c >= 0x80)) {
+						break;
+					}
+					q++;
+				}
+			}
+			else if (q > lstart) {
+				if (!rspamd_url_two_pass_emit_tld(&st, lstart, q - lstart)) {
+					goto out;
+				}
+			}
+
+			p = q > lstart ? q : lstart;
+		}
+	}
+
+	/* Flush the remaining static candidates */
+	rspamd_url_two_pass_flush_static(&st, -1);
+
+out:
+	if (st.matches.spill != NULL) {
+		g_array_free(st.matches.spill, TRUE);
+	}
+
+	return st.ret;
+}
+
 gboolean
 rspamd_url_find(rspamd_mempool_t *pool,
 				const char *begin, gsize len,
@@ -3351,18 +3566,7 @@ rspamd_url_find(rspamd_mempool_t *pool,
 	cb.pool = pool;
 
 	if (how == RSPAMD_URL_FIND_ALL) {
-		if (url_scanner->search_trie_full) {
-			cb.matchers = url_scanner->matchers_full;
-			ret = rspamd_multipattern_lookup(url_scanner->search_trie_full,
-											 begin, len,
-											 rspamd_url_trie_callback, &cb, NULL);
-		}
-		else {
-			cb.matchers = url_scanner->matchers_strict;
-			ret = rspamd_multipattern_lookup(url_scanner->search_trie_strict,
-											 begin, len,
-											 rspamd_url_trie_callback, &cb, NULL);
-		}
+		ret = rspamd_url_scan_text_full(begin, len, rspamd_url_trie_callback, &cb);
 	}
 	else {
 		cb.matchers = url_scanner->matchers_strict;
@@ -3746,18 +3950,8 @@ void rspamd_url_find_multiple(rspamd_mempool_t *pool,
 	cb.newlines = nlines;
 
 	if (how == RSPAMD_URL_FIND_ALL) {
-		if (url_scanner->search_trie_full) {
-			cb.matchers = url_scanner->matchers_full;
-			rspamd_multipattern_lookup(url_scanner->search_trie_full,
-									   in, inlen,
-									   rspamd_url_trie_generic_callback_multiple, &cb, NULL);
-		}
-		else {
-			cb.matchers = url_scanner->matchers_strict;
-			rspamd_multipattern_lookup(url_scanner->search_trie_strict,
-									   in, inlen,
-									   rspamd_url_trie_generic_callback_multiple, &cb, NULL);
-		}
+		rspamd_url_scan_text_full(in, inlen,
+								  rspamd_url_trie_generic_callback_multiple, &cb);
 	}
 	else {
 		cb.matchers = url_scanner->matchers_strict;
@@ -3960,18 +4154,8 @@ void rspamd_url_find_single(rspamd_mempool_t *pool,
 	cb.func = func;
 
 	if (how == RSPAMD_URL_FIND_ALL) {
-		if (url_scanner->search_trie_full) {
-			cb.matchers = url_scanner->matchers_full;
-			rspamd_multipattern_lookup(url_scanner->search_trie_full,
-									   in, inlen,
-									   rspamd_url_trie_generic_callback_single, &cb, NULL);
-		}
-		else {
-			cb.matchers = url_scanner->matchers_strict;
-			rspamd_multipattern_lookup(url_scanner->search_trie_strict,
-									   in, inlen,
-									   rspamd_url_trie_generic_callback_single, &cb, NULL);
-		}
+		rspamd_url_scan_text_full(in, inlen,
+								  rspamd_url_trie_generic_callback_single, &cb);
 	}
 	else {
 		cb.matchers = url_scanner->matchers_strict;

--- a/src/libserver/url.c
+++ b/src/libserver/url.c
@@ -20,6 +20,7 @@
 #include "rspamd.h"
 #include "message.h"
 #include "multipattern.h"
+#include "tld_lookup.h"
 #include "contrib/uthash/utlist.h"
 #include "contrib/http-parser/http_parser.h"
 #include "lua/lua_common.h"
@@ -265,6 +266,7 @@ struct url_match_scanner {
 	GArray *matchers_strict;
 	struct rspamd_multipattern *search_trie_full;
 	struct rspamd_multipattern *search_trie_strict;
+	struct rspamd_tld_lookup *tld_lookup;
 	bool has_tld_file;
 };
 
@@ -552,6 +554,7 @@ void rspamd_url_deinit(void)
 
 		rspamd_multipattern_destroy(url_scanner->search_trie_strict);
 		g_array_free(url_scanner->matchers_strict, TRUE);
+		rspamd_tld_lookup_destroy(url_scanner->tld_lookup);
 		g_free(url_scanner);
 
 		url_scanner = NULL;
@@ -592,10 +595,17 @@ void rspamd_url_init(const char *tld_file)
 		mp_compile_flags |= RSPAMD_MULTIPATTERN_COMPILE_NO_FS;
 	}
 
+	url_scanner->tld_lookup = NULL;
 	rspamd_url_add_static_matchers(url_scanner);
 
 	if (tld_file != NULL) {
 		ret = rspamd_url_parse_tld_file(tld_file, url_scanner);
+
+		url_scanner->tld_lookup = rspamd_tld_lookup_new(tld_file);
+		if (url_scanner->tld_lookup == NULL) {
+			msg_err("cannot load TLD suffixes from '%s'", tld_file);
+			ret = FALSE;
+		}
 
 		if (ret) {
 			url_scanner->has_tld_file = true;
@@ -1733,73 +1743,6 @@ out:
 
 #undef SET_U
 
-static int
-rspamd_tld_trie_callback(struct rspamd_multipattern *mp,
-						 unsigned int strnum,
-						 int match_start,
-						 int match_pos,
-						 const char *text,
-						 gsize len,
-						 void *context)
-{
-	struct url_matcher *matcher;
-	const char *start, *pos, *p;
-	struct rspamd_url *url = context;
-	int ndots;
-
-	matcher = &g_array_index(url_scanner->matchers_full, struct url_matcher,
-							 strnum);
-	ndots = 1;
-
-	if (matcher->flags & URL_MATCHER_FLAG_STAR_MATCH) {
-		/* Skip one more tld component */
-		ndots++;
-	}
-
-	pos = text + match_start;
-	p = pos - 1;
-	start = rspamd_url_host_unsafe(url);
-
-	if (*pos != '.' || match_pos != (int) url->hostlen) {
-		/* Something weird has been found */
-		if (match_pos == (int) url->hostlen - 1) {
-			pos = rspamd_url_host_unsafe(url) + match_pos;
-			if (*pos == '.') {
-				/* This is dot at the end of domain */
-				url->hostlen--;
-			}
-			else {
-				return 0;
-			}
-		}
-		else {
-			return 0;
-		}
-	}
-
-	/* Now we need to find top level domain */
-	pos = start;
-	while (p >= start && ndots > 0) {
-		if (*p == '.') {
-			ndots--;
-			pos = p + 1;
-		}
-		else {
-			pos = p;
-		}
-
-		p--;
-	}
-
-	if ((ndots == 0 || p == start - 1) &&
-		url->tldlen < rspamd_url_host_unsafe(url) + url->hostlen - pos) {
-		url->tldshift = (pos - url->string);
-		url->tldlen = rspamd_url_host_unsafe(url) + url->hostlen - pos;
-	}
-
-	return 0;
-}
-
 static void
 rspamd_url_regen_from_inet_addr(struct rspamd_url *uri, const void *addr, int af,
 								rspamd_mempool_t *pool)
@@ -2673,10 +2616,20 @@ rspamd_url_parse(struct rspamd_url *uri,
 
 	if (uri->protocol & (PROTOCOL_HTTP | PROTOCOL_HTTPS | PROTOCOL_MAILTO | PROTOCOL_FTP | PROTOCOL_FILE)) {
 		/* Find TLD part */
-		if (url_scanner->search_trie_full) {
-			rspamd_multipattern_lookup(url_scanner->search_trie_full,
-									   rspamd_url_host_unsafe(uri), uri->hostlen,
-									   rspamd_tld_trie_callback, uri, NULL);
+		if (url_scanner->tld_lookup) {
+			rspamd_ftok_t tld_tok;
+
+			if (rspamd_tld_lookup_registrable(url_scanner->tld_lookup,
+											  rspamd_url_host_unsafe(uri), uri->hostlen,
+											  &tld_tok)) {
+				if (rspamd_url_host_unsafe(uri)[uri->hostlen - 1] == '.') {
+					/* The trailing dot is not part of the host */
+					uri->hostlen--;
+				}
+
+				uri->tldshift = tld_tok.begin - uri->string;
+				uri->tldlen = tld_tok.len;
+			}
 		}
 
 		if (uri->tldlen == 0) {
@@ -2806,95 +2759,14 @@ rspamd_url_parse(struct rspamd_url *uri,
 	return URI_ERRNO_OK;
 }
 
-struct tld_trie_cbdata {
-	const char *begin;
-	gsize len;
-	rspamd_ftok_t *out;
-};
-
-static int
-rspamd_tld_trie_find_callback(struct rspamd_multipattern *mp,
-							  unsigned int strnum,
-							  int match_start,
-							  int match_pos,
-							  const char *text,
-							  gsize len,
-							  void *context)
-{
-	struct url_matcher *matcher;
-	const char *start, *pos, *p;
-	struct tld_trie_cbdata *cbdata = context;
-	int ndots = 1;
-
-	matcher = &g_array_index(url_scanner->matchers_full, struct url_matcher,
-							 strnum);
-
-	if (matcher->flags & URL_MATCHER_FLAG_STAR_MATCH) {
-		/* Skip one more tld component */
-		ndots = 2;
-	}
-
-	pos = text + match_start;
-	p = pos - 1;
-	start = text;
-
-	if (*pos != '.' || match_pos != (int) cbdata->len) {
-		/* Something weird has been found */
-		if (match_pos != (int) cbdata->len - 1) {
-			/* Search more */
-			return 0;
-		}
-	}
-
-	/* Now we need to find top level domain */
-	pos = start;
-
-	while (p >= start && ndots > 0) {
-		if (*p == '.') {
-			ndots--;
-			pos = p + 1;
-		}
-		else {
-			pos = p;
-		}
-
-		p--;
-	}
-
-	if (ndots == 0 || p == start - 1) {
-		if (cbdata->begin + cbdata->len - pos > cbdata->out->len) {
-			cbdata->out->begin = pos;
-			cbdata->out->len = cbdata->begin + cbdata->len - pos;
-		}
-	}
-
-	return 0;
-}
-
 gboolean
 rspamd_url_find_tld(const char *in, gsize inlen, rspamd_ftok_t *out)
 {
-	struct tld_trie_cbdata cbdata;
-
 	g_assert(in != NULL);
 	g_assert(out != NULL);
 	g_assert(url_scanner != NULL);
 
-	cbdata.begin = in;
-	cbdata.len = inlen;
-	cbdata.out = out;
-	out->len = 0;
-
-	if (url_scanner->search_trie_full) {
-		rspamd_multipattern_lookup(url_scanner->search_trie_full, in, inlen,
-								   rspamd_tld_trie_find_callback, &cbdata, NULL);
-	}
-
-	if (out->len > 0) {
-		return TRUE;
-	}
-
-	return FALSE;
+	return rspamd_tld_lookup_registrable(url_scanner->tld_lookup, in, inlen, out);
 }
 
 static const char url_braces[] = {

--- a/src/libserver/url.h
+++ b/src/libserver/url.h
@@ -239,6 +239,12 @@ const char *rspamd_url_strerror(int err);
  */
 gboolean rspamd_url_find_tld(const char *in, gsize inlen, rspamd_ftok_t *out);
 
+/**
+ * Get the public suffix lookup loaded by rspamd_url_init, or NULL if no
+ * TLD file has been loaded. The object is owned by the url scanner.
+ */
+struct rspamd_tld_lookup *rspamd_url_get_tld_lookup(void);
+
 typedef gboolean (*url_insert_function)(struct rspamd_url *url,
 										gsize start_offset, gsize end_offset, void *ud);
 

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(LUASRC			  ${CMAKE_CURRENT_SOURCE_DIR}/lua_common.c
 					  ${CMAKE_CURRENT_SOURCE_DIR}/lua_rsa.c
 					  ${CMAKE_CURRENT_SOURCE_DIR}/lua_ip.c
 					  ${CMAKE_CURRENT_SOURCE_DIR}/lua_expression.c
+					  ${CMAKE_CURRENT_SOURCE_DIR}/lua_tld_lookup.c
 					  ${CMAKE_CURRENT_SOURCE_DIR}/lua_trie.c
 					  ${CMAKE_CURRENT_SOURCE_DIR}/lua_mimepart.c
 					  ${CMAKE_CURRENT_SOURCE_DIR}/lua_url.c

--- a/src/lua/lua_classnames.c
+++ b/src/lua/lua_classnames.c
@@ -60,6 +60,7 @@ const char *rspamd_tcp_classname = "rspamd{tcp}";
 const char *rspamd_tensor_classname = "rspamd{tensor}";
 const char *rspamd_textpart_classname = "rspamd{textpart}";
 const char *rspamd_text_classname = "rspamd{text}";
+const char *rspamd_tld_lookup_classname = "rspamd{tld_lookup}";
 const char *rspamd_trie_classname = "rspamd{trie}";
 const char *rspamd_upstream_list_classname = "rspamd{upstream_list}";
 const char *rspamd_upstream_classname = "rspamd{upstream}";
@@ -133,6 +134,7 @@ RSPAMD_CONSTRUCTOR(rspamd_lua_init_classnames)
 	CLASS_PUT_STR(tensor);
 	CLASS_PUT_STR(textpart);
 	CLASS_PUT_STR(text);
+	CLASS_PUT_STR(tld_lookup);
 	CLASS_PUT_STR(trie);
 	CLASS_PUT_STR(upstream_list);
 	CLASS_PUT_STR(upstream);

--- a/src/lua/lua_classnames.h
+++ b/src/lua/lua_classnames.h
@@ -63,6 +63,7 @@ extern const char *rspamd_tcp_classname;
 extern const char *rspamd_tensor_classname;
 extern const char *rspamd_textpart_classname;
 extern const char *rspamd_text_classname;
+extern const char *rspamd_tld_lookup_classname;
 extern const char *rspamd_trie_classname;
 extern const char *rspamd_upstream_list_classname;
 extern const char *rspamd_upstream_classname;
@@ -79,7 +80,7 @@ extern const char *rspamd_pdf_text_builder_classname;
 extern const char *rspamd_pdf_cmap_classname;
 
 /* Keep it consistent when adding new classes */
-#define RSPAMD_MAX_LUA_CLASSES 55
+#define RSPAMD_MAX_LUA_CLASSES 56
 
 /*
  * Return a static class name for a given name (only for known classes) or NULL

--- a/src/lua/lua_common.c
+++ b/src/lua/lua_common.c
@@ -957,6 +957,7 @@ rspamd_lua_init(bool wipe_mem)
 	luaopen_mempool(L);
 	luaopen_config(L);
 	luaopen_map(L);
+	luaopen_tld_lookup(L);
 	luaopen_trie(L);
 	luaopen_task(L);
 	luaopen_textpart(L);

--- a/src/lua/lua_common.h
+++ b/src/lua/lua_common.h
@@ -414,6 +414,8 @@ void luaopen_config(lua_State *L);
 
 void luaopen_map(lua_State *L);
 
+void luaopen_tld_lookup(lua_State *L);
+
 void luaopen_trie(lua_State *L);
 
 void luaopen_textpart(lua_State *L);

--- a/src/lua/lua_tld_lookup.c
+++ b/src/lua/lua_tld_lookup.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "lua_common.h"
+#include "libserver/tld_lookup.h"
+#include "libserver/url.h"
+
+/***
+ * @module rspamd_tld_lookup
+ * Longest-suffix matching of hostnames with public suffix list semantics:
+ * exact rules, `*.wildcard` rules and `!exception` rules. Module level
+ * functions query the suffix list loaded by rspamd itself, whilst custom
+ * rule sets (e.g. URL composition maps) can be built with `create`.
+ * @example
+local tld_lookup = require "rspamd_tld_lookup"
+
+-- Query the loaded public suffix list
+local domain, flags = tld_lookup.registrable('mail.example.co.uk')
+-- domain == 'example.co.uk'
+
+-- Custom rule set
+local custom = tld_lookup.create({'example.com', '*.foo.example.com'})
+local d, fl = custom:registrable('baz.example.com')
+-- d == 'baz.example.com'
+if bit.band(fl, tld_lookup.flags.wildcard) ~= 0 then ... end
+ */
+
+LUA_FUNCTION_DEF(tld_lookup, create);
+LUA_FUNCTION_DEF(tld_lookup, registrable);
+LUA_FUNCTION_DEF(tld_lookup, suffix);
+LUA_FUNCTION_DEF(tld_lookup, is_final_label);
+LUA_FUNCTION_DEF(tld_lookup, add_rule);
+LUA_FUNCTION_DEF(tld_lookup, nrules);
+LUA_FUNCTION_DEF(tld_lookup, inst_registrable);
+LUA_FUNCTION_DEF(tld_lookup, inst_suffix);
+LUA_FUNCTION_DEF(tld_lookup, inst_is_final_label);
+LUA_FUNCTION_DEF(tld_lookup, destroy);
+
+static const struct luaL_reg tld_lookup_m[] = {
+	{"add_rule", lua_tld_lookup_add_rule},
+	{"nrules", lua_tld_lookup_nrules},
+	{"registrable", lua_tld_lookup_inst_registrable},
+	{"suffix", lua_tld_lookup_inst_suffix},
+	{"is_final_label", lua_tld_lookup_inst_is_final_label},
+	{"__tostring", rspamd_lua_class_tostring},
+	{"__gc", lua_tld_lookup_destroy},
+	{NULL, NULL}};
+
+static const struct luaL_reg tld_lookup_f[] = {
+	LUA_INTERFACE_DEF(tld_lookup, create),
+	LUA_INTERFACE_DEF(tld_lookup, registrable),
+	LUA_INTERFACE_DEF(tld_lookup, suffix),
+	LUA_INTERFACE_DEF(tld_lookup, is_final_label),
+	{NULL, NULL}};
+
+static struct rspamd_tld_lookup *
+lua_check_tld_lookup(lua_State *L, int pos)
+{
+	void *ud = rspamd_lua_check_udata(L, pos, rspamd_tld_lookup_classname);
+
+	luaL_argcheck(L, ud != NULL, pos, "'tld_lookup' expected");
+	return ud ? *((struct rspamd_tld_lookup **) ud) : NULL;
+}
+
+static int
+lua_tld_lookup_destroy(lua_State *L)
+{
+	struct rspamd_tld_lookup *lookup = lua_check_tld_lookup(L, 1);
+
+	if (lookup) {
+		rspamd_tld_lookup_destroy(lookup);
+	}
+
+	return 0;
+}
+
+/***
+ * @function tld_lookup.create([rules])
+ * Creates a custom suffix rule set, optionally filled from an array of
+ * rule strings in the public suffix list syntax
+ * @param {table} rules optional array of rules
+ * @return {tld_lookup} new rule set
+ */
+static int
+lua_tld_lookup_create(lua_State *L)
+{
+	struct rspamd_tld_lookup *lookup, **plookup;
+
+	lookup = rspamd_tld_lookup_new_empty();
+
+	if (lua_istable(L, 1)) {
+		lua_pushvalue(L, 1);
+		lua_pushnil(L);
+
+		while (lua_next(L, -2) != 0) {
+			gsize len;
+			const char *rule = lua_tolstring(L, -1, &len);
+
+			if (rule) {
+				rspamd_tld_lookup_add_rule(lookup, rule, len);
+			}
+			lua_pop(L, 1);
+		}
+
+		lua_pop(L, 1);
+	}
+
+	plookup = lua_newuserdata(L, sizeof(void *));
+	*plookup = lookup;
+	rspamd_lua_setclass(L, rspamd_tld_lookup_classname, -1);
+
+	return 1;
+}
+
+/***
+ * @method tld_lookup:add_rule(rule)
+ * Adds a single rule (`foo.bar`, `*.foo.bar` or `!baz.foo.bar`)
+ */
+static int
+lua_tld_lookup_add_rule(lua_State *L)
+{
+	struct rspamd_tld_lookup *lookup = lua_check_tld_lookup(L, 1);
+	gsize len;
+	const char *rule = luaL_checklstring(L, 2, &len);
+
+	if (lookup && rule) {
+		rspamd_tld_lookup_add_rule(lookup, rule, len);
+	}
+
+	return 0;
+}
+
+/***
+ * @method tld_lookup:nrules()
+ * @return {number} number of rules in the set
+ */
+static int
+lua_tld_lookup_nrules(lua_State *L)
+{
+	struct rspamd_tld_lookup *lookup = lua_check_tld_lookup(L, 1);
+
+	lua_pushinteger(L, rspamd_tld_lookup_nrules(lookup));
+
+	return 1;
+}
+
+static int
+lua_tld_lookup_registrable_common(lua_State *L, const struct rspamd_tld_lookup *lookup,
+								  int str_pos)
+{
+	gsize len;
+	const char *host = luaL_checklstring(L, str_pos, &len);
+	rspamd_ftok_t tld;
+	unsigned int flags = 0;
+
+	if (lookup == NULL || host == NULL ||
+		!rspamd_tld_lookup_registrable(lookup, host, len, &tld)) {
+		lua_pushnil(L);
+
+		return 1;
+	}
+
+	/* Flags come from the matched suffix */
+	(void) rspamd_tld_lookup_suffix(lookup, host, len, NULL, &flags);
+
+	lua_pushlstring(L, tld.begin, tld.len);
+	lua_pushinteger(L, flags);
+
+	return 2;
+}
+
+static int
+lua_tld_lookup_suffix_common(lua_State *L, const struct rspamd_tld_lookup *lookup,
+							 int str_pos)
+{
+	gsize len;
+	const char *host = luaL_checklstring(L, str_pos, &len);
+	rspamd_ftok_t suffix;
+	unsigned int flags = 0;
+
+	if (lookup == NULL || host == NULL ||
+		!rspamd_tld_lookup_suffix(lookup, host, len, &suffix, &flags)) {
+		lua_pushnil(L);
+
+		return 1;
+	}
+
+	lua_pushlstring(L, suffix.begin, suffix.len);
+	lua_pushinteger(L, flags);
+
+	return 2;
+}
+
+/***
+ * @function tld_lookup.registrable(host)
+ * Finds the registrable domain (eTLD+1) of a host using the public suffix
+ * list loaded by rspamd
+ * @return {string} registrable domain (or nil) and match flags
+ */
+static int
+lua_tld_lookup_registrable(lua_State *L)
+{
+	return lua_tld_lookup_registrable_common(L, rspamd_url_get_tld_lookup(), 1);
+}
+
+/***
+ * @function tld_lookup.suffix(host)
+ * Finds the public suffix of a host using the suffix list loaded by rspamd
+ * @return {string} public suffix (or nil) and match flags
+ */
+static int
+lua_tld_lookup_suffix(lua_State *L)
+{
+	return lua_tld_lookup_suffix_common(L, rspamd_url_get_tld_lookup(), 1);
+}
+
+/***
+ * @function tld_lookup.is_final_label(label)
+ * Checks whether a single label ends any rule of the loaded suffix list
+ */
+static int
+lua_tld_lookup_is_final_label(lua_State *L)
+{
+	gsize len;
+	const char *label = luaL_checklstring(L, 1, &len);
+
+	lua_pushboolean(L,
+					rspamd_tld_lookup_is_final_label(rspamd_url_get_tld_lookup(), label, len));
+
+	return 1;
+}
+
+/***
+ * @method tld_lookup:registrable(host)
+ * As tld_lookup.registrable, but against this custom rule set
+ */
+static int
+lua_tld_lookup_inst_registrable(lua_State *L)
+{
+	return lua_tld_lookup_registrable_common(L, lua_check_tld_lookup(L, 1), 2);
+}
+
+/***
+ * @method tld_lookup:suffix(host)
+ * As tld_lookup.suffix, but against this custom rule set
+ */
+static int
+lua_tld_lookup_inst_suffix(lua_State *L)
+{
+	return lua_tld_lookup_suffix_common(L, lua_check_tld_lookup(L, 1), 2);
+}
+
+/***
+ * @method tld_lookup:is_final_label(label)
+ * As tld_lookup.is_final_label, but against this custom rule set
+ */
+static int
+lua_tld_lookup_inst_is_final_label(lua_State *L)
+{
+	struct rspamd_tld_lookup *lookup = lua_check_tld_lookup(L, 1);
+	gsize len;
+	const char *label = luaL_checklstring(L, 2, &len);
+
+	lua_pushboolean(L, rspamd_tld_lookup_is_final_label(lookup, label, len));
+
+	return 1;
+}
+
+static int
+lua_load_tld_lookup(lua_State *L)
+{
+	lua_newtable(L);
+
+	/* Flags of the matched suffix */
+	lua_pushstring(L, "flags");
+	lua_newtable(L);
+	lua_pushinteger(L, RSPAMD_TLD_SUFFIX_WILDCARD);
+	lua_setfield(L, -2, "wildcard");
+	lua_pushinteger(L, RSPAMD_TLD_SUFFIX_EXCEPTION);
+	lua_setfield(L, -2, "exception");
+	lua_pushinteger(L, RSPAMD_TLD_SUFFIX_PRIVATE);
+	lua_setfield(L, -2, "private");
+	lua_settable(L, -3);
+
+	luaL_register(L, NULL, tld_lookup_f);
+
+	return 1;
+}
+
+void luaopen_tld_lookup(lua_State *L)
+{
+	rspamd_lua_new_class(L, rspamd_tld_lookup_classname, tld_lookup_m);
+	lua_pop(L, 1);
+	rspamd_lua_add_preload(L, "rspamd_tld_lookup", lua_load_tld_lookup);
+}

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -54,6 +54,7 @@
 #include "rspamd_cxx_unit_http_timeout.hxx"
 #include "rspamd_cxx_unit_task_input.hxx"
 #include "rspamd_cxx_unit_ucl_limits.hxx"
+#include "rspamd_cxx_unit_tld_lookup.hxx"
 
 static gboolean verbose = false;
 static const GOptionEntry entries[] =

--- a/test/rspamd_cxx_unit_tld_lookup.hxx
+++ b/test/rspamd_cxx_unit_tld_lookup.hxx
@@ -259,6 +259,42 @@ TEST_SUITE("tld_lookup")
 		rspamd_tld_lookup_destroy(l);
 	}
 
+	TEST_CASE("custom rule set builder")
+	{
+		auto *l = rspamd_tld_lookup_new_empty();
+		REQUIRE(l != nullptr);
+		CHECK(rspamd_tld_lookup_nrules(l) == 0);
+
+		auto add = [&](const char *r) {
+			rspamd_tld_lookup_add_rule(l, r, strlen(r));
+		};
+
+		/* A composition-map style rule set */
+		add("example.com");
+		add("*.foo.example.com");
+		add("!bar.example.com");
+		CHECK(rspamd_tld_lookup_nrules(l) == 3);
+
+		unsigned int flags = 0;
+
+		CHECK(registrable_of(l, "3.baz.example.com") == "baz.example.com");
+		CHECK(registrable_of(l, "example.com") == "example.com");
+
+		rspamd_ftok_t tok;
+		CHECK(rspamd_tld_lookup_registrable(l, "x.bar.example.com", 17, &tok));
+		CHECK(rspamd_tld_lookup_suffix(l, "x.bar.example.com", 17, &tok, &flags));
+		CHECK((flags & RSPAMD_TLD_SUFFIX_EXCEPTION) != 0);
+
+		CHECK(rspamd_tld_lookup_suffix(l, "a.b.foo.example.com", 19, &tok, &flags));
+		CHECK((flags & RSPAMD_TLD_SUFFIX_WILDCARD) != 0);
+
+		/* Rules are folded on insertion */
+		add("UPPER.zz");
+		CHECK(registrable_of(l, "sub.upper.zz") == "sub.upper.zz");
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
 	TEST_CASE("nrules and missing file")
 	{
 		auto *l = make_lookup();

--- a/test/rspamd_cxx_unit_tld_lookup.hxx
+++ b/test/rspamd_cxx_unit_tld_lookup.hxx
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_RSPAMD_CXX_UNIT_TLD_LOOKUP_HXX
+#define RSPAMD_RSPAMD_CXX_UNIT_TLD_LOOKUP_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+#include "libserver/tld_lookup.h"
+
+#include <cstdio>
+#include <string>
+
+TEST_SUITE("tld_lookup")
+{
+	/* A representative fragment of the public suffix list: exact rules,
+	 * wildcards, exceptions, unicode + punycode duals, private section */
+	static const char test_psl[] =
+		"// This is a comment\n"
+		"// ===BEGIN ICANN DOMAINS===\n"
+		"\n"
+		"com\n"
+		"org\n"
+		"uk\n"
+		"co.uk\n"
+		"jp\n"
+		"*.kobe.jp\n"
+		"!city.kobe.jp\n"
+		"*.ck\n"
+		"!www.ck\n"
+		"\xe4\xb8\xad\xe5\x9b\xbd\n" /* 中国 */
+		"xn--fiqs8s\n"
+		"// ===END ICANN DOMAINS===\n"
+		"// ===BEGIN PRIVATE DOMAINS===\n"
+		"github.io\n"
+		"s3.amazonaws.com\n"
+		"// ===END PRIVATE DOMAINS===\n";
+
+	static auto make_lookup() -> rspamd_tld_lookup *
+	{
+		char path[PATH_MAX];
+		const char *tmpdir = getenv("TMPDIR");
+
+		rspamd_snprintf(path, sizeof(path), "%s%c%s", tmpdir ? tmpdir : "/tmp",
+						G_DIR_SEPARATOR, "rspamd-test-tld-XXXXXX");
+
+		int fd = g_mkstemp(path);
+		REQUIRE(fd != -1);
+		REQUIRE(write(fd, test_psl, sizeof(test_psl) - 1) == (ssize_t) (sizeof(test_psl) - 1));
+		close(fd);
+
+		auto *lookup = rspamd_tld_lookup_new(path);
+		unlink(path);
+		REQUIRE(lookup != nullptr);
+
+		return lookup;
+	}
+
+	static auto registrable_of(rspamd_tld_lookup * l, const std::string &host) -> std::string
+	{
+		rspamd_ftok_t tok;
+
+		if (!rspamd_tld_lookup_registrable(l, host.data(), host.size(), &tok)) {
+			return "";
+		}
+
+		return std::string{tok.begin, tok.len};
+	}
+
+	static auto suffix_of(rspamd_tld_lookup * l, const std::string &host,
+						  unsigned int *flags = nullptr) -> std::string
+	{
+		rspamd_ftok_t tok;
+
+		if (!rspamd_tld_lookup_suffix(l, host.data(), host.size(), &tok, flags)) {
+			return "";
+		}
+
+		return std::string{tok.begin, tok.len};
+	}
+
+	TEST_CASE("registrable domain: exact rules")
+	{
+		auto *l = make_lookup();
+
+		CHECK(registrable_of(l, "example.com") == "example.com");
+		CHECK(registrable_of(l, "mail.example.com") == "example.com");
+		CHECK(registrable_of(l, "a.b.c.d.example.com") == "example.com");
+		CHECK(registrable_of(l, "foo.co.uk") == "foo.co.uk");
+		CHECK(registrable_of(l, "a.b.foo.co.uk") == "foo.co.uk");
+		/* Longest suffix must win over the shorter one */
+		CHECK(registrable_of(l, "foo.uk") == "foo.uk");
+
+		/* A host that is itself a public suffix resolves to the whole host */
+		CHECK(registrable_of(l, "com") == "com");
+		CHECK(registrable_of(l, "co.uk") == "co.uk");
+
+		/* No rule matched at all */
+		CHECK(registrable_of(l, "localhost") == "");
+		CHECK(registrable_of(l, "foo.unknown") == "");
+		CHECK(registrable_of(l, "") == "");
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
+	TEST_CASE("registrable domain: wildcard rules")
+	{
+		auto *l = make_lookup();
+
+		/* *.kobe.jp: any single label under kobe.jp is a public suffix */
+		CHECK(registrable_of(l, "kobe.jp") == "kobe.jp");
+		CHECK(registrable_of(l, "x.kobe.jp") == "x.kobe.jp");
+		CHECK(registrable_of(l, "y.x.kobe.jp") == "y.x.kobe.jp");
+		CHECK(registrable_of(l, "z.y.x.kobe.jp") == "y.x.kobe.jp");
+
+		/* *.ck with no bare "ck" rule */
+		CHECK(registrable_of(l, "other.ck") == "other.ck");
+		CHECK(registrable_of(l, "x.other.ck") == "x.other.ck");
+		CHECK(registrable_of(l, "y.x.other.ck") == "x.other.ck");
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
+	TEST_CASE("registrable domain: exception rules")
+	{
+		auto *l = make_lookup();
+
+		/* !city.kobe.jp cancels *.kobe.jp */
+		CHECK(registrable_of(l, "city.kobe.jp") == "city.kobe.jp");
+		CHECK(registrable_of(l, "a.city.kobe.jp") == "city.kobe.jp");
+		CHECK(registrable_of(l, "b.a.city.kobe.jp") == "city.kobe.jp");
+
+		/* !www.ck cancels *.ck */
+		CHECK(registrable_of(l, "www.ck") == "www.ck");
+		CHECK(registrable_of(l, "sub.www.ck") == "www.ck");
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
+	TEST_CASE("registrable domain: unicode and punycode")
+	{
+		auto *l = make_lookup();
+
+		CHECK(registrable_of(l, "foo.\xe4\xb8\xad\xe5\x9b\xbd") ==
+			  "foo.\xe4\xb8\xad\xe5\x9b\xbd");
+		CHECK(registrable_of(l, "foo.xn--fiqs8s") == "foo.xn--fiqs8s");
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
+	TEST_CASE("registrable domain: case and trailing dot")
+	{
+		auto *l = make_lookup();
+
+		/* Case-insensitive match, output preserves the original case */
+		CHECK(registrable_of(l, "FOO.Example.COM") == "Example.COM");
+		CHECK(registrable_of(l, "EXAMPLE.COM") == "EXAMPLE.COM");
+
+		/* FQDN form: single trailing dot is ignored */
+		CHECK(registrable_of(l, "example.com.") == "example.com");
+		CHECK(registrable_of(l, "com.") == "com");
+		CHECK(registrable_of(l, ".") == "");
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
+	TEST_CASE("registrable domain: edge cases")
+	{
+		auto *l = make_lookup();
+
+		/* Deeply nested host: probing is bounded but must still match */
+		CHECK(registrable_of(l, "a.b.c.d.e.f.g.h.i.j.example.com") == "example.com");
+
+		/* 63-char label */
+		std::string long_label(63, 'x');
+		CHECK(registrable_of(l, long_label + ".com") == long_label + ".com");
+
+		/* Oversized host (over the stack buffer) must still work */
+		std::string big_host;
+		for (int i = 0; i < 100; i++) {
+			big_host += "verylonglabel.";
+		}
+		big_host += "example.com";
+		CHECK(registrable_of(l, big_host) == "example.com");
+
+		/* Empty label inside the host must not confuse the search */
+		CHECK(registrable_of(l, "foo..com") == ".com");
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
+	TEST_CASE("public suffix and flags")
+	{
+		auto *l = make_lookup();
+		unsigned int flags = 0;
+
+		CHECK(suffix_of(l, "foo.co.uk", &flags) == "co.uk");
+		CHECK(flags == 0);
+
+		CHECK(suffix_of(l, "z.y.x.kobe.jp", &flags) == "x.kobe.jp");
+		CHECK((flags & RSPAMD_TLD_SUFFIX_WILDCARD) != 0);
+
+		CHECK(suffix_of(l, "a.city.kobe.jp", &flags) == "kobe.jp");
+		CHECK((flags & RSPAMD_TLD_SUFFIX_EXCEPTION) != 0);
+
+		CHECK(suffix_of(l, "foo.github.io", &flags) == "github.io");
+		CHECK((flags & RSPAMD_TLD_SUFFIX_PRIVATE) != 0);
+		CHECK(registrable_of(l, "foo.github.io") == "foo.github.io");
+
+		/* Private multi-label rule */
+		CHECK(registrable_of(l, "bucket.s3.amazonaws.com") == "bucket.s3.amazonaws.com");
+		CHECK(registrable_of(l, "s3.amazonaws.com") == "s3.amazonaws.com");
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
+	TEST_CASE("final labels")
+	{
+		auto *l = make_lookup();
+
+		CHECK(rspamd_tld_lookup_is_final_label(l, "com", 3));
+		CHECK(rspamd_tld_lookup_is_final_label(l, "COM", 3));
+		CHECK(rspamd_tld_lookup_is_final_label(l, "uk", 2));
+		CHECK(rspamd_tld_lookup_is_final_label(l, "jp", 2));
+		/* Final label of wildcard and exception rules */
+		CHECK(rspamd_tld_lookup_is_final_label(l, "ck", 2));
+		/* Private section */
+		CHECK(rspamd_tld_lookup_is_final_label(l, "io", 2));
+		/* Unicode */
+		CHECK(rspamd_tld_lookup_is_final_label(l, "\xe4\xb8\xad\xe5\x9b\xbd", 6));
+
+		CHECK_FALSE(rspamd_tld_lookup_is_final_label(l, "zz", 2));
+		CHECK_FALSE(rspamd_tld_lookup_is_final_label(l, "", 0));
+		CHECK_FALSE(rspamd_tld_lookup_is_final_label(l, "kobe.jp", 7));
+
+		rspamd_tld_lookup_destroy(l);
+	}
+
+	TEST_CASE("nrules and missing file")
+	{
+		auto *l = make_lookup();
+
+		CHECK(rspamd_tld_lookup_nrules(l) == 13);
+		rspamd_tld_lookup_destroy(l);
+
+		CHECK(rspamd_tld_lookup_new("/nonexistent/tld/file") == nullptr);
+		CHECK(rspamd_tld_lookup_nrules(nullptr) == 0);
+	}
+}
+
+#endif

--- a/test/rspamd_cxx_unit_tld_lookup.hxx
+++ b/test/rspamd_cxx_unit_tld_lookup.hxx
@@ -43,6 +43,7 @@ TEST_SUITE("tld_lookup")
 		"*.ck\n"
 		"!www.ck\n"
 		"\xe4\xb8\xad\xe5\x9b\xbd\n" /* 中国 */
+		"\xd1\x80\xd1\x84\n"         /* рф */
 		"xn--fiqs8s\n"
 		"// ===END ICANN DOMAINS===\n"
 		"// ===BEGIN PRIVATE DOMAINS===\n"
@@ -159,6 +160,12 @@ TEST_SUITE("tld_lookup")
 			  "foo.\xe4\xb8\xad\xe5\x9b\xbd");
 		CHECK(registrable_of(l, "foo.xn--fiqs8s") == "foo.xn--fiqs8s");
 
+		/* Unicode case folding: РФ must match the lowercase рф rule, and the
+		 * output must point into the original, unfolded host */
+		CHECK(registrable_of(l, "президент.рф") == "президент.рф");
+		CHECK(registrable_of(l, "ПРЕЗИДЕНТ.РФ") == "ПРЕЗИДЕНТ.РФ");
+		CHECK(registrable_of(l, "mail.ПРЕЗИДЕНТ.РФ") == "ПРЕЗИДЕНТ.РФ");
+
 		rspamd_tld_lookup_destroy(l);
 	}
 
@@ -240,8 +247,10 @@ TEST_SUITE("tld_lookup")
 		CHECK(rspamd_tld_lookup_is_final_label(l, "ck", 2));
 		/* Private section */
 		CHECK(rspamd_tld_lookup_is_final_label(l, "io", 2));
-		/* Unicode */
+		/* Unicode, including non-ASCII case folding */
 		CHECK(rspamd_tld_lookup_is_final_label(l, "\xe4\xb8\xad\xe5\x9b\xbd", 6));
+		CHECK(rspamd_tld_lookup_is_final_label(l, "\xd1\x80\xd1\x84", 4));
+		CHECK(rspamd_tld_lookup_is_final_label(l, "\xd0\xa0\xd0\xa4", 4)); /* РФ */
 
 		CHECK_FALSE(rspamd_tld_lookup_is_final_label(l, "zz", 2));
 		CHECK_FALSE(rspamd_tld_lookup_is_final_label(l, "", 0));
@@ -254,7 +263,7 @@ TEST_SUITE("tld_lookup")
 	{
 		auto *l = make_lookup();
 
-		CHECK(rspamd_tld_lookup_nrules(l) == 13);
+		CHECK(rspamd_tld_lookup_nrules(l) == 14);
 		rspamd_tld_lookup_destroy(l);
 
 		CHECK(rspamd_tld_lookup_new("/nonexistent/tld/file") == nullptr);


### PR DESCRIPTION
This reworks how the public suffix list (`effective_tld_names.dat`) is matched. Previously one ~10.5k-pattern hyperscan database served two very different workloads: free-text URL discovery and per-host registrable-domain resolution. The per-host workload ran a full multipattern scan over every parsed hostname, reported a callback for every matching suffix and emulated longest-match by keeping the maximum, while `!` exception rules were skipped entirely.

## What changed

**New `tld_lookup` component** (`src/libserver/tld_lookup.{h,cxx}`): loads the suffix file once into flat hash maps and resolves the registrable domain by probing host label suffixes right to left (bounded by the deepest rule, at most 7 probes). It implements full public suffix list semantics: wildcard rules, `!` exception rules (previously a TODO) and the ICANN/private section split, and keeps the distinct final labels of all rules for discovery anchoring.

**Host resolution** (`rspamd_url_find_tld`, the URL parse path, and transitively `util.get_tld` and the HTML phishing checks) now uses direct hash lookups instead of scanning the host with the multipattern engine.

**Free-text URL discovery** is now two passes: the small static-matcher multipattern (~20 patterns, always compiled synchronously in memory) provides scheme/prefix candidates, and TLD candidates are anchored on `.<known final label>` occurrences found with a memchr-driven probe of the 1610 distinct final labels. Since the existing matcher logic only accepts TLD candidates at the end of a domain token, anchoring on the final label is equivalent to matching the full suffix. Candidates from both passes are merged in ascending match-end order, which the dedup logic of the processing callbacks relies on.

**Removed**: the url scanner no longer builds the largest hyperscan database in rspamd and no longer registers it in the hs_helper pending-compilation queue. `RSPAMD_MULTIPATTERN_TLD` stays in multipattern as it is exposed through the Lua trie API.

**Lua exposure**: the new `rspamd_tld_lookup` module queries the loaded suffix list (`registrable`, `suffix` with wildcard/exception/private flags, `is_final_label`) and builds custom suffix-like rule sets. The RBL URL composition maps (`lua_urls_compose`) now run on such a rule set instead of per-TLD regex buckets with optional hyperscan tries (−124 lines, same semantics, covered by the existing unit and functional tests).

## Performance

Standalone microbenchmark (vectorscan 5.4.11, Apple M-series, real suffix list, 200k synthetic hosts, 2.1 MiB corpus of the functional-test messages):

| workload | before | after |
|---|---|---|
| host → registrable domain | 632 ns (hyperscan), 158 ns (ACISM fallback) | **116 ns** |
| text scan | ~3.6 GB/s (~0.25 GB/s on domain-dense text) | **1.4–23 GB/s** |
| startup cost | 1.3 s compile, 6.5 MiB serialised db | ~5 ms, ~600 KiB |

Notably the ACISM "fallback" was already ~5x faster than the compiled hyperscan database for short host inputs — the fixed `hs_scan` overhead dominates there, so the async compilation machinery was actively counterproductive for this workload.

## Behaviour changes (deliberate)

1. `!` exception rules are honoured now. E.g. `foo.city.kobe.jp` resolves to `city.kobe.jp` (the exception cancels `*.kobe.jp`); previously the whole host was returned.
2. A host that is itself a public suffix resolves to the whole host instead of being attributed to a shorter suffix (e.g. bare `s3.amazonaws.com` no longer yields `amazonaws.com` for reputation purposes).

## Validation

- New doctest suite for the component (wildcards, exceptions, unicode + punycode, private section, edge cases).
- Full C++ (388 cases) and Lua (1227 tests) unit suites pass.
- Functional merged + URL suites: 444/444 pass.
- Differential `rspamadm mime urls` and `rspamadm mime urls -t` over all 182 functional-test messages against master: zero differences.
