### PR TITLE
[Feature] metadata_exporter: custom variables, MIME/multipart alerts, SMTP hardening, and rule schema validation

### DIFF
--- a/lualib/lua_smtp.lua
+++ b/lualib/lua_smtp.lua
@@ -122,13 +122,72 @@ local function sendmail(opts, message, callback)
           return msg
         end
 
+        -- RFC 5321 4.5.2 transparency: a line starting with '.' is transmitted
+        -- with an extra leading '.', which the receiver strips. Without this a
+        -- lone '.' line in the body would end the DATA phase early and
+        -- truncate the message. Runs after CRLF normalization, so every line
+        -- is known to end in CRLF.
+        -- `at_line_start` carries line state across chunks of a split message
+        -- so a '.' at the head of a chunk is only stuffed when the previous
+        -- chunk actually ended a line.
+        local function dot_stuff(msg, at_line_start)
+          local mtype = type(msg)
+          local len
+
+          if mtype == 'userdata' then
+            len = msg:len()
+          elseif mtype == 'string' then
+            len = #msg
+          else
+            return msg, at_line_start
+          end
+
+          if len == 0 then
+            return msg, at_line_start
+          end
+
+          -- Matching on LF alone also covers CRLF, so stuffing stays correct
+          -- even if the content reaches us with mixed line endings
+          local leading_dot, embedded_dot
+          if mtype == 'userdata' then
+            -- len/at/find inspect the text in place; only stuffing copies it
+            leading_dot = at_line_start and msg:at(1) == 46
+            embedded_dot = msg:find('\n.') ~= nil
+          else
+            leading_dot = at_line_start and string.sub(msg, 1, 1) == '.'
+            embedded_dot = string.find(msg, '\n.', 1, true) ~= nil
+          end
+
+          local ends_line
+          if mtype == 'userdata' then
+            ends_line = msg:at(len) == 10
+          else
+            ends_line = string.sub(msg, -1) == '\n'
+          end
+
+          if not leading_dot and not embedded_dot then
+            return msg, ends_line
+          end
+
+          local str = mtype == 'userdata' and msg:str() or msg
+          str = string.gsub(str, '\n%.', '\n..')
+          if leading_dot then
+            str = '.' .. str
+          end
+
+          return str, ends_line
+        end
+
         if type(message) == 'string' or type(message) == 'userdata' then
           message = normalize_to_crlf(message)
+          message = dot_stuff(message, true)
           conn:add_write(pre_quit_cb, { message, CRLF .. '.' .. CRLF })
         else
           -- Array of chunks
+          local at_line_start = true
           for i = 1, #message do
             message[i] = normalize_to_crlf(message[i])
+            message[i], at_line_start = dot_stuff(message[i], at_line_start)
           end
           table.insert(message, CRLF .. '.' .. CRLF)
           conn:add_write(pre_quit_cb, message)

--- a/lualib/lua_smtp.lua
+++ b/lualib/lua_smtp.lua
@@ -240,23 +240,80 @@ local function sendmail(opts, message, callback)
         conn:add_read(from_done_cb, CRLF)
       end
     end
-    local function hello_done_cb(merr, mdata)
-      if no_error_read(merr, mdata) then
-        stage = 'from'
-        conn:add_write(from_cb, string.format(
-            'MAIL FROM: <%s>%s', opts.from, CRLF))
-      end
+    local supports_8bitmime = false
+
+    local function send_mail_from()
+      stage = 'from'
+      local mail_params = supports_8bitmime and ' BODY=8BITMIME' or ''
+      conn:add_write(from_cb, string.format(
+          'MAIL FROM: <%s>%s%s', opts.from, mail_params, CRLF))
     end
 
-    -- HELO stage
-    local function hello_cb(merr)
+    -- HELO stage (fallback used when EHLO is rejected or unsupported)
+    local function helo_done_cb(merr, mdata)
+      if no_error_read(merr, mdata) then
+        send_mail_from()
+      end
+    end
+    local function helo_cb(merr)
       if no_error_write(merr) then
-        conn:add_read(hello_done_cb, CRLF)
+        conn:add_read(helo_done_cb, CRLF)
+      end
+    end
+    local function send_helo()
+      stage = 'helo'
+      supports_8bitmime = false
+      conn:add_write(helo_cb, string.format('HELO %s%s',
+          opts.helo, CRLF))
+    end
+
+    -- EHLO stage
+    local ehlo_done_cb
+    local ehlo_ok = true
+    ehlo_done_cb = function(merr, mdata)
+      if merr then
+        callback(false, string.format('error on stage %s: %s',
+            stage, merr))
+        if conn then
+          conn:close()
+        end
+        return
+      end
+      if type(mdata) ~= 'string' then
+        mdata = tostring(mdata)
+      end
+      local code, sep = string.match(mdata, '^(%d%d%d)([ %-])')
+      if not code then
+        callback(false, string.format('bad smtp response on stage %s: "%s"',
+            stage, mdata))
+        if conn then
+          conn:close()
+        end
+        return
+      end
+      if string.sub(code, 1, 1) ~= '2' then
+        ehlo_ok = false
+      end
+      local capability = string.match(mdata, '^%d%d%d[ %-]%s*([%w][%w-]*)')
+      if capability and string.upper(capability) == '8BITMIME' then
+        supports_8bitmime = true
+      end
+      if sep == '-' then
+        conn:add_read(ehlo_done_cb, CRLF)
+      elseif ehlo_ok then
+        send_mail_from()
+      else
+        send_helo()
+      end
+    end
+    local function ehlo_cb(merr)
+      if no_error_write(merr) then
+        conn:add_read(ehlo_done_cb, CRLF)
       end
     end
     if no_error_read(err, data) then
-      stage = 'helo'
-      conn:add_write(hello_cb, string.format('HELO %s%s',
+      stage = 'ehlo'
+      conn:add_write(ehlo_cb, string.format('EHLO %s%s',
           opts.helo, CRLF))
     end
   end
@@ -268,6 +325,12 @@ local function sendmail(opts, message, callback)
   local tcp_opts = lua_util.shallowcopy(opts)
   tcp_opts.stop_pattern = CRLF
   tcp_opts.timeout = opts.timeout or default_timeout
+  -- Opt into per-phase timeouts so EHLO (and a HELO fallback retry) can't
+  -- eat into the budget later stages (RCPT/DATA/QUIT) need; otherwise a
+  -- single non-renewed budget is deducted across the whole transaction.
+  tcp_opts.connect_timeout = opts.connect_timeout or tcp_opts.timeout
+  tcp_opts.read_timeout = opts.read_timeout or tcp_opts.timeout
+  tcp_opts.write_timeout = opts.write_timeout or tcp_opts.timeout
   tcp_opts.callback = mail_cb
 
   if not rspamd_tcp.request(tcp_opts) then

--- a/lualib/lua_util.lua
+++ b/lualib/lua_util.lua
@@ -1505,22 +1505,26 @@ exports.maybe_decrypt_header = function(encrypted_header, settings, prefix, nonc
 end
 
 ---[[[
--- @function lua_util.callback_from_string(str)
+-- @function lua_util.callback_from_string(str[, chunkname[, return_chunk]])
 -- Converts a string like `return function(...) end` to lua function and return true and this function
 -- or returns false + error message
+-- @param {string} chunkname optional name used to identify the chunk in syntax error messages
+-- @param {boolean} return_chunk evaluate the string as a chunk that must return a function
 -- @return status code and function object or an error message
 --]]]
-exports.callback_from_string = function(s)
+exports.callback_from_string = function(s, chunkname, return_chunk)
   local loadstring = loadstring or load
 
-  if not s or #s == 0 then
+  if type(s) ~= 'string' or #s == 0 then
     return false, 'invalid or empty string'
   end
 
   s = exports.rspamd_str_trim(s)
   local inp
 
-  if s:match('^return%s*function') then
+  if return_chunk then
+    inp = s
+  elseif s:match('^return%s*function') then
     -- 'return function', can be evaluated directly
     inp = s
   elseif s:match('^function%s*%(') then
@@ -1530,18 +1534,26 @@ exports.callback_from_string = function(s)
     inp = 'return function(...)\n' .. s .. '; end'
   end
 
-  local chunk, err = loadstring(inp)
+  -- '=' prefix makes Lua print chunkname verbatim instead of '[string "..."]'
+  local chunk, err = loadstring(inp, chunkname and ('=' .. chunkname) or nil)
   if not chunk then
     return false, err
   end
 
   local ret, res_or_err = pcall(chunk)
 
-  if not ret or type(res_or_err) ~= 'function' then
-    return false, res_or_err
+  if not ret then
+    -- Runtime error while evaluating the chunk, res_or_err carries its message
+    return false, tostring(res_or_err)
   end
 
-  return ret, res_or_err
+  if type(res_or_err) ~= 'function' then
+    -- The chunk itself is valid Lua but yields no callback; report that as an
+    -- error message rather than handing the bare value back as if it was one
+    return false, string.format('chunk did not return a function, got %s', type(res_or_err))
+  end
+
+  return true, res_or_err
 end
 
 ---[[[

--- a/lualib/plugins/metadata_exporter.lua
+++ b/lualib/plugins/metadata_exporter.lua
@@ -1,0 +1,176 @@
+--[[
+Copyright (c) 2026, Vsevolod Stakhov <vsevolod@rspamd.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]] --
+
+local T = require "lua_shape.core"
+local PluginSchema = require "lua_shape.plugin_schema"
+
+-- Schema for metadata_exporter rules (validated per-rule in src/plugins/lua/metadata_exporter.lua)
+
+local encodings = { 'auto', 'base64', 'quoted-printable', '7bit', '8bit' }
+
+-- Accepts a single string or an array of strings; callers normalize to an
+-- array themselves (see resolve part content in metadata_exporter.lua) since
+-- lua_shape does not apply nested transforms when a schema is reused as the
+-- inner type of another transform (the email_parts lone-object case below)
+local content_source_schema = T.one_of({
+  T.array(T.string(), { min_items = 1 }),
+  T.string(),
+}):optional()
+
+local part_schema = T.table({
+  content = content_source_schema
+      :doc({ summary = "Literal/template body content, expanded like the email template" }),
+  content_from_variables = content_source_schema
+      :doc({ summary = "Name(s) of registered variables whose raw value becomes the part body" }),
+  content_type = T.string():optional()
+      :doc({ summary = "MIME content type of the part" }),
+  filename = T.string():optional()
+      :doc({ summary = "Attachment filename" }),
+  disposition = T.string():optional()
+      :doc({ summary = "Content-Disposition of the part (inline/attachment)" }),
+  encoding = T.enum(encodings):optional()
+      :doc({ summary = "Content-Transfer-Encoding to use for this part" }),
+}):doc({ summary = "email_alert MIME part definition" })
+
+-- A lone `email_parts { ... }` block arrives from UCL as a single object, not
+-- an array of one; normalize it here so callers always see an array.
+-- An empty table is array-like, so it would otherwise fall through to the
+-- lone-object variant (every part field is optional) and be normalized into an
+-- array holding one empty part; reject it here instead
+local email_parts_schema = T.one_of({
+  T.array(part_schema, { min_items = 1 }),
+  T.transform(part_schema, function(part)
+    if next(part) == nil then
+      return nil
+    end
+    return { part }
+  end),
+}):optional()
+
+local rule_schema = T.table({
+  backend = T.string()
+            :doc({ summary = "Push backend: http, send_mail, redis_pubsub, redis_stream, " ..
+                "json_raw_tcp, or a custom_push name" }),
+  selector = T.string():optional()
+      :doc({ summary = "Selector name deciding which messages are exported" }),
+  formatter = T.string():optional()
+      :doc({ summary = "Formatter name producing the payload" }),
+  defer = T.boolean():optional()
+      :doc({ summary = "Soft-reject the message if the push fails" }),
+  timeout = T.number():optional()
+      :doc({ summary = "Network timeout for this rule" }),
+  connect_timeout = T.number():optional()
+      :doc({ summary = "Connect timeout override" }),
+  read_timeout = T.number():optional()
+      :doc({ summary = "Read timeout override" }),
+  write_timeout = T.number():optional()
+      :doc({ summary = "Write timeout override" }),
+  ssl_timeout = T.number():optional()
+      :doc({ summary = "TLS handshake timeout override" }),
+
+  -- http backend
+  url = T.string():optional()
+      :doc({ summary = "URL to push data to (http backend)" }),
+  user = T.string():optional()
+      :doc({ summary = "HTTP basic auth user (http backend)" }),
+  password = T.string():optional()
+      :doc({ summary = "HTTP basic auth password (http backend)" }),
+  mime_type = T.string():optional()
+      :doc({ summary = "Content-Type sent with the HTTP push (http backend)" }),
+  gzip = T.boolean():optional()
+      :doc({ summary = "Gzip-compress the HTTP body (http backend)" }),
+  keepalive = T.boolean():optional()
+      :doc({ summary = "Reuse HTTP connections (http backend)" }),
+  no_ssl_verify = T.boolean():optional()
+      :doc({ summary = "Disable TLS certificate verification (http backend)" }),
+  meta_headers = T.boolean():optional()
+      :doc({ summary = "Deprecated: use formatter = multipart/json instead" }),
+  meta_header_prefix = T.string():optional()
+      :doc({ summary = "Header prefix used by the deprecated meta_headers option" }),
+
+  -- send_mail backend
+  smtp = T.string():optional()
+      :doc({ summary = "SMTP server address (send_mail backend)" }),
+  smtp_port = T.number():optional()
+      :doc({ summary = "SMTP server port (send_mail backend)" }),
+  helo = T.string():optional()
+      :doc({ summary = "HELO/EHLO string (send_mail backend)" }),
+  mail_from = T.string():optional()
+      :doc({ summary = "Envelope sender (send_mail backend)" }),
+  mail_to = T.one_of({ T.string(), T.array(T.string()) }):optional()
+      :doc({ summary = "Envelope recipient(s) (send_mail backend)" }),
+  email_template = T.string():optional()
+      :doc({ summary = "Message template (send_mail backend)" }),
+  email_alert_sender = T.boolean():optional()
+      :doc({ summary = "Add the message's SMTP sender as a recipient" }),
+  email_alert_sender_variable = T.string():optional()
+      :doc({ summary = "Variable providing an extra recipient address" }),
+  email_alert_user = T.boolean():optional()
+      :doc({ summary = "Add the authenticated user as a recipient" }),
+  email_alert_recipients = T.boolean():optional()
+      :doc({ summary = "Add the message's SMTP recipients as recipients" }),
+  email_auto_encode_headers = T.boolean():optional()
+      :doc({ summary = "RFC 2047-encode non-ASCII header values" }),
+  email_parts_type = T.string({ pattern = "^[%w!#$%%&'*+%-.%^_`|~]+$" }):optional()
+      :doc({ summary = "multipart/<type> subtype for email_parts" }),
+  email_parts = email_parts_schema
+      :doc({ summary = "Extra MIME parts; use one array (email_parts = [ {...}, {...} ]), not repeated blocks" }),
+
+  -- redis_pubsub backend
+  channel = T.string():optional()
+      :doc({ summary = "Redis channel to publish to (redis_pubsub backend)" }),
+
+  -- redis_stream backend
+  stream_key = T.string():optional()
+      :doc({ summary = "Redis stream key (redis_stream backend)" }),
+  per_recipient = T.boolean():optional()
+      :doc({ summary = "Use one stream per recipient (redis_stream/redis_list backend)" }),
+  max_len = T.number():optional()
+      :doc({ summary = "XADD MAXLEN value / RPUSH LTRIM cap (redis_stream/redis_list backend)" }),
+  zstd_compress = T.boolean():optional()
+      :doc({ summary = "Compress the payload with zstd (redis_stream backend)" }),
+
+  -- redis_list backend
+  list_key = T.string():optional()
+      :doc({ summary = "Redis list key (redis_list backend)" }),
+
+  -- json_raw_tcp backend
+  host = T.string():optional()
+      :doc({ summary = "TCP host to push to (json_raw_tcp backend)" }),
+  port = T.number():optional()
+      :doc({ summary = "TCP port to push to (json_raw_tcp backend)" }),
+}, { open = false }):doc({ summary = "metadata_exporter rule configuration" })
+
+-- Required fields per backend, checked against a rule AFTER it has been
+-- merged with plugin-wide defaults (a rule may rely on a global mail_to/smtp)
+local backend_required_elements = {
+  http = { 'url' },
+  send_mail = { 'mail_to', 'smtp' },
+  redis_pubsub = { 'channel' },
+  json_raw_tcp = { 'host', 'port' },
+  redis_stream = { 'stream_key' },
+  redis_list = { 'list_key' },
+}
+
+PluginSchema.register("plugins.metadata_exporter.rule", rule_schema)
+PluginSchema.register("plugins.metadata_exporter.part", part_schema)
+
+return {
+  rule_schema = rule_schema,
+  part_schema = part_schema,
+  backend_required_elements = backend_required_elements,
+  encodings = encodings,
+}

--- a/lualib/plugins/metadata_exporter.lua
+++ b/lualib/plugins/metadata_exporter.lua
@@ -128,6 +128,8 @@ local rule_schema = T.table({
       :doc({ summary = "multipart/<type> subtype for email_parts" }),
   email_parts = email_parts_schema
       :doc({ summary = "Extra MIME parts; use one array (email_parts = [ {...}, {...} ]), not repeated blocks" }),
+  auto_grouping = T.boolean():optional()
+      :doc({ summary = "Wrap a text/plain + text/html email_parts pair in multipart/alternative (default true)" }),
 
   -- redis_pubsub backend
   channel = T.string():optional()
@@ -165,6 +167,82 @@ local backend_required_elements = {
   redis_list = { 'list_key' },
 }
 
+-- Classifies a part for multipart/alternative auto-grouping: an inline
+-- text/plain or text/html part (no filename, not an explicit attachment) is
+-- a grouping candidate, everything else stays a sibling part
+local function classify_text_kind(content_type, filename, disposition)
+  if filename then
+    return 'other'
+  end
+  if string.lower(disposition or 'inline') ~= 'inline' then
+    return 'other'
+  end
+  -- %f[%W] is a frontier guard so the subtype must end here (at ';', at
+  -- whitespace or at end of string) rather than matching e.g. text/plaintext
+  local ctype = string.lower(content_type or '')
+  if string.find(ctype, '^text/plain%f[%W]') then
+    return 'plain'
+  elseif string.find(ctype, '^text/html%f[%W]') then
+    return 'html'
+  end
+  return 'other'
+end
+
+-- Decides the MIME layout for a set of classified parts. `descriptors` is an
+-- ordered array of { kind = 'plain'|'html'|'other', part = <opaque> } (`part`
+-- may be omitted by callers that only need the ambiguity check). Returns
+-- subtype, tree on success - tree entries are { part = <opaque> } or
+-- { alternative = { leaf, leaf } } - or nil, err if the grouping is ambiguous
+-- (more than one plain or html candidate, which multipart/alternative cannot
+-- represent without silently discarding one of them).
+local function plan_layout(descriptors, opts)
+  opts = opts or {}
+  local fallback_subtype = opts.email_parts_type or 'mixed'
+
+  local function flat()
+    local tree = {}
+    for _, d in ipairs(descriptors) do
+      tree[#tree + 1] = { part = d.part }
+    end
+    return fallback_subtype, tree
+  end
+
+  if opts.auto_grouping == false then
+    return flat()
+  end
+
+  local plain, html, other = {}, {}, {}
+  for _, d in ipairs(descriptors) do
+    if d.kind == 'plain' then
+      plain[#plain + 1] = d
+    elseif d.kind == 'html' then
+      html[#html + 1] = d
+    else
+      other[#other + 1] = d
+    end
+  end
+
+  if #plain == 0 or #html == 0 then
+    return flat()
+  end
+  if #plain > 1 or #html > 1 then
+    return nil, 'has multiple text/plain or text/html email_parts, which is ambiguous inside ' ..
+        'multipart/alternative - merge them into one part using an array content/content_from_variables ' ..
+        'value, or set auto_grouping = false'
+  end
+
+  local alternative = { { part = plain[1].part }, { part = html[1].part } }
+  if #other == 0 and not opts.email_parts_type then
+    return 'alternative', alternative
+  end
+
+  local tree = { { alternative = alternative } }
+  for _, d in ipairs(other) do
+    tree[#tree + 1] = { part = d.part }
+  end
+  return fallback_subtype, tree
+end
+
 PluginSchema.register("plugins.metadata_exporter.rule", rule_schema)
 PluginSchema.register("plugins.metadata_exporter.part", part_schema)
 
@@ -173,4 +251,6 @@ return {
   part_schema = part_schema,
   backend_required_elements = backend_required_elements,
   encodings = encodings,
+  classify_text_kind = classify_text_kind,
+  plan_layout = plan_layout,
 }

--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -30,10 +30,18 @@ local lua_redis = require "lua_redis"
 local lua_mime = require "lua_mime"
 local lua_selectors = require "lua_selectors"
 local ucl = require "ucl"
+local T = require "lua_shape.core"
+local schema = require "plugins/metadata_exporter"
 local E = {}
 local N = 'metadata_exporter'
 local HOSTNAME = rspamd_util.get_hostname()
 local selector_cache = {}
+
+-- Inlined values reach mail headers, URLs and Redis keys, so they must never
+-- break framing: collapse every CR/LF run to a single space
+local function sanitize_inline(str)
+  return (string.gsub(str, '[\r\n]+', ' '))
+end
 
 local settings = {
   pusher_enabled = {},
@@ -113,8 +121,7 @@ local function expand_selectors(task, str, meta)
     else
       str_val = tostring(extracted)
     end
-    -- Expanded values reach mail headers, URLs and Redis keys, so they must never break framing
-    return (string.gsub(str_val, '[\r\n]+', ' '))
+    return sanitize_inline(str_val)
   end
 
   str = string.gsub(str, '%$([%w_]+)', function(name)
@@ -606,13 +613,22 @@ local function stringify_part_value(value)
   return table.concat(out, '\n')
 end
 
+-- content/content_from_variables accept a single string or an array; the
+-- schema does not normalize this (see lualib/plugins/metadata_exporter.lua)
+local function part_content_names(value)
+  if type(value) == 'table' then
+    return value
+  end
+  return { value }
+end
+
 -- Builds the multipart/<rule.email_parts_type> body for email_alert: an
 -- optional leading part from the template's own body (skipped only when
 -- that body is truly empty - a whitespace-only body still becomes a part),
 -- followed by one part per rule.email_parts entry. Returns nil on any
 -- unresolvable part so the caller aborts the whole message rather than
 -- sending a report with a silently missing/garbled part.
-local function assemble_email_parts(task, rule, template_body, template_part_headers, boundary)
+local function assemble_email_parts(task, rule, template_body, template_part_headers, boundary, meta)
   local parts = {}
 
   if #template_body > 0 then
@@ -632,21 +648,40 @@ local function assemble_email_parts(task, rule, template_body, template_part_hea
   end
 
   for i, entry in ipairs(rule.email_parts) do
-    if not entry.variable or not variables[entry.variable] then
-      rspamd_logger.errx(task, 'email_parts[%s] references unknown variable [%s]', i, entry.variable)
-      return nil
-    end
-    local value = stringify_part_value(variables[entry.variable](task))
-    if value == nil then
-      rspamd_logger.errx(task, 'email_parts[%s] variable [%s] returned nil or unconvertible content',
-        i, entry.variable)
-      return nil
+    local value
+    if entry.content_from_variables ~= nil then
+      local resolved = {}
+      for _, name in ipairs(part_content_names(entry.content_from_variables)) do
+        if not variables[name] then
+          rspamd_logger.errx(task, 'email_parts[%s] references unknown variable [%s]', i, name)
+          return nil
+        end
+        local v = stringify_part_value(variables[name](task))
+        if v == nil then
+          rspamd_logger.errx(task, 'email_parts[%s] variable [%s] returned nil or unconvertible content',
+            i, name)
+          return nil
+        end
+        table.insert(resolved, v)
+      end
+      value = table.concat(resolved, '\n')
+    else
+      -- Literal/template content is expanded like the email template itself
+      local text = table.concat(part_content_names(entry.content), '\n')
+      text = expand_selectors(task, text, meta)
+      value = lua_util.template(text, meta)
     end
 
-    local filename = entry.filename and stringify_part_value(expand_selectors(task, entry.filename)) or nil
+    local filename
+    if entry.filename then
+      local expanded_filename = expand_selectors(task, entry.filename, meta)
+      filename = stringify_part_value(lua_util.template(expanded_filename, meta))
+    end
     if filename == '' then
       filename = nil
     end
+    -- Config-time validation always fills content_type in; the fallback only
+    -- guards against a part that somehow reached here unvalidated
     local content_type = entry.content_type or 'application/octet-stream'
     local disposition = entry.disposition or (filename and 'attachment' or 'inline')
     local cte = entry.encoding
@@ -804,7 +839,15 @@ local function get_general_metadata(task, flatten, no_content)
       if not flatten then
         return l
       else
-        return table.concat(l, '\n')
+        -- Fold duplicates the way format_symlist does: joining them with a bare
+        -- '\n' lets an empty duplicate insert a blank line, which moves the
+        -- header/body boundary that split_headers_body finds in the rendered
+        -- email_template
+        local folded = {}
+        for i, v in ipairs(l) do
+          folded[i] = sanitize_inline(v)
+        end
+        return table.concat(folded, '\n\t')
       end
     else
       return 'unknown'
@@ -895,7 +938,7 @@ local formatters = {
       local boundary = rspamd_util.random_hex(16)
       local multipart_headers, template_part_headers = build_multipart_header_block(
         header_block, rule.email_parts_type or 'mixed', boundary)
-      local mp_body = assemble_email_parts(task, rule, body, template_part_headers, boundary)
+      local mp_body = assemble_email_parts(task, rule, body, template_part_headers, boundary, meta)
       if not mp_body then
         return nil
       end
@@ -1347,41 +1390,81 @@ local opts = rspamd_config:get_all_opt(N)
 if not opts then
   return
 end
+
+-- Compiles a custom Lua snippet at config time, naming the chunk so a syntax
+-- error or a non-function result is caught and reported here instead of
+-- surfacing as a runtime crash on the first scanned message
+local function compile_custom(kind, name, code)
+  local chunkname = string.format('metadata_exporter %s[%s]', kind, name)
+  local ok, fn_or_err = lua_util.callback_from_string(code, chunkname, true)
+  if not ok then
+    local msg = string.format('%s: invalid Lua code: %s', chunkname, tostring(fn_or_err))
+    rspamd_logger.errx(rspamd_config, '%s', msg)
+    lua_util.config_utils.push_config_error(N, msg)
+    return nil
+  end
+  return fn_or_err
+end
+
 local process_settings = {
   select = function(val)
-    selectors.custom = assert(load(val))()
+    local fn = compile_custom('select', 'custom', val)
+    if fn then
+      selectors.custom = fn
+    end
   end,
   format = function(val)
-    formatters.custom = assert(load(val))()
+    local fn = compile_custom('format', 'custom', val)
+    if fn then
+      formatters.custom = fn
+    end
   end,
   push = function(val)
-    pushers.custom = assert(load(val))()
+    local fn = compile_custom('push', 'custom', val)
+    if fn then
+      pushers.custom = fn
+    end
   end,
   custom_push = function(val)
     if type(val) == 'table' then
       for k, v in pairs(val) do
-        pushers[k] = assert(load(v))()
+        local fn = compile_custom('custom_push', k, v)
+        if fn then
+          pushers[k] = fn
+        end
       end
     end
   end,
   custom_variables = function(val)
     if type(val) == 'table' then
       for k, v in pairs(val) do
-        variables[k] = assert(load(v))()
+        if variables[k] then
+          rspamd_logger.warnx(rspamd_config, 'custom_variables[%s] shadows a builtin variable', k)
+        end
+        local fn = compile_custom('custom_variables', k, v)
+        if fn then
+          variables[k] = fn
+        end
       end
     end
   end,
   custom_select = function(val)
     if type(val) == 'table' then
       for k, v in pairs(val) do
-        selectors[k] = assert(load(v))()
+        local fn = compile_custom('custom_select', k, v)
+        if fn then
+          selectors[k] = fn
+        end
       end
     end
   end,
   custom_format = function(val)
     if type(val) == 'table' then
       for k, v in pairs(val) do
-        formatters[k] = assert(load(v))()
+        local fn = compile_custom('custom_format', k, v)
+        if fn then
+          formatters[k] = fn
+        end
       end
     end
   end,
@@ -1553,204 +1636,133 @@ if not settings.rules or not next(settings.rules) then
   rspamd_logger.errx(rspamd_config, 'No rules enabled')
   return
 end
-local backend_required_elements = {
-  http = {
-    'url',
-  },
-  smtp = {
-    'mail_to',
-    'smtp',
-  },
-  redis_pubsub = {
-    'channel',
-  },
-  json_raw_tcp = {
-    'host',
-    'port',
-  },
-  redis_stream = {
-    'stream_key',
-  },
-  redis_list = {
-    'list_key',
-  },
-}
-local check_element = {
-  selector = function(k, v)
-    if not selectors[v] then
-      rspamd_logger.errx(rspamd_config, 'Rule %s has invalid selector %s', k, v)
-      return false
-    else
-      return true
-    end
-  end,
-  formatter = function(k, v)
-    if not formatters[v] then
-      rspamd_logger.errx(rspamd_config, 'Rule %s has invalid formatter %s', k, v)
-      return false
-    else
-      return true
-    end
-  end,
-  meta_headers = function(k, v)
-    if v then
-      rspamd_logger.warnx(rspamd_config,
-        'Rule %s uses deprecated meta_headers option; use format = "multipart" or format = "json" instead', k)
-    end
-    return true
-  end,
-  email_parts_type = function(k, v)
-    if type(v) ~= 'string' or not string.match(v, "^[%w!#$%%&'*+%-.%^_`|~]+$") then
-      rspamd_logger.errx(rspamd_config, 'Rule %s has invalid email_parts_type', k)
-      return false
-    end
-    return true
-  end,
-  email_parts = function(k, v)
-    if type(v) ~= 'table' then
-      rspamd_logger.errx(rspamd_config, 'Rule %s has invalid email_parts (must be an array)', k)
-      return false
-    end
-    if #v == 0 then
-      rspamd_logger.errx(rspamd_config, 'Rule %s has empty email_parts', k)
-      return false
-    end
-    for i, part in ipairs(v) do
-      if type(part) ~= 'table' then
-        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] must be a table', k, i)
-        return false
-      end
-      if not part.variable then
-        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] misses variable', k, i)
-        return false
-      end
-      if not variables[part.variable] then
-        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] references unknown variable %s', k, i, part.variable)
-        return false
-      end
-      if not part.content_type then
-        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] misses content_type', k, i)
-        return false
-      end
-      for _, field in ipairs({ 'content_type', 'filename', 'disposition' }) do
-        if part[field] ~= nil and type(part[field]) ~= 'string' then
-          rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] has non-string %s', k, i, field)
-          return false
-        end
-      end
-      local parsed_content_type
-      if not string.find(part.content_type, '[\r\n]') then
-        parsed_content_type = rspamd_util.parse_content_type(
-          part.content_type, rspamd_config:get_mempool())
-      end
-      if not parsed_content_type or not parsed_content_type.type or not parsed_content_type.subtype then
-        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] has invalid content_type', k, i)
-        return false
-      end
-      if part.disposition and (string.find(part.disposition, '[\r\n]') or
-          not string.match(part.disposition, "^[%w!#$%%&'*+%-.%^_`|~]+$")) then
-        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] has invalid disposition', k, i)
-        return false
-      end
-      if part.encoding and not ({
-        auto = true,
-        base64 = true,
-        ['quoted-printable'] = true,
-        ['7bit'] = true,
-        ['8bit'] = true,
-      })[part.encoding] then
-        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] has invalid encoding %s',
-          k, i, part.encoding)
-        return false
-      end
-    end
-    return true
-  end,
-}
-local backend_check = {
-  default = function(k, rule)
-    local reqset = backend_required_elements[rule.backend]
-    if reqset then
-      for _, e in ipairs(reqset) do
-        if not rule[e] then
-          rspamd_logger.errx(rspamd_config, 'Rule %s misses required setting %s', k, e)
-          settings.rules[k] = nil
-        end
-      end
-    end
-    for sett, v in pairs(rule) do
-      local f = check_element[sett]
-      if f then
-        if not f(sett, v) then
-          settings.rules[k] = nil
-        end
-      end
-    end
-  end,
-}
-backend_check.redis_pubsub = function(k, rule)
-  if not redis_params then
-    redis_params = rspamd_parse_redis_server(N)
+
+-- Validates one email_parts entry; mutates it in place to fill in the
+-- content_type default so runtime code never has to guess it again
+local function validate_email_part(k, i, part)
+  local has_content = part.content ~= nil
+  local has_vars = part.content_from_variables ~= nil
+  if has_content and has_vars then
+    rspamd_logger.errx(rspamd_config,
+      'rule %s: email_parts[%s] has both content and content_from_variables, use exactly one', k, i)
+    return false
   end
-  if not redis_params then
-    rspamd_logger.errx(rspamd_config, 'No redis servers are specified')
-    settings.rules[k] = nil
-  else
-    backend_check.default(k, rule)
-    rule.timeout = redis_params.timeout
+  if not has_content and not has_vars then
+    rspamd_logger.errx(rspamd_config,
+      'rule %s: email_parts[%s] misses content or content_from_variables', k, i)
+    return false
   end
+  if has_vars then
+    for _, name in ipairs(part_content_names(part.content_from_variables)) do
+      if not variables[name] then
+        rspamd_logger.errx(rspamd_config,
+          'rule %s: email_parts[%s] references unknown variable %s', k, i, name)
+        return false
+      end
+    end
+  end
+  -- content_from_variables may carry a binary blob; content is always literal/template text
+  part.content_type = part.content_type or (has_content and 'text/plain; charset=utf-8' or 'application/octet-stream')
+  local parsed_content_type
+  if not string.find(part.content_type, '[\r\n]') then
+    parsed_content_type = rspamd_util.parse_content_type(part.content_type, rspamd_config:get_mempool())
+  end
+  if not parsed_content_type or not parsed_content_type.type or not parsed_content_type.subtype then
+    rspamd_logger.errx(rspamd_config, 'rule %s: email_parts[%s] has invalid content_type', k, i)
+    return false
+  end
+  if part.disposition and (string.find(part.disposition, '[\r\n]') or
+      not string.match(part.disposition, "^[%w!#$%%&'*+%-.%^_`|~]+$")) then
+    rspamd_logger.errx(rspamd_config, 'rule %s: email_parts[%s] has invalid disposition', k, i)
+    return false
+  end
+  return true
 end
-backend_check.redis_stream = function(k, rule)
-  if not redis_params then
-    redis_params = rspamd_parse_redis_server(N)
+
+-- Dynamic checks that the schema cannot express: selector/formatter/backend
+-- names are extensible at runtime via custom_select/custom_format/custom_push,
+-- and per-backend required settings may be satisfied by a plugin-wide default
+local function validate_rule(k, rule)
+  for _, e in ipairs(schema.backend_required_elements[rule.backend] or E) do
+    if rule[e] == nil and settings[e] == nil then
+      rspamd_logger.errx(rspamd_config,
+        'rule %s: misses required setting %s for backend %s', k, e, rule.backend)
+      return false
+    end
   end
-  if not redis_params then
-    rspamd_logger.errx(rspamd_config, 'No redis servers are specified')
-    settings.rules[k] = nil
-  else
-    backend_check.default(k, rule)
-    rule.timeout = redis_params.timeout
+  if not selectors[rule.selector or 'default'] then
+    rspamd_logger.errx(rspamd_config, 'rule %s: has invalid selector %s', k, rule.selector)
+    return false
   end
+  if not formatters[rule.formatter or 'default'] then
+    rspamd_logger.errx(rspamd_config, 'rule %s: has invalid formatter %s', k, rule.formatter)
+    return false
+  end
+  if rule.meta_headers then
+    rspamd_logger.warnx(rspamd_config,
+      'rule %s: uses deprecated meta_headers option; use formatter = "multipart" or "json" instead', k)
+  end
+  if rule.email_parts then
+    for i, part in ipairs(rule.email_parts) do
+      if not validate_email_part(k, i, part) then
+        return false
+      end
+    end
+  end
+  return true
 end
-backend_check.redis_list = function(k, rule)
-  if not redis_params then
-    redis_params = rspamd_parse_redis_server(N)
-  end
-  if not redis_params then
-    rspamd_logger.errx(rspamd_config, 'No redis servers are specified')
-    settings.rules[k] = nil
-  else
-    backend_check.default(k, rule)
-    rule.timeout = redis_params.timeout
-  end
-end
-setmetatable(backend_check, {
-  __index = function()
-    return backend_check.default
-  end,
-})
+
 for k, v in pairs(settings.rules) do
-  if type(v) == 'table' then
-    -- UCL writes a lone object without brackets, which would otherwise pass
-    -- the ipairs-based validation vacuously and then be skipped at runtime
-    if type(v.email_parts) == 'table' and #v.email_parts == 0 and v.email_parts.variable then
-      v.email_parts = { v.email_parts }
-    end
+  if type(v) ~= 'table' then
+    rspamd_logger.errx(rspamd_config, 'rule %s: has bad type: %s', k, type(v))
+    lua_util.config_utils.push_config_error(N, string.format('rule %s: has bad type: %s', k, type(v)))
+    settings.rules[k] = nil
+  else
     local backend = v.backend
     if not backend then
-      rspamd_logger.errx(rspamd_config, 'Rule %s has no backend', k)
+      rspamd_logger.errx(rspamd_config, 'rule %s: has no backend', k)
+      lua_util.config_utils.push_config_error(N, string.format('rule %s: has no backend', k))
       settings.rules[k] = nil
     elseif not pushers[backend] then
-      rspamd_logger.errx(rspamd_config, 'Rule %s has invalid backend %s', k, backend)
+      rspamd_logger.errx(rspamd_config, 'rule %s: has invalid backend %s', k, backend)
+      lua_util.config_utils.push_config_error(N, string.format('rule %s: has invalid backend %s', k, backend))
       settings.rules[k] = nil
     else
-      local f = backend_check[backend]
-      f(k, v)
+      local res, err = schema.rule_schema:transform(v)
+      if not res then
+        local msg = string.format('rule %s: invalid configuration -> rule DISABLED: %s', k, T.format_error(err))
+        rspamd_logger.errx(rspamd_config, '%s', msg)
+        lua_util.config_utils.push_config_error(N, msg)
+        settings.rules[k] = nil
+      else
+        settings.rules[k] = res
+        if (backend == 'redis_pubsub' or backend == 'redis_stream' or backend == 'redis_list') then
+          if not redis_params then
+            redis_params = rspamd_parse_redis_server(N)
+          end
+          if not redis_params then
+            rspamd_logger.errx(rspamd_config, 'rule %s: no redis servers are specified', k)
+            lua_util.config_utils.push_config_error(N, string.format('rule %s: no redis servers are specified', k))
+            settings.rules[k] = nil
+          else
+            res.timeout = redis_params.timeout
+          end
+        end
+        if settings.rules[k] and not validate_rule(k, res) then
+          lua_util.config_utils.push_config_error(N,
+            string.format('rule %s: invalid configuration -> rule DISABLED', k))
+          settings.rules[k] = nil
+        end
+      end
     end
-  else
-    rspamd_logger.errx(rspamd_config, 'Rule %s has bad type: %s', k, type(v))
-    settings.rules[k] = nil
   end
+end
+
+if not next(settings.rules) then
+  rspamd_logger.errx(rspamd_config, 'No rules enabled')
+  lua_util.config_utils.push_config_error(N, 'no valid rules remain after validation')
+  lua_util.disable_module(N, 'config')
+  return
 end
 
 -- Compile selectors used by rules at config time to validate them and to keep them off the hot path
@@ -1799,10 +1811,6 @@ local function gen_exporter(rule)
   end
 end
 
-if not next(settings.rules) then
-  rspamd_logger.errx(rspamd_config, 'No rules enabled')
-  lua_util.disable_module(N, "config")
-end
 for k, r in pairs(settings.rules) do
   local registration_timeout = tonumber(r.timeout) or tonumber(settings.timeout) or 0.0
   rspamd_config:register_symbol({

--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -1195,6 +1195,9 @@ local pushers = {
       recipients = recipients,
       helo = rule.helo,
       timeout = rule.timeout,
+      connect_timeout = rule.connect_timeout,
+      read_timeout = rule.read_timeout,
+      write_timeout = rule.write_timeout,
     }, formatted, sendmail_cb)
   end,
   json_raw_tcp = function(task, formatted, rule)

--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -70,6 +70,7 @@ Symbols: $symbols]],
   gzip = false,
   keepalive = false,
   no_ssl_verify = false,
+  email_auto_encode_headers = true,
 }
 
 local variables = {
@@ -185,6 +186,7 @@ local settings_fallback_fields = {
   'channel',
   'connect_timeout',
   'defer',
+  'email_auto_encode_headers',
   'gzip',
   'helo',
   'host',
@@ -286,6 +288,125 @@ local function normalize_mail_from(task, value)
   end
   rspamd_logger.errx(task, 'mail_from is not a valid single email address: %s', value)
   return nil
+end
+
+local address_headers = {
+  from = true,
+  to = true,
+  cc = true,
+  bcc = true,
+  sender = true,
+  ['reply-to'] = true,
+  ['resent-from'] = true,
+  ['resent-to'] = true,
+  ['resent-cc'] = true,
+  ['resent-bcc'] = true,
+  ['resent-sender'] = true,
+}
+
+local structured_headers = {
+  ['authentication-results'] = true,
+  ['arc-authentication-results'] = true,
+  ['arc-message-signature'] = true,
+  ['arc-seal'] = true,
+  ['content-disposition'] = true,
+  ['content-transfer-encoding'] = true,
+  ['content-type'] = true,
+  date = true,
+  ['dkim-signature'] = true,
+  ['in-reply-to'] = true,
+  ['list-archive'] = true,
+  ['list-help'] = true,
+  ['list-id'] = true,
+  ['list-owner'] = true,
+  ['list-post'] = true,
+  ['list-subscribe'] = true,
+  ['list-unsubscribe'] = true,
+  ['message-id'] = true,
+  ['mime-version'] = true,
+  received = true,
+  references = true,
+  ['resent-date'] = true,
+  ['resent-message-id'] = true,
+  ['return-path'] = true,
+}
+
+local function is_ascii(str)
+  return not string.find(str, '[\128-\255]')
+end
+
+local function encode_address_header(task, value)
+  if string.find(value, '[():]') then
+    return value
+  end
+
+  local parsed = rspamd_util.parse_mail_address(value, task:get_mempool())
+  if not parsed or #parsed == 0 then
+    return value
+  end
+
+  local changed = false
+  local out = {}
+  for _, a in ipairs(parsed) do
+    if a.name and a.name ~= '' and not is_ascii(a.name) then
+      changed = true
+      local encoded_name = rspamd_util.mime_header_encode(a.name, true)
+      if a.addr and a.addr ~= '' then
+        table.insert(out, encoded_name .. ' <' .. a.addr .. '>')
+      else
+        table.insert(out, encoded_name)
+      end
+    else
+      table.insert(out, a.raw)
+    end
+  end
+
+  if not changed then
+    return value
+  end
+
+  return table.concat(out, ', ')
+end
+
+local function encode_email_headers(task, text)
+  local sep_start, sep_end = string.find(text, '\r?\n\r?\n')
+  if not sep_start then
+    return text
+  end
+  local header_block = string.sub(text, 1, sep_start - 1)
+  local separator = string.sub(text, sep_start, sep_end)
+  local body = string.sub(text, sep_end + 1)
+
+  local logical = {}
+  for line in (header_block .. '\n'):gmatch('(.-)\n') do
+    if #logical > 0 and string.match(line, '^[ \t]') then
+      logical[#logical] = logical[#logical] .. '\n' .. line
+    else
+      table.insert(logical, line)
+    end
+  end
+
+  local out = {}
+  for _, entry in ipairs(logical) do
+    local colon = string.find(entry, ':', 1, true)
+    if not colon then
+      table.insert(out, entry)
+    else
+      local name = string.sub(entry, 1, colon - 1)
+      local value = string.gsub(string.sub(entry, colon + 1), '\r?\n[ \t]+', ' ')
+      value = string.match(value, '^[ \t]*(.*)$')
+      local lname = string.lower(name)
+      if address_headers[lname] then
+        table.insert(out, name .. ': ' .. encode_address_header(task, value))
+      elseif structured_headers[lname] then
+        table.insert(out, name .. ': ' .. lua_util.fold_header_with_encoding(task, name, value, { encode = false }))
+      else
+        table.insert(out, name .. ': ' .. lua_util.fold_header_with_encoding(task, name, value, { encode = true }))
+      end
+    end
+  end
+
+  return table.concat(out, '\n') .. separator .. body
 end
 
 local function get_general_metadata(task, flatten, no_content)
@@ -470,7 +591,11 @@ local formatters = {
     meta.our_message_id = rspamd_util.random_hex(12) .. '@rspamd'
     meta.date = rspamd_util.time_to_string(rspamd_util.get_time())
     tmpl = expand_selectors(task, tmpl, meta)
-    return lua_util.template(tmpl, meta), { mail_targets = mail_targets }
+    local rendered = lua_util.template(tmpl, meta)
+    if rule.email_auto_encode_headers then
+      rendered = encode_email_headers(task, rendered)
+    end
+    return rendered, { mail_targets = mail_targets }
   end,
   json = function(task)
     return ucl.to_format(get_general_metadata(task), 'json-compact')

--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -190,6 +190,7 @@ local expandable_rule_fields = {
 }
 
 local settings_fallback_fields = {
+  'auto_grouping',
   'channel',
   'connect_timeout',
   'defer',
@@ -393,6 +394,21 @@ local function logical_header_name(entry)
   return name and string.lower(name) or nil
 end
 
+local function logical_header_value(entry)
+  local colon = string.find(entry, ':', 1, true)
+  return colon and string.match(string.sub(entry, colon + 1), '^%s*(.-)%s*$') or ''
+end
+
+local function has_mime_parameter(value, name)
+  local unfolded = string.lower(string.gsub(value, '\r?\n[ \t]+', ' '))
+  for parameter in string.gmatch(unfolded, ';%s*([^=;%s]+)%s*=') do
+    if parameter == name or string.match(parameter, '^' .. name .. '%*%d*%*?$') then
+      return true
+    end
+  end
+  return false
+end
+
 local function encode_email_headers(task, text)
   local sep_start, sep_end = string.find(text, '\r?\n\r?\n')
   if not sep_start then
@@ -554,6 +570,19 @@ local function build_part_header_lines(content_type, filename, disposition, cte)
   return table.concat(lines, '\n')
 end
 
+-- Joins already-rendered MIME part blocks (header+blank+body each) behind one
+-- boundary, RFC 2046 style: a boundary line before every part, a closing one
+-- (with trailing "--") at the end.
+local function render_multipart(parts, boundary)
+  local body = {}
+  for _, p in ipairs(parts) do
+    table.insert(body, '--' .. boundary)
+    table.insert(body, p)
+  end
+  table.insert(body, '--' .. boundary .. '--')
+  return table.concat(body, '\n')
+end
+
 -- Flattens one custom variable result into part content. Arrays (a
 -- selector-backed list, for instance) are flattened depth-first into one line
 -- per element rather than stringified as a table address; anything that cannot
@@ -622,29 +651,49 @@ local function part_content_names(value)
   return { value }
 end
 
--- Builds the multipart/<rule.email_parts_type> body for email_alert: an
--- optional leading part from the template's own body (skipped only when
--- that body is truly empty - a whitespace-only body still becomes a part),
--- followed by one part per rule.email_parts entry. Returns nil on any
+-- Renders the template's own body into a part block, returning its
+-- classification kind alongside it for the layout planner
+local function build_template_part(task, template_body, template_part_headers)
+  local content_type = 'text/plain; charset=utf-8'
+  if template_part_headers.content_type then
+    for _, entry in ipairs(template_part_headers) do
+      if logical_header_name(entry) == 'content-type' then
+        content_type = logical_header_value(entry)
+      end
+    end
+  end
+
+  local headers = {}
+  for _, entry in ipairs(template_part_headers) do
+    table.insert(headers, entry)
+  end
+  if not template_part_headers.content_type then
+    table.insert(headers, 'Content-Type: ' .. content_type)
+  end
+  if not template_part_headers.cte then
+    local cte = guess_text_cte(template_body)
+    table.insert(headers, 'Content-Transfer-Encoding: ' .. cte)
+    template_body = encode_part_content(task, template_body, cte)
+  end
+  local part = table.concat(headers, '\n') .. '\n\n' .. template_body
+  local has_filename = template_part_headers.filename or has_mime_parameter(content_type, 'name')
+  return schema.classify_text_kind(content_type, has_filename, template_part_headers.disposition), part
+end
+
+-- Builds the multipart body for email_alert: an optional leading part from
+-- the template's own body (skipped only when that body is truly empty - a
+-- whitespace-only body still becomes a part), followed by one part per
+-- rule.email_parts entry. A text/plain + text/html pair is wrapped in a
+-- nested multipart/alternative unless rule.auto_grouping is false (see
+-- lualib/plugins/metadata_exporter.lua plan_layout). Returns nil on any
 -- unresolvable part so the caller aborts the whole message rather than
 -- sending a report with a silently missing/garbled part.
-local function assemble_email_parts(task, rule, template_body, template_part_headers, boundary, meta)
-  local parts = {}
+local function assemble_email_parts(task, rule, template_body, template_part_headers, meta)
+  local descriptors = {}
 
   if #template_body > 0 then
-    local headers = {}
-    for _, entry in ipairs(template_part_headers) do
-      table.insert(headers, entry)
-    end
-    if not template_part_headers.content_type then
-      table.insert(headers, 'Content-Type: text/plain; charset=utf-8')
-    end
-    if not template_part_headers.cte then
-      local cte = guess_text_cte(template_body)
-      table.insert(headers, 'Content-Transfer-Encoding: ' .. cte)
-      template_body = encode_part_content(task, template_body, cte)
-    end
-    table.insert(parts, table.concat(headers, '\n') .. '\n\n' .. template_body)
+    local kind, part = build_template_part(task, template_body, template_part_headers)
+    table.insert(descriptors, { kind = kind, part = part })
   end
 
   for i, entry in ipairs(rule.email_parts) do
@@ -691,28 +740,57 @@ local function assemble_email_parts(task, rule, template_body, template_part_hea
     end
     cte = sanitize_cte(task, string.format('email_parts[%s]', i), cte, value)
 
-    table.insert(parts, build_part_header_lines(content_type, filename, disposition, cte)
-      .. '\n\n' .. encode_part_content(task, value, cte))
+    local part = build_part_header_lines(content_type, filename, disposition, cte)
+      .. '\n\n' .. encode_part_content(task, value, cte)
+    table.insert(descriptors, { kind = schema.classify_text_kind(content_type, filename, disposition), part = part })
   end
 
-  if #parts == 0 then
+  if #descriptors == 0 then
     rspamd_logger.errx(task, 'email_alert with email_parts produced no parts to send')
     return nil
   end
 
-  local body = {}
-  for _, p in ipairs(parts) do
-    table.insert(body, '--' .. boundary)
-    table.insert(body, p)
+  -- plan_layout returns either (subtype, tree) or (nil, error string)
+  local subtype, tree_or_err = schema.plan_layout(descriptors, {
+    auto_grouping = rule.auto_grouping,
+    email_parts_type = rule.email_parts_type,
+  })
+  local tree = tree_or_err
+  if not subtype then
+    -- Only the template's body part can create this at runtime - a rule's own
+    -- email_parts were already rejected by validate_rule if ambiguous
+    rspamd_logger.warnx(task, 'email_alert: %s; using flat multipart/%s instead',
+      tree_or_err, rule.email_parts_type or 'mixed')
+    subtype = rule.email_parts_type or 'mixed'
+    tree = {}
+    for _, d in ipairs(descriptors) do
+      table.insert(tree, { part = d.part })
+    end
   end
-  table.insert(body, '--' .. boundary .. '--')
 
-  return table.concat(body, '\n'), boundary
+  local top_level_parts = {}
+  for _, node in ipairs(tree) do
+    if node.alternative then
+      local inner_boundary = rspamd_util.random_hex(16)
+      local inner_parts = {}
+      for _, leaf in ipairs(node.alternative) do
+        table.insert(inner_parts, leaf.part)
+      end
+      table.insert(top_level_parts,
+        string.format('Content-Type: multipart/alternative; boundary="%s"', inner_boundary)
+        .. '\n\n' .. render_multipart(inner_parts, inner_boundary))
+    else
+      table.insert(top_level_parts, node.part)
+    end
+  end
+
+  local boundary = rspamd_util.random_hex(16)
+  return render_multipart(top_level_parts, boundary), subtype, boundary
 end
 
 -- email_parts owns the top-level MIME framing. The template's content headers
 -- move to its body part so its media type and transfer encoding are preserved.
-local function build_multipart_header_block(header_block, subtype, boundary)
+local function split_template_content_headers(header_block)
   local out = {}
   local template_part_headers = {}
   local has_mime_version = false
@@ -725,6 +803,11 @@ local function build_multipart_header_block(header_block, subtype, boundary)
     elseif name == 'content-transfer-encoding' then
       template_part_headers.cte = true
       table.insert(template_part_headers, entry)
+    elseif name == 'content-disposition' then
+      local value = logical_header_value(entry)
+      template_part_headers.disposition = string.match(value, '^([^;%s]+)')
+      template_part_headers.filename = has_mime_parameter(value, 'filename')
+      table.insert(template_part_headers, entry)
     else
       if name == 'mime-version' then
         has_mime_version = true
@@ -733,12 +816,21 @@ local function build_multipart_header_block(header_block, subtype, boundary)
     end
   end
 
+  return out, template_part_headers, has_mime_version
+end
+
+-- Appends MIME-Version (if not already declared) and the top-level
+-- Content-Type once the final subtype/boundary are known from assemble_email_parts
+local function finalize_multipart_headers(other_headers, has_mime_version, subtype, boundary)
+  local out = {}
+  for _, entry in ipairs(other_headers) do
+    table.insert(out, entry)
+  end
   if not has_mime_version then
     table.insert(out, 'MIME-Version: 1.0')
   end
   table.insert(out, string.format('Content-Type: multipart/%s; boundary="%s"', subtype, boundary))
-
-  return table.concat(out, '\n'), template_part_headers
+  return table.concat(out, '\n')
 end
 
 local function get_general_metadata(task, flatten, no_content)
@@ -935,13 +1027,12 @@ local formatters = {
 
     if rule.email_parts and #rule.email_parts > 0 then
       local header_block, separator, body = split_headers_body(rendered)
-      local boundary = rspamd_util.random_hex(16)
-      local multipart_headers, template_part_headers = build_multipart_header_block(
-        header_block, rule.email_parts_type or 'mixed', boundary)
-      local mp_body = assemble_email_parts(task, rule, body, template_part_headers, boundary, meta)
+      local other_headers, template_part_headers, has_mime_version = split_template_content_headers(header_block)
+      local mp_body, subtype, boundary = assemble_email_parts(task, rule, body, template_part_headers, meta)
       if not mp_body then
         return nil
       end
+      local multipart_headers = finalize_multipart_headers(other_headers, has_mime_version, subtype, boundary)
       rendered = multipart_headers .. separator .. mp_body
     end
 
@@ -1707,6 +1798,23 @@ local function validate_rule(k, rule)
       if not validate_email_part(k, i, part) then
         return false
       end
+    end
+    local descriptors = {}
+    for _, part in ipairs(rule.email_parts) do
+      table.insert(descriptors,
+        { kind = schema.classify_text_kind(part.content_type, part.filename, part.disposition) })
+    end
+    -- Mirror the settings fallback resolve_rule applies at runtime, so a
+    -- plugin-wide auto_grouping is honoured by this check too
+    local auto_grouping = rule.auto_grouping
+    if auto_grouping == nil then
+      auto_grouping = settings.auto_grouping
+    end
+    local subtype, err = schema.plan_layout(descriptors,
+      { auto_grouping = auto_grouping, email_parts_type = rule.email_parts_type })
+    if not subtype then
+      rspamd_logger.errx(rspamd_config, 'rule %s: %s', k, err)
+      return false
     end
   end
   return true

--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -28,10 +28,12 @@ local rspamd_logger = require "rspamd_logger"
 local rspamd_tcp = require "rspamd_tcp"
 local lua_redis = require "lua_redis"
 local lua_mime = require "lua_mime"
+local lua_selectors = require "lua_selectors"
 local ucl = require "ucl"
 local E = {}
 local N = 'metadata_exporter'
 local HOSTNAME = rspamd_util.get_hostname()
+local selector_cache = {}
 
 local settings = {
   pusher_enabled = {},
@@ -69,6 +71,222 @@ Symbols: $symbols]],
   keepalive = false,
   no_ssl_verify = false,
 }
+
+local variables = {
+  content = function(task)
+    local content = task:get_content()
+    return content and content:str() or ''
+  end,
+  uid = function(task)
+    return string.sub(task:get_uid(), 1, 6)
+  end,
+  local_date = function(_)
+    return os.date("%c")
+  end,
+  our_boundary = function(_)
+    return "----=_MIME_BOUNDARY_" .. rspamd_util.random_hex(15)
+  end,
+}
+
+local function get_selector(log_obj, expr)
+  local selector = selector_cache[expr]
+  if selector == nil then
+    selector = lua_selectors.create_selector_closure(rspamd_config, expr, '', true) or false
+    selector_cache[expr] = selector
+    if not selector then
+      rspamd_logger.errx(log_obj, 'could not create selector [%s]', expr)
+    end
+  end
+  return selector or nil
+end
+
+local function expand_selectors(task, str, meta)
+  if not str or not string.find(str, '$', 1, true) then
+    return str
+  end
+
+  local function stringify(extracted)
+    local str_val
+    if type(extracted) == 'table' then
+      str_val = table.concat(extracted, ',')
+    else
+      str_val = tostring(extracted)
+    end
+    -- Expanded values reach mail headers, URLs and Redis keys, so they must never break framing
+    return (string.gsub(str_val, '[\r\n]+', ' '))
+  end
+
+  str = string.gsub(str, '%$([%w_]+)', function(name)
+    if meta and meta[name] ~= nil then
+      return '$' .. name
+    end
+    if variables[name] then
+      local extracted = variables[name](task)
+      if extracted ~= nil then
+        return stringify(extracted)
+      end
+      rspamd_logger.errx(task, 'custom variable [%s] returned no value', name)
+      return '((error extracting value))'
+    end
+    return '$' .. name
+  end)
+
+  local function process_placeholder(whole, expr)
+    if meta and meta[expr] ~= nil then
+      return whole
+    end
+
+    local extracted
+    if variables[expr] then
+      extracted = variables[expr](task)
+    else
+      local selector = get_selector(task, expr)
+      if not selector then
+        return '((could not create selector))'
+      end
+      extracted = selector(task)
+    end
+    if extracted then
+      extracted = stringify(extracted)
+    else
+      rspamd_logger.errx(task, 'could not extract value with selector [%s]', expr)
+      extracted = '((error extracting value))'
+    end
+    return extracted
+  end
+
+  return (string.gsub(str, '(%${(.-)})', process_placeholder))
+end
+
+local function expand_value(task, val)
+  if type(val) == 'string' then
+    return expand_selectors(task, val)
+  elseif type(val) == 'table' then
+    local expanded = {}
+    for k, elt in pairs(val) do
+      expanded[k] = expand_value(task, elt)
+    end
+    return expanded
+  end
+  return val
+end
+
+-- Only per-message routing values may come from selectors or custom variables;
+-- connection, credential and behaviour options stay literal by design
+local expandable_rule_fields = {
+  channel = true,
+  helo = true,
+  mail_from = true,
+  mail_to = true,
+  stream_key = true,
+}
+
+local settings_fallback_fields = {
+  'channel',
+  'connect_timeout',
+  'defer',
+  'gzip',
+  'helo',
+  'host',
+  'keepalive',
+  'mail_from',
+  'mail_to',
+  'max_len',
+  'mime_type',
+  'no_ssl_verify',
+  'port',
+  'read_timeout',
+  'smtp',
+  'smtp_port',
+  'ssl_timeout',
+  'stream_key',
+  'timeout',
+  'url',
+  'write_timeout',
+}
+
+local function resolve_rule(task, rule)
+  local resolved = {}
+  for name, val in pairs(rule) do
+    if expandable_rule_fields[name] then
+      resolved[name] = expand_value(task, val)
+    else
+      resolved[name] = val
+    end
+  end
+  for _, name in ipairs(settings_fallback_fields) do
+    if resolved[name] == nil and settings[name] ~= nil then
+      if expandable_rule_fields[name] then
+        resolved[name] = expand_value(task, settings[name])
+      else
+        resolved[name] = settings[name]
+      end
+    end
+  end
+  return resolved
+end
+
+local function add_template_variables(task, tmpl, meta)
+  local requested = {}
+  for name in string.gmatch(tmpl, '%$([%w_]+)') do
+    requested[name] = true
+  end
+  for name in string.gmatch(tmpl, '%${([%w_]+)}') do
+    requested[name] = true
+  end
+  for name in pairs(requested) do
+    if meta[name] == nil and variables[name] then
+      meta[name] = variables[name](task)
+    end
+  end
+end
+
+local function add_mail_targets(task, source, values, mail_targets, display_emails)
+  if type(values) == 'table' then
+    for _, value in ipairs(values) do
+      add_mail_targets(task, source, value, mail_targets, display_emails)
+    end
+    return
+  end
+
+  if type(values) ~= 'string' or values == '' then
+    rspamd_logger.errx(task, '%s returned no email address', source)
+    return
+  end
+
+  local parsed = rspamd_util.parse_mail_address(values, task:get_mempool())
+  if not parsed or #parsed == 0 then
+    rspamd_logger.errx(task, '%s returned an invalid email address: %s', source, values)
+    return
+  end
+
+  for _, address in ipairs(parsed) do
+    if address.flags and address.flags.valid and address.addr and address.addr ~= '' then
+      table.insert(mail_targets, address.addr)
+      table.insert(display_emails, string.format('<%s>', address.addr))
+    else
+      rspamd_logger.errx(task, '%s returned an invalid email address: %s', source,
+        address.raw or values)
+    end
+  end
+end
+
+local function normalize_mail_from(task, value)
+  if value == '' then
+    return value
+  end
+  if type(value) ~= 'string' then
+    rspamd_logger.errx(task, 'mail_from is not a string')
+    return nil
+  end
+
+  local parsed = rspamd_util.parse_mail_address(value, task:get_mempool())
+  if parsed and #parsed == 1 and parsed[1].flags and parsed[1].flags.valid then
+    return parsed[1].addr
+  end
+  rspamd_logger.errx(task, 'mail_from is not a valid single email address: %s', value)
+  return nil
+end
 
 local function get_general_metadata(task, flatten, no_content)
   local r = {}
@@ -127,9 +345,9 @@ local function get_general_metadata(task, flatten, no_content)
     r.from = 'unknown'
   end
   local syminf = task:get_symbols_all()
-  if flatten then
+  local function format_symlist(list)
     local l = {}
-    for _, sym in ipairs(syminf) do
+    for _, sym in ipairs(list) do
       local txt
       if sym.options then
         local topt = table.concat(sym.options, ', ')
@@ -139,7 +357,22 @@ local function get_general_metadata(task, flatten, no_content)
       end
       table.insert(l, txt)
     end
-    r.symbols = table.concat(l, '\n\t')
+    return table.concat(l, '\n\t')
+  end
+
+  if flatten then
+    local function copy_and_sort(list, cmp)
+      local out = {}
+      for i, v in ipairs(list) do
+        out[i] = v
+      end
+      table.sort(out, cmp)
+      return out
+    end
+
+    r.symbols = format_symlist(syminf)
+    r.symbols_sorted = format_symlist(copy_and_sort(syminf, function(a, b) return a.name < b.name end))
+    r.symbols_score = format_symlist(copy_and_sort(syminf, function(a, b) return a.score > b.score end))
   else
     r.symbols = syminf
   end
@@ -187,33 +420,36 @@ local formatters = {
   default = function(task)
     return task:get_content(), {}
   end,
-  email_alert = function(task, rule, extra)
+  email_alert = function(task, rule)
     local meta = get_general_metadata(task, true)
     local display_emails = {}
     local mail_targets = {}
-    meta.mail_from = rule.mail_from or settings.mail_from
-    local mail_rcpt = rule.mail_to or settings.mail_to
-    if type(mail_rcpt) ~= 'table' then
-      table.insert(display_emails, string.format('<%s>', mail_rcpt))
-      table.insert(mail_targets, mail_rcpt)
-    else
-      for _, e in ipairs(mail_rcpt) do
-        table.insert(display_emails, string.format('<%s>', e))
-        table.insert(mail_targets, e)
-      end
+    local tmpl = rule.email_template or settings.email_template
+    add_template_variables(task, tmpl, meta)
+    meta.mail_from = normalize_mail_from(task, rule.mail_from)
+    if not meta.mail_from then
+      return nil
     end
+    add_mail_targets(task, 'mail_to', rule.mail_to, mail_targets, display_emails)
     if rule.email_alert_sender then
       local x = task:get_from('smtp')
       if x and string.len(x[1].addr) > 0 then
-        table.insert(mail_targets, x)
-        table.insert(display_emails, string.format('<%s>', x[1].addr))
+        add_mail_targets(task, 'email_alert_sender', x[1].addr, mail_targets, display_emails)
+      end
+    end
+    if rule.email_alert_sender_variable then
+      if variables[rule.email_alert_sender_variable] then
+        local addr = variables[rule.email_alert_sender_variable](task)
+        lua_util.debugm(N, task, 'email_alert_sender_variable: %s: %s', rule.email_alert_sender_variable, addr)
+        add_mail_targets(task, 'email_alert_sender_variable', addr, mail_targets, display_emails)
+      else
+        rspamd_logger.errx(task, 'no such variable: %s', rule.email_alert_sender_variable)
       end
     end
     if rule.email_alert_user then
       local x = task:get_user()
       if x then
-        table.insert(mail_targets, x)
-        table.insert(display_emails, string.format('<%s>', x))
+        add_mail_targets(task, 'email_alert_user', x, mail_targets, display_emails)
       end
     end
     if rule.email_alert_recipients then
@@ -221,16 +457,20 @@ local formatters = {
       if x then
         for _, e in ipairs(x) do
           if string.len(e.addr) > 0 then
-            table.insert(mail_targets, e.addr)
-            table.insert(display_emails, string.format('<%s>', e.addr))
+            add_mail_targets(task, 'email_alert_recipients', e.addr, mail_targets, display_emails)
           end
         end
       end
     end
+    if #mail_targets == 0 then
+      rspamd_logger.errx(task, 'email alert has no valid recipients')
+      return nil
+    end
     meta.mail_to = table.concat(display_emails, ', ')
     meta.our_message_id = rspamd_util.random_hex(12) .. '@rspamd'
     meta.date = rspamd_util.time_to_string(rspamd_util.get_time())
-    return lua_util.template(rule.email_template or settings.email_template, meta), { mail_targets = mail_targets }
+    tmpl = expand_selectors(task, tmpl, meta)
+    return lua_util.template(tmpl, meta), { mail_targets = mail_targets }
   end,
   json = function(task)
     return ucl.to_format(get_general_metadata(task), 'json-compact')
@@ -450,7 +690,7 @@ local pushers = {
       return maybe_defer(task, rule)
     end
     local hdrs = {}
-    local mime_type = rule.mime_type or settings.mime_type
+    local mime_type = rule.mime_type
 
     if extra and extra.multipart_boundary then
       mime_type = string.format('multipart/form-data; boundary="%s"', extra.multipart_boundary)
@@ -477,15 +717,15 @@ local pushers = {
       callback = http_callback,
       mime_type = mime_type,
       headers = hdrs,
-      timeout = rule.timeout or settings.timeout,
-      gzip = rule.gzip or settings.gzip,
-      keepalive = rule.keepalive or settings.keepalive,
-      no_ssl_verify = rule.no_ssl_verify or settings.no_ssl_verify,
+      timeout = rule.timeout,
+      gzip = rule.gzip,
+      keepalive = rule.keepalive,
+      no_ssl_verify = rule.no_ssl_verify,
       -- staged timeouts
-      connect_timeout = rule.connect_timeout or settings.connect_timeout,
-      ssl_timeout = rule.ssl_timeout or settings.ssl_timeout,
-      write_timeout = rule.write_timeout or settings.write_timeout,
-      read_timeout = rule.read_timeout or settings.read_timeout,
+      connect_timeout = rule.connect_timeout,
+      ssl_timeout = rule.ssl_timeout,
+      write_timeout = rule.write_timeout,
+      read_timeout = rule.read_timeout,
     })
   end,
   send_mail = function(task, formatted, rule, extra)
@@ -497,14 +737,29 @@ local pushers = {
       end
     end
 
+    local mail_from = normalize_mail_from(task, rule.mail_from)
+    if not mail_from then
+      return maybe_defer(task, rule)
+    end
+
+    local recipients = extra and extra.mail_targets
+    if not recipients then
+      recipients = {}
+      add_mail_targets(task, 'mail_to', rule.mail_to, recipients, {})
+      if #recipients == 0 then
+        rspamd_logger.errx(task, 'SMTP export has no valid recipients')
+        return maybe_defer(task, rule)
+      end
+    end
+
     lua_smtp.sendmail({
       task = task,
       host = rule.smtp,
-      port = rule.smtp_port or settings.smtp_port or 25,
-      from = rule.mail_from or settings.mail_from,
-      recipients = extra.mail_targets or rule.mail_to or settings.mail_to,
-      helo = rule.helo or settings.helo,
-      timeout = rule.timeout or settings.timeout,
+      port = rule.smtp_port or 25,
+      from = mail_from,
+      recipients = recipients,
+      helo = rule.helo,
+      timeout = rule.timeout,
     }, formatted, sendmail_cb)
   end,
   json_raw_tcp = function(task, formatted, rule)
@@ -521,7 +776,7 @@ local pushers = {
       port = rule.port,
       data = formatted,
       callback = json_raw_tcp_callback,
-      timeout = rule.timeout or settings.timeout,
+      timeout = rule.timeout,
       read = false,
     })
   end,
@@ -614,7 +869,7 @@ local pushers = {
       if rule.max_len then
         table.insert(args, 'MAXLEN')
         table.insert(args, '~')
-        table.insert(args, tostring(rule.max_len))
+        table.insert(args, string.format('%d', math.floor(rule.max_len)))
       end
       table.insert(args, '*')
       table.insert(args, 'data')
@@ -634,14 +889,15 @@ local pushers = {
     end
     if rule.per_recipient then
       local rcpt = task:get_recipients('smtp')
+      local stream_key = rule.stream_key
       if rcpt then
         for _, a in ipairs(rcpt) do
           if a.addr and #a.addr > 0 then
-            do_xadd(rule.stream_key .. ':' .. a.addr)
+            do_xadd(stream_key .. ':' .. a.addr)
           end
         end
       else
-        do_xadd(rule.stream_key)
+        do_xadd(stream_key)
       end
     else
       do_xadd(rule.stream_key)
@@ -667,6 +923,13 @@ local process_settings = {
     if type(val) == 'table' then
       for k, v in pairs(val) do
         pushers[k] = assert(load(v))()
+      end
+    end
+  end,
+  custom_variables = function(val)
+    if type(val) == 'table' then
+      for k, v in pairs(val) do
+        variables[k] = assert(load(v))()
       end
     end
   end,
@@ -801,6 +1064,7 @@ if type(settings.rules) ~= 'table' then
       r.defer = settings.defer
       r.selector = settings.pusher_select.http
       r.formatter = settings.pusher_format.http
+      r.timeout = settings.timeout or 0.0
       settings.rules[r.backend:upper()] = r
     end
   end
@@ -820,6 +1084,7 @@ if type(settings.rules) ~= 'table' then
       r.defer = settings.defer
       r.selector = settings.pusher_select.send_mail
       r.formatter = settings.pusher_format.send_mail
+      r.timeout = settings.timeout or 0.0
       settings.rules[r.backend:upper()] = r
     end
   end
@@ -978,6 +1243,29 @@ for k, v in pairs(settings.rules) do
   end
 end
 
+-- Compile selectors used by rules at config time to validate them and to keep them off the hot path
+local function warm_selectors(val)
+  if type(val) == 'table' then
+    for _, elt in pairs(val) do
+      warm_selectors(elt)
+    end
+  elseif type(val) == 'string' then
+    for expr in string.gmatch(val, '%${(.-)}') do
+      if not variables[expr] then
+        get_selector(rspamd_config, expr)
+      end
+    end
+  end
+end
+
+for _, r in pairs(settings.rules) do
+  for name, val in pairs(r) do
+    if expandable_rule_fields[name] or name == 'email_template' then
+      warm_selectors(val)
+    end
+  end
+end
+
 local function gen_exporter(rule)
   return function(task)
     if task:has_flag('skip') then
@@ -988,9 +1276,10 @@ local function gen_exporter(rule)
     if selected then
       lua_util.debugm(N, task, 'Message selected for processing')
       local formatter = rule.formatter or 'default'
-      local formatted, extra = formatters[formatter](task, rule)
+      local resolved_rule = resolve_rule(task, rule)
+      local formatted, extra = formatters[formatter](task, resolved_rule)
       if formatted then
-        pushers[rule.backend](task, formatted, rule, extra)
+        pushers[rule.backend](task, formatted, resolved_rule, extra)
       else
         lua_util.debugm(N, task, 'Formatter [%s] returned non-truthy value [%s]', formatter, formatted)
       end
@@ -1005,11 +1294,12 @@ if not next(settings.rules) then
   lua_util.disable_module(N, "config")
 end
 for k, r in pairs(settings.rules) do
+  local registration_timeout = tonumber(r.timeout) or tonumber(settings.timeout) or 0.0
   rspamd_config:register_symbol({
     name = 'EXPORT_METADATA_' .. k,
     type = 'idempotent',
     callback = gen_exporter(r),
     flags = 'empty,explicit_disable,ignore_passthrough',
-    augmentations = { string.format("timeout=%f", r.timeout or settings.timeout or 0.0) }
+    augmentations = { string.format("timeout=%f", registration_timeout) }
   })
 end

--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -368,6 +368,24 @@ local function encode_address_header(task, value)
   return table.concat(out, ', ')
 end
 
+-- Joins folded continuation lines so each entry is one logical header
+local function split_logical_headers(header_block)
+  local logical = {}
+  for line in (header_block .. '\n'):gmatch('(.-)\n') do
+    if #logical > 0 and string.match(line, '^[ \t]') then
+      logical[#logical] = logical[#logical] .. '\n' .. line
+    else
+      table.insert(logical, line)
+    end
+  end
+  return logical
+end
+
+local function logical_header_name(entry)
+  local name = string.match(entry, '^([^:]+):')
+  return name and string.lower(name) or nil
+end
+
 local function encode_email_headers(task, text)
   local sep_start, sep_end = string.find(text, '\r?\n\r?\n')
   if not sep_start then
@@ -377,17 +395,8 @@ local function encode_email_headers(task, text)
   local separator = string.sub(text, sep_start, sep_end)
   local body = string.sub(text, sep_end + 1)
 
-  local logical = {}
-  for line in (header_block .. '\n'):gmatch('(.-)\n') do
-    if #logical > 0 and string.match(line, '^[ \t]') then
-      logical[#logical] = logical[#logical] .. '\n' .. line
-    else
-      table.insert(logical, line)
-    end
-  end
-
   local out = {}
-  for _, entry in ipairs(logical) do
+  for _, entry in ipairs(split_logical_headers(header_block)) do
     local colon = string.find(entry, ':', 1, true)
     if not colon then
       table.insert(out, entry)
@@ -407,6 +416,294 @@ local function encode_email_headers(task, text)
   end
 
   return table.concat(out, '\n') .. separator .. body
+end
+
+-- Splits a rendered email_template into (header_block, separator, body).
+-- Unlike encode_email_headers, a missing blank-line separator is not an
+-- error case here: it just means the template has no body of its own,
+-- which email_parts assembly treats as "no implicit first part".
+local function split_headers_body(text)
+  local sep_start, sep_end = string.find(text, '\r?\n\r?\n')
+  if not sep_start then
+    -- No blank-line separator: the whole text is headers. Strip any
+    -- trailing newline so callers that re-join with their own '\n' don't
+    -- end up inserting a blank line before what they append.
+    return (string.gsub(text, '\r?\n$', '')), '\n\n', ''
+  end
+  return string.sub(text, 1, sep_start - 1), string.sub(text, sep_start, sep_end), string.sub(text, sep_end + 1)
+end
+
+-- 7bit/8bit put content on the wire verbatim, so NUL bytes and lines over the
+-- RFC 5322 998-octet limit break framing there. Quoted-printable encodes and
+-- folds both away. A bare "." line needs no handling here: dot-stuffing is the
+-- SMTP transport's job and lua_smtp does it (RFC 5321 4.5.2).
+local function needs_encoding_for_transport(content)
+  -- Plain find of a literal NUL: the %z class was removed in Lua 5.2 and
+  -- matches the letter 'z' there instead
+  if string.find(content, '\0', 1, true) then
+    return true
+  end
+  for line in (content .. '\n'):gmatch('(.-)\n') do
+    if #(string.gsub(line, '\r$', '')) > 998 then
+      return true
+    end
+  end
+  return false
+end
+
+local function guess_text_cte(content)
+  if not is_ascii(content) or needs_encoding_for_transport(content) then
+    return 'quoted-printable'
+  end
+  return '8bit'
+end
+
+-- An explicitly configured encoding is honoured unless it violates its MIME
+-- constraints or would corrupt the message on the wire.
+local function sanitize_cte(task, label, cte, content)
+  if cte == '7bit' and (not is_ascii(content) or needs_encoding_for_transport(content)) then
+    rspamd_logger.warnx(task,
+      '%s content is not valid 7bit data, using quoted-printable instead', label)
+    return 'quoted-printable'
+  elseif cte == '8bit' and needs_encoding_for_transport(content) then
+    rspamd_logger.warnx(task,
+      '%s content has NUL bytes or over-long lines, using quoted-printable instead of 8bit', label)
+    return 'quoted-printable'
+  end
+  return cte
+end
+
+local function encode_part_content(task, value, cte)
+  local encoded
+  if cte == 'base64' then
+    encoded = rspamd_util.encode_base64(value, 76, task:get_newlines_type())
+  elseif cte == 'quoted-printable' then
+    encoded = rspamd_util.encode_qp(value, 76, task:get_newlines_type())
+  else
+    return value
+  end
+  -- encode_base64/encode_qp return rspamd_text userdata, not a Lua string
+  return type(encoded) == 'string' and encoded or encoded:str()
+end
+
+-- RFC 2231 encoding of a header parameter. Long values are split into numbered
+-- sections (only section 0 carries the charset prefix) and folded onto
+-- continuation lines, so a selector-derived filename cannot push the header
+-- past the 998-octet line limit. Sections are assembled from whole encoded
+-- characters so a split never lands inside a %XX escape.
+local function encode_rfc2231_parameter(name, value)
+  local safe = "!#$&+-.^_`|~"
+  local encoded = {}
+  for i = 1, #value do
+    local ch = string.sub(value, i, i)
+    if string.match(ch, '[A-Za-z0-9]') or string.find(safe, ch, 1, true) then
+      table.insert(encoded, ch)
+    else
+      table.insert(encoded, string.format('%%%02X', string.byte(ch)))
+    end
+  end
+
+  local sections = {}
+  local current = ''
+  for _, chunk in ipairs(encoded) do
+    if #current + #chunk > 60 then
+      table.insert(sections, current)
+      current = ''
+    end
+    current = current .. chunk
+  end
+  table.insert(sections, current)
+
+  if #sections == 1 then
+    return string.format("%s*=UTF-8''%s", name, sections[1])
+  end
+
+  local out = {}
+  for i, section in ipairs(sections) do
+    if i == 1 then
+      table.insert(out, string.format("%s*0*=UTF-8''%s", name, section))
+    else
+      table.insert(out, string.format('%s*%d*=%s', name, i - 1, section))
+    end
+  end
+  return table.concat(out, ';\n ')
+end
+
+local function build_part_header_lines(content_type, filename, disposition, cte)
+  local lines = {}
+  if filename then
+    table.insert(lines, 'Content-Type: ' .. content_type .. ';\n ' ..
+      encode_rfc2231_parameter('name', filename))
+  else
+    table.insert(lines, 'Content-Type: ' .. content_type)
+  end
+  table.insert(lines, 'Content-Transfer-Encoding: ' .. cte)
+  if filename then
+    table.insert(lines, string.format('Content-Disposition: %s;\n %s', disposition,
+      encode_rfc2231_parameter('filename', filename)))
+  else
+    table.insert(lines, 'Content-Disposition: ' .. disposition)
+  end
+  return table.concat(lines, '\n')
+end
+
+-- Flattens one custom variable result into part content. Arrays (a
+-- selector-backed list, for instance) are flattened depth-first into one line
+-- per element rather than stringified as a table address; anything that cannot
+-- carry body text is rejected so the caller aborts instead of attaching junk.
+local function flatten_part_value(value, out)
+  local vtype = type(value)
+
+  if vtype == 'table' then
+    for _, elt in ipairs(value) do
+      if not flatten_part_value(elt, out) then
+        return false
+      end
+    end
+    return true
+  end
+
+  if vtype == 'string' then
+    table.insert(out, value)
+    return true
+  end
+
+  if vtype == 'number' or vtype == 'boolean' then
+    table.insert(out, tostring(value))
+    return true
+  end
+
+  if vtype == 'userdata' then
+    -- rspamd_text and friends carry their bytes behind :str()
+    local ok, converted = pcall(function()
+      return value:str()
+    end)
+    if ok and type(converted) == 'string' then
+      table.insert(out, converted)
+      return true
+    end
+  end
+
+  return false
+end
+
+local function stringify_part_value(value)
+  if value == nil then
+    return nil
+  end
+
+  local out = {}
+  if not flatten_part_value(value, out) then
+    return nil
+  end
+
+  -- A table with no array part carries no body text; an empty one is just
+  -- empty content, which is allowed
+  if #out == 0 and type(value) == 'table' and next(value) ~= nil then
+    return nil
+  end
+
+  return table.concat(out, '\n')
+end
+
+-- Builds the multipart/<rule.email_parts_type> body for email_alert: an
+-- optional leading part from the template's own body (skipped only when
+-- that body is truly empty - a whitespace-only body still becomes a part),
+-- followed by one part per rule.email_parts entry. Returns nil on any
+-- unresolvable part so the caller aborts the whole message rather than
+-- sending a report with a silently missing/garbled part.
+local function assemble_email_parts(task, rule, template_body, template_part_headers, boundary)
+  local parts = {}
+
+  if #template_body > 0 then
+    local headers = {}
+    for _, entry in ipairs(template_part_headers) do
+      table.insert(headers, entry)
+    end
+    if not template_part_headers.content_type then
+      table.insert(headers, 'Content-Type: text/plain; charset=utf-8')
+    end
+    if not template_part_headers.cte then
+      local cte = guess_text_cte(template_body)
+      table.insert(headers, 'Content-Transfer-Encoding: ' .. cte)
+      template_body = encode_part_content(task, template_body, cte)
+    end
+    table.insert(parts, table.concat(headers, '\n') .. '\n\n' .. template_body)
+  end
+
+  for i, entry in ipairs(rule.email_parts) do
+    if not entry.variable or not variables[entry.variable] then
+      rspamd_logger.errx(task, 'email_parts[%s] references unknown variable [%s]', i, entry.variable)
+      return nil
+    end
+    local value = stringify_part_value(variables[entry.variable](task))
+    if value == nil then
+      rspamd_logger.errx(task, 'email_parts[%s] variable [%s] returned nil or unconvertible content',
+        i, entry.variable)
+      return nil
+    end
+
+    local filename = entry.filename and stringify_part_value(expand_selectors(task, entry.filename)) or nil
+    if filename == '' then
+      filename = nil
+    end
+    local content_type = entry.content_type or 'application/octet-stream'
+    local disposition = entry.disposition or (filename and 'attachment' or 'inline')
+    local cte = entry.encoding
+    if not cte or cte == 'auto' then
+      -- MIME type names are case-insensitive, so match accordingly
+      cte = string.match(string.lower(content_type), '^text/') and guess_text_cte(value) or 'base64'
+    end
+    cte = sanitize_cte(task, string.format('email_parts[%s]', i), cte, value)
+
+    table.insert(parts, build_part_header_lines(content_type, filename, disposition, cte)
+      .. '\n\n' .. encode_part_content(task, value, cte))
+  end
+
+  if #parts == 0 then
+    rspamd_logger.errx(task, 'email_alert with email_parts produced no parts to send')
+    return nil
+  end
+
+  local body = {}
+  for _, p in ipairs(parts) do
+    table.insert(body, '--' .. boundary)
+    table.insert(body, p)
+  end
+  table.insert(body, '--' .. boundary .. '--')
+
+  return table.concat(body, '\n'), boundary
+end
+
+-- email_parts owns the top-level MIME framing. The template's content headers
+-- move to its body part so its media type and transfer encoding are preserved.
+local function build_multipart_header_block(header_block, subtype, boundary)
+  local out = {}
+  local template_part_headers = {}
+  local has_mime_version = false
+
+  for _, entry in ipairs(split_logical_headers(header_block)) do
+    local name = logical_header_name(entry)
+    if name == 'content-type' then
+      template_part_headers.content_type = true
+      table.insert(template_part_headers, entry)
+    elseif name == 'content-transfer-encoding' then
+      template_part_headers.cte = true
+      table.insert(template_part_headers, entry)
+    else
+      if name == 'mime-version' then
+        has_mime_version = true
+      end
+      table.insert(out, entry)
+    end
+  end
+
+  if not has_mime_version then
+    table.insert(out, 'MIME-Version: 1.0')
+  end
+  table.insert(out, string.format('Content-Type: multipart/%s; boundary="%s"', subtype, boundary))
+
+  return table.concat(out, '\n'), template_part_headers
 end
 
 local function get_general_metadata(task, flatten, no_content)
@@ -592,6 +889,19 @@ local formatters = {
     meta.date = rspamd_util.time_to_string(rspamd_util.get_time())
     tmpl = expand_selectors(task, tmpl, meta)
     local rendered = lua_util.template(tmpl, meta)
+
+    if rule.email_parts and #rule.email_parts > 0 then
+      local header_block, separator, body = split_headers_body(rendered)
+      local boundary = rspamd_util.random_hex(16)
+      local multipart_headers, template_part_headers = build_multipart_header_block(
+        header_block, rule.email_parts_type or 'mixed', boundary)
+      local mp_body = assemble_email_parts(task, rule, body, template_part_headers, boundary)
+      if not mp_body then
+        return nil
+      end
+      rendered = multipart_headers .. separator .. mp_body
+    end
+
     if rule.email_auto_encode_headers then
       rendered = encode_email_headers(task, rendered)
     end
@@ -1286,6 +1596,73 @@ local check_element = {
     end
     return true
   end,
+  email_parts_type = function(k, v)
+    if type(v) ~= 'string' or not string.match(v, "^[%w!#$%%&'*+%-.%^_`|~]+$") then
+      rspamd_logger.errx(rspamd_config, 'Rule %s has invalid email_parts_type', k)
+      return false
+    end
+    return true
+  end,
+  email_parts = function(k, v)
+    if type(v) ~= 'table' then
+      rspamd_logger.errx(rspamd_config, 'Rule %s has invalid email_parts (must be an array)', k)
+      return false
+    end
+    if #v == 0 then
+      rspamd_logger.errx(rspamd_config, 'Rule %s has empty email_parts', k)
+      return false
+    end
+    for i, part in ipairs(v) do
+      if type(part) ~= 'table' then
+        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] must be a table', k, i)
+        return false
+      end
+      if not part.variable then
+        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] misses variable', k, i)
+        return false
+      end
+      if not variables[part.variable] then
+        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] references unknown variable %s', k, i, part.variable)
+        return false
+      end
+      if not part.content_type then
+        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] misses content_type', k, i)
+        return false
+      end
+      for _, field in ipairs({ 'content_type', 'filename', 'disposition' }) do
+        if part[field] ~= nil and type(part[field]) ~= 'string' then
+          rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] has non-string %s', k, i, field)
+          return false
+        end
+      end
+      local parsed_content_type
+      if not string.find(part.content_type, '[\r\n]') then
+        parsed_content_type = rspamd_util.parse_content_type(
+          part.content_type, rspamd_config:get_mempool())
+      end
+      if not parsed_content_type or not parsed_content_type.type or not parsed_content_type.subtype then
+        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] has invalid content_type', k, i)
+        return false
+      end
+      if part.disposition and (string.find(part.disposition, '[\r\n]') or
+          not string.match(part.disposition, "^[%w!#$%%&'*+%-.%^_`|~]+$")) then
+        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] has invalid disposition', k, i)
+        return false
+      end
+      if part.encoding and not ({
+        auto = true,
+        base64 = true,
+        ['quoted-printable'] = true,
+        ['7bit'] = true,
+        ['8bit'] = true,
+      })[part.encoding] then
+        rspamd_logger.errx(rspamd_config, 'Rule %s email_parts[%s] has invalid encoding %s',
+          k, i, part.encoding)
+        return false
+      end
+    end
+    return true
+  end,
 }
 local backend_check = {
   default = function(k, rule)
@@ -1351,6 +1728,11 @@ setmetatable(backend_check, {
 })
 for k, v in pairs(settings.rules) do
   if type(v) == 'table' then
+    -- UCL writes a lone object without brackets, which would otherwise pass
+    -- the ipairs-based validation vacuously and then be skipped at runtime
+    if type(v.email_parts) == 'table' and #v.email_parts == 0 and v.email_parts.variable then
+      v.email_parts = { v.email_parts }
+    end
     local backend = v.backend
     if not backend then
       rspamd_logger.errx(rspamd_config, 'Rule %s has no backend', k)
@@ -1385,7 +1767,7 @@ end
 
 for _, r in pairs(settings.rules) do
   for name, val in pairs(r) do
-    if expandable_rule_fields[name] or name == 'email_template' then
+    if expandable_rule_fields[name] or name == 'email_template' or name == 'email_parts' then
       warm_selectors(val)
     end
   end

--- a/src/plugins/lua/metadata_exporter.lua
+++ b/src/plugins/lua/metadata_exporter.lua
@@ -1896,7 +1896,7 @@ for _, r in pairs(settings.rules) do
   end
 end
 
-local function gen_exporter(rule)
+local function gen_exporter(rule, rule_name)
   return function(task)
     if task:has_flag('skip') then
       return
@@ -1904,17 +1904,17 @@ local function gen_exporter(rule)
     local selector = rule.selector or 'default'
     local selected = selectors[selector](task)
     if selected then
-      lua_util.debugm(N, task, 'Message selected for processing')
+      lua_util.debugm(N, task, 'rule %s: message selected for processing', rule_name)
       local formatter = rule.formatter or 'default'
       local resolved_rule = resolve_rule(task, rule)
       local formatted, extra = formatters[formatter](task, resolved_rule)
       if formatted then
         pushers[rule.backend](task, formatted, resolved_rule, extra)
       else
-        lua_util.debugm(N, task, 'Formatter [%s] returned non-truthy value [%s]', formatter, formatted)
+        lua_util.debugm(N, task, 'rule %s: formatter [%s] returned non-truthy value [%s]', rule_name, formatter, formatted)
       end
     else
-      lua_util.debugm(N, task, 'Selector [%s] returned non-truthy value [%s]', selector, selected)
+      lua_util.debugm(N, task, 'rule %s: selector [%s] returned non-truthy value [%s]', rule_name, selector, selected)
     end
   end
 end
@@ -1924,7 +1924,7 @@ for k, r in pairs(settings.rules) do
   rspamd_config:register_symbol({
     name = 'EXPORT_METADATA_' .. k,
     type = 'idempotent',
-    callback = gen_exporter(r),
+    callback = gen_exporter(r, k),
     flags = 'empty,explicit_disable,ignore_passthrough',
     augmentations = { string.format("timeout=%f", registration_timeout) }
   })

--- a/test/functional/cases/560_metadata_exporter_structured.robot
+++ b/test/functional/cases/560_metadata_exporter_structured.robot
@@ -17,6 +17,8 @@ ${RSPAMD_URL_TLD}      ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
 ${REDIS_SCOPE}         Suite
 ${SMTP_STATUS}         ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp.status
 ${SMTP_PID}            ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp.pid
+${SMTP_STATUS_2}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp2.status
+${SMTP_PID_2}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp2.pid
 
 *** Test Cases ***
 Structured export to Redis stream - UUID v7 and metadata
@@ -95,16 +97,43 @@ Email export expands and validates selector addresses
   Should Contain  ${rspamd_log}  METADATA_OPTIONS_EXPANDED
   Should Not Contain  ${rspamd_log}  METADATA_OPTIONS_FAILED
 
+Email export auto-encodes non-ASCII headers
+  [Documentation]  Non-ASCII address display names and Subject get RFC 2047-encoded
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com,second@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS_2}
+  ${smtp2} =  Get File  ${SMTP_STATUS_2}
+  Should Contain  ${smtp2}  From: J=?UTF-8?Q?
+  Should Contain  ${smtp2}  To: =?UTF-8?Q?
+  Should Contain  ${smtp2}  Subject: Pr=?UTF-8?Q?
+  Should Contain  ${smtp2}  <sender@example.com>
+  Should Contain  ${smtp2}  <first@example.com>, <second@example.com>
+  Should Contain  ${smtp2}  Cc: Jörg <third@example.com> (Kommentar)
+  Should Contain  ${smtp2}  Metadata alert
+  Should Not Contain  ${smtp2}  Jörg Müller
+  Should Not Contain  ${smtp2}  Änne Beispiel
+  Should Not Contain  ${smtp2}  Prüfung möglich
+
 *** Keywords ***
 Metadata Exporter Structured Setup
   Run Redis
+  Remove Files  ${SMTP_STATUS}  ${SMTP_STATUS_2}
   ${smtp} =  Start Dummy Smtp  11126  sink  127.0.0.1  ${SMTP_PID}
   ...  --status-file  ${SMTP_STATUS}
   Set Test Variable  ${DUMMY_SMTP_PROC}  ${smtp}
+  ${smtp2} =  Start Dummy Smtp  11127  sink  127.0.0.1  ${SMTP_PID_2}
+  ...  --status-file  ${SMTP_STATUS_2}
+  Set Test Variable  ${DUMMY_SMTP_PROC_2}  ${smtp2}
   Rspamd Setup
 
 Metadata Exporter Structured Teardown
   Rspamd Teardown
   Terminate Process  ${DUMMY_SMTP_PROC}
   Wait For Process  ${DUMMY_SMTP_PROC}
+  Terminate Process  ${DUMMY_SMTP_PROC_2}
+  Wait For Process  ${DUMMY_SMTP_PROC_2}
   Redis Teardown

--- a/test/functional/cases/560_metadata_exporter_structured.robot
+++ b/test/functional/cases/560_metadata_exporter_structured.robot
@@ -27,6 +27,8 @@ ${SMTP_STATUS_5}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp5.status
 ${SMTP_PID_5}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp5.pid
 ${SMTP_STATUS_6}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp6.status
 ${SMTP_PID_6}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp6.pid
+${SMTP_STATUS_7}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp7.status
+${SMTP_PID_7}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp7.pid
 
 *** Test Cases ***
 Structured export to Redis stream - UUID v7 and metadata
@@ -247,11 +249,55 @@ Email export falls back to HELO when EHLO is rejected
   Should Contain  ${smtp6}  MAIL FROM: <sender@example.com>
   Should Not Contain  ${smtp6}  BODY=8BITMIME
 
+Email export renders a literal content part
+  [Documentation]  A `content` part (as opposed to content_from_variables) is
+  ...  expanded via variables/selectors and lua_util.template, exactly like
+  ...  the email template body.
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS_7}
+  ${smtp7} =  Get File  ${SMTP_STATUS_7}
+  ${info} =  Validate Multipart Email  ${smtp7}
+
+  Should Be True  ${info}[is_multipart]
+  Should Be Equal As Integers  ${info}[part_count]  1
+
+  ${part1} =  Set Variable  ${info}[parts][0]
+  Should Be Equal  ${part1}[content_type]  text/plain
+  Should Be Equal  ${part1}[cte]  7bit
+  Should Be Equal  ${part1}[filename]  selector-test@example.com-template-custom.txt
+  Should Be Equal  ${part1}[decoded_text]
+  ...  Static literal line one.\nHost is 127.0.0.1 and template value is template-custom.
+
+Invalid rule with unknown key fails configtest
+  [Documentation]  A rule with an unrecognized option is rejected by the
+  ...  schema, disabled at config load time, and reported by configtest.
+  ${rspamd_log} =  Get File  ${RSPAMD_TMPDIR}/rspamd.log
+  Should Contain  ${rspamd_log}  INVALID_RULE_BAD_KEY
+  Should Contain  ${rspamd_log}  invalid configuration
+  Should Contain  ${rspamd_log}  DISABLED
+  ${result} =  Run Process  ${RSPAMADM}
+  ...  configtest  -c  ${CONFIG}
+  ...  env:RSPAMD_LOCAL_CONFDIR=/non-existent
+  ...  env:RSPAMD_TMPDIR=${RSPAMD_TMPDIR}
+  ...  env:RSPAMD_CONFDIR=${RSPAMD_TESTDIR}/../../conf/
+  Should Not Be Equal As Integers  ${result.rc}  0
+  Should Contain  ${result.stdout}${result.stderr}  configuration error: module metadata_exporter
+  Should Contain  ${result.stdout}${result.stderr}  INVALID_RULE_BAD_KEY
+  Should Contain  ${result.stdout}${result.stderr}  INVALID_PART_BOTH_SOURCES
+  Should Contain  ${result.stdout}${result.stderr}  INVALID_PART_NO_SOURCE
+  Should Contain  ${result.stdout}${result.stderr}  custom_variables[invalid_non_string]
+  Should Contain  ${result.stdout}${result.stderr}  custom_variables[invalid_no_callback]
+
 *** Keywords ***
 Metadata Exporter Structured Setup
   Run Redis
   Remove Files  ${SMTP_STATUS}  ${SMTP_STATUS_2}  ${SMTP_STATUS_3}  ${SMTP_STATUS_4}
-  ...  ${SMTP_STATUS_5}  ${SMTP_STATUS_6}
+  ...  ${SMTP_STATUS_5}  ${SMTP_STATUS_6}  ${SMTP_STATUS_7}
   ${smtp} =  Start Dummy Smtp  11126  sink  127.0.0.1  ${SMTP_PID}
   ...  --status-file  ${SMTP_STATUS}
   Set Test Variable  ${DUMMY_SMTP_PROC}  ${smtp}
@@ -270,6 +316,9 @@ Metadata Exporter Structured Setup
   ${smtp6} =  Start Dummy Smtp  11131  sink  127.0.0.1  ${SMTP_PID_6}
   ...  --status-file  ${SMTP_STATUS_6}  --reject-ehlo
   Set Test Variable  ${DUMMY_SMTP_PROC_6}  ${smtp6}
+  ${smtp7} =  Start Dummy Smtp  11132  sink  127.0.0.1  ${SMTP_PID_7}
+  ...  --status-file  ${SMTP_STATUS_7}
+  Set Test Variable  ${DUMMY_SMTP_PROC_7}  ${smtp7}
   Rspamd Setup
 
 Metadata Exporter Structured Teardown
@@ -286,4 +335,6 @@ Metadata Exporter Structured Teardown
   Wait For Process  ${DUMMY_SMTP_PROC_5}
   Terminate Process  ${DUMMY_SMTP_PROC_6}
   Wait For Process  ${DUMMY_SMTP_PROC_6}
+  Terminate Process  ${DUMMY_SMTP_PROC_7}
+  Wait For Process  ${DUMMY_SMTP_PROC_7}
   Redis Teardown

--- a/test/functional/cases/560_metadata_exporter_structured.robot
+++ b/test/functional/cases/560_metadata_exporter_structured.robot
@@ -23,6 +23,10 @@ ${SMTP_STATUS_3}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp3.status
 ${SMTP_PID_3}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp3.pid
 ${SMTP_STATUS_4}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp4.status
 ${SMTP_PID_4}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp4.pid
+${SMTP_STATUS_5}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp5.status
+${SMTP_PID_5}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp5.pid
+${SMTP_STATUS_6}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp6.status
+${SMTP_PID_6}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp6.pid
 
 *** Test Cases ***
 Structured export to Redis stream - UUID v7 and metadata
@@ -89,7 +93,7 @@ Email export expands and validates selector addresses
   Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS}
   ${smtp} =  Get File  ${SMTP_STATUS}
   Should Contain  ${smtp}  MAIL FROM: <sender@example.com>
-  Should Contain  ${smtp}  HELO selector-test@example.com
+  Should Contain  ${smtp}  EHLO selector-test@example.com
   Should Contain  ${smtp}  RCPT TO: <first@example.com>
   Should Contain  ${smtp}  RCPT TO: <second@example.com>
   Should Not Contain  ${smtp}  not-an-address
@@ -193,6 +197,7 @@ Email export preserves template body MIME headers
   ${smtp4} =  Get File  ${SMTP_STATUS_4}
   ${info} =  Validate Multipart Email  ${smtp4}
 
+  Should Not Contain  ${smtp4}  BODY=8BITMIME
   Should Be True  ${info}[is_multipart]
   Should Be Equal  ${info}[subtype]  mixed
   Should Be Equal  ${info}[mime_version]  1.0
@@ -211,10 +216,42 @@ Email export preserves template body MIME headers
   Should Be Equal  ${part2}[content_type]  text/plain
   Should Be Equal  ${part2}[decoded_text]  alpha\nbeta\ngamma
 
+Email export negotiates BODY=8BITMIME when advertised
+  [Documentation]  lua_smtp tries EHLO first; when the server advertises
+  ...  8BITMIME, MAIL FROM gets the BODY=8BITMIME parameter.
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS_5}
+  ${smtp5} =  Get File  ${SMTP_STATUS_5}
+  Should Contain  ${smtp5}  EHLO selector-test@example.com
+  Should Contain  ${smtp5}  MAIL FROM: <sender@example.com> BODY=8BITMIME
+  Should Not Contain  ${smtp5}  HELO selector-test@example.com
+
+Email export falls back to HELO when EHLO is rejected
+  [Documentation]  A server that rejects EHLO gets a plain HELO retry, and
+  ...  MAIL FROM is sent without a BODY= parameter.
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS_6}
+  ${smtp6} =  Get File  ${SMTP_STATUS_6}
+  Should Contain  ${smtp6}  EHLO selector-test@example.com
+  Should Contain  ${smtp6}  HELO selector-test@example.com
+  Should Contain  ${smtp6}  MAIL FROM: <sender@example.com>
+  Should Not Contain  ${smtp6}  BODY=8BITMIME
+
 *** Keywords ***
 Metadata Exporter Structured Setup
   Run Redis
   Remove Files  ${SMTP_STATUS}  ${SMTP_STATUS_2}  ${SMTP_STATUS_3}  ${SMTP_STATUS_4}
+  ...  ${SMTP_STATUS_5}  ${SMTP_STATUS_6}
   ${smtp} =  Start Dummy Smtp  11126  sink  127.0.0.1  ${SMTP_PID}
   ...  --status-file  ${SMTP_STATUS}
   Set Test Variable  ${DUMMY_SMTP_PROC}  ${smtp}
@@ -225,8 +262,14 @@ Metadata Exporter Structured Setup
   ...  --status-file  ${SMTP_STATUS_3}
   Set Test Variable  ${DUMMY_SMTP_PROC_3}  ${smtp3}
   ${smtp4} =  Start Dummy Smtp  11129  sink  127.0.0.1  ${SMTP_PID_4}
-  ...  --status-file  ${SMTP_STATUS_4}
+  ...  --status-file  ${SMTP_STATUS_4}  --ehlo-caps  X8BITMIME
   Set Test Variable  ${DUMMY_SMTP_PROC_4}  ${smtp4}
+  ${smtp5} =  Start Dummy Smtp  11130  sink  127.0.0.1  ${SMTP_PID_5}
+  ...  --status-file  ${SMTP_STATUS_5}  --ehlo-caps  8BITMIME
+  Set Test Variable  ${DUMMY_SMTP_PROC_5}  ${smtp5}
+  ${smtp6} =  Start Dummy Smtp  11131  sink  127.0.0.1  ${SMTP_PID_6}
+  ...  --status-file  ${SMTP_STATUS_6}  --reject-ehlo
+  Set Test Variable  ${DUMMY_SMTP_PROC_6}  ${smtp6}
   Rspamd Setup
 
 Metadata Exporter Structured Teardown
@@ -239,4 +282,8 @@ Metadata Exporter Structured Teardown
   Wait For Process  ${DUMMY_SMTP_PROC_3}
   Terminate Process  ${DUMMY_SMTP_PROC_4}
   Wait For Process  ${DUMMY_SMTP_PROC_4}
+  Terminate Process  ${DUMMY_SMTP_PROC_5}
+  Wait For Process  ${DUMMY_SMTP_PROC_5}
+  Terminate Process  ${DUMMY_SMTP_PROC_6}
+  Wait For Process  ${DUMMY_SMTP_PROC_6}
   Redis Teardown

--- a/test/functional/cases/560_metadata_exporter_structured.robot
+++ b/test/functional/cases/560_metadata_exporter_structured.robot
@@ -2,6 +2,7 @@
 Test Setup      Metadata Exporter Structured Setup
 Test Teardown   Metadata Exporter Structured Teardown
 Library         Process
+Library         OperatingSystem
 Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
 Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
 Variables       ${RSPAMD_TESTDIR}/lib/vars.py
@@ -14,6 +15,8 @@ ${RSPAMD_LUA_SCRIPT}   ${RSPAMD_TESTDIR}/lua/metadata_exporter_structured.lua
 ${RSPAMD_SCOPE}        Suite
 ${RSPAMD_URL_TLD}      ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
 ${REDIS_SCOPE}         Suite
+${SMTP_STATUS}         ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp.status
+${SMTP_PID}            ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp.pid
 
 *** Test Cases ***
 Structured export to Redis stream - UUID v7 and metadata
@@ -70,11 +73,38 @@ Attachment with detected MIME type
   ${count} =  Validate Attachments Have Content Type  ${data}
   Should Be True  ${count} >= 1  msg=Expected at least 1 attachment with content_type
 
+Email export expands and validates selector addresses
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com,second@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS}
+  ${smtp} =  Get File  ${SMTP_STATUS}
+  Should Contain  ${smtp}  MAIL FROM: <sender@example.com>
+  Should Contain  ${smtp}  HELO selector-test@example.com
+  Should Contain  ${smtp}  RCPT TO: <first@example.com>
+  Should Contain  ${smtp}  RCPT TO: <second@example.com>
+  Should Not Contain  ${smtp}  not-an-address
+  Should Contain  ${smtp}  From: <sender@example.com>
+  Should Contain  ${smtp}  To: <first@example.com>, <second@example.com>
+  Should Contain  ${smtp}  X-Custom: template-custom
+  Should Contain  ${smtp}  X-Selector: selector-test@example.com
+  ${rspamd_log} =  Get File  ${RSPAMD_TMPDIR}/rspamd.log
+  Should Contain  ${rspamd_log}  METADATA_OPTIONS_EXPANDED
+  Should Not Contain  ${rspamd_log}  METADATA_OPTIONS_FAILED
+
 *** Keywords ***
 Metadata Exporter Structured Setup
   Run Redis
+  ${smtp} =  Start Dummy Smtp  11126  sink  127.0.0.1  ${SMTP_PID}
+  ...  --status-file  ${SMTP_STATUS}
+  Set Test Variable  ${DUMMY_SMTP_PROC}  ${smtp}
   Rspamd Setup
 
 Metadata Exporter Structured Teardown
   Rspamd Teardown
+  Terminate Process  ${DUMMY_SMTP_PROC}
+  Wait For Process  ${DUMMY_SMTP_PROC}
   Redis Teardown

--- a/test/functional/cases/560_metadata_exporter_structured.robot
+++ b/test/functional/cases/560_metadata_exporter_structured.robot
@@ -29,6 +29,10 @@ ${SMTP_STATUS_6}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp6.status
 ${SMTP_PID_6}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp6.pid
 ${SMTP_STATUS_7}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp7.status
 ${SMTP_PID_7}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp7.pid
+${SMTP_STATUS_8}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp8.status
+${SMTP_PID_8}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp8.pid
+${SMTP_STATUS_9}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp9.status
+${SMTP_PID_9}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp9.pid
 
 *** Test Cases ***
 Structured export to Redis stream - UUID v7 and metadata
@@ -273,6 +277,63 @@ Email export renders a literal content part
   Should Be Equal  ${part1}[decoded_text]
   ...  Static literal line one.\nHost is 127.0.0.1 and template value is template-custom.
 
+Email export auto-groups plain and html into a nested alternative
+  [Documentation]  A text/plain + text/html pair auto-groups into a nested
+  ...  multipart/alternative; the attached template body and zip attachment
+  ...  stay siblings in the outer multipart/mixed.
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS_8}
+  ${smtp8} =  Get File  ${SMTP_STATUS_8}
+  ${info} =  Validate Multipart Email  ${smtp8}
+
+  Should Be True  ${info}[is_multipart]
+  Should Be Equal  ${info}[subtype]  mixed
+  Should Be Equal As Integers  ${info}[part_count]  3
+
+  ${alt} =  Set Variable  ${info}[parts][0]
+  Should Be Equal  ${alt}[subtype]  alternative
+  Should Be Equal As Integers  ${alt}[part_count]  2
+  Should Be Equal  ${alt}[subparts][0][content_type]  text/plain
+  Should Be Equal  ${alt}[subparts][0][decoded_text]  Plain alternative body.
+  Should Be Equal  ${alt}[subparts][1][content_type]  text/html
+  Should Be Equal  ${alt}[subparts][1][decoded_text]  <p>HTML alternative body.</p>
+
+  ${template_attachment} =  Set Variable  ${info}[parts][1]
+  Should Be Equal  ${template_attachment}[content_type]  text/html
+  Should Contain  ${template_attachment}[disposition]  ATTACHMENT
+  Should Be Equal  ${template_attachment}[filename]  template.html
+  Should Be Equal  ${template_attachment}[decoded_text]  <p>Attached template body.</p>
+
+  ${attachment} =  Set Variable  ${info}[parts][2]
+  Should Be Equal  ${attachment}[content_type]  application/zip
+  Should Be Equal  ${attachment}[filename]  attachment.zip
+
+Email export uses a top-level alternative when it is the only content
+  [Documentation]  A text/plain + text/html pair with no other parts sets the
+  ...  top-level subtype to alternative and emits both parts directly in it.
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS_9}
+  ${smtp9} =  Get File  ${SMTP_STATUS_9}
+  ${info} =  Validate Multipart Email  ${smtp9}
+
+  Should Be True  ${info}[is_multipart]
+  Should Be Equal  ${info}[subtype]  alternative
+  Should Be Equal As Integers  ${info}[part_count]  2
+  Should Be Equal  ${info}[parts][0][content_type]  text/plain
+  Should Be Equal  ${info}[parts][0][decoded_text]  Plain only body.
+  Should Be Equal  ${info}[parts][1][content_type]  text/html
+  Should Be Equal  ${info}[parts][1][decoded_text]  <p>HTML only body.</p>
+
 Invalid rule with unknown key fails configtest
   [Documentation]  A rule with an unrecognized option is rejected by the
   ...  schema, disabled at config load time, and reported by configtest.
@@ -297,7 +358,8 @@ Invalid rule with unknown key fails configtest
 Metadata Exporter Structured Setup
   Run Redis
   Remove Files  ${SMTP_STATUS}  ${SMTP_STATUS_2}  ${SMTP_STATUS_3}  ${SMTP_STATUS_4}
-  ...  ${SMTP_STATUS_5}  ${SMTP_STATUS_6}  ${SMTP_STATUS_7}
+  ...  ${SMTP_STATUS_5}  ${SMTP_STATUS_6}  ${SMTP_STATUS_7}  ${SMTP_STATUS_8}
+  ...  ${SMTP_STATUS_9}
   ${smtp} =  Start Dummy Smtp  11126  sink  127.0.0.1  ${SMTP_PID}
   ...  --status-file  ${SMTP_STATUS}
   Set Test Variable  ${DUMMY_SMTP_PROC}  ${smtp}
@@ -319,6 +381,12 @@ Metadata Exporter Structured Setup
   ${smtp7} =  Start Dummy Smtp  11132  sink  127.0.0.1  ${SMTP_PID_7}
   ...  --status-file  ${SMTP_STATUS_7}
   Set Test Variable  ${DUMMY_SMTP_PROC_7}  ${smtp7}
+  ${smtp8} =  Start Dummy Smtp  11134  sink  127.0.0.1  ${SMTP_PID_8}
+  ...  --status-file  ${SMTP_STATUS_8}
+  Set Test Variable  ${DUMMY_SMTP_PROC_8}  ${smtp8}
+  ${smtp9} =  Start Dummy Smtp  11135  sink  127.0.0.1  ${SMTP_PID_9}
+  ...  --status-file  ${SMTP_STATUS_9}
+  Set Test Variable  ${DUMMY_SMTP_PROC_9}  ${smtp9}
   Rspamd Setup
 
 Metadata Exporter Structured Teardown
@@ -337,4 +405,8 @@ Metadata Exporter Structured Teardown
   Wait For Process  ${DUMMY_SMTP_PROC_6}
   Terminate Process  ${DUMMY_SMTP_PROC_7}
   Wait For Process  ${DUMMY_SMTP_PROC_7}
+  Terminate Process  ${DUMMY_SMTP_PROC_8}
+  Wait For Process  ${DUMMY_SMTP_PROC_8}
+  Terminate Process  ${DUMMY_SMTP_PROC_9}
+  Wait For Process  ${DUMMY_SMTP_PROC_9}
   Redis Teardown

--- a/test/functional/cases/560_metadata_exporter_structured.robot
+++ b/test/functional/cases/560_metadata_exporter_structured.robot
@@ -19,6 +19,10 @@ ${SMTP_STATUS}         ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp.status
 ${SMTP_PID}            ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp.pid
 ${SMTP_STATUS_2}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp2.status
 ${SMTP_PID_2}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp2.pid
+${SMTP_STATUS_3}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp3.status
+${SMTP_PID_3}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp3.pid
+${SMTP_STATUS_4}       ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp4.status
+${SMTP_PID_4}          ${RSPAMD_TMP_PREFIX}/metadata_exporter_smtp4.pid
 
 *** Test Cases ***
 Structured export to Redis stream - UUID v7 and metadata
@@ -118,16 +122,111 @@ Email export auto-encodes non-ASCII headers
   Should Not Contain  ${smtp2}  Änne Beispiel
   Should Not Contain  ${smtp2}  Prüfung möglich
 
+Email export builds multipart from email_parts
+  [Documentation]  email_parts assembles a multipart/mixed message: an
+  ...  auto-quoted-printable text part and a base64 attachment with an
+  ...  RFC 2231-encoded filename. The template's own body is empty, so no
+  ...  extra leading part should appear. Numeric and empty values are valid.
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS_3}
+  ${smtp3} =  Get File  ${SMTP_STATUS_3}
+  ${info} =  Validate Multipart Email  ${smtp3}
+
+  Should Be True  ${info}[is_multipart]
+  Should Be Equal  ${info}[subtype]  mixed
+  Should Be Equal As Integers  ${info}[part_count]  6
+  Should Be True  ${info}[max_line_length] <= 998
+  Should Be Equal  ${info}[mime_version]  1.0
+  Should Not Be Equal  ${info}[message_id]  ${None}
+
+  ${part1} =  Set Variable  ${info}[parts][0]
+  Should Be Equal  ${part1}[content_type]  text/plain
+  Should Be Equal  ${part1}[cte]  quoted-printable
+  Should Be Equal  ${part1}[disposition]  inline
+  Should Be Equal  ${part1}[decoded_text]  Prüfung ergab: alles in Ordnung.
+
+  ${part2} =  Set Variable  ${info}[parts][1]
+  Should Be Equal  ${part2}[content_type]  application/zip
+  Should Be Equal  ${part2}[cte]  base64
+  Should Contain  ${part2}[disposition]  attachment
+  Should Be Equal  ${part2}[filename]  Bericht ö selector-test@example.com.zip
+  Should Be Equal As Integers  ${part2}[decoded_length]  211
+  Should Be Equal  ${part2}[decoded_sha256]  afa3a88349b72766447f9600846a12e539b3033ca5e7b12a836e72a46e586daf
+
+  ${part3} =  Set Variable  ${info}[parts][2]
+  Should Be Equal  ${part3}[content_type]  text/plain
+  Should Be Equal  ${part3}[cte]  7bit
+  Should Be Equal  ${part3}[decoded_text]  42
+
+  ${part4} =  Set Variable  ${info}[parts][3]
+  Should Be Equal  ${part4}[content_type]  application/octet-stream
+  Should Be Equal  ${part4}[cte]  base64
+  Should Be Equal As Integers  ${part4}[decoded_length]  0
+
+  # A bare "." line survives DATA intact via SMTP dot-stuffing, so the
+  # configured 8bit encoding is kept rather than escalated
+  ${part5} =  Set Variable  ${info}[parts][4]
+  Should Be Equal  ${part5}[content_type]  text/plain
+  Should Be Equal  ${part5}[cte]  8bit
+  Should Be Equal  ${part5}[decoded_text]  before\n.\nafter
+
+  # Long filename survives RFC 2231 continuation splitting intact
+  ${part6} =  Set Variable  ${info}[parts][5]
+  Should Be Equal  ${part6}[filename]
+  ...  Jahresabschlussbericht-Ärger-mit-Umlauten-und-sehr-langem-Namen-für-die-Ablage-2026-Quartal-vier-final.zip
+
+Email export preserves template body MIME headers
+  [Documentation]  The template's text/html Content-Type and 8bit CTE move to
+  ...  its leading multipart part. A table-valued variable is flattened.
+  Scan File  ${MESSAGE}
+  ...  From=sender@example.com
+  ...  Rcpt=first@example.com
+  ...  User=selector-test@example.com
+  ...  Settings={symbols_enabled = []}
+
+  Wait Until Keyword Succeeds  5s  100ms  File Should Exist  ${SMTP_STATUS_4}
+  ${smtp4} =  Get File  ${SMTP_STATUS_4}
+  ${info} =  Validate Multipart Email  ${smtp4}
+
+  Should Be True  ${info}[is_multipart]
+  Should Be Equal  ${info}[subtype]  mixed
+  Should Be Equal  ${info}[mime_version]  1.0
+  # Template body headers move to the leading part, not the multipart wrapper
+  Should Be Equal As Integers  ${info}[content_type_header_count]  1
+  Should Be Equal As Integers  ${info}[cte_header_count]  0
+  # Template body becomes part 1, email_parts entry follows
+  Should Be Equal As Integers  ${info}[part_count]  2
+
+  ${part1} =  Set Variable  ${info}[parts][0]
+  Should Be Equal  ${part1}[content_type]  text/html
+  Should Be Equal  ${part1}[cte]  8bit
+  Should Be Equal  ${part1}[decoded_text]  <p>Grüße</p>
+
+  ${part2} =  Set Variable  ${info}[parts][1]
+  Should Be Equal  ${part2}[content_type]  text/plain
+  Should Be Equal  ${part2}[decoded_text]  alpha\nbeta\ngamma
+
 *** Keywords ***
 Metadata Exporter Structured Setup
   Run Redis
-  Remove Files  ${SMTP_STATUS}  ${SMTP_STATUS_2}
+  Remove Files  ${SMTP_STATUS}  ${SMTP_STATUS_2}  ${SMTP_STATUS_3}  ${SMTP_STATUS_4}
   ${smtp} =  Start Dummy Smtp  11126  sink  127.0.0.1  ${SMTP_PID}
   ...  --status-file  ${SMTP_STATUS}
   Set Test Variable  ${DUMMY_SMTP_PROC}  ${smtp}
   ${smtp2} =  Start Dummy Smtp  11127  sink  127.0.0.1  ${SMTP_PID_2}
   ...  --status-file  ${SMTP_STATUS_2}
   Set Test Variable  ${DUMMY_SMTP_PROC_2}  ${smtp2}
+  ${smtp3} =  Start Dummy Smtp  11128  sink  127.0.0.1  ${SMTP_PID_3}
+  ...  --status-file  ${SMTP_STATUS_3}
+  Set Test Variable  ${DUMMY_SMTP_PROC_3}  ${smtp3}
+  ${smtp4} =  Start Dummy Smtp  11129  sink  127.0.0.1  ${SMTP_PID_4}
+  ...  --status-file  ${SMTP_STATUS_4}
+  Set Test Variable  ${DUMMY_SMTP_PROC_4}  ${smtp4}
   Rspamd Setup
 
 Metadata Exporter Structured Teardown
@@ -136,4 +235,8 @@ Metadata Exporter Structured Teardown
   Wait For Process  ${DUMMY_SMTP_PROC}
   Terminate Process  ${DUMMY_SMTP_PROC_2}
   Wait For Process  ${DUMMY_SMTP_PROC_2}
+  Terminate Process  ${DUMMY_SMTP_PROC_3}
+  Wait For Process  ${DUMMY_SMTP_PROC_3}
+  Terminate Process  ${DUMMY_SMTP_PROC_4}
+  Wait For Process  ${DUMMY_SMTP_PROC_4}
   Redis Teardown

--- a/test/functional/configs/metadata_exporter_structured.conf
+++ b/test/functional/configs/metadata_exporter_structured.conf
@@ -90,6 +90,18 @@ EOD;
       email_alert_sender_variable = "invalid_recipient";
       selector = "email_test";
     }
+    EMAIL_EXPORT_ENCODED_HEADERS {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11127;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}"];
+      email_template = "From: \"Jörg Müller\" <$mail_from>\nTo: \"Änne Example\" <first@example.com>, <second@example.com>\nCc: Jörg <third@example.com> (Kommentar)\nSubject: Prüfung möglich\n\nMetadata alert";
+      selector = "email_test";
+    }
     VERIFY_OPTIONS {
       backend = "verify_options";
       formatter = "default";

--- a/test/functional/configs/metadata_exporter_structured.conf
+++ b/test/functional/configs/metadata_exporter_structured.conf
@@ -176,6 +176,30 @@ EOD;
       ];
       selector = "email_test";
     }
+    EMAIL_EXPORT_8BITMIME {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11130;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}"];
+      email_template = "From: <$mail_from>\nTo: $mail_to\n\nMetadata alert";
+      selector = "email_test";
+    }
+    EMAIL_EXPORT_HELO_FALLBACK {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11131;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}"];
+      email_template = "From: <$mail_from>\nTo: $mail_to\n\nMetadata alert";
+      selector = "email_test";
+    }
     VERIFY_OPTIONS {
       backend = "verify_options";
       formatter = "default";

--- a/test/functional/configs/metadata_exporter_structured.conf
+++ b/test/functional/configs/metadata_exporter_structured.conf
@@ -22,6 +22,9 @@ metadata_exporter {
     parts_list = "return function() return {'alpha', 'beta', 'gamma'} end";
     parts_dotline = "return function() return 'before\\n.\\nafter' end";
     parts_longname = "return function() return 'payload' end";
+    invalid_non_string = 42;
+    # Valid Lua that yields no callback: must be reported, not thrown
+    invalid_no_callback = "local x = 1";
   }
   custom_push {
     verify_options = <<EOD
@@ -122,34 +125,34 @@ EOD;
       email_parts_type = "mixed";
       email_parts = [
         {
-          variable = "parts_text";
+          content_from_variables = "parts_text";
           content_type = "text/plain; charset=utf-8";
           encoding = "7bit";
         },
         {
-          variable = "parts_binary";
+          content_from_variables = "parts_binary";
           filename = "Bericht ö ${user}.zip";
           content_type = "application/zip";
         },
         {
-          variable = "parts_number";
+          content_from_variables = "parts_number";
           content_type = "text/plain";
           encoding = "7bit";
         },
         {
-          variable = "parts_empty";
+          content_from_variables = "parts_empty";
           content_type = "application/octet-stream";
         },
         # SMTP dot-stuffing preserves a bare "." line without changing CTE
         {
-          variable = "parts_dotline";
+          content_from_variables = "parts_dotline";
           content_type = "text/plain; charset=utf-8";
           encoding = "8bit";
         },
         # Long filename must be split into RFC 2231 continuation sections
         # rather than emitted as one over-long header line
         {
-          variable = "parts_longname";
+          content_from_variables = "parts_longname";
           content_type = "application/octet-stream";
           filename = "Jahresabschlussbericht-Ärger-mit-Umlauten-und-sehr-langem-Namen-für-die-Ablage-2026-Quartal-vier-final.zip";
         }
@@ -170,11 +173,56 @@ EOD;
       email_template = "From: <$mail_from>\nTo: $mail_to\nMIME-Version: 1.0\nContent-Type: text/html; charset=utf-8\nContent-Transfer-Encoding: 8bit\nSubject: HTML parts export\n\n<p>Grüße</p>";
       email_parts = [
         {
-          variable = "parts_list";
+          content_from_variables = "parts_list";
           content_type = "text/plain; charset=utf-8";
         }
       ];
       selector = "email_test";
+    }
+    # A `content` part (as opposed to content_from_variables) is expanded via
+    # variables/selectors and lua_util.template, exactly like the template body
+    EMAIL_EXPORT_CONTENT {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11132;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}"];
+      email_template = "From: <$mail_from>\nTo: $mail_to\nMIME-Version: 1.0\nMessage-ID: <$our_message_id>\nSubject: Literal content export\n";
+      email_parts = [
+        {
+          content = "Static literal line one.\nHost is $loopback and template value is $template_value.";
+          content_type = "text/plain; charset=utf-8";
+          filename = "$user-$template_value.txt";
+          encoding = "7bit";
+        }
+      ];
+      selector = "email_test";
+    }
+    # Unknown key -> rejected by the schema and disabled at startup, other rules unaffected
+    INVALID_RULE_BAD_KEY {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11133;
+      mail_to = "postmaster@example.com";
+      totally_unknown_option = true;
+    }
+    INVALID_PART_BOTH_SOURCES {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      mail_to = "postmaster@example.com";
+      email_parts = [{ content = "literal"; content_from_variables = "parts_text"; }];
+    }
+    INVALID_PART_NO_SOURCE {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      mail_to = "postmaster@example.com";
+      email_parts = [{ content_type = "text/plain"; }];
     }
     EMAIL_EXPORT_8BITMIME {
       backend = "send_mail";

--- a/test/functional/configs/metadata_exporter_structured.conf
+++ b/test/functional/configs/metadata_exporter_structured.conf
@@ -15,6 +15,13 @@ metadata_exporter {
     stream_zstd_key = "return function() return 'test:structured_zstd' end";
     template_value = "return function() return 'template-custom' end";
     unused_failure = "return function() error('unused custom variable evaluated') end";
+    parts_text = "return function() return 'Prüfung ergab: alles in Ordnung.' end";
+    parts_binary = "return function() return string.char(0,1,2,3,4,5,6,7,255,254,253) .. string.rep('B', 200) end";
+    parts_number = "return function() return 42 end";
+    parts_empty = "return function() return '' end";
+    parts_list = "return function() return {'alpha', 'beta', 'gamma'} end";
+    parts_dotline = "return function() return 'before\\n.\\nafter' end";
+    parts_longname = "return function() return 'payload' end";
   }
   custom_push {
     verify_options = <<EOD
@@ -100,6 +107,73 @@ EOD;
       mail_from = "${from('smtp'):addr}";
       mail_to = ["${rcpts:addr}"];
       email_template = "From: \"Jörg Müller\" <$mail_from>\nTo: \"Änne Example\" <first@example.com>, <second@example.com>\nCc: Jörg <third@example.com> (Kommentar)\nSubject: Prüfung möglich\n\nMetadata alert";
+      selector = "email_test";
+    }
+    EMAIL_EXPORT_PARTS {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11128;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}"];
+      email_template = "From: <$mail_from>\nTo: $mail_to\nMIME-Version: 1.0\nMessage-ID: <$our_message_id>\nSubject: Parts export\n";
+      email_parts_type = "mixed";
+      email_parts = [
+        {
+          variable = "parts_text";
+          content_type = "text/plain; charset=utf-8";
+          encoding = "7bit";
+        },
+        {
+          variable = "parts_binary";
+          filename = "Bericht ö ${user}.zip";
+          content_type = "application/zip";
+        },
+        {
+          variable = "parts_number";
+          content_type = "text/plain";
+          encoding = "7bit";
+        },
+        {
+          variable = "parts_empty";
+          content_type = "application/octet-stream";
+        },
+        # SMTP dot-stuffing preserves a bare "." line without changing CTE
+        {
+          variable = "parts_dotline";
+          content_type = "text/plain; charset=utf-8";
+          encoding = "8bit";
+        },
+        # Long filename must be split into RFC 2231 continuation sections
+        # rather than emitted as one over-long header line
+        {
+          variable = "parts_longname";
+          content_type = "application/octet-stream";
+          filename = "Jahresabschlussbericht-Ärger-mit-Umlauten-und-sehr-langem-Namen-für-die-Ablage-2026-Quartal-vier-final.zip";
+        }
+      ];
+      selector = "email_test";
+    }
+    # The template's body MIME headers move to its leading multipart part.
+    # parts_list returns a table and must be flattened into body text.
+    EMAIL_EXPORT_PARTS_DEFAULT {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11129;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}"];
+      email_template = "From: <$mail_from>\nTo: $mail_to\nMIME-Version: 1.0\nContent-Type: text/html; charset=utf-8\nContent-Transfer-Encoding: 8bit\nSubject: HTML parts export\n\n<p>Grüße</p>";
+      email_parts = [
+        {
+          variable = "parts_list";
+          content_type = "text/plain; charset=utf-8";
+        }
+      ];
       selector = "email_test";
     }
     VERIFY_OPTIONS {

--- a/test/functional/configs/metadata_exporter_structured.conf
+++ b/test/functional/configs/metadata_exporter_structured.conf
@@ -8,21 +8,111 @@ redis {
 
 # Configure metadata_exporter with structured formatter and redis_stream backend
 metadata_exporter {
+  custom_variables {
+    invalid_recipient = "return function() return 'not-an-address' end";
+    loopback = "return function() return '127.0.0.1' end";
+    stream_key = "return function() return 'test:structured' end";
+    stream_zstd_key = "return function() return 'test:structured_zstd' end";
+    template_value = "return function() return 'template-custom' end";
+    unused_failure = "return function() error('unused custom variable evaluated') end";
+  }
+  custom_push {
+    verify_options = <<EOD
+local logger = require 'rspamd_logger'
+return function(task, _, rule)
+  local checks = {
+    -- routing values are expanded from custom variables and selectors
+    mail_from = rule.mail_from == 'sender@example.com',
+    mail_to = rule.mail_to[1] == 'template-custom',
+    helo = rule.helo == 'selector-test@example.com',
+    channel = rule.channel == 'template-custom',
+    stream_key = rule.stream_key == 'selector-test@example.com',
+    -- connection, credential and behaviour values must stay literal
+    url = rule.url == '$template_value/${user}',
+    host = rule.host == '$loopback',
+    smtp = rule.smtp == '$loopback',
+    user = rule.user == '$template_value',
+    password = rule.password == '${user}',
+    mime_type = rule.mime_type == '$template_value',
+    meta_header_prefix = rule.meta_header_prefix == '${user}',
+    port = type(rule.port) == 'number' and rule.port == 11126,
+    smtp_port = type(rule.smtp_port) == 'number' and rule.smtp_port == 11126,
+    timeout = type(rule.timeout) == 'number' and rule.timeout == 5,
+    max_len = type(rule.max_len) == 'number' and rule.max_len == 100,
+    gzip = rule.gzip == true,
+    keepalive = rule.keepalive == false,
+    zstd_compress = rule.zstd_compress == true,
+  }
+  local failed = {}
+  for name, valid in pairs(checks) do
+    if not valid then
+      failed[#failed + 1] = name
+    end
+  end
+  if #failed == 0 then
+    logger.messagex(task, 'METADATA_OPTIONS_EXPANDED')
+  else
+    logger.messagex(task, 'METADATA_OPTIONS_%s: %s', 'FAILED', table.concat(failed, ','))
+  end
+end
+EOD;
+  }
+  custom_select {
+    email_test = "return function(task) return task:get_user() == 'selector-test@example.com' end";
+  }
   rules {
     STRUCTURED_EXPORT {
       backend = "redis_stream";
       formatter = "structured";
-      stream_key = "test:structured";
+      stream_key = "$stream_key";
       max_len = 100;
+      per_recipient = false;
       selector = "default";
     }
     STRUCTURED_EXPORT_ZSTD {
       backend = "redis_stream";
       formatter = "structured";
       zstd_compress = true;
-      stream_key = "test:structured_zstd";
+      stream_key = "$stream_zstd_key";
       max_len = 100;
       selector = "default";
+    }
+    EMAIL_EXPORT {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11126;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}", "$invalid_recipient"];
+      email_template = "From: <$mail_from>\nTo: $mail_to\nX-Custom: $template_value\nX-Selector: ${user}\n\nMetadata alert";
+      email_alert_sender_variable = "invalid_recipient";
+      selector = "email_test";
+    }
+    VERIFY_OPTIONS {
+      backend = "verify_options";
+      formatter = "default";
+      selector = "email_test";
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["$template_value"];
+      helo = "${user}";
+      channel = "$template_value";
+      stream_key = "${user}";
+      url = "$template_value/${user}";
+      host = "$loopback";
+      smtp = "$loopback";
+      user = "$template_value";
+      password = "${user}";
+      mime_type = "$template_value";
+      meta_header_prefix = "${user}";
+      port = 11126;
+      smtp_port = 11126;
+      timeout = 5;
+      max_len = 100;
+      gzip = true;
+      keepalive = false;
+      zstd_compress = true;
     }
   }
 }

--- a/test/functional/configs/metadata_exporter_structured.conf
+++ b/test/functional/configs/metadata_exporter_structured.conf
@@ -161,6 +161,8 @@ EOD;
     }
     # The template's body MIME headers move to its leading multipart part.
     # parts_list returns a table and must be flattened into body text.
+    # auto_grouping = false keeps this test focused on header-preservation
+    # rather than the multipart/alternative auto-grouping tested separately.
     EMAIL_EXPORT_PARTS_DEFAULT {
       backend = "send_mail";
       formatter = "email_alert";
@@ -171,6 +173,7 @@ EOD;
       mail_from = "${from('smtp'):addr}";
       mail_to = ["${rcpts:addr}"];
       email_template = "From: <$mail_from>\nTo: $mail_to\nMIME-Version: 1.0\nContent-Type: text/html; charset=utf-8\nContent-Transfer-Encoding: 8bit\nSubject: HTML parts export\n\n<p>Grüße</p>";
+      auto_grouping = false;
       email_parts = [
         {
           content_from_variables = "parts_list";
@@ -196,6 +199,64 @@ EOD;
           content = "Static literal line one.\nHost is $loopback and template value is $template_value.";
           content_type = "text/plain; charset=utf-8";
           filename = "$user-$template_value.txt";
+          encoding = "7bit";
+        }
+      ];
+      selector = "email_test";
+    }
+    # A text/plain + text/html pair auto-groups into a nested
+    # multipart/alternative, with the zip attachment staying a sibling in the
+    # outer multipart/mixed
+    EMAIL_EXPORT_ALTERNATIVE {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11134;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}"];
+      email_template = "From: <$mail_from>\nTo: $mail_to\nMIME-Version: 1.0\nMessage-ID: <$our_message_id>\nSubject: Alternative export\nContent-Type: text/html; charset=utf-8\nContent-Disposition: ATTACHMENT; filename=\"template.html\"\n\n<p>Attached template body.</p>";
+      email_parts = [
+        {
+          content = "Plain alternative body.";
+          content_type = "text/plain; charset=utf-8";
+          encoding = "7bit";
+        },
+        {
+          content = "<p>HTML alternative body.</p>";
+          content_type = "text/html; charset=utf-8";
+          encoding = "7bit";
+        },
+        {
+          content_from_variables = "parts_binary";
+          filename = "attachment.zip";
+          content_type = "application/zip";
+        }
+      ];
+      selector = "email_test";
+    }
+    # A text/plain + text/html pair with nothing else becomes a top-level
+    # multipart/alternative containing those two parts directly
+    EMAIL_EXPORT_ALTERNATIVE_ONLY {
+      backend = "send_mail";
+      formatter = "email_alert";
+      smtp = "127.0.0.1";
+      smtp_port = 11135;
+      helo = "${user}";
+      timeout = 5;
+      mail_from = "${from('smtp'):addr}";
+      mail_to = ["${rcpts:addr}"];
+      email_template = "From: <$mail_from>\nTo: $mail_to\nMIME-Version: 1.0\nMessage-ID: <$our_message_id>\nSubject: Alternative only export\n";
+      email_parts = [
+        {
+          content = "Plain only body.";
+          content_type = "text/plain; charset=utf-8";
+          encoding = "7bit";
+        },
+        {
+          content = "<p>HTML only body.</p>";
+          content_type = "text/html; charset=utf-8";
           encoding = "7bit";
         }
       ];

--- a/test/functional/lib/rspamd.py
+++ b/test/functional/lib/rspamd.py
@@ -1425,6 +1425,9 @@ def validate_multipart_email(status_text):
     Returns a dict: is_multipart, content_type, subtype, part_count,
     mime_version, message_id, and parts (list of dicts with content_type,
     cte, disposition, filename - RFC 2231 parameters are decoded by email).
+    A nested multipart part (e.g. a multipart/alternative group inside a
+    multipart/mixed message) is summarized as {content_type, subtype,
+    subparts: [...]} instead of decoded_text/decoded_length/decoded_sha256.
 
     Example:
     | ${info} = | Validate Multipart Email | ${smtp_status} |
@@ -1432,6 +1435,29 @@ def validate_multipart_email(status_text):
     import email
     import email.policy
     import hashlib
+
+    def summarize_part(part):
+        if part.is_multipart():
+            subparts = [summarize_part(p) for p in part.get_payload()]
+            return {
+                'content_type': part.get_content_type(),
+                'subtype': part.get_content_subtype(),
+                'part_count': len(subparts),
+                'subparts': subparts,
+            }
+        decoded = part.get_payload(decode=True) or b''
+        decoded_text = ''
+        if part.get_content_maintype() == 'text':
+            decoded_text = decoded.decode(part.get_content_charset() or 'utf-8')
+        return {
+            'content_type': part.get_content_type(),
+            'cte': part.get('Content-Transfer-Encoding', ''),
+            'disposition': part.get('Content-Disposition', ''),
+            'filename': part.get_filename(),
+            'decoded_text': decoded_text,
+            'decoded_length': len(decoded),
+            'decoded_sha256': hashlib.sha256(decoded).hexdigest(),
+        }
 
     lines = status_text.splitlines()
     try:
@@ -1446,20 +1472,7 @@ def validate_multipart_email(status_text):
     parts = []
     if msg.is_multipart():
         for part in msg.get_payload():
-            decoded = part.get_payload(decode=True) or b''
-            decoded_text = ''
-            if part.get_content_maintype() == 'text':
-                decoded_text = decoded.decode(
-                    part.get_content_charset() or 'utf-8')
-            parts.append({
-                'content_type': part.get_content_type(),
-                'cte': part.get('Content-Transfer-Encoding', ''),
-                'disposition': part.get('Content-Disposition', ''),
-                'filename': part.get_filename(),
-                'decoded_text': decoded_text,
-                'decoded_length': len(decoded),
-                'decoded_sha256': hashlib.sha256(decoded).hexdigest(),
-            })
+            parts.append(summarize_part(part))
 
     return {
         'is_multipart': msg.is_multipart(),

--- a/test/functional/lib/rspamd.py
+++ b/test/functional/lib/rspamd.py
@@ -1416,3 +1416,66 @@ def validate_attachments_have_content_type(data):
         if 'content_type' in att and att['content_type']:
             count += 1
     return count
+
+
+def validate_multipart_email(status_text):
+    """Parse the DATA portion of a dummy_smtp 'sink' status file as a MIME
+    message and summarize its top-level multipart structure for assertions.
+
+    Returns a dict: is_multipart, content_type, subtype, part_count,
+    mime_version, message_id, and parts (list of dicts with content_type,
+    cte, disposition, filename - RFC 2231 parameters are decoded by email).
+
+    Example:
+    | ${info} = | Validate Multipart Email | ${smtp_status} |
+    """
+    import email
+    import email.policy
+    import hashlib
+
+    lines = status_text.splitlines()
+    try:
+        idx = lines.index('MESSAGE')
+    except ValueError:
+        raise Exception('No MESSAGE marker found in SMTP status file')
+
+    raw_message = '\n'.join(lines[idx + 1:])
+    msg = email.message_from_bytes(
+        raw_message.encode('utf-8'), policy=email.policy.compat32)
+
+    parts = []
+    if msg.is_multipart():
+        for part in msg.get_payload():
+            decoded = part.get_payload(decode=True) or b''
+            decoded_text = ''
+            if part.get_content_maintype() == 'text':
+                decoded_text = decoded.decode(
+                    part.get_content_charset() or 'utf-8')
+            parts.append({
+                'content_type': part.get_content_type(),
+                'cte': part.get('Content-Transfer-Encoding', ''),
+                'disposition': part.get('Content-Disposition', ''),
+                'filename': part.get_filename(),
+                'decoded_text': decoded_text,
+                'decoded_length': len(decoded),
+                'decoded_sha256': hashlib.sha256(decoded).hexdigest(),
+            })
+
+    return {
+        'is_multipart': msg.is_multipart(),
+        'content_type': msg.get_content_type(),
+        'subtype': msg.get_content_subtype(),
+        'part_count': len(parts),
+        'parts': parts,
+        'mime_version': msg.get('MIME-Version'),
+        'message_id': msg.get('Message-Id'),
+        # Only the wrapper's own Content-Type belongs at top level; the
+        # template's Content-Type, if any, moves onto its own part instead
+        'content_type_header_count': len(msg.get_all('Content-Type') or []),
+        'cte_header_count': len(
+            msg.get_all('Content-Transfer-Encoding') or []),
+        # RFC 5322 caps a line at 998 octets; long parameters must be folded
+        'max_line_length': max(
+            (len(line.encode('utf-8')) for line in raw_message.splitlines()),
+            default=0),
+    }

--- a/test/functional/lua/metadata_exporter_structured.lua
+++ b/test/functional/lua/metadata_exporter_structured.lua
@@ -1,5 +1,1 @@
--- Lua helper for metadata_exporter structured formatter functional tests
--- This file is loaded by the test config
-
--- No additional symbols needed - the metadata_exporter plugin handles everything
--- This file exists just to satisfy the lua = config option
+-- Loaded by the functional test configuration.

--- a/test/functional/util/dummy_killer.py
+++ b/test/functional/util/dummy_killer.py
@@ -11,7 +11,14 @@ def setup_killer(server, method = None):
         method = default_method
 
     def alarm_handler(signum, frame):
-        method()
+        try:
+            method()
+        finally:
+            # Closing the socket here can race with an in-flight
+            # serve_forever() select/epoll loop on the same fd, which then
+            # busy-spins instead of exiting (the closed fd keeps reporting
+            # ready). Force an immediate exit so we never spin.
+            os._exit(0)
 
     signal.signal(signal.SIGALRM, alarm_handler)
     signal.signal(signal.SIGTERM, alarm_handler)

--- a/test/functional/util/dummy_smtp.py
+++ b/test/functional/util/dummy_smtp.py
@@ -61,6 +61,42 @@ def _make_handler(args):
             if args.pre_wait > 0:
                 time.sleep(args.pre_wait)
 
+            if args.mode == "sink":
+                transcript = []
+                message = []
+                in_data = False
+                stream = self.request.makefile("rwb", buffering=0)
+                stream.write(b"220 dummy smtp\r\n")
+                while True:
+                    line = stream.readline()
+                    if not line:
+                        break
+                    text = line.decode("utf-8", errors="replace").rstrip("\r\n")
+                    if in_data:
+                        if text == ".":
+                            in_data = False
+                            stream.write(b"250 queued\r\n")
+                        else:
+                            message.append(text)
+                        continue
+
+                    transcript.append(text)
+                    command = text.upper()
+                    if command.startswith(("HELO ", "EHLO ", "MAIL FROM:", "RCPT TO:")):
+                        stream.write(b"250 ok\r\n")
+                    elif command == "DATA":
+                        in_data = True
+                        stream.write(b"354 send data\r\n")
+                    elif command == "QUIT":
+                        stream.write(b"221 bye\r\n")
+                        break
+                    else:
+                        stream.write(b"500 unsupported\r\n")
+
+                _write_status(args.status_file,
+                              "\n".join(transcript + ["MESSAGE"] + message))
+                return
+
             if args.mode == "silent":
                 try:
                     time.sleep(30)
@@ -147,7 +183,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=11125)
     parser.add_argument("--mode",
-                        choices=["silent", "error", "messy",
+                        choices=["silent", "error", "messy", "sink",
                                  "greeting_single", "greeting_multi"],
                         default="silent")
     parser.add_argument("--host", default="127.0.0.1")

--- a/test/functional/util/dummy_smtp.py
+++ b/test/functional/util/dummy_smtp.py
@@ -77,6 +77,10 @@ def _make_handler(args):
                             in_data = False
                             stream.write(b"250 queued\r\n")
                         else:
+                            # RFC 5321 4.5.2: the receiver strips the extra
+                            # leading '.' the sender added for transparency
+                            if text.startswith("."):
+                                text = text[1:]
                             message.append(text)
                         continue
 

--- a/test/functional/util/dummy_smtp.py
+++ b/test/functional/util/dummy_smtp.py
@@ -31,6 +31,13 @@
 #   --status-file PATH   (optional)     write final status here for the test
 #                                        to verify QUIT timing out-of-band
 #   --pid-file PATH      (default /tmp/dummy_smtp_<mode>.pid)
+#   --ehlo-caps CAPS     (sink mode)    comma-separated EHLO capability
+#                                        tokens advertised in a multi-line
+#                                        250- / 250 reply, e.g. "8BITMIME".
+#                                        Default: plain single-line "250 ok".
+#   --reject-ehlo        (sink mode)    reply 502 to EHLO (HELO is still
+#                                        accepted normally) to exercise a
+#                                        client's HELO fallback.
 
 import argparse
 import os
@@ -86,7 +93,19 @@ def _make_handler(args):
 
                     transcript.append(text)
                     command = text.upper()
-                    if command.startswith(("HELO ", "EHLO ", "MAIL FROM:", "RCPT TO:")):
+                    if command.startswith("EHLO "):
+                        if args.reject_ehlo:
+                            stream.write(b"502-command not implemented\r\n")
+                            stream.write(b"502 use HELO instead\r\n")
+                        elif args.ehlo_caps:
+                            caps = args.ehlo_caps.split(",")
+                            stream.write(b"250-dummy smtp\r\n")
+                            for i, cap in enumerate(caps):
+                                sep = b" " if i == len(caps) - 1 else b"-"
+                                stream.write(b"250" + sep + cap.encode("ascii") + b"\r\n")
+                        else:
+                            stream.write(b"250 ok\r\n")
+                    elif command.startswith(("HELO ", "MAIL FROM:", "RCPT TO:")):
                         stream.write(b"250 ok\r\n")
                     elif command == "DATA":
                         in_data = True
@@ -196,6 +215,13 @@ if __name__ == "__main__":
                         default=0.2)
     parser.add_argument("--status-file", dest="status_file", default=None)
     parser.add_argument("--pid-file", dest="pid_file", default=None)
+    parser.add_argument("--ehlo-caps", dest="ehlo_caps", default=None,
+                        help="sink mode: comma-separated EHLO capability "
+                             "tokens, e.g. '8BITMIME'")
+    parser.add_argument("--reject-ehlo", dest="reject_ehlo",
+                        action="store_true",
+                        help="sink mode: reply 502 to EHLO to exercise "
+                             "HELO fallback")
     args = parser.parse_args()
 
     if not args.pid_file:

--- a/test/lua/unit/lua_util.misc.lua
+++ b/test/lua/unit/lua_util.misc.lua
@@ -6,12 +6,13 @@ context("Lua util - callback_from_string", function()
     {'function', 'function(a, b) return a + b end'},
     {'plain ops', 'local c = select(1, ...)\nreturn c + select(2, ...)'},
   }
+  -- Wrapped in {label, value} pairs: a bare nil first element would end the
+  -- ipairs walk immediately and silently register none of these as tests
   local fail_cases = {
-    nil,
-    '',
-    'return function(a, b) ( end',
-    'function(a, b) ( end',
-    'return a + b'
+    { 'nil', nil },
+    { 'empty string', '' },
+    { 'return function syntax error', 'return function(a, b) ( end' },
+    { 'function syntax error', 'function(a, b) ( end' },
   }
 
   for _,c in ipairs(cases) do
@@ -21,12 +22,66 @@ context("Lua util - callback_from_string", function()
       assert_equal(f(2, 2), 4)
     end)
   end
-  for i,c in ipairs(fail_cases) do
-    test('Failure case: ' .. tostring(i), function()
-      local ret,f = util.callback_from_string(c)
+  for _,c in ipairs(fail_cases) do
+    test('Failure case: ' .. c[1], function()
+      local ret,err = util.callback_from_string(c[2])
       assert_false(ret)
+      assert_equal(type(err), 'string')
     end)
   end
+
+  -- A bare expression is wrapped into 'return function(...) <s>; end', so it
+  -- compiles even when it references undefined globals: the error surfaces on
+  -- the first call, not at load time
+  test('a bare expression compiles into a callback that may fail when called', function()
+    local ret, f = util.callback_from_string('return a + b')
+    assert_true(ret, f)
+    assert_false((pcall(f)))
+  end)
+
+  test('chunkname appears in syntax error message', function()
+    local ret, err = util.callback_from_string('return function(a, b) ( end', 'my_chunk')
+    assert_false(ret)
+    assert_not_nil(string.find(err, 'my_chunk', 1, true), err)
+  end)
+
+  test('whole chunk may set up locals before returning a callback', function()
+    local ret, callback = util.callback_from_string(
+      'local offset = 3\nreturn function(value) return value + offset end',
+      'setup_chunk', true)
+    assert_true(ret, callback)
+    assert_equal(callback(2), 5)
+  end)
+
+  test('non-string input is rejected without throwing', function()
+    local ok, ret, err = pcall(util.callback_from_string, {}, 'bad_chunk', true)
+    assert_true(ok)
+    assert_false(ret)
+    assert_equal(err, 'invalid or empty string')
+  end)
+
+  -- A valid chunk that yields no callback must report a string error: callers
+  -- feed the second return value straight into string.format('%s', ...), which
+  -- throws on nil or on a table under LuaJIT
+  for _, c in ipairs({
+    { 'nothing', 'local x = 1', 'nil' },
+    { 'a table', 'return { 1, 2 }', 'table' },
+    { 'a string', 'return "not a function"', 'string' },
+  }) do
+    test('chunk returning ' .. c[1] .. ' yields a string error', function()
+      local ret, err = util.callback_from_string(c[2], 'no_callback_chunk', true)
+      assert_false(ret)
+      assert_equal(type(err), 'string')
+      assert_not_nil(string.find(err, c[3], 1, true), err)
+    end)
+  end
+
+  test('runtime error inside the chunk yields a string error', function()
+    local ret, err = util.callback_from_string('error("boom")', 'boom_chunk', true)
+    assert_false(ret)
+    assert_equal(type(err), 'string')
+    assert_not_nil(string.find(err, 'boom', 1, true), err)
+  end)
 end)
 
 context("Lua util - str_endswith", function()

--- a/test/lua/unit/metadata_exporter_schema.lua
+++ b/test/lua/unit/metadata_exporter_schema.lua
@@ -151,3 +151,132 @@ context("metadata_exporter email_parts schema", function()
     assert_not_nil(err)
   end)
 end)
+
+context("metadata_exporter multipart/alternative layout planner", function()
+  local schema = require "plugins/metadata_exporter"
+
+  test("classify_text_kind recognizes inline text/plain and text/html", function()
+    assert_equal(schema.classify_text_kind("text/plain; charset=utf-8", nil, nil), "plain")
+    assert_equal(schema.classify_text_kind("text/html", nil, nil), "html")
+    assert_equal(schema.classify_text_kind("TEXT/HTML", nil, nil), "html")
+    assert_equal(schema.classify_text_kind("text/html", nil, "Inline"), "html")
+  end)
+
+  test("classify_text_kind treats an attached or filenamed text part as other", function()
+    assert_equal(schema.classify_text_kind("text/plain", "report.txt", nil), "other")
+    assert_equal(schema.classify_text_kind("text/plain", nil, "attachment"), "other")
+    assert_equal(schema.classify_text_kind("text/html", nil, "ATTACHMENT"), "other")
+    assert_equal(schema.classify_text_kind("application/zip", nil, nil), "other")
+  end)
+
+  -- The subtype must end where it ends: a prefix match alone would pull
+  -- unrelated types such as text/plaintext into the alternative group
+  test("classify_text_kind does not match a longer subtype sharing the prefix", function()
+    assert_equal(schema.classify_text_kind("text/plaintext", nil, nil), "other")
+    assert_equal(schema.classify_text_kind("text/htmlish", nil, nil), "other")
+    assert_equal(schema.classify_text_kind("text/plain;charset=utf-8", nil, nil), "plain")
+    assert_equal(schema.classify_text_kind("text/html", nil, nil), "html")
+  end)
+
+  test("plain + html with no other parts groups under a top-level alternative", function()
+    local descriptors = {
+      { kind = "plain", part = "P" },
+      { kind = "html", part = "H" },
+    }
+    local subtype, tree = schema.plan_layout(descriptors, {})
+    assert_equal(subtype, "alternative")
+    assert_equal(#tree, 2)
+    assert_equal(tree[1].part, "P")
+    assert_equal(tree[2].part, "H")
+  end)
+
+  test("plain + html + attachment nests the alternative inside multipart/mixed", function()
+    local descriptors = {
+      { kind = "plain", part = "P" },
+      { kind = "html", part = "H" },
+      { kind = "other", part = "A" },
+    }
+    local subtype, tree = schema.plan_layout(descriptors, {})
+    assert_equal(subtype, "mixed")
+    assert_equal(#tree, 2)
+    assert_not_nil(tree[1].alternative)
+    assert_equal(tree[2].part, "A")
+  end)
+
+  test("html before plain is reordered so plain comes first inside the alternative", function()
+    local descriptors = {
+      { kind = "html", part = "H" },
+      { kind = "plain", part = "P" },
+    }
+    local _, tree = schema.plan_layout(descriptors, {})
+    assert_equal(tree[1].part, "P")
+    assert_equal(tree[2].part, "H")
+  end)
+
+  test("attachment-only parts stay a flat multipart/mixed", function()
+    local descriptors = {
+      { kind = "other", part = "A" },
+      { kind = "other", part = "B" },
+    }
+    local subtype, tree = schema.plan_layout(descriptors, {})
+    assert_equal(subtype, "mixed")
+    assert_equal(#tree, 2)
+    assert_equal(tree[1].part, "A")
+    assert_equal(tree[2].part, "B")
+  end)
+
+  test("auto_grouping = false keeps a flat layout even with plain + html", function()
+    local descriptors = {
+      { kind = "plain", part = "P" },
+      { kind = "html", part = "H" },
+    }
+    local subtype, tree = schema.plan_layout(descriptors, { auto_grouping = false })
+    assert_equal(subtype, "mixed")
+    assert_equal(#tree, 2)
+    assert_equal(tree[1].part, "P")
+    assert_equal(tree[2].part, "H")
+  end)
+
+  test("an explicit email_parts_type wraps the alternative instead of collapsing it", function()
+    local descriptors = {
+      { kind = "plain", part = "P" },
+      { kind = "html", part = "H" },
+    }
+    local subtype, tree = schema.plan_layout(descriptors, { email_parts_type = "related" })
+    assert_equal(subtype, "related")
+    assert_equal(#tree, 1)
+    assert_not_nil(tree[1].alternative)
+  end)
+
+  test("two text/plain parts alongside one html part is rejected as ambiguous", function()
+    local descriptors = {
+      { kind = "plain", part = "P1" },
+      { kind = "plain", part = "P2" },
+      { kind = "html", part = "H" },
+    }
+    local subtype, err = schema.plan_layout(descriptors, {})
+    assert_nil(subtype)
+    assert_not_nil(err)
+  end)
+
+  test("two text/html parts alongside one plain part is rejected as ambiguous", function()
+    local descriptors = {
+      { kind = "plain", part = "P" },
+      { kind = "html", part = "H1" },
+      { kind = "html", part = "H2" },
+    }
+    local subtype, err = schema.plan_layout(descriptors, {})
+    assert_nil(subtype)
+    assert_not_nil(err)
+  end)
+
+  test("multiple plain parts with no html at all is not ambiguous", function()
+    local descriptors = {
+      { kind = "plain", part = "P1" },
+      { kind = "plain", part = "P2" },
+    }
+    local subtype, tree = schema.plan_layout(descriptors, {})
+    assert_equal(subtype, "mixed")
+    assert_equal(#tree, 2)
+  end)
+end)

--- a/test/lua/unit/metadata_exporter_schema.lua
+++ b/test/lua/unit/metadata_exporter_schema.lua
@@ -1,0 +1,153 @@
+-- Unit tests for lualib/plugins/metadata_exporter.lua (rule/part schema)
+
+context("metadata_exporter rule schema", function()
+  local schema = require "plugins/metadata_exporter"
+  local T = require "lua_shape.core"
+
+  test("minimal http rule is valid", function()
+    local res, err = schema.rule_schema:transform({
+      backend = "http",
+      url = "http://example.com/push",
+    })
+    assert_not_nil(res, err and T.format_error(err))
+  end)
+
+  test("minimal send_mail rule is valid", function()
+    local res, err = schema.rule_schema:transform({
+      backend = "send_mail",
+      smtp = "127.0.0.1",
+      mail_to = "postmaster@example.com",
+    })
+    assert_not_nil(res, err and T.format_error(err))
+  end)
+
+  test("mail_to accepts a single string or an array", function()
+    local res = schema.rule_schema:transform({
+      backend = "send_mail",
+      smtp = "127.0.0.1",
+      mail_to = { "a@example.com", "b@example.com" },
+    })
+    assert_not_nil(res)
+    assert_equal(#res.mail_to, 2)
+  end)
+
+  test("unknown rule key is rejected", function()
+    local res, err = schema.rule_schema:transform({
+      backend = "send_mail",
+      smtp = "127.0.0.1",
+      mail_to = "postmaster@example.com",
+      -- typo: not a real option
+      email_alert_recipient = true,
+    })
+    assert_nil(res)
+    assert_not_nil(err)
+  end)
+
+  test("rule without a backend is rejected", function()
+    local res, err = schema.rule_schema:transform({
+      url = "http://example.com/push",
+    })
+    assert_nil(res)
+    assert_not_nil(err)
+  end)
+
+  test("backend_required_elements lists smtp and mail_to for send_mail", function()
+    local reqset = schema.backend_required_elements.send_mail
+    local has_smtp, has_mail_to = false, false
+    for _, e in ipairs(reqset) do
+      if e == 'smtp' then has_smtp = true end
+      if e == 'mail_to' then has_mail_to = true end
+    end
+    assert_true(has_smtp)
+    assert_true(has_mail_to)
+  end)
+end)
+
+context("metadata_exporter email_parts schema", function()
+  local schema = require "plugins/metadata_exporter"
+  local T = require "lua_shape.core"
+
+  local function with_parts(parts)
+    return schema.rule_schema:transform({
+      backend = "send_mail",
+      smtp = "127.0.0.1",
+      mail_to = "postmaster@example.com",
+      email_parts = parts,
+    })
+  end
+
+  test("a lone part object is normalized into a one-element array", function()
+    local res, err = with_parts({
+      content = "hello",
+      content_type = "text/plain",
+    })
+    assert_not_nil(res, err and T.format_error(err))
+    assert_equal(#res.email_parts, 1)
+    assert_equal(res.email_parts[1].content, "hello")
+  end)
+
+  test("an explicit array of parts is accepted", function()
+    local res, err = with_parts({
+      { content = "one", content_type = "text/plain" },
+      { content_from_variables = "some_var", content_type = "application/octet-stream" },
+    })
+    assert_not_nil(res, err and T.format_error(err))
+    assert_equal(#res.email_parts, 2)
+  end)
+
+  test("content accepts a single string or an array of strings", function()
+    local res, err = with_parts({
+      { content = { "line one", "line two" }, content_type = "text/plain" },
+    })
+    assert_not_nil(res, err and T.format_error(err))
+    assert_equal(#res.email_parts[1].content, 2)
+  end)
+
+  test("content_from_variables accepts a single name or an array of names", function()
+    local res, err = with_parts({
+      { content_from_variables = { "var_a", "var_b" }, content_type = "application/octet-stream" },
+    })
+    assert_not_nil(res, err and T.format_error(err))
+    assert_equal(#res.email_parts[1].content_from_variables, 2)
+  end)
+
+  -- An empty table is array-like, so it fails the min_items=1 array variant and
+  -- would otherwise fall through to the lone-object variant (every part field
+  -- is optional) and be normalized into an array holding one empty part
+  test("an empty email_parts value is rejected", function()
+    local res, err = with_parts({})
+    assert_nil(res)
+    assert_not_nil(err)
+  end)
+
+  test("an unknown key inside a part is rejected", function()
+    local res, err = with_parts({
+      { content = "hello", content_type = "text/plain", oops = true },
+    })
+    assert_nil(res)
+    assert_not_nil(err)
+  end)
+
+  test("a bad encoding value is rejected", function()
+    local res, err = with_parts({
+      { content = "hello", content_type = "text/plain", encoding = "uuencode" },
+    })
+    assert_nil(res)
+    assert_not_nil(err)
+  end)
+
+  -- Reproduces the UCL duplicate-key-merge symptom: two `email_parts { ... }`
+  -- blocks under a `duplicate=merge` include collapse into ONE object whose
+  -- scalar fields become arrays (e.g. content_type = {"text/plain", "application/zip"}).
+  -- content_type/filename/disposition must stay string-only so this is still
+  -- caught here rather than silently accepted now that content/
+  -- content_from_variables legitimately accept arrays.
+  test("a merged-duplicate email_parts block (array-valued content_type) is rejected", function()
+    local res, err = with_parts({
+      content_from_variables = { "a", "b" },
+      content_type = { "text/plain", "application/zip" },
+    })
+    assert_nil(res)
+    assert_not_nil(err)
+  end)
+end)


### PR DESCRIPTION
### Summary

A batch of related `metadata_exporter` improvements built on top of `lua_smtp`
hardening, covering routing/templating flexibility, correct MIME output, and
config-time validation.

### Custom variables & selector expansion
- Add a `custom_variables` config block (Lua functions evaluated per message,
  like `custom_select`/`custom_format`/`custom_push`).
- Add `$name` / `${expr}` placeholder expansion for a small allowlist of
  per-message routing options: `mail_from`, `mail_to`, `helo`, `channel`,
  `stream_key`, plus the `email_alert` `email_template` body. `${expr}` falls
  back to a `lua_selectors` expression when no matching custom variable exists.
- Connection, credential, timeout and boolean options are never expanded, even
  if the configured value contains a literal `$`.
- Invalid addresses produced by `mail_from`/`mail_to` expansion are validated
  and dropped instead of sent; CR/LF in expanded values is collapsed to
  prevent header/protocol injection.
- Add `email_alert_sender_variable` to route an extra alert copy to an address
  produced by a named custom variable.

### MIME correctness for email_alert
- Auto-encode non-ASCII headers (RFC 2047) via the new
  `email_auto_encode_headers` rule setting (default `true`); address-list
  headers are parsed per-address so only the display name is encoded.
- Add `email_parts` / `email_parts_type` so an alert can be built as
  `multipart/<type>` with per-part `content_type`, `filename`, `disposition`,
  and transfer encoding (`auto`, `base64`, `quoted-printable`, `7bit`, `8bit`),
  with defensive encoding selection and RFC 2231 filename encoding.
- Auto-group inline, unnamed `text/plain` + `text/html` parts into a
  `multipart/alternative` (new `auto_grouping` option, default `true`, plain
  first per RFC 2046 5.1.4).

### Config validation
- Rules and `email_parts` are now schema-validated
  (`lualib/plugins/metadata_exporter.lua`) at config load time instead of
  ad-hoc checks, reporting failures via `push_config_error` so `rspamadm
  configtest` fails on invalid config.
- Include the rule name in debug log messages.

### lua_smtp hardening (shared with metadata_exporter's SMTP backend)
- Dot-stuff SMTP DATA content per RFC 5321 4.5.2, fixing silent truncation of
  message bodies containing a bare `.` line.
- Negotiate EHLO/8BITMIME with HELO fallback: read the EHLO response to
  completion before deciding to fall back, and match the 8BITMIME capability
  by exact keyword instead of substring search.
- Opt into separate connect/read/write timeouts (falling back to the overall
  timeout when unset), wired through metadata_exporter's `send_mail` backend.

### Supporting fix
- `lua_util.callback_from_string`: add `chunkname`/`return_chunk` params so
  whole-chunk callback snippets (used by `custom_variables`/`custom_select`/
  `custom_push`) compile correctly instead of being mis-wrapped as a single
  expression.

### Testing
- Functional coverage (`560_metadata_exporter_structured.robot`) for custom
  variable/selector expansion, non-ASCII header encoding, multipart
  `email_parts` assembly and dot-stuffing, EHLO/8BITMIME negotiation and HELO
  fallback, schema validation errors, content/content_from_variables, and
  multipart/alternative auto-grouping.
- Unit tests for the schema validator and `callback_from_string`.
- Fix a CPU-spin in the dummy SMTP test server helpers on shutdown.