### PR TITLE
[Feature] force_actions: composite-aware postfilter promotion and priority arbitrationFeature/force actions

### DIFF
--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -2147,6 +2147,13 @@ lua_config_get_symbol_flags(lua_State *L)
 		flags = rspamd_symcache_get_symbol_flags(cfg->cache,
 												 name);
 
+		/* Item type bits are stripped off the stored flags when a cache item is
+		 * created, so re-add the composite one that callers rely upon */
+		if (rspamd_symcache_get_symbol_stage(cfg->cache, name) ==
+			SYMBOL_TYPE_COMPOSITE) {
+			flags |= SYMBOL_TYPE_COMPOSITE;
+		}
+
 		if (flags != 0) {
 			lua_push_symbol_flags(L, flags, LUA_SYMOPT_FLAG_CREATE_ARRAY);
 		}

--- a/src/plugins/lua/force_actions.lua
+++ b/src/plugins/lua/force_actions.lua
@@ -201,6 +201,11 @@ local function gen_cb(params)
       else
         task:set_pre_result { action = params.act, module = N, flags = flags, priority = params.priority }
       end
+
+      if params.priority then
+        return true, params.act, string.format('priority:%s', params.priority)
+      end
+
       return true, params.act
     end
 

--- a/src/plugins/lua/force_actions.lua
+++ b/src/plugins/lua/force_actions.lua
@@ -35,18 +35,89 @@ local lua_selectors = require "lua_selectors"
 -- 'normal' symbol cannot depend on them via register_dependency (the cache
 -- rejects such cross-stage deps). Any rule referencing a composite atom must
 -- therefore be registered as a postfilter instead.
+-- Such a rule is still starved if any earlier pre-result was set without
+-- `process_all`, since that suppresses composite evaluation entirely.
 local function has_composite_atom(atoms)
   for _, a in ipairs(atoms) do
-    local fl = rspamd_config:get_symbol_flags(a)
-    if fl and fl.composite then
-      return true
+    -- get_symbol_flags returns an array of flag names, not a keyed map
+    for _, fl in ipairs(rspamd_config:get_symbol_flags(a) or {}) do
+      if fl == 'composite' then
+        return true
+      end
     end
   end
   return false
 end
 
+-- Passthrough priority band from src/libmime/scan_result.h:
+-- 0 = low, 1 = normal (default), 2 = high, 3 = critical (used by the core for
+-- broken messages). The C side stores it as unsigned int, so a negative value
+-- would wrap around and outrank everything.
+local min_priority, max_priority = 0, 3
+local named_priorities = {
+  low = 0,
+  normal = 1,
+  high = 2,
+  critical = 3,
+}
+
+local function check_priority(name, priority)
+  if priority == nil then
+    return nil
+  end
+
+  if type(priority) == 'string' then
+    local named = named_priorities[string.lower(priority)]
+
+    if named then
+      return named
+    end
+
+    -- UCL may hand us a quoted number
+    local as_number = tonumber(priority)
+
+    if not as_number then
+      rspamd_logger.warnx(rspamd_config,
+          'force_actions rule %1: unknown priority name "%2", expected one of low/normal/high/critical; ignored',
+          name, priority)
+      return nil
+    end
+
+    priority = as_number
+  end
+
+  if type(priority) ~= 'number' then
+    rspamd_logger.warnx(rspamd_config, 'force_actions rule %1: priority must be a number or a name, got %2; ignored',
+        name, type(priority))
+    return nil
+  end
+
+  -- NaN is the only number that does not compare equal to itself
+  if priority ~= priority then
+    rspamd_logger.warnx(rspamd_config, 'force_actions rule %1: priority is NaN; ignored', name)
+    return nil
+  end
+
+  local adjusted = math.floor(priority)
+
+  if adjusted ~= priority then
+    rspamd_logger.warnx(rspamd_config, 'force_actions rule %1: priority %2 is not an integer, adjusted to %3',
+        name, priority, adjusted)
+  end
+
+  if adjusted < min_priority or adjusted > max_priority then
+    local clamped = math.max(min_priority, math.min(max_priority, adjusted))
+    rspamd_logger.warnx(rspamd_config,
+        'force_actions rule %1: priority %2 is out of the allowed range [%3..%4], adjusted to %5',
+        name, adjusted, min_priority, max_priority, clamped)
+    adjusted = clamped
+  end
+
+  return adjusted
+end
+
 -- Params table fields:
--- expr, act, pool, message, subject, raction, honor, limit, flags
+-- expr, act, pool, message, subject, raction, honor, limit, flags, priority
 local function gen_cb(params)
 
   local function parse_atom(str)
@@ -125,9 +196,10 @@ local function gen_cb(params)
       if type(params.message) == 'string' then
         -- process selector expressions in the message
         local message = string.gsub(params.message, '(${(.-)})', process_message_selectors)
-        task:set_pre_result { action = params.act, message = message, module = N, flags = flags }
+        task:set_pre_result { action = params.act, message = message, module = N, flags = flags,
+                              priority = params.priority }
       else
-        task:set_pre_result { action = params.act, module = N, flags = flags }
+        task:set_pre_result { action = params.act, module = N, flags = flags, priority = params.priority }
       end
       return true, params.act
     end
@@ -195,7 +267,16 @@ local function configure_module()
       end
     end
   elseif type(opts.rules) == 'table' then
-    for name, sett in pairs(opts.rules) do
+    -- Register in a stable order: pairs() over a UCL object is arbitrary, and
+    -- registration order leaks into the symcache ordering heuristics.
+    local rule_names = {}
+    for name in pairs(opts.rules) do
+      table.insert(rule_names, name)
+    end
+    table.sort(rule_names)
+
+    for _, name in ipairs(rule_names) do
+      local sett = opts.rules[name]
       local action = sett.action
       local expr = sett.expression
 
@@ -209,6 +290,13 @@ local function configure_module()
         end
         local raction = lua_util.list_to_hash(sett.require_action)
         local honor = lua_util.list_to_hash(sett.honor_action)
+        local priority = check_priority(name, sett.priority)
+        if priority and sett.least then
+          rspamd_logger.warnx(rspamd_config,
+              'force_actions rule %1: `least` is set, so `priority` cannot outrank a non-least rule ' ..
+              '(any non-least result always wins); it only orders this rule against other `least` rules',
+              name)
+        end
         local cb, atoms = gen_cb { expr = expr,
                                    act = action,
                                    pool = rspamd_config:get_mempool(),
@@ -217,6 +305,7 @@ local function configure_module()
                                    raction = raction,
                                    honor = honor,
                                    limit = sett.limit,
+                                   priority = priority,
                                    flags = table.concat(flags, ',') }
         if cb and atoms then
           local composite_dep = has_composite_atom(atoms)
@@ -239,13 +328,17 @@ local function configure_module()
             for _, a in ipairs(atoms) do
               rspamd_config:register_dependency(t.name, a)
             end
-            rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> with dependencies [%3]',
-                t.name, expr, table.concat(atoms, ','))
+            rspamd_logger.infox(rspamd_config,
+                'Registered symbol %1 <%2> with dependencies [%3]; action %4, passthrough priority %5',
+                t.name, expr, table.concat(atoms, ','), action, priority or 1)
           elseif composite_dep and not (raction or honor) then
             rspamd_logger.infox(rspamd_config,
-                'Registered symbol %1 <%2> as postfilter (expression uses composite symbol(s))', t.name, expr)
+                'Registered symbol %1 <%2> as postfilter (expression uses composite symbol(s)); ' ..
+                'action %3, passthrough priority %4', t.name, expr, action, priority or 1)
           else
-            rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> as postfilter', t.name, expr)
+            rspamd_logger.infox(rspamd_config,
+                'Registered symbol %1 <%2> as postfilter; action %3, passthrough priority %4',
+                t.name, expr, action, priority or 1)
           end
         end
       end

--- a/src/plugins/lua/force_actions.lua
+++ b/src/plugins/lua/force_actions.lua
@@ -31,6 +31,20 @@ local rspamd_expression = require "rspamd_expression"
 local rspamd_logger = require "rspamd_logger"
 local lua_selectors = require "lua_selectors"
 
+-- Composite symbols are only resolved after normal filters have run, so a
+-- 'normal' symbol cannot depend on them via register_dependency (the cache
+-- rejects such cross-stage deps). Any rule referencing a composite atom must
+-- therefore be registered as a postfilter instead.
+local function has_composite_atom(atoms)
+  for _, a in ipairs(atoms) do
+    local fl = rspamd_config:get_symbol_flags(a)
+    if fl and fl.composite then
+      return true
+    end
+  end
+  return false
+end
+
 -- Params table fields:
 -- expr, act, pool, message, subject, raction, honor, limit, flags
 local function gen_cb(params)
@@ -151,18 +165,30 @@ local function configure_module()
               local h = rspamd_cryptobox_hash.create()
               h:update(expr)
               local name = 'FORCE_ACTION_' .. string.upper(string.sub(h:hex(), 1, 12))
-              rspamd_config:register_symbol({
-                type = 'normal',
+              local composite_dep = has_composite_atom(atoms)
+              local t = {
                 name = name,
                 callback = cb,
                 flags = 'empty',
                 group = N,
-              })
-              for _, a in ipairs(atoms) do
-                rspamd_config:register_dependency(name, a)
+              }
+              if composite_dep then
+                t.type = 'postfilter'
+                t.priority = lua_util.symbols_priorities.high
+              else
+                t.type = 'normal'
               end
-              rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> with dependencies [%3]',
-                  name, expr, table.concat(atoms, ','))
+              rspamd_config:register_symbol(t)
+              if t.type == 'normal' then
+                for _, a in ipairs(atoms) do
+                  rspamd_config:register_dependency(name, a)
+                end
+                rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> with dependencies [%3]',
+                    name, expr, table.concat(atoms, ','))
+              else
+                rspamd_logger.infox(rspamd_config,
+                    'Registered symbol %1 <%2> as postfilter (expression uses composite symbol(s))', name, expr)
+              end
             end
           end
         end
@@ -193,8 +219,9 @@ local function configure_module()
                                    limit = sett.limit,
                                    flags = table.concat(flags, ',') }
         if cb and atoms then
+          local composite_dep = has_composite_atom(atoms)
           local t = {}
-          if (raction or honor) then
+          if (raction or honor or composite_dep) then
             t.type = 'postfilter'
             t.priority = lua_util.symbols_priorities.high
           else
@@ -214,6 +241,9 @@ local function configure_module()
             end
             rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> with dependencies [%3]',
                 t.name, expr, table.concat(atoms, ','))
+          elseif composite_dep and not (raction or honor) then
+            rspamd_logger.infox(rspamd_config,
+                'Registered symbol %1 <%2> as postfilter (expression uses composite symbol(s))', t.name, expr)
           else
             rspamd_logger.infox(rspamd_config, 'Registered symbol %1 <%2> as postfilter', t.name, expr)
           end

--- a/test/functional/cases/360_force_actions.robot
+++ b/test/functional/cases/360_force_actions.robot
@@ -42,3 +42,56 @@ FORCE ACTIONS from add header to reject
   Expect Action  reject
   Expect Symbol  FORCE_ACTION_FORCE_ADD_HEADER_TO_REJECT
 
+FORCE ACTIONS with composite in expression
+  [Documentation]  A composite is only resolved after the filter stage, so the
+  ...  rule has to be registered as a postfilter to observe it
+  Scan File  ${MESSAGE}  Settings-Id=id_composite
+  Expect Action  reject
+  Expect Symbol  FORCE_ACTION_FORCE_COMPOSITE_TO_REJECT
+
+FORCE ACTIONS higher priority wins when registered first
+  Scan File  ${MESSAGE}  Settings-Id=id_priority_add_header_wins
+  Expect Action  add header
+  Expect Symbol  FORCE_ACTION_FORCE_PRIO_A_ADD_HEADER
+  Expect Symbol  FORCE_ACTION_FORCE_PRIO_A_REJECT
+
+FORCE ACTIONS higher priority wins when registered last
+  [Documentation]  Same as above with the priorities swapped, so that only the
+  ...  priority and not the registration order can decide the winner
+  Scan File  ${MESSAGE}  Settings-Id=id_priority_reject_wins
+  Expect Action  reject
+  Expect Symbol  FORCE_ACTION_FORCE_PRIO_B_ADD_HEADER
+  Expect Symbol  FORCE_ACTION_FORCE_PRIO_B_REJECT
+
+FORCE ACTIONS numeric priority on main stage
+  Scan File  ${MESSAGE}  Settings-Id=id_priority_numeric
+  Expect Action  reject
+  Expect Symbol  FORCE_ACTION_FORCE_PRIO_C_ADD_HEADER
+  Expect Symbol  FORCE_ACTION_FORCE_PRIO_C_REJECT
+
+FORCE ACTIONS main stage rule outranks later postfilter rule
+  [Documentation]  The postfilter rule runs last but has the lower priority, so
+  ...  it must not override the main stage result
+  Scan File  ${MESSAGE}  Settings-Id=id_priority_mixed_main_wins
+  Expect Action  add header
+  Expect Symbol  FORCE_ACTION_FORCE_MIX_MAIN_WINS_ADD_HEADER
+  Expect Symbol  FORCE_ACTION_FORCE_MIX_MAIN_WINS_REJECT
+
+FORCE ACTIONS postfilter rule outranks earlier main stage rule
+  Scan File  ${MESSAGE}  Settings-Id=id_priority_mixed_post_wins
+  Expect Action  reject
+  Expect Symbol  FORCE_ACTION_FORCE_MIX_POST_WINS_ADD_HEADER
+  Expect Symbol  FORCE_ACTION_FORCE_MIX_POST_WINS_REJECT
+
+FORCE ACTIONS priority validation
+  ${log} =  Get File  ${RSPAMD_TMPDIR}/rspamd.log  encoding_errors=ignore
+  Should Contain  ${log}  priority -10 is out of the allowed range [0..3], adjusted to 0
+  Should Contain  ${log}  priority 10 is out of the allowed range [0..3], adjusted to 3
+  Should Contain  ${log}  unknown priority name "invalid"
+  Should Contain  ${log}  priority 1.5 is not an integer, adjusted to 1
+  Should Contain  ${log}  priority is NaN; ignored
+  Should Contain  ${log}  `least` is set, so `priority` cannot outrank a non-least rule
+  Scan File  ${MESSAGE}  Settings-Id=id_priority_validation
+  Expect Action  reject
+  Expect Symbol  FORCE_ACTION_FORCE_PRIO_RANGE_ADD_HEADER
+  Expect Symbol  FORCE_ACTION_FORCE_PRIO_RANGE_REJECT

--- a/test/functional/configs/force_actions.conf
+++ b/test/functional/configs/force_actions.conf
@@ -32,6 +32,118 @@ force_actions {
         	expression = "UBER_ADD_HEADER2";
         	require_action = ["add header"];
 		}
+		# Expression uses a composite, which is only resolved after the filter
+		# stage: the rule must be auto-registered as a postfilter.
+		FORCE_COMPOSITE_TO_REJECT {
+			action = "reject";
+			expression = "FA_COMPOSITE";
+		}
+		# Two rules matching at once; the higher priority one must win. Here the
+		# winner is also registered first (rules are registered name-sorted).
+		FORCE_PRIO_A_ADD_HEADER {
+			action = "add header";
+			expression = "FA_PRIO1";
+			priority = "high";
+		}
+		FORCE_PRIO_A_REJECT {
+			action = "reject";
+			expression = "FA_PRIO1";
+			priority = "low";
+		}
+		# Same, but the winner is registered last, so only priority can decide.
+		FORCE_PRIO_B_ADD_HEADER {
+			action = "add header";
+			expression = "FA_PRIO2";
+			priority = "low";
+		}
+		FORCE_PRIO_B_REJECT {
+			action = "reject";
+			expression = "FA_PRIO2";
+			priority = "high";
+		}
+		# Numeric priority form, both rules again on the main (filter) stage.
+		FORCE_PRIO_C_ADD_HEADER {
+			action = "add header";
+			expression = "FA_PRIO3";
+			priority = 0;
+		}
+		FORCE_PRIO_C_REJECT {
+			action = "reject";
+			expression = "FA_PRIO3";
+			priority = 2;
+		}
+		# Main-stage rule competing with a postfilter (composite) rule.
+		# process_all is required on the main-stage rule: without it the pre-result
+		# disables the whole cache, the composite is never evaluated and the
+		# postfilter rule could not fire at all.
+		FORCE_MIX_MAIN_WINS_ADD_HEADER {
+			action = "add header";
+			expression = "FA_MIX_A";
+			priority = "high";
+			process_all = true;
+		}
+		FORCE_MIX_MAIN_WINS_REJECT {
+			action = "reject";
+			expression = "FA_MIX_COMPOSITE";
+			priority = "low";
+		}
+		FORCE_MIX_POST_WINS_ADD_HEADER {
+			action = "add header";
+			expression = "FA_MIX2_A";
+			priority = "low";
+			process_all = true;
+		}
+		FORCE_MIX_POST_WINS_REJECT {
+			action = "reject";
+			expression = "FA_MIX2_COMPOSITE";
+			priority = "high";
+		}
+		FORCE_PRIO_RANGE_ADD_HEADER {
+			action = "add header";
+			expression = "FA_PRIO_RANGE";
+			priority = -10;
+		}
+		FORCE_PRIO_RANGE_REJECT {
+			action = "reject";
+			expression = "FA_PRIO_RANGE";
+			priority = 10;
+		}
+		FORCE_PRIO_INVALID_NAME {
+			action = "no action";
+			expression = "FA_PRIO_RANGE";
+			priority = "invalid";
+		}
+		FORCE_PRIO_FRACTIONAL {
+			action = "no action";
+			expression = "FA_PRIO_RANGE";
+			priority = 1.5;
+		}
+		FORCE_PRIO_NAN {
+			action = "no action";
+			expression = "FA_PRIO_RANGE";
+			priority = "nan";
+		}
+		FORCE_PRIO_LEAST {
+			action = "no action";
+			expression = "FA_PRIO_RANGE";
+			priority = "critical";
+			least = true;
+		}
+	}
+}
+
+composites {
+	FA_COMPOSITE {
+		expression = "FA_COMP_A & FA_COMP_B";
+		score = 0.0;
+	}
+	FA_MIX_COMPOSITE {
+		expression = "FA_MIX_A & FA_MIX_B";
+		score = 0.0;
+	}
+	FA_MIX2_COMPOSITE {
+		expression = "FA_MIX2_A & FA_MIX2_B";
+		score = 0.0;
 	}
 }
 
@@ -84,5 +196,64 @@ settings {
     		UBER_ADD_HEADER2 = 50500.0;
     		}
     	}
+	}
+	id_composite {
+		id = "id_composite";
+		apply {
+			symbols {
+				FA_COMP_A = 0.0;
+				FA_COMP_B = 0.0;
+			}
+		}
+	}
+	id_priority_add_header_wins {
+		id = "id_priority_add_header_wins";
+		apply {
+			symbols {
+				FA_PRIO1 = 0.0;
+			}
+		}
+	}
+	id_priority_reject_wins {
+		id = "id_priority_reject_wins";
+		apply {
+			symbols {
+				FA_PRIO2 = 0.0;
+			}
+		}
+	}
+	id_priority_numeric {
+		id = "id_priority_numeric";
+		apply {
+			symbols {
+				FA_PRIO3 = 0.0;
+			}
+		}
+	}
+	id_priority_mixed_main_wins {
+		id = "id_priority_mixed_main_wins";
+		apply {
+			symbols {
+				FA_MIX_A = 0.0;
+				FA_MIX_B = 0.0;
+			}
+		}
+	}
+	id_priority_mixed_post_wins {
+		id = "id_priority_mixed_post_wins";
+		apply {
+			symbols {
+				FA_MIX2_A = 0.0;
+				FA_MIX2_B = 0.0;
+			}
+		}
+	}
+	id_priority_validation {
+		id = "id_priority_validation";
+		apply {
+			symbols {
+				FA_PRIO_RANGE = 0.0;
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Summary

Fixes `force_actions` rules that depend on composite symbols and adds
priority-based arbitration between multiple matching rules.

### Auto-promote composite-dependent rules to postfilter
`register_dependency()` from a `normal`-stage symbol on a composite silently
fails, since composites run in their own stage after all normal filters — so
a rule whose expression referenced a composite symbol never actually waited
for it. Composite atoms are now detected via
`rspamd_config:get_symbol_flags()`, and such rules are registered as
postfilters instead, same as the existing `require_action`/`honor_action`
handling. Applied to both the `rules` and legacy `actions` config paths.

### Priority arbitration
- Fix `has_composite_atom()`: `get_symbol_flags()` returns an array of flag
  names, not a keyed map, so it now iterates the array instead of testing a
  non-existent `.composite` field.
- `lua_config`: `get_symbol_flags()` was stripping the
  `SYMBOL_TYPE_COMPOSITE` bit before returning flags to Lua; restored so
  composite detection actually works.
- Add an optional `priority` rule setting (`low`/`normal`/`high`/`critical` or
  `0`-`3`) to arbitrate which of several matching rules' passthrough result
  wins, with validation, range clamping, and a warning when combined with
  `least`.
- Register rules in a stable, name-sorted order instead of relying on UCL's
  unspecified `pairs()` iteration order.
- Expose the configured priority as a `priority:N` symbol option alongside
  the existing action-name option, so it's visible in scan output next to the
  fired `FORCE_ACTION_*` symbol.

### Known limitation
A rule matching on a composite can still be starved if an earlier pre-result
was set without `process_all`, since that suppresses composite evaluation
entirely; set `process_all = true` on whichever rule fires first.

### Testing
Expanded `360_force_actions.robot` functional coverage: composite-triggered
postfilter promotion, priority ordering (named, numeric, mixed main/postfilter
stages), and priority validation warnings.