### PR TITLE
[Feature] Show git build id in WebUI cluster table

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ export default [
 
             "camelcase": "off",
             "capitalized-comments": "off",
+            "complexity": ["warn", 22],
             "curly": ["error", "multi-line"],
             "func-names": "off",
             "func-style": ["error", "declaration"],

--- a/interface/css/rspamd.css
+++ b/interface/css/rspamd.css
@@ -618,9 +618,14 @@ input.action-scores {
 #clusterTable td.cluster-toggle[aria-expanded="false"] .cluster-toggle-icon {
     transform: rotate(-90deg);
 }
-/* Cluster drift badge (version / configuration ID mismatch) */
+/* Cluster drift badge (version / git ID / configuration ID mismatch) */
 #clusterTable .cluster-drift {
     color: var(--rspamd-text-warning);
+}
+/* The Git ID column is hidden entirely unless some live server reports a
+   git_id (release builds and backends predating it send none) */
+#clusterTable.cluster-hide-git .cluster-git {
+    display: none;
 }
 /* "seen <time> ago": on narrow screens the note wraps under the status glyph
    to save horizontal space; on large screens it stays on the glyph's line,

--- a/interface/index.html
+++ b/interface/index.html
@@ -211,6 +211,7 @@
 												<th class="w-1">Latency</th>
 												<th class="w-1">Uptime</th>
 												<th class="w-1">Version</th>
+												<th class="w-1 cluster-git">Git ID</th>
 												<th>Configuration ID</th>
 											</tr>
 										</thead>

--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -107,6 +107,7 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                 row_class: "danger",
                 glyph_status: "fas fa-times",
                 version: "???",
+                git_id: "",
                 uptime: "???",
                 short_id: "???",
                 scan_times: {
@@ -146,6 +147,9 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             }
             if ("version" in val.data) {
                 state.version = val.data.version;
+            }
+            if ("git_id" in val.data) {
+                state.git_id = val.data.git_id;
             }
             if (key === "All SERVERS") {
                 state.short_id = "";
@@ -327,7 +331,7 @@ define(["app/common", "app/libft", "d3pie", "d3"],
         // Details row revealed by clicking a server row: the /stat fields not
         // shown in the main row (traffic and memory counters) — no extra
         // requests.
-        function buildDetailsRow(data, expanded) {
+        function buildDetailsRow(data, expanded, cols) {
             function fmtInt(value) {
                 return Number.isFinite(value) ? d3.format(",")(value) : "-";
             }
@@ -340,7 +344,7 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             }
 
             return '<tr class="cluster-details' + (expanded ? "" : " d-none") + '">' +
-                '<td colspan="11">' +
+                '<td colspan="' + cols + '">' +
                 // mx-0 cancels .row negative gutters that would overflow the td
                 '<div class="row row-cols-1 row-cols-sm-2 g-3 mx-0 py-1 small text-secondary">' +
                 '<div class="col"><div class="fw-bold">Traffic</div>' +
@@ -507,7 +511,8 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             }
             common.show(statWidgets);
 
-            const clusterTbody = document.querySelector("#clusterTable tbody");
+            const clusterTable = document.querySelector("#clusterTable");
+            const clusterTbody = clusterTable.querySelector("tbody");
             const selSrv = document.getElementById("selSrv");
             clusterTbody.replaceChildren();
             selSrv.replaceChildren();
@@ -516,8 +521,15 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             const realServers = Object.entries(servers)
                 .filter(([key, val]) => key !== "All SERVERS" && val.status)
                 .map(([key, val]) => ({name: key, data: val.data || {}}));
+            // Hide the Git ID column unless some live server reports one
+            const anyGit = realServers.some((server) => "git_id" in server.data);
+            clusterTable.classList.toggle("cluster-hide-git", !anyGit);
+            // Details rows must span exactly the visible columns; the Git ID
+            // column is the only conditionally hidden one
+            const detailCols = clusterTable.querySelectorAll("thead th").length - (anyGit ? 0 : 1);
             const configDrift = findDeviants(realServers, "config_id");
             const versionDrift = findDeviants(realServers, "version");
+            const gitDrift = findDeviants(realServers, "git_id");
 
             // @ warning triangle marking a server deviating from the cluster majority
             function driftBadge(drift, what, value) {
@@ -579,13 +591,18 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                             ? driftBadge(versionDrift, "Version", "run " + versionDrift.majorityValue)
                             : "") +
                     "</td>" +
+                    '<td class="cluster-git">' + common.escapeHTML(rowState.git_id) +
+                        (gitDrift?.deviants.has(key)
+                            ? driftBadge(gitDrift, "Git ID", "run " + gitDrift.majorityValue)
+                            : "") +
+                    "</td>" +
                     "<td>" + common.escapeHTML(rowState.short_id) +
                         (configDrift?.deviants.has(key)
                             ? driftBadge(configDrift, "Configuration ID",
                                 "share " + String(configDrift.majorityValue).substring(0, 8))
                             : "") +
                     "</td></tr>" +
-                    (realUp ? buildDetailsRow(val.data, expanded) : "")
+                    (realUp ? buildDetailsRow(val.data, expanded, detailCols) : "")
                 );
 
                 selSrv.insertAdjacentHTML("beforeend",

--- a/src/controller.c
+++ b/src/controller.c
@@ -3140,6 +3140,10 @@ rspamd_controller_handle_stat_common(
 	rspamd_controller_task_set_transport(session, task);
 
 	ucl_object_insert_key(top, ucl_object_fromstring(RVERSION), "version", 0, false);
+	/* Build git id (RID, -DGIT_ID builds); release builds send no git_id */
+#if defined(GIT_VERSION) && GIT_VERSION == 1
+	ucl_object_insert_key(top, ucl_object_fromstring(RID), "git_id", 0, false);
+#endif
 	ucl_object_insert_key(top, ucl_object_fromstring(session->ctx->cfg->checksum), "config_id", 0, false);
 	uptime = ev_time() - session->ctx->srv->start_time;
 	ucl_object_insert_key(top, ucl_object_fromint(uptime), "uptime", 0, false);

--- a/test/playwright/tests/charts.spec.mjs
+++ b/test/playwright/tests/charts.spec.mjs
@@ -37,6 +37,9 @@ test.describe.serial("WebUI Status / Throughput / History rendering", () => {
         await page.waitForResponse((r) => r.url().includes("/stat") && r.ok());
         await expect(page.locator("#clusterTable thead")).toContainText("Load");
         await expect(page.locator("#clusterTable thead")).toContainText("Latency");
+        // CI builds pass no -DGIT_ID, so no server reports git_id and the
+        // Git ID column stays hidden
+        await expect(page.locator("#clusterTable thead th.cluster-git")).toBeHidden();
         await expect(page.locator("#clusterTable tbody td[title='Messages scanned per minute']").first())
             .toHaveText(/-|[\d.]+\/min/);
 

--- a/test/playwright/tests/cluster.spec.mjs
+++ b/test/playwright/tests/cluster.spec.mjs
@@ -1,0 +1,65 @@
+import {expect, test} from "@playwright/test";
+import {login} from "../helpers/auth.mjs";
+
+// The Git ID column lights up only when some server reports git_id in /stat.
+// CI builds pass no -DGIT_ID (that hidden path is asserted in charts.spec),
+// so the positive path is exercised against a mocked 3-server cluster: the
+// /neighbours map points at path prefixes on the same origin (keeps the
+// Password-header XHRs free of CORS), and every /n<N>/stat reply is the real
+// /stat body with git_id injected, so the schema stays in sync with the
+// backend.
+test("Git ID column: values, drift badge, details colspan", async ({page, request}, testInfo) => {
+    const {enablePassword, readOnlyPassword} = testInfo.project.use.rspamdPasswords;
+    const baseStat = await (await request.get("/stat", {headers: {Password: readOnlyPassword}})).json();
+
+    const git = {n1: "a1b2c3d", n2: "a1b2c3d", n3: "e5f6a7b<b>x</b>"}; // n3: deviant + escaping canary
+    await page.route("**/neighbours", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            srv1: {host: "127.0.0.1", url: "http://localhost:11334/n1/"},
+            srv2: {host: "127.0.0.1", url: "http://localhost:11334/n2/"},
+            srv3: {host: "127.0.0.1", url: "http://localhost:11334/n3/"},
+        }),
+    }));
+    for (const n of Object.keys(git)) {
+        await page.route(`**/${n}/stat`, (route) => route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({...baseStat, git_id: git[n]}),
+        }));
+        // The login-time auth fan-out and the health probes must not 404
+        for (const ep of ["auth", "healthy", "ready"]) {
+            await page.route(`**/${n}/${ep}`, (route) => route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify(ep === "auth"
+                    ? {auth: "ok", version: baseStat.version}
+                    : {}),
+            }));
+        }
+    }
+
+    await login(page, enablePassword);
+    await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    await Promise.all([
+        page.waitForResponse((r) => r.url().includes("/n3/stat")),
+        page.locator("#status_nav").click(),
+    ]);
+
+    // Column visible; n3's value rendered as text (proves escaping: broken
+    // escapeHTML would parse <b> as an element and drop it from innerText)
+    await expect(page.locator("#clusterTable thead th.cluster-git")).toBeVisible();
+    await expect(page.locator('tr[data-server="srv1"] td.cluster-git')).toHaveText("a1b2c3d");
+    await expect(page.locator('tr[data-server="srv3"] td.cluster-git')).toContainText("e5f6a7b<b>x</b>");
+
+    // Identical versions and config ids: the git deviant carries the only badge
+    await expect(page.locator("#clusterTable .cluster-drift")).toHaveCount(1);
+    await expect(page.locator('tr[data-server="srv3"] td.cluster-git .cluster-drift'))
+        .toHaveAttribute("title", "Git ID differs: 2 of 3 servers run a1b2c3d");
+
+    // The details row spans all 12 visible columns
+    await page.locator('tr[data-server="srv1"] td').nth(2).click();
+    await expect(page.locator("#clusterTable tr.cluster-details td").first())
+        .toHaveAttribute("colspan", "12");
+});


### PR DESCRIPTION
Expose the build-time git id (RID, -DGIT_ID builds) as "git_id" in /stat and render it in a dedicated WebUI cluster-table column, hidden when no live server reports one. Differing ids get a drift badge like version/configuration mismatches, so dev builds of different commits can be told apart in a cluster.