### PR TITLE
[Feature] rbl: merge duplicate DNS queries produced by multiple checks

### DIFF
--- a/lualib/plugins/rbl.lua
+++ b/lualib/plugins/rbl.lua
@@ -56,6 +56,7 @@ local default_options = {
   ['default_no_ip'] = false,
   ['default_dkim_match_from'] = false,
   ['default_selector_flatten'] = true,
+  ['default_merge_checks'] = true,
 }
 
 local return_codes_schema = T.table({}, {
@@ -145,6 +146,8 @@ local rule_schema_tbl = {
       :doc({ summary = "Treat this RBL as a whitelist (positive result means whitelisted)" }),
   local_exclude_ip_map = T.string():optional()
       :doc({ summary = "Path to map file containing IPs to exclude from this RBL check" }),
+  merge_checks = T.boolean():optional()
+      :doc({ summary = "Insert the symbol once with a combined option when several checks yield the same DNS query" }),
   monitored_address = T.string():optional()
       :doc({ summary = "Specific address to use for RBL health monitoring queries" }),
   no_ip = T.boolean():optional()
@@ -293,9 +296,12 @@ local function convert_checks(rule, name)
 end
 
 
--- Add default boolean flags to the schema
+-- Add default boolean flags to the schema, keeping any explicitly documented entry
 for def_k, _ in pairs(default_options) do
-  rule_schema_tbl[def_k:sub(#('default_') + 1)] = T.boolean():optional()
+  local rule_k = def_k:sub(#('default_') + 1)
+  if not rule_schema_tbl[rule_k] then
+    rule_schema_tbl[rule_k] = T.boolean():optional()
+  end
 end
 
 local rule_schema = T.table(rule_schema_tbl):doc({ summary = "RBL rule configuration schema" })
@@ -329,6 +335,8 @@ local plugin_schema = T.table({
       :doc({ summary = "Default value for dkim_match_from option in rules" }),
   default_selector_flatten = T.boolean():optional()
       :doc({ summary = "Default value for selector_flatten option in rules" }),
+  default_merge_checks = T.boolean():optional()
+      :doc({ summary = "Default value for merge_checks option in rules" }),
   default_received_flags = T.array(T.string()):optional()
       :doc({ summary = "Default received flags for all rules" }),
   default_received_nflags = T.array(T.string()):optional()

--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -254,45 +254,81 @@ matchers.glob = function(_, to_match, _, map)
 end
 
 local function rbl_dns_process(task, rbl, to_resolve, results, err, resolve_table_elt, match)
-  local function make_option(ip, label)
+  local function make_option(origin, ip, label)
     if ip then
       return string.format('%s:%s:%s',
-          resolve_table_elt.orig,
+          origin,
           label,
           ip)
     else
       return string.format('%s:%s',
-          resolve_table_elt.orig,
+          origin,
           label)
     end
   end
 
-  local function insert_result(s, ip, label)
-    if rbl.symbols_prefixes then
-      local prefix = rbl.symbols_prefixes[label]
-
-      if not prefix then
-        rspamd_logger.warnx(task, 'unlisted symbol prefix for %s', label)
-        task:insert_result(s, 1.0, make_option(ip, label))
-      else
-        task:insert_result(prefix .. '_' .. s, 1.0, make_option(ip, label))
-      end
-    else
-      task:insert_result(s, 1.0, make_option(ip, label))
-    end
-  end
+  -- merge_checks false restores the pre-4.1.6 one-insertion-per-check behavior
+  local merge_checks = rbl.merge_checks ~= false
 
   local function insert_results(s, ip)
-    for label in pairs(resolve_table_elt.what) do
-      insert_result(s, ip, label)
+    -- Only the first insertion of a symbol carries score; later spellings just add options
+    local scored_symbols = {}
+
+    local function insert_origin_labels(sym_name, origin, labels)
+      table.sort(labels)
+
+      if merge_checks then
+        local weight = scored_symbols[sym_name] and 0.0 or 1.0
+        scored_symbols[sym_name] = true
+        task:insert_result(sym_name, weight,
+            make_option(origin, ip, table.concat(labels, ',')))
+      else
+        for _, label in ipairs(labels) do
+          task:insert_result(sym_name, 1.0, make_option(origin, ip, label))
+        end
+      end
+    end
+
+    for origin, origin_labels in pairs(resolve_table_elt.origins) do
+      if rbl.symbols_prefixes then
+        local by_prefix = {}
+        for label in pairs(origin_labels) do
+          local prefix = rbl.symbols_prefixes[label]
+          local sym_name
+          if not prefix then
+            rspamd_logger.warnx(task, 'unlisted symbol prefix for %s', label)
+            sym_name = s
+          else
+            sym_name = prefix .. '_' .. s
+          end
+          if not by_prefix[sym_name] then
+            by_prefix[sym_name] = {}
+          end
+          by_prefix[sym_name][#by_prefix[sym_name] + 1] = tostring(label)
+        end
+        for sym_name, labels in pairs(by_prefix) do
+          insert_origin_labels(sym_name, origin, labels)
+        end
+      else
+        local labels = {}
+        for label in pairs(origin_labels) do
+          labels[#labels + 1] = tostring(label)
+        end
+        insert_origin_labels(s, origin, labels)
+      end
     end
   end
 
   if err and (err ~= 'requested record is not found' and
       err ~= 'no records with this name') then
     rspamd_logger.infox(task, 'error looking up %s: %s', to_resolve, err)
-    task:insert_result(rbl.symbol .. '_FAIL', 1, string.format('%s:%s',
-        resolve_table_elt.orig, err))
+    -- Report every merged origin, but only the first insertion carries weight
+    local failed_origins = lua_util.keys(resolve_table_elt.origins)
+    table.sort(failed_origins)
+    for i, origin in ipairs(failed_origins) do
+      task:insert_result(rbl.symbol .. '_FAIL', i == 1 and 1.0 or 0.0,
+          string.format('%s:%s', origin, err))
+    end
     return
   end
 
@@ -375,15 +411,17 @@ local function gen_rbl_callback(rule)
     if whitelist then
       local wl = whitelist[req_str]
       if wl then
-        lua_util.debugm(N, task,
-            'whitelisted request to %s by %s (%s) rbl rule (%s checked type, %s whitelist type)',
-            req_str, wl.type, wl.symbol, what, wl.type)
-        if wl.type == what then
-          -- This was decided to be a bad idea as in case of whitelisting a request to blacklist
-          -- is not even sent
-          --task:adjust_result(wl.symbol, 0.0 / 0.0, rule.symbol)
+        for _, wl_entry in ipairs(wl) do
+          lua_util.debugm(N, task,
+              'whitelisted request to %s by %s (%s) rbl rule (%s checked type, %s whitelist type)',
+              req_str, wl_entry.type, wl_entry.symbol, what, wl_entry.type)
+          if wl_entry.type == what then
+            -- This was decided to be a bad idea as in case of whitelisting a request to blacklist
+            -- is not even sent
+            --task:adjust_result(wl_entry.symbol, 0.0 / 0.0, rule.symbol)
 
-          return true
+            return true
+          end
         end
       end
     end
@@ -392,10 +430,14 @@ local function gen_rbl_callback(rule)
   end
 
   local function add_dns_request(task, req, forced, is_ip, requests_table, label, whitelist)
-    local req_str = req
-    if is_ip then
-      req_str = tostring(req)
+    -- Discard empty queries to avoid querying the RBL suffix itself
+    if not is_ip and (not req or req == '') then
+      lua_util.debugm(N, task, 'skip empty RBL request for %s (%s)',
+          rule.symbol, label)
+      return
     end
+
+    local req_str = tostring(req)
 
     if whitelist and is_whitelisted(task, req, req_str, whitelist, label) then
       return
@@ -413,7 +455,14 @@ local function gen_rbl_callback(rule)
       end
       if not nreq.what[label] then
         nreq.what[label] = true
+        lua_util.debugm(N, task, 'merging duplicate RBL request for %s: %s (%s added to %s)',
+            rule.symbol, req_str, label,
+            table.concat(lua_util.keys(nreq.what), ','))
       end
+      if not nreq.origins[req_str] then
+        nreq.origins[req_str] = {}
+      end
+      nreq.origins[req_str][label] = true
 
       return true, nreq -- Duplicate
     else
@@ -426,19 +475,21 @@ local function gen_rbl_callback(rule)
         if processed then
           nreq = {
             forced = forced,
-            n = processed,
+            n = tostring(processed):lower(),
             orig = req_str,
             resolve_ip = resolve_ip,
             what = { [label] = true },
+            origins = { [req_str] = { [label] = true } },
           }
           requests_table[req] = nreq
         end
       else
         local to_resolve
-        local origin = req
+        -- Strip trailing dots first so hashing treats "foo." and "foo" alike
+        local origin = tostring(req):gsub('%.+$', '')
 
         if not resolve_ip then
-          origin = maybe_make_hash(req, rule)
+          origin = maybe_make_hash(origin, rule)
           to_resolve = string.format('%s.%s',
               origin,
               rule.rbl)
@@ -446,6 +497,7 @@ local function gen_rbl_callback(rule)
           -- First, resolve origin stuff without hashing or anything
           to_resolve = origin
         end
+        to_resolve = to_resolve:lower()
 
         nreq = {
           forced = forced,
@@ -453,6 +505,7 @@ local function gen_rbl_callback(rule)
           orig = req_str,
           resolve_ip = resolve_ip,
           what = { [label] = true },
+          origins = { [req_str] = { [label] = true } },
         }
         requests_table[req] = nreq
       end
@@ -944,6 +997,36 @@ local function gen_rbl_callback(rule)
     end
 
     -- Now check all DNS requests pending and emit them
+    -- Deduplicate by actual DNS query name to merge equivalent queries from different checks
+    local deduped_req = {}
+    for _, req in pairs(dns_req) do
+      local dedupe_key = tostring(req.n):lower()
+      req.n = dedupe_key
+      local existing = deduped_req[dedupe_key]
+      if existing then
+        for label, _ in pairs(req.what) do
+          if not existing.what[label] then
+            existing.what[label] = true
+          end
+        end
+        for origin, labels in pairs(req.origins) do
+          if not existing.origins[origin] then
+            existing.origins[origin] = {}
+          end
+          for label in pairs(labels) do
+            existing.origins[origin][label] = true
+          end
+        end
+        if req.forced and not existing.forced then
+          existing.forced = true
+        end
+        lua_util.debugm(N, task, 'merging DNS request for %s: %s (same query %s)',
+            rule.symbol, req.orig, req.n)
+      else
+        deduped_req[dedupe_key] = req
+      end
+    end
+
     local r = task:get_resolver()
     -- Used for 2 passes ip resolution
     local resolved_req = {}
@@ -957,12 +1040,22 @@ local function gen_rbl_callback(rule)
             -- Check if we have rspamd{ip} userdata
             if type(dns_res) == 'userdata' then
               -- Add result as an actual RBL request
-              local label = next(orig_resolve_table_elt.what)
-              local dup, nreq = add_dns_request(task, dns_res, false, true,
-                  resolved_req, label)
-              -- Add original name
-              if not dup then
-                nreq.orig = nreq.orig .. ':' .. orig_resolve_table_elt.n
+              local nreq
+              for label in pairs(orig_resolve_table_elt.what) do
+                _, nreq = add_dns_request(task, dns_res, false, true,
+                    resolved_req, label)
+              end
+
+              local ip_str = tostring(dns_res)
+              nreq.origins[ip_str] = nil
+              for origin, labels in pairs(orig_resolve_table_elt.origins) do
+                local resolved_origin = string.format('%s:%s', ip_str, origin)
+                if not nreq.origins[resolved_origin] then
+                  nreq.origins[resolved_origin] = {}
+                end
+                for label in pairs(labels) do
+                  nreq.origins[resolved_origin][label] = true
+                end
               end
             end
           end
@@ -992,7 +1085,7 @@ local function gen_rbl_callback(rule)
       end
     end
 
-    for name, req in pairs(dns_req) do
+    for name, req in pairs(deduped_req) do
       local val_res, val_error = validate_dns(req.n)
       if val_res then
         lua_util.debugm(N, task, "rbl %s; resolve %s -> %s",
@@ -1410,10 +1503,16 @@ local function rbl_callback_white(task)
         lua_util.debugm(N, task, 'found whitelist from %s: %s(%s)', w,
             elt, what)
         if elt and what then
-          whitelisted_elements[elt] = {
-            type = what,
-            symbol = w,
-          }
+          if not whitelisted_elements[elt] then
+            whitelisted_elements[elt] = {}
+          end
+          -- `what` might be a comma-joined list of labels (merged request)
+          for label in what:gmatch('[^,]+') do
+            table.insert(whitelisted_elements[elt], {
+              type = label,
+              symbol = w,
+            })
+          end
         end
       end
     end

--- a/test/functional/cases/001_merged/300_rbl.robot
+++ b/test/functional/cases/001_merged/300_rbl.robot
@@ -63,18 +63,70 @@ CONTENT URLS
   Expect Symbol With Option  URIBL_WITHCONTENT  8.8.8.8:url
   Expect Symbol With Exact Options  URIBL_CONTENTONLY  example.com:url
 
-SELECTORS
+SELECTORS SEPARATE
   Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml  From=user@example.com  Helo=example.org
   ...  Settings={symbols_enabled = [RBL_SELECTOR_SINGLE, RBL_SELECTOR_MULTIPLE]}
   Expect Symbol With Exact Options  RBL_SELECTOR_SINGLE  example.org:selector
-  Expect Symbol With Option  RBL_SELECTOR_MULTIPLE  example.com:sel_from
-  Expect Symbol With Option  RBL_SELECTOR_MULTIPLE  example.org:sel_helo
+  # Different domains -> different DNS queries -> not merged, one option each
+  Expect Symbol With Exact Options  RBL_SELECTOR_MULTIPLE  example.com:sel_from  example.org:sel_helo
 
 SELECTORS COMBINED
   Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml  From=user@example.org  Helo=example.org
   ...  Settings={symbols_enabled = [RBL_SELECTOR_MULTIPLE]}
-  Expect Symbol With Option  RBL_SELECTOR_MULTIPLE  example.org:sel_from
-  Expect Symbol With Option  RBL_SELECTOR_MULTIPLE  example.org:sel_helo
+  # Same domain -> same DNS query -> merged into a single, comma-joined option
+  Expect Symbol With Exact Options  RBL_SELECTOR_MULTIPLE  example.org:sel_from,sel_helo
+
+SELECTORS MERGED FAIL
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml
+  ...  Settings={symbols_enabled = [RBL_MERGED_ERR]}
+  # A failing merged query reports every origin, not an arbitrary one
+  Expect Symbol With Exact Options  RBL_MERGED_ERR_FAIL
+  ...  FAILTEST.EXAMPLE:server fail  failtest.example:server fail
+  Expect Symbol With Score  RBL_MERGED_ERR_FAIL  1.0
+
+SELECTORS HASHED TRAILING DOT
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml
+  ...  Settings={symbols_enabled = [RBL_SELECTOR_HASH]}
+  # The trailing dot is stripped before hashing, so both spellings hash alike
+  Expect Symbol With Exact Options  RBL_SELECTOR_HASH  example.org:plain  example.org.:dotted
+
+SELECTORS COMBINED DISABLED
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml
+  ...  Settings={symbols_enabled = [RBL_SELECTOR_NOMERGE]}
+  # merge_checks = false -> one option (and one score shot) per check
+  Expect Symbol With Exact Options  RBL_SELECTOR_NOMERGE  example.org:sel_from  example.org:sel_helo
+  Expect Symbol With Score  RBL_SELECTOR_NOMERGE  4.0
+
+SELECTORS COMBINED SYMBOL PREFIXES
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml
+  ...  Settings={symbols_enabled = [RBL_SELECTOR_PREFIXES_CHECK]}
+  Expect Symbol With Exact Options  RBL_CODE_2  example.org:from
+  Expect Symbol With Exact Options  RECEIVED_CODE_2  example.org:received
+  # Merging the query does not merge the symbols: each prefix scores in full
+  Expect Symbol With Score  RBL_CODE_2  2.0
+  Expect Symbol With Score  RECEIVED_CODE_2  3.0
+
+SELECTORS CASE INSENSITIVE
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml
+  ...  Settings={symbols_enabled = [RBL_SELECTOR_CASE]}
+  Expect Symbol With Exact Options  RBL_SELECTOR_CASE  example.org:lower  EXAMPLE.ORG:upper
+  # Both origins are the same listing, so the score is only counted once
+  Expect Symbol With Score  RBL_SELECTOR_CASE  2.0
+
+SELECTOR IP USERDATA
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml  IP=1.2.3.4
+  ...  Settings={symbols_enabled = [RBL_SELECTOR_IP]}
+  Expect Symbol With Exact Options  RBL_SELECTOR_IP  1.2.3.4:selector
+
+SELECTORS RESOLVE IP COMBINED
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml
+  ...  Settings={symbols_enabled = [RBL_SELECTOR_RESOLVE]}
+  Expect Symbol With Exact Options  RBL_SELECTOR_RESOLVE_HIT  8.8.8.9:example.ru:first,second
+
+SELECTORS MERGED WHITELIST
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml
+  ...  Settings={symbols_enabled = [RBL_SELECTOR_WL]}
+  Expect Symbol With Exact Options  RBL_SELECTOR_WL_HIT  example.org:plain  example.org.:dotted
 
 NUMERIC URLS
   Scan File  ${RSPAMD_TESTDIR}/messages/numeric_urls.eml

--- a/test/functional/configs/merged-local.conf
+++ b/test/functional/configs/merged-local.conf
@@ -1054,6 +1054,23 @@ options = {
           replies = ["127.0.0.2"];
         },
         {
+          name = "1.2.3.4.test9.uribl";
+          type = a;
+          replies = ["127.0.0.2"];
+        },
+        {
+          # sha1("example.org") -- "example.org." must hash to the same name
+          name = "20116dfd6774a9e7b32eddfea3f6cb094e38fc3f.test9.uribl";
+          type = a;
+          replies = ["127.0.0.2"];
+        },
+        {
+          # Resolver error, so _FAIL must list every merged origin
+          name = "failtest.example.test9.uribl";
+          type = a;
+          rcode = "servfail";
+        },
+        {
           name = "4.3.2.1.test9.uribl";
           type = a;
           replies = ["127.0.0.2"];
@@ -1149,6 +1166,24 @@ spf {
 }
 
 symbols {
+  # Scored so that 300_rbl can assert merged origins are counted once
+  RBL_SELECTOR_CASE = {
+    score = 2.0
+  }
+  RBL_SELECTOR_NOMERGE = {
+    score = 2.0
+  }
+  # A merged failure is one failure, not one per origin
+  RBL_MERGED_ERR_FAIL = {
+    score = 1.0
+  }
+  # Prefixed symbols score independently of each other
+  RBL_CODE_2 = {
+    score = 2.0
+  }
+  RECEIVED_CODE_2 = {
+    score = 3.0
+  }
   FOUR_POINTS = {
     score = 4.0
   }

--- a/test/functional/configs/merged-override.conf
+++ b/test/functional/configs/merged-override.conf
@@ -390,6 +390,85 @@ rbl {
         sel_helo = "helo()";
       }
     }
+    RBL_MERGED_ERR {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      selector = {
+        lower = "id('failtest.example')";
+        upper = "id('FAILTEST.EXAMPLE')";
+      }
+    }
+    RBL_SELECTOR_HASH {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      hash = "sha1";
+      hash_format = "hex";
+      selector = {
+        plain = "id('example.org')";
+        dotted = "id('example.org.')";
+      }
+    }
+    RBL_SELECTOR_NOMERGE {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      merge_checks = false;
+      selector = {
+        sel_from = "id('example.org')";
+        sel_helo = "id('example.org')";
+      }
+    }
+    RBL_SELECTOR_PREFIXES {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      selector = {
+        from = "id('example.org')";
+        received = "id('example.org')";
+      }
+      symbols_prefixes = {
+        received = "RECEIVED";
+        from = "RBL";
+      }
+      returncodes = {
+        CODE_2 = "127.0.0.2";
+      }
+    }
+    RBL_SELECTOR_CASE {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      selector = {
+        lower = "id('example.org')";
+        upper = "id('EXAMPLE.ORG')";
+      }
+    }
+    RBL_SELECTOR_IP {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      selector = "ip";
+    }
+    RBL_SELECTOR_RESOLVE {
+      rbl = "test4.uribl";
+      ignore_defaults = true;
+      resolve_ip = true;
+      selector = {
+        first = "id('example.ru')";
+        second = "id('example.ru')";
+      }
+      returncodes = {
+        RBL_SELECTOR_RESOLVE_HIT = "127.0.0.3";
+      }
+    }
+    RBL_SELECTOR_WL {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      is_whitelist = true;
+      selector = {
+        dotted = "id('example.org.')";
+        plain = "id('example.org')";
+      }
+      returncodes = {
+        RBL_SELECTOR_WL_HIT = "127.0.0.2";
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Summary

Requests that resolve to the same DNS query (case-insensitive, ignoring a
trailing dot) are now deduplicated and sent once instead of once per check.

By default, checks sharing a query also share a single symbol insertion:
their labels are combined into one comma-separated option and the symbol's
weight is counted only once.

### Behaviour change

Since `default_merge_checks` is `true`, this changes existing scoring: a rule
that previously scored once per check for the same value now scores once per
matched value instead. Set `merge_checks = false` (or `default_merge_checks =
false`) to keep the pre-4.1.6 behaviour of one insertion per check.

### Additional fixes

- Whitelisting now tracks every RBL rule that whitelists a given value
  instead of only the last one processed.
- `resolve_ip` carries origins/labels from all merged sender-side checks
  through to the second-phase query and to failure reports.
- Empty lookup values are skipped instead of being queried against the bare
  RBL suffix.

### Testing

Added functional coverage for merged DNS requests: `merge_checks` scoring and
disabling it, `symbols_prefixes` grouping, case-insensitive and trailing-dot
deduplication, `resolve_ip` origin propagation, and whitelisting of merged
requests.