### PR TITLE
[Fix] Converge cold passive workers on HTTP maps quickly

### DIFF
--- a/src/libserver/maps/map.c
+++ b/src/libserver/maps/map.c
@@ -1395,6 +1395,11 @@ rspamd_map_periodic_dtor(struct map_periodic_cbdata *periodic)
 		/* Need to notify the real data structure */
 		periodic->map->fin_callback(&periodic->cbdata, periodic->map->user_data);
 
+		if (periodic->need_modify && !periodic->cbdata.errored &&
+			periodic->cbdata.cur_data != NULL) {
+			map->has_data = true;
+		}
+
 		if (map->on_load_function) {
 			map->on_load_function(map, map->on_load_ud);
 		}
@@ -1531,6 +1536,16 @@ rspamd_map_schedule_periodic(struct rspamd_map *map, int how)
 			else if (how & RSPAMD_MAP_SCHEDULE_LOCKED) {
 				timeout = map->poll_timeout * lock_mult;
 				reason = "locked scheduled check";
+			}
+			else if (!map->active_http && !map->file_only && !map->has_data) {
+				/*
+				 * A passive worker that has not read the map yet: the active
+				 * worker is expected to fetch it and announce via the shared
+				 * cache, so check that cache frequently instead of sleeping
+				 * through the whole poll interval while serving no data
+				 */
+				timeout = min_timer_interval;
+				reason = "cold passive HTTP map wait";
 			}
 			else {
 				reason = "normal scheduled check";
@@ -2318,7 +2333,8 @@ rspamd_map_common_http_callback(struct rspamd_map *map,
 	if (g_atomic_int_get(&data->cache->available) == 1) {
 		/* Read cached data */
 		if (check) {
-			if (data->last_modified < data->cache->last_modified) {
+			if (data->last_modified < data->cache->last_modified ||
+				!map->has_data) {
 				msg_info_map("need to reread cached map triggered by %s "
 							 "(%d our modify time, %d cached modify time)",
 							 bk->uri,
@@ -2358,6 +2374,33 @@ rspamd_map_common_http_callback(struct rspamd_map *map,
 		}
 	}
 	else if (!map->active_http) {
+		if (g_atomic_int_get(&map->shared->cached) == 1) {
+			/*
+			 * The shm cache is not available (e.g. the active worker is
+			 * re-downloading the map), but a cache file has already been
+			 * saved on disk; use that file instead of waiting for the next
+			 * shm cache announcement
+			 */
+			if (check && !map->has_data) {
+				msg_info_map("%s: has no data but the map is saved in the "
+							 "cache file; schedule loading from that file",
+							 bk->uri);
+				periodic->need_modify = TRUE;
+				periodic->cur_backend = 0;
+				rspamd_map_process_periodic(periodic);
+
+				return;
+			}
+			else if (!check && rspamd_map_read_http_cached_file(map, bk, data,
+																&periodic->cbdata)) {
+				/* Switch to the next backend */
+				periodic->cur_backend++;
+				rspamd_map_process_periodic(periodic);
+
+				return;
+			}
+		}
+
 		/* Switch to the next backend */
 		periodic->cur_backend++;
 		rspamd_map_process_periodic(periodic);
@@ -2890,6 +2933,7 @@ void rspamd_map_preload(struct rspamd_config *cfg)
 				}
 
 				map->seen = true;
+				map->has_data = true;
 			}
 			else {
 				msg_info_map("preload of %s failed", map->name);

--- a/src/libserver/maps/map_private.h
+++ b/src/libserver/maps/map_private.h
@@ -209,6 +209,7 @@ struct rspamd_map {
 	bool static_only;          /* No need to check */
 	bool no_file_read;         /* Do not read files, pass filename to consumer */
 	bool seen;                 /* This map has already been watched or pre-loaded */
+	bool has_data;             /* Map data has been delivered to the consumer in this process */
 	gsize no_file_read_offset; /* Payload offset when consumer mmaps the file (0 for file, 4096 for HTTP cache) */
 	/* Shared lock for temporary disabling of map reading (e.g. when this map is written by UI) */
 	struct rspamd_map_shared_data *shared;


### PR DESCRIPTION
## Problem

Scanner workers never fetch HTTP maps themselves: only the primary controller does (`active_http`), and scanners wait for it to announce the downloaded map via the shared memory cache, polling that cache on their own periodic timers.

On a cold start (no cached map files on disk, so the pre-fork `rspamd_map_preload()` is a no-op) every scanner checks the shm cache exactly once at startup — before the controller has finished its first download — finds nothing, and then sleeps through a **full jittered poll interval** (`[poll_timeout, 2*poll_timeout)`, i.e. minutes at defaults) while serving no map data.

The observable result in production: sibling workers of the same instance disagree about multimap lookups for the first 1–2 poll intervals, each forked scanner independently cold and converging on its own jittered schedule, while the controller reports every map as loaded (the `shared->loaded`/`cached` flags are instance-wide shm flags set by whichever process loads first — they say nothing about per-worker state).

## Fix

A new per-process `map->has_data` flag tracks whether *this* process has delivered map data to its consumer (set in the periodic dtor after a successful fin callback, and in `rspamd_map_preload()` pre-fork so children inherit it, including maps loaded from fallback files):

* **Cold fast retry**: a passive worker with an HTTP map and no data reschedules its check every 2–4 s (jittered `min_timer_interval`) instead of a full poll interval, until the first successful load. Cheap: one atomic read per tick, and it stops as soon as data arrives.
* A cold worker that finds the shm cache available forces a read even when the `last_modified` comparison alone would skip it.
* **Disk cache fallback**: when the shm announcement is absent but `shared->cached` indicates the active worker has already saved the map cache file (e.g. its re-download swap window, or shm cache expiry), a cold passive worker loads directly from that file via `rspamd_map_read_http_cached_file()` instead of skipping the backend.

## Verification

* All unit tests pass (390 C++ cases, 1254 Lua tests).
* Live reproduction: fresh empty DBDIR, 2 scanner workers + controller, HTTP map server with a 5 s response delay. Before: scanners would sleep a full jittered poll interval after their startup miss. After: scanners cold-poll at 2–4 s and converge **1–2 seconds** after the controller publishes, then return to the normal cadence. Maps with shipped fallback files correctly never enter cold mode (preload marks them warm pre-fork).