### PR TITLE
[Feature] auto-register symbol() dependencies for selector-based rules (rbl, reputation, clustering, multimap, dmarc, ratelimit)

### DIFF
--- a/lualib/lua_maps_expressions.lua
+++ b/lualib/lua_maps_expressions.lua
@@ -102,7 +102,7 @@ exports.schema = T.table({
 })
 
 --[[[
--- @function lua_maps_expression.create(config, object, module_name)
+-- @function lua_maps_expression.create(cfg, obj, module_name, own_symbol)
 -- Creates a new maps combination from `object` for `module_name`.
 -- The input should be table with the following fields:
 --
@@ -120,9 +120,11 @@ exports.schema = T.table({
 -- In case if `expression` is false a `nil` value is returned.
 -- @param {rspamd_config} cfg rspamd config
 -- @param {table} obj configuration table
+-- @param {string} module_name optional module name for logging, defaults to `lua_maps_expressions`
+-- @param {string} own_symbol optional symbol name; registers a dependency on any symbol() referenced by a rule's selector
 --
 --]]
-local function create(cfg, obj, module_name)
+local function create(cfg, obj, module_name, own_symbol)
   if not module_name then
     module_name = 'lua_maps_expressions'
   end
@@ -139,8 +141,15 @@ local function create(cfg, obj, module_name)
     module_name = module_name
   }
 
+  -- Registered only after a successful build, so a bailout below leaves no dangling dependency
+  local selector_symbol_deps = {}
+
   for name, rule in pairs(obj.rules) do
-    local sel = lua_selectors.create_selector_closure(cfg, rule.selector)
+    local sel, sel_deps = lua_selectors.create_selector_closure(cfg, rule.selector)
+
+    for _, dep in ipairs(sel_deps or {}) do
+      selector_symbol_deps[#selector_symbol_deps + 1] = dep
+    end
 
     if not sel then
       rspamd_logger.errx(cfg, 'cannot add selector for element %s in module %s',
@@ -215,6 +224,8 @@ local function create(cfg, obj, module_name)
   end
 
   ret.symbol = obj.symbol
+  ret.selector_symbol_deps = selector_symbol_deps
+  lua_selectors.register_symbol_deps(cfg, own_symbol, selector_symbol_deps)
 
   return ret
 end

--- a/lualib/lua_selectors/init.lua
+++ b/lualib/lua_selectors/init.lua
@@ -634,15 +634,70 @@ end
 
 
 --[[[
--- @function lua_selectors.create_closure(log_obj, cfg, selector_str, delimiter, fn)
--- Creates a closure from a string selector, using the specific combinator function
+-- @function lua_selectors.get_selector_symbol_deps(parsed)
+-- Walks an already parsed selector pipe (as returned by `parse_selector`) and
+-- returns an array of unique symbol names referenced via the `symbol()`
+-- extractor, so that callers can wire up an automatic
+-- `rspamd_config:register_dependency` on them.
 --]]
-exports.create_selector_closure_fn = function(log_obj, cfg, selector_str, delimiter, fn)
+exports.get_selector_symbol_deps = function(parsed)
+  local seen = {}
+  local res = {}
+
+  for _, sel in ipairs(parsed or E) do
+    if sel.selector and sel.selector.name == 'symbol' and sel.selector.args then
+      local dep = sel.selector.args[1]
+      if dep and not seen[dep] then
+        seen[dep] = true
+        table.insert(res, dep)
+      end
+    end
+  end
+
+  return res
+end
+
+--[[[
+-- @function lua_selectors.register_symbol_deps(cfg, own_symbol, deps)
+-- Registers a dependency from `own_symbol` on every symbol in `deps` (as returned
+-- by `get_selector_symbol_deps`), skipping self references and duplicates.
+--]]
+exports.register_symbol_deps = function(cfg, own_symbol, deps)
+  if not (cfg and own_symbol and deps) then
+    return
+  end
+
+  local seen = {}
+
+  for _, dep in ipairs(deps) do
+    if dep ~= own_symbol and not seen[dep] then
+      seen[dep] = true
+      cfg:register_dependency(own_symbol, dep)
+      lua_util.debugm(M, cfg, 'registered automatic dependency %s -> %s from symbol() selector',
+          own_symbol, dep)
+    end
+  end
+end
+
+--[[[
+-- @function lua_selectors.create_closure(log_obj, cfg, selector_str, delimiter, fn, own_symbol)
+-- Creates a closure from a string selector, using the specific combinator function.
+-- If `own_symbol` is given, automatically registers a dependency from `own_symbol`
+-- on every symbol name referenced via `symbol()` in the selector, so that the
+-- consuming rule is not evaluated before its `symbol()` dependencies are ready.
+-- @return {function,table} closure that processes selector on task, and the list of
+-- symbol() names the selector depends on (nil, nil on parse failure)
+--]]
+exports.create_selector_closure_fn = function(log_obj, cfg, selector_str, delimiter, fn, own_symbol)
   local selector = exports.parse_selector(cfg, selector_str)
 
   if not selector then
     return nil
   end
+
+  local selector_symbol_deps = exports.get_selector_symbol_deps(selector)
+
+  exports.register_symbol_deps(cfg, own_symbol, selector_symbol_deps)
 
   return function(task)
     local res = exports.process_selectors(task, selector)
@@ -652,17 +707,21 @@ exports.create_selector_closure_fn = function(log_obj, cfg, selector_str, delimi
     end
 
     return nil
-  end
+  end, selector_symbol_deps
 end
 
 --[[[
--- @function lua_selectors.create_closure(cfg, selector_str, delimiter='', flatten=false)
+-- @function lua_selectors.create_closure(cfg, selector_str, delimiter='', flatten=false, own_symbol=nil)
 -- Creates a closure from a string selector
+-- @param {string} own_symbol optional symbol name; if given, a dependency is
+-- automatically registered on any symbol referenced via `symbol()`
+-- @return {function,table} closure that processes selector on task, and the list of
+-- symbol() names the selector depends on (nil on error)
 --]]
-exports.create_selector_closure = function(cfg, selector_str, delimiter, flatten)
+exports.create_selector_closure = function(cfg, selector_str, delimiter, flatten, own_symbol)
   local combinator_fn = flatten and exports.flatten_selectors or exports.combine_selectors
 
-  return exports.create_selector_closure_fn(nil, cfg, selector_str, delimiter, combinator_fn)
+  return exports.create_selector_closure_fn(nil, cfg, selector_str, delimiter, combinator_fn, own_symbol)
 end
 
 local function display_selectors(tbl)
@@ -724,15 +783,18 @@ exports.list_combinators = function()
 end
 
 --[[[
--- @function lua_selectors.create_selector_closure_with_combinator(cfg, selector_str, delimiter, combinator_name)
+-- @function lua_selectors.create_selector_closure_with_combinator(cfg, selector_str, delimiter, combinator_name, own_symbol)
 -- Creates a closure from a string selector using named combinator
 -- @param {rspamd_config} cfg rspamd config object
 -- @param {string} selector_str selector string to parse
 -- @param {string} delimiter delimiter for combining results (used by some combinators)
 -- @param {string} combinator_name name of combinator: 'string', 'array', or 'object'
--- @return {function} closure that processes selector on task, or nil on error
+-- @param {string} own_symbol optional symbol name; if given, a dependency is
+-- automatically registered on any symbol referenced via `symbol()`
+-- @return {function,table} closure that processes selector on task, and the list of
+-- symbol() names the selector depends on (nil on error)
 --]]
-exports.create_selector_closure_with_combinator = function(cfg, selector_str, delimiter, combinator_name)
+exports.create_selector_closure_with_combinator = function(cfg, selector_str, delimiter, combinator_name, own_symbol)
   local combinator_fn = combinators[combinator_name or 'string']
 
   if not combinator_fn then
@@ -741,7 +803,7 @@ exports.create_selector_closure_with_combinator = function(cfg, selector_str, de
     return nil
   end
 
-  return exports.create_selector_closure_fn(cfg, cfg, selector_str, delimiter, combinator_fn)
+  return exports.create_selector_closure_fn(cfg, cfg, selector_str, delimiter, combinator_fn, own_symbol)
 end
 
 -- Publish log target

--- a/src/libserver/symcache/symcache_impl.cxx
+++ b/src/libserver/symcache/symcache_impl.cxx
@@ -38,6 +38,14 @@ INIT_LOG_MODULE_PUBLIC(symcache)
 auto symcache::init() -> bool
 {
 	auto res = true;
+
+	if (cache_initialized) {
+		/* e.g. `init_subsystem('symcache')` called again from Lua; nothing left to do */
+		msg_debug_cache("symcache is already initialised, skip the second init");
+
+		return res;
+	}
+
 	reload_time = cfg->cache_reload_time;
 
 	if (cfg->cache_filename != nullptr) {
@@ -112,45 +120,17 @@ auto symcache::init() -> bool
 	/* Deal with the delayed dependencies */
 	msg_debug_cache("resolving delayed dependencies: %d in list", (int) delayed_deps->size());
 	for (const auto &delayed_dep: *delayed_deps) {
-		auto virt_source = get_item_by_name(delayed_dep.from, false);
 		auto real_source = get_item_by_name(delayed_dep.from, true);
 
-		auto real_destination = get_item_by_name(delayed_dep.to, true);
-
-		if (virt_source == nullptr || real_source == nullptr || real_destination == nullptr) {
-			if (real_destination != nullptr) {
-				msg_err_cache("cannot register delayed dependency %s -> %s: "
-							  "source %s is missing",
-							  delayed_dep.from.data(),
-							  delayed_dep.to.data(), delayed_dep.from.data());
-			}
-			else {
-				msg_err_cache("cannot register delayed dependency %s -> %s: "
-							  "destination %s is missing",
-							  delayed_dep.from.data(),
-							  delayed_dep.to.data(), delayed_dep.to.data());
-			}
+		if (real_source != nullptr && disabled_ids.contains(real_source->id)) {
+			msg_debug_cache("no delayed between %s -> %s; %s is disabled",
+							delayed_dep.from.data(),
+							delayed_dep.to.data(),
+							delayed_dep.from.data());
+			continue;
 		}
-		else {
 
-			if (!disabled_ids.contains(real_source->id)) {
-				msg_debug_cache("delayed %sbetween %s(%d:%d) -> %s",
-								delayed_dep.hard ? "weak " : "",
-								delayed_dep.from.data(),
-								real_source->id, virt_source->id,
-								delayed_dep.to.data());
-				add_dependency(real_source->id, delayed_dep.to, real_destination->id,
-							   virt_source != real_source ? virt_source->id : -1,
-							   delayed_dep.hard);
-			}
-			else {
-				msg_debug_cache("no delayed between %s(%d:%d) -> %s; %s is disabled",
-								delayed_dep.from.data(),
-								real_source->id, virt_source->id,
-								delayed_dep.to.data(),
-								delayed_dep.from.data());
-			}
-		}
+		resolve_delayed_dependency(delayed_dep);
 	}
 
 	/* Remove delayed dependencies, as they are no longer needed at this point */
@@ -242,7 +222,85 @@ auto symcache::init() -> bool
 							 (void *) this);
 	}
 
+	cache_initialized = true;
+
 	return res;
+}
+
+auto symcache::resolve_delayed_dependency(const delayed_cache_dependency &dep)
+	-> std::optional<std::pair<cache_item *, cache_item *>>
+{
+	auto *virt_source = get_item_by_name_mut(dep.from, false);
+	auto *real_source = get_item_by_name_mut(dep.from, true);
+	auto *real_destination = get_item_by_name_mut(dep.to, true);
+
+	if (virt_source == nullptr || real_source == nullptr || real_destination == nullptr) {
+		if (real_destination != nullptr) {
+			msg_err_cache("cannot register delayed dependency %s -> %s: "
+						  "source %s is missing",
+						  dep.from.data(),
+						  dep.to.data(), dep.from.data());
+		}
+		else {
+			msg_err_cache("cannot register delayed dependency %s -> %s: "
+						  "destination %s is missing",
+						  dep.from.data(),
+						  dep.to.data(), dep.to.data());
+		}
+
+		return std::nullopt;
+	}
+
+	msg_debug_cache("delayed %sbetween %s(%d:%d) -> %s",
+					dep.hard ? "hard " : "",
+					dep.from.data(),
+					real_source->id, virt_source->id,
+					dep.to.data());
+
+	if (!add_dependency(real_source->id, dep.to, real_destination->id,
+						virt_source != real_source ? virt_source->id : -1,
+						dep.hard)) {
+		/* Duplicate or bogus edge, nothing has been changed */
+		return std::nullopt;
+	}
+
+	return std::make_pair(real_source, virt_source);
+}
+
+auto symcache::add_delayed_dependency(std::string_view from, std::string_view to, bool hard) -> void
+{
+	if (cache_initialized) {
+		/* Cache is already loaded (e.g. from a Lua add_on_load callback): apply the edge now */
+		if (scans_started) {
+			msg_warn_cache("ignore dependency %s -> %s: registered after the first scan has started",
+						   from.data(), to.data());
+
+			return;
+		}
+
+		delayed_cache_dependency dep{from, to, hard};
+		auto maybe_sources = resolve_delayed_dependency(dep);
+
+		if (maybe_sources) {
+			auto [real_source, virt_source] = maybe_sources.value();
+
+			real_source->process_deps(*this);
+
+			if (virt_source != nullptr && virt_source != real_source) {
+				virt_source->process_deps(*this);
+			}
+
+			promote_resort();
+		}
+
+		return;
+	}
+
+	if (!delayed_deps) {
+		delayed_deps = std::make_unique<std::vector<delayed_cache_dependency>>();
+	}
+
+	delayed_deps->emplace_back(from, to, hard);
 }
 
 auto symcache::load_items() -> bool
@@ -462,12 +520,12 @@ auto symcache::metric_connect_cb(void *k, void *v, void *ud) -> void
 
 auto symcache::get_item_by_id(int id, bool resolve_parent) const -> const cache_item *
 {
-	if (id < 0 || id >= items_by_id.size()) {
-		msg_err_cache("internal error: requested item with id %d, when we have just %d items in the cache",
-					  id, (int) items_by_id.size());
+	if (id < 0) {
+		msg_err_cache("internal error: requested item with an invalid id %d", id);
 		return nullptr;
 	}
 
+	/* Ids are not contiguous after `init` removed the statically disabled symbols */
 	const auto &maybe_item = rspamd::find_map(items_by_id, id);
 
 	if (!maybe_item.has_value()) {
@@ -487,12 +545,12 @@ auto symcache::get_item_by_id(int id, bool resolve_parent) const -> const cache_
 
 auto symcache::get_item_by_id_mut(int id, bool resolve_parent) const -> cache_item *
 {
-	if (id < 0 || id >= items_by_id.size()) {
-		msg_err_cache("internal error: requested item with id %d, when we have just %d items in the cache",
-					  id, (int) items_by_id.size());
+	if (id < 0) {
+		msg_err_cache("internal error: requested item with an invalid id %d", id);
 		return nullptr;
 	}
 
+	/* Ids are not contiguous after `init` removed the statically disabled symbols */
 	const auto &maybe_item = rspamd::find_map(items_by_id, id);
 
 	if (!maybe_item.has_value()) {
@@ -541,14 +599,28 @@ auto symcache::get_item_by_name_mut(std::string_view name, bool resolve_parent) 
 	return it->second;
 }
 
-auto symcache::add_dependency(int id_from, std::string_view to, int id_to, int virtual_id_from, bool hard) -> void
+auto symcache::add_dependency(int id_from, std::string_view to, int id_to, int virtual_id_from, bool hard) -> bool
 {
-	g_assert(id_from >= 0 && id_from < (int) items_by_id.size());
-	g_assert(id_to >= 0 && id_to < (int) items_by_id.size());
-	const auto &source = items_by_id[id_from];
-	const auto &dest = items_by_id[id_to];
-	g_assert(source.get() != nullptr);
-	g_assert(dest.get() != nullptr);
+	/* Ids are dense only at registration time, so `items_by_id` must be probed */
+	const auto &maybe_source = rspamd::find_map(items_by_id, id_from);
+	const auto &maybe_dest = rspamd::find_map(items_by_id, id_to);
+
+	if (!maybe_source.has_value() || !maybe_dest.has_value()) {
+		msg_err_cache("internal error: cannot add dependency %d -> %s(%d): item is missing",
+					  id_from, to.data(), id_to);
+
+		return false;
+	}
+
+	const auto &source = maybe_source.value().get();
+	const auto &dest = maybe_dest.value().get();
+
+	if (source.get() == nullptr || dest.get() == nullptr) {
+		msg_err_cache("internal error: cannot add dependency %d -> %s(%d): item is empty; qed",
+					  id_from, to.data(), id_to);
+
+		return false;
+	}
 
 	if (!source->deps.contains(id_to)) {
 		msg_debug_cache("add %sdependency %s(%d) -> %s(%d)",
@@ -561,15 +633,22 @@ auto symcache::add_dependency(int id_from, std::string_view to, int id_to, int v
 	else {
 		msg_debug_cache("duplicate dependency %s -> %s",
 						source->symbol.c_str(), to.data());
-		return;
+		return false;
 	}
 
 
 	if (virtual_id_from >= 0) {
-		g_assert(virtual_id_from < (int) items_by_id.size());
 		/* We need that for settings id propagation */
-		const auto &vsource = items_by_id[virtual_id_from];
-		g_assert(vsource.get() != nullptr);
+		const auto &maybe_vsource = rspamd::find_map(items_by_id, virtual_id_from);
+
+		if (!maybe_vsource.has_value() || maybe_vsource.value().get().get() == nullptr) {
+			msg_err_cache("internal error: cannot add virtual dependency %d -> %s(%d): item is missing",
+						  virtual_id_from, to.data(), id_to);
+
+			return true;
+		}
+
+		const auto &vsource = maybe_vsource.value().get();
 
 		if (!vsource->deps.contains(id_to)) {
 			msg_debug_cache("add virtual %sdependency %s -> %s",
@@ -584,6 +663,8 @@ auto symcache::add_dependency(int id_from, std::string_view to, int id_to, int v
 							vsource->symbol.c_str(), to.data());
 		}
 	}
+
+	return true;
 }
 
 auto symcache::resort() -> void
@@ -1162,6 +1243,9 @@ symcache::~symcache()
 
 auto symcache::maybe_resort() -> bool
 {
+	/* Called once per task, so this is the point where the graph stops being mutable */
+	scans_started = true;
+
 	if (items_by_order->generation_id != cur_order_gen) {
 		/*
 		 * Cache has been modified, need to resort it

--- a/src/libserver/symcache/symcache_internal.hxx
+++ b/src/libserver/symcache/symcache_internal.hxx
@@ -30,6 +30,7 @@
 #include <string>
 #include <string_view>
 #include <memory>
+#include <optional>
 #include <variant>
 
 #include "rspamd_symcache.h"
@@ -280,6 +281,10 @@ private:
 	/* These are stored within pointer to clean up after init */
 	std::unique_ptr<std::vector<delayed_cache_dependency>> delayed_deps;
 	std::unique_ptr<std::vector<delayed_cache_condition>> delayed_conditions;
+	/* True once init() has fully completed (graph processed, first order generated) */
+	bool cache_initialized = false;
+	/* True once the first task runtime has been created; the graph is frozen from then on */
+	bool scans_started = false;
 	/* Delayed statically enabled or disabled symbols */
 	using delayed_symbol_names = ankerl::unordered_dense::set<delayed_symbol_elt,
 															  delayed_symbol_elt_hash, delayed_symbol_elt_equal>;
@@ -317,6 +322,13 @@ private:
 	auto get_item_specific_vector(const cache_item &) -> items_ptr_vec &;
 	/* Helper for g_hash_table_foreach */
 	static auto metric_connect_cb(void *k, void *v, void *ud) -> void;
+	/*
+	 * Resolves a single (delayed or post-init) dependency.
+	 * Returns the resolved (real source, virtual source) pair if an edge has been added,
+	 * std::nullopt if the dependency cannot be resolved or the edge already exists
+	 */
+	auto resolve_delayed_dependency(const delayed_cache_dependency &dep)
+		-> std::optional<std::pair<cache_item *, cache_item *>>;
 
 public:
 	explicit symcache(struct rspamd_config *cfg)
@@ -371,23 +383,18 @@ public:
 	 * @param id_from
 	 * @param to
 	 * @param virtual_id_from
-	 * @return
+	 * @return true if a new edge has been added, false on a duplicate or on a missing item
 	 */
-	auto add_dependency(int id_from, std::string_view to, int id_to, int virtual_id_from, bool hard = false) -> void;
+	auto add_dependency(int id_from, std::string_view to, int id_to, int virtual_id_from, bool hard = false) -> bool;
 
 	/**
-	 * Add a delayed dependency between symbols that will be resolved on the init stage
+	 * Add a delayed dependency between symbols that will be resolved on the init stage;
+	 * if the cache is already initialised (e.g. called from a Lua add_on_load callback),
+	 * resolves and applies the dependency immediately instead of queueing it
 	 * @param from
 	 * @param to
 	 */
-	auto add_delayed_dependency(std::string_view from, std::string_view to, bool hard = false) -> void
-	{
-		if (!delayed_deps) {
-			delayed_deps = std::make_unique<std::vector<delayed_cache_dependency>>();
-		}
-
-		delayed_deps->emplace_back(from, to, hard);
-	}
+	auto add_delayed_dependency(std::string_view from, std::string_view to, bool hard = false) -> void;
 
 	/**
 	 * Adds a symbol to the list of the disabled symbols

--- a/src/plugins/lua/clustering.lua
+++ b/src/plugins/lua/clustering.lua
@@ -309,12 +309,20 @@ if opts['rules'] then
         rule.prefix = k .. "_"
       end
 
-      rule.source_selector = lua_selectors.create_selector_closure(rspamd_config,
+      local source_deps, cluster_deps
+      rule.source_selector, source_deps = lua_selectors.create_selector_closure(rspamd_config,
           rule.source_selector, '')
-      rule.cluster_selector = lua_selectors.create_selector_closure(rspamd_config,
+      rule.cluster_selector, cluster_deps = lua_selectors.create_selector_closure(rspamd_config,
           rule.cluster_selector, '')
       if rule.source_selector and rule.cluster_selector then
         rule.name = k
+        -- Deps are registered merely for the rules we keep, as a dropped rule
+        -- never registers its symbol
+        local all_deps = lua_util.shallowcopy(source_deps)
+        for _, dep in ipairs(cluster_deps) do
+          all_deps[#all_deps + 1] = dep
+        end
+        lua_selectors.register_symbol_deps(rspamd_config, rule.symbol, all_deps)
         table.insert(rules, rule)
       end
     end

--- a/src/plugins/lua/dmarc.lua
+++ b/src/plugins/lua/dmarc.lua
@@ -814,7 +814,7 @@ if settings.munging then
 
   if munging_opts.munge_map_condition then
     munging_opts.munge_map_condition = lua_maps_expressions.create(rspamd_config,
-      munging_opts.munge_map_condition, N)
+      munging_opts.munge_map_condition, N, 'DMARC_MUNGED')
   end
 
   rspamd_config:register_symbol({

--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -2014,7 +2014,7 @@ local function add_multimap_rule(key, newrule)
       if combinator then
         -- Use named combinator for structured output (array, object, string)
         selector = lua_selectors.create_selector_closure_with_combinator(
-          rspamd_config, newrule['selector'], newrule['delimiter'] or "", combinator)
+          rspamd_config, newrule['selector'], newrule['delimiter'] or "", combinator, newrule['symbol'])
 
         if not selector then
           rspamd_logger.errx(rspamd_config, 'selector map has invalid selector or combinator: "%s", combinator: %s, symbol: %s',
@@ -2027,7 +2027,7 @@ local function add_multimap_rule(key, newrule)
       else
         -- Default behavior: use combine_selectors (string output)
         selector = lua_selectors.create_selector_closure(
-          rspamd_config, newrule['selector'], newrule['delimiter'] or "")
+          rspamd_config, newrule['selector'], newrule['delimiter'] or "", false, newrule['symbol'])
 
         if not selector then
           rspamd_logger.errx(rspamd_config, 'selector map has invalid selector: "%s", symbol: %s',
@@ -2066,7 +2066,7 @@ local function add_multimap_rule(key, newrule)
 
     if combinator then
       selector = lua_selectors.create_selector_closure_with_combinator(
-        rspamd_config, selector_str, newrule['delimiter'] or "", combinator)
+        rspamd_config, selector_str, newrule['delimiter'] or "", combinator, newrule['symbol'])
 
       if not selector then
         rspamd_logger.errx(rspamd_config, 'redis selector map has invalid selector or combinator: "%s", combinator: %s, symbol: %s',
@@ -2078,7 +2078,7 @@ local function add_multimap_rule(key, newrule)
         combinator, newrule['symbol'])
     else
       selector = lua_selectors.create_selector_closure(
-        rspamd_config, selector_str, newrule['delimiter'] or "")
+        rspamd_config, selector_str, newrule['delimiter'] or "", false, newrule['symbol'])
 
       if not selector then
         rspamd_logger.errx(rspamd_config, 'redis selector map has invalid selector: "%s", symbol: %s',

--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -2097,7 +2097,7 @@ local function add_multimap_rule(key, newrule)
         expression = newrule.expression,
         description = newrule.description,
         on_load = newrule.dynamic_symbols and multimap_on_load_gen(newrule) or nil,
-      }, N, 'Combined map for ' .. newrule.symbol)
+      }, N, newrule.symbol)
     if not newrule.combined then
       rspamd_logger.errx(rspamd_config, 'cannot add combined map for %s', newrule.symbol)
     else

--- a/src/plugins/lua/ratelimit.lua
+++ b/src/plugins/lua/ratelimit.lua
@@ -607,6 +607,9 @@ if opts then
     rspamd_logger.errx(rspamd_config, 'Legacy ratelimit config format no longer supported')
   end
 
+  -- Deps from all limits' symbol() selectors, registered once RATELIMIT_CHECK is known
+  local ratelimit_symbol_deps = {}
+
   if opts['rates'] and type(opts['rates']) == 'table' then
     -- new way of setting limits
     fun.each(function(t, lim)
@@ -652,6 +655,9 @@ if opts then
           end
 
           settings.limits[t].selector = selector
+          for _, dep in ipairs(lua_selectors.get_selector_symbol_deps(selector)) do
+            table.insert(ratelimit_symbol_deps, dep)
+          end
         end
       else
         rspamd_logger.warnx(rspamd_config, 'old syntax for ratelimits: %s', lim)
@@ -749,6 +755,7 @@ if opts then
     }
 
     local id = rspamd_config:register_symbol(s)
+    lua_selectors.register_symbol_deps(rspamd_config, s.name, ratelimit_symbol_deps)
 
     -- Register per bucket symbols
     -- Display what's enabled

--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -1061,6 +1061,7 @@ local function add_rbl(key, rbl, global_opts)
   if rbl.selector then
 
     rbl.selectors = {}
+    rbl.selector_symbol_deps = {}
     if type(rbl.selector) ~= 'table' then
       rbl.selector = { ['selector'] = rbl.selector }
     end
@@ -1070,13 +1071,16 @@ local function add_rbl(key, rbl, global_opts)
         lua_util.debugm(N, rspamd_config, 'reuse selector id %s',
             known_selectors[selector].id)
         rbl.selectors[selector_label] = known_selectors[selector].selector
+        for _, dep in ipairs(known_selectors[selector].deps or {}) do
+          rbl.selector_symbol_deps[#rbl.selector_symbol_deps + 1] = dep
+        end
       else
 
         if type(rbl.selector_flatten) ~= 'boolean' then
           -- Fail-safety
           rbl.selector_flatten = true
         end
-        local sel = selectors.create_selector_closure(rspamd_config, selector, '',
+        local sel, deps = selectors.create_selector_closure(rspamd_config, selector, '',
             rbl.selector_flatten)
 
         if not sel then
@@ -1088,8 +1092,12 @@ local function add_rbl(key, rbl, global_opts)
         known_selectors[selector] = {
           selector = sel,
           id = #lua_util.keys(known_selectors) + 1,
+          deps = deps,
         }
         rbl.selectors[selector_label] = known_selectors[selector].selector
+        for _, dep in ipairs(deps or {}) do
+          rbl.selector_symbol_deps[#rbl.selector_symbol_deps + 1] = dep
+        end
       end
     end
 
@@ -1220,6 +1228,8 @@ local function add_rbl(key, rbl, global_opts)
         rspamd_config:register_dependency(check_sym, dep)
       end
     end
+
+    selectors.register_symbol_deps(rspamd_config, check_sym, rbl.selector_symbol_deps)
 
     -- Failure symbol
     rspamd_config:register_symbol {

--- a/src/plugins/lua/reputation.lua
+++ b/src/plugins/lua/reputation.lua
@@ -715,7 +715,7 @@ local function generic_reputation_init(rule)
   end
 
   local selector = lua_selectors.create_selector_closure(rspamd_config,
-      cfg.selector, cfg.delimiter)
+      cfg.selector, cfg.delimiter, false, rule.symbol)
 
   if not selector then
     rspamd_logger.errx(rspamd_config, 'cannot configure generic rule: bad selector: %s',

--- a/src/plugins/lua/reputation.lua
+++ b/src/plugins/lua/reputation.lua
@@ -1315,10 +1315,34 @@ local function parse_rule(name, tbl)
   tbl.backend = nil
   rule.config = lua_util.override_defaults(rule.config, tbl)
 
+  local symbol = rule.selector.config.symbol or name
+  if tbl.symbol then
+    symbol = tbl.symbol
+  end
+  rule.symbol = symbol
+
+  -- Moved before whitelist: it can still bail out, and whitelist may register deps on symbol
+  if rule.config.exclusion_map then
+    local map_type = 'set' -- Default to set for string-based selectors (dkim, url, spf, generic)
+    if sel_type == 'ip' or sel_type == 'sender' then
+      map_type = 'radix' -- Use radix for IP-based selectors
+    end
+    local map = lua_maps.map_add_from_ucl(rule.config.exclusion_map,
+        map_type,
+        sel_type .. ' reputation exclusion map')
+    if not map then
+      rspamd_logger.errx(rspamd_config, "cannot parse exclusion map config for %s: (%s)",
+          sel_type,
+          rule.config.exclusion_map)
+      return false
+    end
+    rule.config.exclusion_map = map
+  end
+
   if rule.config.whitelist then
     if lua_maps_exprs.schema:check(rule.config.whitelist) then
       rule.config.whitelist_map = lua_maps_exprs.create(rspamd_config,
-          rule.config.whitelist, N)
+          rule.config.whitelist, N, symbol)
     elseif lua_maps.map_schema:check(rule.config.whitelist) then
       -- Determine map type and check method based on selector type
       local map_type = 'set' -- Default for string-based selectors
@@ -1421,30 +1445,6 @@ local function parse_rule(name, tbl)
     end
   end
 
-  -- Parse exclusion_map for reputation exclusion lists
-  if rule.config.exclusion_map then
-    local map_type = 'set' -- Default to set for string-based selectors (dkim, url, spf, generic)
-    if sel_type == 'ip' or sel_type == 'sender' then
-      map_type = 'radix' -- Use radix for IP-based selectors
-    end
-    local map = lua_maps.map_add_from_ucl(rule.config.exclusion_map,
-        map_type,
-        sel_type .. ' reputation exclusion map')
-    if not map then
-      rspamd_logger.errx(rspamd_config, "cannot parse exclusion map config for %s: (%s)",
-          sel_type,
-          rule.config.exclusion_map)
-      return false
-    end
-    rule.config.exclusion_map = map
-  end
-
-  local symbol = rule.selector.config.symbol or name
-  if tbl.symbol then
-    symbol = tbl.symbol
-  end
-
-  rule.symbol = symbol
   rule.enabled = true
   if rule.selector.init then
     rule.enabled = false

--- a/test/functional/cases/001_merged/102_multimap.robot
+++ b/test/functional/cases/001_merged/102_multimap.robot
@@ -95,6 +95,11 @@ MAP - COMBINED MISS
   Do Not Expect Symbol  COMBINED_MAP_AND
   Do Not Expect Symbol  COMBINED_MAP_OR
 
+MAP - COMBINED SYMBOL DEPENDENCY
+  Scan File  ${MESSAGE}
+  ...   Settings={symbols_enabled = [COMBINED_MAP_SELECTOR_DEP, SELECTOR_RBL_DEP]}
+  Expect Symbol  COMBINED_MAP_SELECTOR_DEP
+
 MAP - FROM MISS
   Scan File  ${MESSAGE}  From=user@other.com
   ...   Settings={symbols_enabled = [FROM_MAP]}

--- a/test/functional/cases/001_merged/115_dmarc.robot
+++ b/test/functional/cases/001_merged/115_dmarc.robot
@@ -20,6 +20,11 @@ DMARC NONE PASS SPF
   ...  Settings=${DMARC_SETTINGS}
   Expect Symbol  DMARC_POLICY_ALLOW
 
+DMARC MUNGING MAP EXPRESSION SYMBOL DEPENDENCY
+  Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/pass_none.eml
+  ...  Settings={symbols_enabled = [DMARC_CHECK, DKIM_CHECK, SPF_CHECK, DMARC_MUNGED, SELECTOR_RBL_DEP]}
+  Expect Symbol  DMARC_MUNGED
+
 DMARC NONE FAIL
   Scan File  ${RSPAMD_TESTDIR}/messages/dmarc/fail_none.eml
   ...  Settings=${DMARC_SETTINGS}

--- a/test/functional/cases/001_merged/300_rbl.robot
+++ b/test/functional/cases/001_merged/300_rbl.robot
@@ -70,6 +70,12 @@ SELECTORS
   Expect Symbol With Option  RBL_SELECTOR_MULTIPLE  example.com:sel_from
   Expect Symbol With Option  RBL_SELECTOR_MULTIPLE  example.org:sel_helo
 
+SELECTORS SYMBOL DEPENDENCIES
+  Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml
+  ...  Settings={symbols_enabled = [RBL_SELECTOR_SYMBOL_FIRST, RBL_SELECTOR_SYMBOL_SECOND, SELECTOR_RBL_DEP]}
+  Expect Symbol With Exact Options  RBL_SELECTOR_SYMBOL_FIRST  example.org:selector
+  Expect Symbol With Exact Options  RBL_SELECTOR_SYMBOL_SECOND  example.org:selector
+
 SELECTORS COMBINED
   Scan File  ${RSPAMD_TESTDIR}/messages/btc.eml  From=user@example.org  Helo=example.org
   ...  Settings={symbols_enabled = [RBL_SELECTOR_MULTIPLE]}

--- a/test/functional/cases/101_lua.robot
+++ b/test/functional/cases/101_lua.robot
@@ -21,6 +21,7 @@ Dependencies
   [Setup]  Lua Setup  ${RSPAMD_TESTDIR}/lua/deps.lua
   Scan File  ${MESSAGE}
   Expect Symbol  DEP10
+  Expect Symbol  POSTINIT_DEP
 
 Pre and Post Filters
   [Setup]  Lua Setup  ${RSPAMD_TESTDIR}/lua/prepostfilters.lua

--- a/test/functional/cases/500_ratelimit.robot
+++ b/test/functional/cases/500_ratelimit.robot
@@ -52,3 +52,19 @@ RATELIMIT CHECK MULTIPLE BUCKETS
   # restrictive one must fire. Before the fix only the last bucket (burst 20)
   # was tracked, so a soft reject would never happen at the third message.
   Basic Test  bar@example.net  multi@example.net  2
+
+RATELIMIT CHECK SELECTOR SYMBOL DEPENDENCY
+  # Bucket key comes from symbol('SELECTOR_RBL_DEP'), which only has a value
+  # if RATELIMIT_CHECK is guaranteed to run after it via the automatic
+  # symbol() dependency (it deliberately has a lower priority).
+  Scan File  ${MESSAGE}
+  ...  From=depselector@example.net
+  ...  Rcpt=depselector@example.net
+  ...  Settings={symbols_enabled = [RATELIMIT_CHECK, RATELIMIT_UPDATE, SELECTOR_RBL_DEP]}
+  Expect Symbol  SELECTOR_RBL_DEP
+  Expect Action  no action
+  Scan File  ${MESSAGE}
+  ...  From=depselector@example.net
+  ...  Rcpt=depselector@example.net
+  ...  Settings={symbols_enabled = [RATELIMIT_CHECK, RATELIMIT_UPDATE, SELECTOR_RBL_DEP]}
+  Expect Action  soft reject

--- a/test/functional/configs/merged-local.conf
+++ b/test/functional/configs/merged-local.conf
@@ -5,6 +5,18 @@ dmarc {
     domain = 'example.com'; # Domain to serve
     org_name = 'Example organisation'; # Organisation
   }
+  munging {
+    list_map = ["foo@rspamd.tk"];
+    munge_map_condition {
+      rules {
+        selector_dependency {
+          map = ["example.org"];
+          selector = "symbol('SELECTOR_RBL_DEP'):options";
+        }
+      }
+      expression = "selector_dependency";
+    }
+  }
 }
 
 

--- a/test/functional/configs/merged-override.conf
+++ b/test/functional/configs/merged-override.conf
@@ -249,6 +249,16 @@ multimap {
     }
     expression = "from || ip"
   }
+  COMBINED_MAP_SELECTOR_DEP {
+    type = "combined";
+    rules {
+      selector_dependency = {
+        map = ["example.org"];
+        selector = "symbol('SELECTOR_RBL_DEP'):options";
+      }
+    }
+    expression = "selector_dependency";
+  }
 
   EXTERNAL_MULTIMAP {
       type = "hostname";

--- a/test/functional/configs/merged-override.conf
+++ b/test/functional/configs/merged-override.conf
@@ -382,6 +382,16 @@ rbl {
       ignore_defaults = true;
       selector = "helo()";
     }
+    RBL_SELECTOR_SYMBOL_FIRST {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      selector = "symbol('SELECTOR_RBL_DEP'):options";
+    }
+    RBL_SELECTOR_SYMBOL_SECOND {
+      rbl = "test9.uribl";
+      ignore_defaults = true;
+      selector = "symbol('SELECTOR_RBL_DEP'):options";
+    }
     RBL_SELECTOR_MULTIPLE {
       rbl = "test9.uribl";
       ignore_defaults = true;

--- a/test/functional/configs/ratelimit.conf
+++ b/test/functional/configs/ratelimit.conf
@@ -1,4 +1,5 @@
 .include(duplicate=append,priority=0) "{= env.TESTDIR =}/configs/plugins.conf"
+lua = "{= env.TESTDIR =}/lua/selector_test.lua"
 
 redis {
   servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
@@ -33,6 +34,16 @@ ratelimit {
           rate = "1 / 1s";
         }
       ];
+    }
+    to_selector_dep {
+      # Bucket key depends on SELECTOR_RBL_DEP (registered with a low
+      # priority so it only runs before RATELIMIT_CHECK via the automatic
+      # symbol() dependency, not by priority ordering alone).
+      selector = "symbol('SELECTOR_RBL_DEP');to.in('depselector@example.net')";
+      bucket {
+        burst = 1;
+        rate = "1 / 1s";
+      }
     }
   }
 }

--- a/test/functional/lua/deps.lua
+++ b/test/functional/lua/deps.lua
@@ -28,3 +28,20 @@ for i = 2, 10 do
   rspamd_config:register_symbol('DEP' .. tostring(i), 1.0, cb_gen(i - 1))
   rspamd_config:register_dependency('DEP' .. tostring(i), 'DEP' .. tostring(i - 1))
 end
+
+-- High priority puts this ahead of the DEP1..DEP10 chain topologically, so it
+-- can only see TOP if the add_on_load dependency below was actually applied.
+rspamd_config:register_symbol({
+  name = 'POSTINIT_DEP',
+  weight = 1.0,
+  priority = 200,
+  callback = function(task)
+    if task:get_symbol('TOP') then
+      task:insert_result('POSTINIT_DEP', 1.0)
+    end
+  end
+})
+
+rspamd_config:add_on_load(function(cfg, _ev_base, _worker)
+  cfg:register_dependency('POSTINIT_DEP', 'TOP')
+end)

--- a/test/functional/lua/selector_test.lua
+++ b/test/functional/lua/selector_test.lua
@@ -38,3 +38,12 @@ rspamd_config:register_symbol({
     return true, string.format('%s|%s', cur or 'nil', orig or 'nil')
   end
 })
+
+rspamd_config:register_symbol({
+  name = 'SELECTOR_RBL_DEP',
+  priority = -10,
+  score = 0.0,
+  callback = function()
+    return true, 'example.org'
+  end,
+})

--- a/test/lua/unit/lua_maps_expressions.lua
+++ b/test/lua/unit/lua_maps_expressions.lua
@@ -1,0 +1,71 @@
+context("Lua maps expressions test", function()
+  local lua_maps_expressions = require "lua_maps_expressions"
+
+  local function make_test_cfg(registered)
+    return {
+      register_dependency = function(_, source, destination)
+        table.insert(registered, { source, destination })
+      end,
+    }
+  end
+
+  test("registers own_symbol dependency for symbol() selectors", function()
+    local registered = {}
+    local test_cfg = make_test_cfg(registered)
+
+    local combined = lua_maps_expressions.create(test_cfg, {
+      rules = {
+        dep_rule = {
+          selector = "symbol('MAPEXPR_DEP_ONE')",
+          map = { 'value' },
+          type = 'set',
+        },
+      },
+      expression = 'dep_rule',
+    }, 'test_maps_expressions', 'MAPEXPR_CONSUMER')
+
+    assert_not_nil(combined)
+    assert_equal(#registered, 1)
+    assert_equal(registered[1][1], 'MAPEXPR_CONSUMER')
+    assert_equal(registered[1][2], 'MAPEXPR_DEP_ONE')
+  end)
+
+  test("does not register any dependency without own_symbol", function()
+    local registered = {}
+    local test_cfg = make_test_cfg(registered)
+
+    local combined = lua_maps_expressions.create(test_cfg, {
+      rules = {
+        dep_rule = {
+          selector = "symbol('MAPEXPR_DEP_TWO')",
+          map = { 'value' },
+          type = 'set',
+        },
+      },
+      expression = 'dep_rule',
+    }, 'test_maps_expressions')
+
+    assert_not_nil(combined)
+    assert_equal(#registered, 0)
+  end)
+
+  test("does not register dependencies when the object cannot be built", function()
+    local registered = {}
+    local test_cfg = make_test_cfg(registered)
+
+    -- expression references an undefined atom, so create() bails out with no dependency registered
+    local combined = lua_maps_expressions.create(test_cfg, {
+      rules = {
+        dep_rule = {
+          selector = "symbol('MAPEXPR_DEP_THREE')",
+          map = { 'value' },
+          type = 'set',
+        },
+      },
+      expression = 'undefined_rule',
+    }, 'test_maps_expressions', 'MAPEXPR_CONSUMER')
+
+    assert_nil(combined)
+    assert_equal(#registered, 0)
+  end)
+end)

--- a/test/lua/unit/selectors.lua
+++ b/test/lua/unit/selectors.lua
@@ -48,6 +48,35 @@ context("Selectors test", function()
     return elts
   end
 
+  test("symbol selector dependencies", function()
+    local registered = {}
+    local test_cfg = {
+      register_dependency = function(_, source, destination)
+        table.insert(registered, { source, destination })
+      end,
+    }
+    local parsed = lua_selectors.parse_selector(test_cfg,
+        "symbol('SELECTOR_DEP_ONE');symbol('SELECTOR_DEP_TWO');symbol('SELECTOR_DEP_ONE')")
+    local selector, deps = lua_selectors.create_selector_closure(test_cfg,
+        "symbol('SELECTOR_DEP_ONE');symbol('SELECTOR_DEP_TWO');symbol('SELECTOR_DEP_ONE')", '', false,
+        'SELECTOR_CONSUMER')
+
+    assert_not_nil(selector)
+    assert_rspamd_table_eq_sorted({
+      actual = lua_selectors.get_selector_symbol_deps(parsed),
+      expect = { 'SELECTOR_DEP_ONE', 'SELECTOR_DEP_TWO' },
+    })
+    assert_rspamd_table_eq_sorted({
+      actual = deps,
+      expect = { 'SELECTOR_DEP_ONE', 'SELECTOR_DEP_TWO' },
+    })
+    assert_equal(#registered, 2)
+    assert_equal(registered[1][1], 'SELECTOR_CONSUMER')
+    assert_equal(registered[1][2], 'SELECTOR_DEP_ONE')
+    assert_equal(registered[2][1], 'SELECTOR_CONSUMER')
+    assert_equal(registered[2][2], 'SELECTOR_DEP_TWO')
+  end)
+
   local cases_plain = {
     ["ip"] = {
                 selector = "ip",


### PR DESCRIPTION
### Summary

Rules built from a `lua_selectors` expression that references
`symbol('OTHER')` previously ran with no guaranteed ordering relative to
`OTHER` unless a manual `register_dependency()` call was added by hand — an
easy thing to forget, and easy to silently get wrong. This PR makes that
dependency automatic wherever such rules are built from a selector.

### symcache: apply post-init dependencies instead of dropping them
`add_delayed_dependency()` previously only queued edges before `init()` ran
and silently discarded any dependency registered afterwards (e.g. from a Lua
`add_on_load` callback, which is how the reputation/RBL selector wiring below
registers deps). It now resolves and applies such edges immediately against
the live graph, guarded by a new `scans_started` flag that rejects
registration once tasks have started scanning against a shared graph.
Also hardens `add_dependency()`/`get_item_by_id(_mut)()` to probe
`items_by_id` via `find_map()` instead of assuming dense/contiguous ids,
which no longer holds once `init()` prunes statically disabled symbols.

### lua_selectors: auto-register symbol() dependencies
`create_selector_closure()` / `create_selector_closure_with_combinator()`
now accept an optional `own_symbol` argument. When given, a dependency is
automatically registered from `own_symbol` on every symbol referenced via a
`symbol()` extractor in the selector. The raw dependency list is also
exposed via new `get_selector_symbol_deps()`/`register_symbol_deps()`
helpers, for callers building several selectors per rule that need to merge
dependencies before registering once.

### Wired into consumers
- **rbl, reputation, clustering, multimap**: pass `own_symbol` through to
  `lua_selectors` so rules built from a `symbol("OTHER"):...` selector
  automatically depend on `OTHER`. `clustering.lua` merges source/cluster
  selector deps into a single `register_symbol_deps()` call.
- **lua_maps_expressions**: accumulate selector dependencies from every rule
  while the object is built, and register them against `own_symbol` only
  once the whole object (all rules + combining expression) has built
  successfully, avoiding a dangling dependency if `create()` bails out.
  Wired through `dmarc` (`munge_map_condition`), `multimap` (combined
  rules), and `reputation` (whitelist).
- **ratelimit**: accumulate `symbol()` dependencies from every rate's
  selector while parsing, and register them against `RATELIMIT_CHECK` once
  known.

### Testing
- Unit tests for `lua_selectors`' dependency auto-registration and
  `lua_maps_expressions`' deferred registration.
- Functional coverage: RBL rules sharing one `symbol()` selector (exercising
  the selector-cache-hit path), a combined multimap rule and a DMARC
  `munge_map_condition` referencing `symbol('SELECTOR_RBL_DEP')`, and a
  ratelimit rule keyed on a deliberately low-priority symbol proving the
  bucket key is only stable once the automatic dependency is in place.