### PR TITLE
[Rework] Symbols cache: one scheduler over the dependency graph

### DIFF
--- a/lualib/lua_selectors/extractors.lua
+++ b/lualib/lua_selectors/extractors.lua
@@ -125,6 +125,7 @@ addresses as they were seen in the message, before any rewrite (e.g. by the alia
       end
     end,
     ['description'] = [[Get country (ASN module must be executed first)]],
+    ['dependencies'] = { 'ASN_CHECK' },
   },
   -- Get ASN number
   ['asn'] = {
@@ -138,6 +139,7 @@ addresses as they were seen in the message, before any rewrite (e.g. by the alia
       end
     end,
     ['description'] = [[Get AS number (ASN module must be executed first)]],
+    ['dependencies'] = { 'ASN_CHECK' },
   },
   -- Get authenticated username
   ['user'] = {
@@ -561,7 +563,10 @@ The first argument must be header name.]],
     ['description'] = 'Get specific symbol. The first argument must be the symbol name. ' ..
         'The second argument is an optional shadow result name. ' ..
         'Returns the symbol table. See task:get_symbol()',
-    ['args_schema'] = { T.string(), T.string():optional() }
+    ['args_schema'] = { T.string(), T.string():optional() },
+    ['dependencies'] = function(args)
+      return { args[1] }
+    end,
   },
   -- Get full scan result
   ['scan_result'] = {

--- a/lualib/lua_selectors/init.lua
+++ b/lualib/lua_selectors/init.lua
@@ -466,6 +466,84 @@ exports.parse_selector = function(cfg, str)
 end
 
 --[[[
+-- @function lua_selectors.get_dependencies(cfg, str)
+-- Returns the list of symbols that must be executed before the selector can
+-- produce a value (e.g. `ASN_CHECK` for `asn`, the symbol itself for
+-- `symbol(NAME)`), or nil if the selector cannot be parsed
+--]]
+exports.get_dependencies = function(cfg, str)
+  local parsed = exports.parse_selector(cfg, str)
+
+  if not parsed then
+    return nil
+  end
+
+  local seen = {}
+  local deps = {}
+
+  for _, sel in ipairs(parsed) do
+    local extractor_deps = sel.selector.dependencies
+
+    if type(extractor_deps) == 'function' then
+      extractor_deps = extractor_deps(sel.selector.args)
+    end
+
+    for _, dep in ipairs(extractor_deps or E) do
+      if not seen[dep] then
+        seen[dep] = true
+        deps[#deps + 1] = dep
+      end
+    end
+  end
+
+  return deps
+end
+
+--[[[
+-- @function lua_selectors.register_dependencies(cfg, symbol, str)
+-- Registers the dependencies of a selector (see `get_dependencies`) for the
+-- symbol that evaluates it, so the symbols cache executes them first: a
+-- prefilter that uses `symbol(DKIM_CHECK)` gets DKIM_CHECK hoisted to the
+-- prefilter stage. Composites and classifiers are produced by the task stages
+-- rather than by symbols, and a dependency on a symbol of a later stage cannot
+-- be satisfied: those are skipped with a warning
+--]]
+exports.register_dependencies = function(cfg, symbol, str)
+  local deps = exports.get_dependencies(cfg, str)
+
+  if not deps or #deps == 0 then
+    return
+  end
+
+  local stage_rank = {
+    connfilter = 1,
+    prefilter = 2,
+    filter = 3,
+    postfilter = 4,
+    idempotent = 5,
+  }
+  local sym_type = cfg:get_symbol_type(symbol)
+
+  for _, dep in ipairs(deps) do
+    local dep_type = cfg:get_symbol_type(dep)
+
+    if dep_type and not stage_rank[dep_type] then
+      lua_util.debugm(M, cfg, 'selector "%s" needs %s (%s) which is not executed by the symbols cache; ' ..
+          'no dependency registered for %s', str, dep, dep_type, symbol)
+    elseif dep_type and sym_type and stage_rank[sym_type] and
+        stage_rank[dep_type] > stage_rank[sym_type] and
+        not (sym_type == 'prefilter' and dep_type == 'filter') then
+      logger.warnx(cfg, 'selector "%s" of %s (%s) needs %s (%s) which is executed later; ' ..
+          'the selector will have no value', str, symbol, sym_type, dep, dep_type)
+    else
+      -- Unknown symbols are resolved (or reported) when the cache is initialised
+      lua_util.debugm(M, cfg, 'register dependency %s -> %s for selector "%s"', symbol, dep, str)
+      cfg:register_dependency(symbol, dep)
+    end
+  end
+end
+
+--[[[
 -- @function lua_selectors.register_extractor(cfg, name, selector)
 --]]
 exports.register_extractor = function(cfg, name, selector)

--- a/src/libmime/scan_result.c
+++ b/src/libmime/scan_result.c
@@ -872,6 +872,35 @@ rspamd_find_action_config_for_action(struct rspamd_scan_result *scan_result,
 	return NULL;
 }
 
+bool rspamd_scan_result_has_passthrough(const struct rspamd_scan_result *res)
+{
+	struct rspamd_passthrough_result *pr;
+
+	if (res == NULL || res->passthrough_result == NULL) {
+		return false;
+	}
+
+	DL_FOREACH(res->passthrough_result, pr)
+	{
+		struct rspamd_action_config *act_config =
+			rspamd_find_action_config_for_action((struct rspamd_scan_result *) res, pr->action);
+
+		/* Least results and the results that explicitly allow further processing */
+		if (pr->flags & (RSPAMD_PASSTHROUGH_LEAST | RSPAMD_PASSTHROUGH_PROCESS_ALL)) {
+			continue;
+		}
+
+		/* Disabled actions */
+		if (act_config && (act_config->flags & RSPAMD_ACTION_RESULT_DISABLED)) {
+			continue;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
 struct rspamd_action *
 rspamd_check_action_metric(struct rspamd_task *task,
 						   struct rspamd_passthrough_result **ppr,

--- a/src/libmime/scan_result.h
+++ b/src/libmime/scan_result.h
@@ -152,6 +152,14 @@ bool rspamd_add_passthrough_result(struct rspamd_task *task,
 								   const char *module, unsigned int flags,
 								   struct rspamd_scan_result *scan_result);
 
+/**
+ * Checks if a scan result has a passthrough result that stops further checks:
+ * `least` and `process_all` results and disabled actions do not count
+ * @param res scan result (NULL is allowed)
+ * @return true if further checks and classification should be skipped
+ */
+bool rspamd_scan_result_has_passthrough(const struct rspamd_scan_result *res);
+
 enum rspamd_symbol_insert_flags {
 	RSPAMD_SYMBOL_INSERT_DEFAULT = 0,
 	RSPAMD_SYMBOL_INSERT_SINGLE = (1 << 0),

--- a/src/libserver/rspamd_symcache.h
+++ b/src/libserver/rspamd_symcache.h
@@ -292,6 +292,35 @@ void rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
 										const char *symbol,
 										ucl_object_t *this_sym_ucl);
 
+/**
+ * Execution plan of a symbol: the stage that runs it, its level within the
+ * stage (a higher level runs earlier) and the symbol that hoisted it, if any
+ */
+struct rspamd_symcache_exec_info {
+	const char *stage;
+	int level;
+	const char *hoisted_by;
+};
+
+/**
+ * Fills the execution plan of a symbol (virtual symbols are resolved to their parents)
+ * @param cache
+ * @param symbol
+ * @param info
+ * @return FALSE if the symbol is unknown or is not executed by the cache
+ */
+gboolean rspamd_symcache_get_symbol_exec_info(struct rspamd_symcache *cache,
+											  const char *symbol,
+											  struct rspamd_symcache_exec_info *info);
+
+/**
+ * Dumps the execution plan: an array of buckets (stage, level, symbols with
+ * their dependencies) in the execution order
+ * @param cache
+ * @return newly allocated ucl object
+ */
+ucl_object_t *rspamd_symcache_dump_exec_plan(struct rspamd_symcache *cache);
+
 
 /**
  * Process settings for task

--- a/src/libserver/symcache/symcache_c.cxx
+++ b/src/libserver/symcache/symcache_c.cxx
@@ -422,7 +422,136 @@ void rspamd_symcache_get_symbol_details(struct rspamd_symcache *cache,
 
 		ucl_object_insert_key(this_sym_ucl, flags_ucl,
 							  "flags", strlen("flags"), false);
+
+		/* Execution plan: virtual symbols report the values of their parents */
+		const auto *exec_sym = sym;
+
+		if (sym->is_virtual()) {
+			exec_sym = sym->get_parent(*real_cache);
+		}
+
+		if (exec_sym != nullptr && exec_sym->is_executable()) {
+			ucl_object_insert_key(this_sym_ucl,
+								  ucl_object_fromstring(rspamd::symcache::exec_stage_to_str(exec_sym->get_stage())),
+								  "stage", strlen("stage"), false);
+			ucl_object_insert_key(this_sym_ucl,
+								  ucl_object_fromint(exec_sym->get_level()),
+								  "level", strlen("level"), false);
+			ucl_object_insert_key(this_sym_ucl,
+								  ucl_object_fromint(exec_sym->priority),
+								  "priority", strlen("priority"), false);
+
+			if (exec_sym->is_hoisted()) {
+				ucl_object_insert_key(this_sym_ucl,
+									  ucl_object_fromstring(exec_sym->hoisted_by->get_name().c_str()),
+									  "hoisted_by", strlen("hoisted_by"), false);
+			}
+
+			if (!exec_sym->deps.empty()) {
+				auto *deps_ucl = ucl_object_typed_new(UCL_ARRAY);
+
+				for (const auto &[_id, dep]: exec_sym->deps) {
+					if (dep.item != nullptr) {
+						auto *dep_ucl = ucl_object_typed_new(UCL_OBJECT);
+						ucl_object_insert_key(dep_ucl,
+											  ucl_object_fromstring(dep.item->get_name().c_str()),
+											  "symbol", strlen("symbol"), false);
+						ucl_object_insert_key(dep_ucl,
+											  ucl_object_frombool(dep.hard),
+											  "hard", strlen("hard"), false);
+						ucl_array_append(deps_ucl, dep_ucl);
+					}
+				}
+
+				ucl_object_insert_key(this_sym_ucl, deps_ucl,
+									  "dependencies", strlen("dependencies"), false);
+			}
+		}
 	}
+}
+
+gboolean rspamd_symcache_get_symbol_exec_info(struct rspamd_symcache *cache,
+											  const char *symbol,
+											  struct rspamd_symcache_exec_info *info)
+{
+	auto *real_cache = C_API_SYMCACHE(cache);
+
+	const auto *sym = real_cache->get_item_by_name(symbol, true);
+
+	if (sym == nullptr || !sym->is_executable() || info == nullptr) {
+		return FALSE;
+	}
+
+	info->stage = rspamd::symcache::exec_stage_to_str(sym->get_stage());
+	info->level = sym->get_level();
+	info->hoisted_by = sym->is_hoisted() ? sym->hoisted_by->get_name().c_str() : nullptr;
+
+	return TRUE;
+}
+
+ucl_object_t *rspamd_symcache_dump_exec_plan(struct rspamd_symcache *cache)
+{
+	auto *real_cache = C_API_SYMCACHE(cache);
+
+	real_cache->maybe_resort();
+	auto order = real_cache->get_cache_order();
+	auto *out = ucl_object_typed_new(UCL_ARRAY);
+
+	if (!order) {
+		return out;
+	}
+
+	for (const auto &bucket: order->buckets) {
+		auto *bucket_ucl = ucl_object_typed_new(UCL_OBJECT);
+
+		ucl_object_insert_key(bucket_ucl,
+							  ucl_object_fromstring(rspamd::symcache::exec_stage_to_str(bucket.stage)),
+							  "stage", strlen("stage"), false);
+		ucl_object_insert_key(bucket_ucl,
+							  ucl_object_fromint(bucket.level),
+							  "level", strlen("level"), false);
+
+		auto *symbols_ucl = ucl_object_typed_new(UCL_ARRAY);
+
+		for (auto i = bucket.first; i < bucket.first + bucket.count; i++) {
+			const auto &sym = order->d[i];
+			auto *sym_ucl = ucl_object_typed_new(UCL_OBJECT);
+
+			ucl_object_insert_key(sym_ucl,
+								  ucl_object_fromstring(sym->get_name().c_str()),
+								  "symbol", strlen("symbol"), false);
+			ucl_object_insert_key(sym_ucl,
+								  ucl_object_fromstring(sym->get_type_str()),
+								  "type", strlen("type"), false);
+
+			if (sym->is_hoisted()) {
+				ucl_object_insert_key(sym_ucl,
+									  ucl_object_fromstring(sym->hoisted_by->get_name().c_str()),
+									  "hoisted_by", strlen("hoisted_by"), false);
+			}
+
+			if (!sym->deps.empty()) {
+				auto *deps_ucl = ucl_object_typed_new(UCL_ARRAY);
+
+				for (const auto &[_id, dep]: sym->deps) {
+					if (dep.item != nullptr) {
+						ucl_array_append(deps_ucl, ucl_object_fromstring(dep.item->get_name().c_str()));
+					}
+				}
+
+				ucl_object_insert_key(sym_ucl, deps_ucl,
+									  "dependencies", strlen("dependencies"), false);
+			}
+
+			ucl_array_append(symbols_ucl, sym_ucl);
+		}
+
+		ucl_object_insert_key(bucket_ucl, symbols_ucl,
+							  "symbols", strlen("symbols"), false);
+		ucl_array_append(out, bucket_ucl);
+	}
+
+	return out;
 }
 
 void rspamd_symcache_foreach(struct rspamd_symcache *cache,
@@ -505,6 +634,11 @@ void rspamd_symcache_disable_all_symbols(struct rspamd_task *task,
 										 unsigned int skip_mask)
 {
 	auto *cache_runtime = C_API_SYMCACHE_RUNTIME(task->symcache_runtime);
+
+	if (cache_runtime == nullptr) {
+		/* E.g. a learn task that never runs the symbols */
+		return;
+	}
 
 	cache_runtime->disable_all_symbols(skip_mask);
 }
@@ -691,7 +825,7 @@ unsigned int rspamd_symcache_item_async_inc_full(struct rspamd_task *task,
 	if (nevents > 1) {
 		/* Item is async */
 		static_item->internal_flags &= ~rspamd::symcache::cache_item::bit_sync;
-		real_dyn_item->status = rspamd::symcache::cache_item_status::pending;
+		cache_runtime->set_status(real_dyn_item, rspamd::symcache::cache_item_status::pending);
 	}
 
 	return nevents;
@@ -767,7 +901,7 @@ void rspamd_symcache_composites_foreach(struct rspamd_task *task,
 		if (dyn_item && dyn_item->status == rspamd::symcache::cache_item_status::not_started) {
 			auto *old_item = cache_runtime->set_cur_item(dyn_item);
 			func((void *) item->get_name().c_str(), item->get_cbdata(), fd);
-			dyn_item->status = rspamd::symcache::cache_item_status::finished;
+			cache_runtime->set_status(dyn_item, rspamd::symcache::cache_item_status::finished);
 			cache_runtime->set_cur_item(old_item);
 		}
 	});

--- a/src/libserver/symcache/symcache_impl.cxx
+++ b/src/libserver/symcache/symcache_impl.cxx
@@ -582,8 +582,18 @@ auto symcache::compute_exec_plan() -> void
 {
 	auto log_func = RSPAMD_LOG_FUNC;
 
-	/* Seed from the declared types and priorities */
+	/*
+	 * Seed from the declared types and priorities. Items that already have a
+	 * plan keep it: this function runs on every resort, so the symbols
+	 * registered after the init (e.g. from maps) get their plan too, while the
+	 * levels of the others stay as they were assigned at the init time
+	 */
 	for (const auto &[_id, it]: items_by_id) {
+		if (it->planned) {
+			continue;
+		}
+
+		it->planned = true;
 		it->stage = declared_exec_stage(it->type);
 		it->hoisted_by = nullptr;
 
@@ -681,17 +691,14 @@ auto symcache::compute_exec_plan() -> void
 			}
 		}
 	}
-
-	exec_plan_ready = true;
 }
 
 auto symcache::resort() -> void
 {
 	auto log_func = RSPAMD_LOG_FUNC;
 
-	if (!exec_plan_ready) {
-		compute_exec_plan();
-	}
+	/* Plan the symbols registered since the last resort (a no-op for the rest) */
+	compute_exec_plan();
 
 	auto ord = std::make_shared<order_generation>(items_by_id.size(), cur_order_gen);
 
@@ -704,6 +711,13 @@ auto symcache::resort() -> void
 	for (const auto *vec: {&connfilters, &prefilters, &filters, &postfilters, &idempotent}) {
 		for (auto &it: *vec) {
 			if (it) {
+				if (it->stage == exec_stage::none) {
+					/* Must not happen: every executable item is planned above */
+					msg_err_cache("internal error: symbol %s (%s) has no execution stage; use the declared one",
+								  it->symbol.c_str(), it->get_type_str());
+					it->stage = declared_exec_stage(it->type);
+				}
+
 				total_hits += it->st->total_hits;
 				/* Unmask topological order */
 				it->order = 0;
@@ -1489,10 +1503,8 @@ auto symcache::get_max_timeout(std::vector<std::pair<double, const cache_item *>
 	auto log_func = RSPAMD_LOG_FUNC;
 	ankerl::unordered_dense::set<const cache_item *> seen_items;
 
-	if (!exec_plan_ready) {
-		/* E.g. called before init: then merely the declared types are used */
-		compute_exec_plan();
-	}
+	/* E.g. called before init: then merely the declared types are used */
+	compute_exec_plan();
 
 	auto get_item_timeout = [](const cache_item *it) {
 		return it->get_numeric_augmentation("timeout").value_or(0.0);

--- a/src/libserver/symcache/symcache_impl.cxx
+++ b/src/libserver/symcache/symcache_impl.cxx
@@ -218,20 +218,12 @@ auto symcache::init() -> bool
 		it->process_deps(*this);
 	}
 
-	/* Sorting stuff */
-	constexpr auto postfilters_cmp = [](const auto &it1, const auto &it2) -> bool {
-		return it1->priority < it2->priority;
-	};
-	constexpr auto prefilters_cmp = [](const auto &it1, const auto &it2) -> bool {
-		return it1->priority > it2->priority;
-	};
-
-	msg_debug_cache("sorting stuff");
-	std::stable_sort(std::begin(connfilters), std::end(connfilters), prefilters_cmp);
-	std::stable_sort(std::begin(prefilters), std::end(prefilters), prefilters_cmp);
-	std::stable_sort(std::begin(postfilters), std::end(postfilters), postfilters_cmp);
-	std::stable_sort(std::begin(idempotent), std::end(idempotent), postfilters_cmp);
-
+	/*
+	 * Assign stages and levels once: as the pre/postfilter ordering did before,
+	 * this uses the priorities known at the init time; later adjustments
+	 * (e.g. by `validate`) merely affect the soft ordering of filters
+	 */
+	compute_exec_plan();
 	resort();
 
 	/* Connect metric symbols with symcache symbols */
@@ -586,24 +578,137 @@ auto symcache::add_dependency(int id_from, std::string_view to, int id_to, int v
 	}
 }
 
+auto symcache::compute_exec_plan() -> void
+{
+	auto log_func = RSPAMD_LOG_FUNC;
+
+	/* Seed from the declared types and priorities */
+	for (const auto &[_id, it]: items_by_id) {
+		it->stage = declared_exec_stage(it->type);
+		it->hoisted_by = nullptr;
+
+		switch (it->stage) {
+		case exec_stage::connfilters:
+		case exec_stage::prefilters:
+			it->level = it->priority;
+			break;
+		case exec_stage::postfilters:
+		case exec_stage::idempotent:
+			/* A higher priority runs later for these stages */
+			it->level = -it->priority;
+			break;
+		case exec_stage::filters:
+		default:
+			/* Priority of filters is merely a soft ordering key */
+			it->level = 0;
+			break;
+		}
+	}
+
+	/* True if (st1, l1) is executed before (st2, l2) */
+	constexpr auto is_earlier = [](exec_stage st1, int l1, exec_stage st2, int l2) {
+		return st1 < st2 || (st1 == st2 && l1 > l2);
+	};
+
+	/* Items on the current DFS path, to detect cycles */
+	ankerl::unordered_dense::set<int> path;
+
+	/*
+	 * Push the (stage, level) of an item down to its dependencies: a dependency
+	 * must run before the dependent, so it inherits the earliest position among
+	 * all dependents. Every push moves an item strictly earlier, so the walk
+	 * terminates.
+	 */
+	const auto propagate = [&](cache_item *it, auto &&rec) -> void {
+		path.insert(it->id);
+
+		for (auto &[_dep_id, dep]: it->deps) {
+			auto *dit = dep.item;
+
+			if (dit == nullptr || !dit->is_executable()) {
+				continue;
+			}
+
+			if (path.contains(dit->id)) {
+				msg_err_cache_lambda("cyclic dependency: %s depends on %s which (indirectly) depends on it",
+									 it->symbol.c_str(), dit->symbol.c_str());
+				continue;
+			}
+
+			if (is_earlier(it->stage, it->level, dit->stage, dit->level)) {
+				auto *cause = it->hoisted_by ? it->hoisted_by : it;
+
+				if (dit->stage != it->stage) {
+					msg_info_cache_lambda("symbol %s (%s) is hoisted to the %s stage, level %d, "
+										  "as %s depends on it",
+										  dit->symbol.c_str(), item_type_to_str(dit->type),
+										  exec_stage_to_str(it->stage), it->level,
+										  cause->symbol.c_str());
+				}
+				else {
+					msg_debug_cache_lambda("symbol %s is raised to level %d (from %d) at the %s stage, "
+										   "as %s depends on it",
+										   dit->symbol.c_str(), it->level, dit->level,
+										   exec_stage_to_str(it->stage),
+										   cause->symbol.c_str());
+				}
+
+				dit->stage = it->stage;
+				dit->level = it->level;
+				dit->hoisted_by = cause;
+				rec(dit, rec);
+			}
+		}
+
+		path.erase(it->id);
+	};
+
+	for (const auto &[_id, it]: items_by_id) {
+		if (it->is_executable()) {
+			propagate(it.get(), propagate);
+		}
+	}
+
+	/* Virtual symbols are produced by their parents */
+	for (const auto &[_id, it]: items_by_id) {
+		if (it->is_virtual()) {
+			const auto *parent = it->get_parent(*this);
+
+			if (parent != nullptr) {
+				it->stage = parent->stage;
+				it->level = parent->level;
+				it->hoisted_by = parent->hoisted_by;
+			}
+		}
+	}
+
+	exec_plan_ready = true;
+}
+
 auto symcache::resort() -> void
 {
 	auto log_func = RSPAMD_LOG_FUNC;
-	auto ord = std::make_shared<order_generation>(filters.size() +
-													  prefilters.size() +
-													  composites.size() +
-													  postfilters.size() +
-													  idempotent.size() +
-													  connfilters.size() +
-													  classifiers.size(),
-												  cur_order_gen);
 
-	for (auto &it: filters) {
-		if (it) {
-			total_hits += it->st->total_hits;
-			/* Unmask topological order */
-			it->order = 0;
-			ord->d.emplace_back(it->getptr());
+	if (!exec_plan_ready) {
+		compute_exec_plan();
+	}
+
+	auto ord = std::make_shared<order_generation>(items_by_id.size(), cur_order_gen);
+
+	/*
+	 * All executable items are ordered together: by stage, then by level, then
+	 * topologically (dependencies first), then by the soft ordering keys
+	 */
+	total_hits = 0;
+
+	for (const auto *vec: {&connfilters, &prefilters, &filters, &postfilters, &idempotent}) {
+		for (auto &it: *vec) {
+			if (it) {
+				total_hits += it->st->total_hits;
+				/* Unmask topological order */
+				it->order = 0;
+				ord->d.emplace_back(it->getptr());
+			}
 		}
 	}
 
@@ -669,9 +774,8 @@ auto symcache::resort() -> void
 	/*
 	 * Topological sort
 	 */
-	total_hits = 0;
 	auto used_items = ord->d.size();
-	msg_debug_cache("topologically sort %z filters", used_items);
+	msg_debug_cache("topologically sort %z executable items", used_items);
 
 	for (const auto &it: ord->d) {
 		if (it->order == 0) {
@@ -688,15 +792,34 @@ auto symcache::resort() -> void
 				(t > time_alpha ? t : time_alpha));
 	};
 
-	auto cache_order_cmp = [&](const auto &it1, const auto &it2) -> auto {
-		constexpr const auto topology_mult = 1e7,
-							 priority_mult = 1e6,
-							 augmentations1_mult = 1e5;
-		auto w1 = tsort_unmask(it1.get()) * topology_mult,
-			 w2 = tsort_unmask(it2.get()) * topology_mult;
+	auto cache_order_cmp = [&](const auto &it1, const auto &it2) -> bool {
+		/* Stage, then level: this is what the runtime relies on */
+		if (it1->stage != it2->stage) {
+			return it1->stage < it2->stage;
+		}
 
-		w1 += it1->priority * priority_mult;
-		w2 += it2->priority * priority_mult;
+		if (it1->level != it2->level) {
+			return it1->level > it2->level;
+		}
+
+		/* Inside a bucket: dependencies go first */
+		auto topo1 = tsort_unmask(it1.get()), topo2 = tsort_unmask(it2.get());
+
+		if (topo1 != topo2) {
+			return topo1 > topo2;
+		}
+
+		if (it1->stage != exec_stage::filters) {
+			/* Pre/postfilters keep the registration order, as they always did */
+			return it1->id < it2->id;
+		}
+
+		/* Filters: soft priority, augmentations and the runtime statistics */
+		constexpr const auto priority_mult = 1e6,
+							 augmentations1_mult = 1e5;
+		auto w1 = it1->priority * priority_mult,
+			 w2 = it2->priority * priority_mult;
+
 		w1 += it1->get_augmentation_weight() * augmentations1_mult;
 		w2 += it2->get_augmentation_weight() * augmentations1_mult;
 
@@ -715,34 +838,58 @@ auto symcache::resort() -> void
 	};
 
 	std::stable_sort(std::begin(ord->d), std::end(ord->d), cache_order_cmp);
-	/*
-	 * Here lives some ugly legacy!
-	 * We have several filters classes, connfilters, prefilters, filters... etc
-	 *
-	 * Our order is meaningful merely for filters, but we have to add other classes
-	 * to understand if those symbols are checked or disabled.
-	 * We can disable symbols for almost everything but not for virtual symbols.
-	 * The rule of thumb is that if a symbol has explicit parent, then it is a
-	 * virtual symbol that follows it's special rules
-	 */
+
+	/* Group the sorted executable items into (stage, level) buckets */
+	for (auto &range: ord->stage_buckets) {
+		range = {order_generation::no_bucket, order_generation::no_bucket};
+	}
+
+	for (const auto [i, it]: rspamd::enumerate(ord->d)) {
+		if (ord->buckets.empty() ||
+			ord->buckets.back().stage != it->stage ||
+			ord->buckets.back().level != it->level) {
+			ord->buckets.push_back(exec_bucket{it->stage, it->level, (unsigned int) i, 0});
+
+			auto &range = ord->stage_buckets[static_cast<unsigned int>(it->stage)];
+
+			if (range.first == order_generation::no_bucket) {
+				range.first = ord->buckets.size() - 1;
+			}
+
+			range.second = ord->buckets.size();
+		}
+
+		ord->buckets.back().count++;
+		ord->item_bucket.push_back(ord->buckets.size() - 1);
+	}
+
+	for (auto &range: ord->stage_buckets) {
+		if (range.first == order_generation::no_bucket) {
+			/* No items at this stage */
+			range = {0, 0};
+		}
+	}
+
+	for (const auto &bucket: ord->buckets) {
+		msg_debug_cache("bucket: stage %s, level %d, %d items starting from %s",
+						exec_stage_to_str(bucket.stage), bucket.level, (int) bucket.count,
+						ord->d[bucket.first]->symbol.c_str());
+	}
 
 	/*
-	 * We enrich ord with all other symbol types without any sorting,
-	 * as it is done in another place
+	 * Composites and classifiers are not executed by the runtime, but they need
+	 * dynamic items to track whether they have been checked or disabled
 	 */
 	const auto append_items_vec = [&](const auto &vec, auto &out, const char *what) {
 		msg_debug_cache_lambda("append %d items; type = %s", (int) vec.size(), what);
 		for (const auto &it: vec) {
 			if (it) {
 				out.emplace_back(it->getptr());
+				ord->item_bucket.push_back(order_generation::no_bucket);
 			}
 		}
 	};
 
-	append_items_vec(connfilters, ord->d, "connection filters");
-	append_items_vec(prefilters, ord->d, "prefilters");
-	append_items_vec(postfilters, ord->d, "postfilters");
-	append_items_vec(idempotent, ord->d, "idempotent filters");
 	append_items_vec(composites, ord->d, "composites");
 	append_items_vec(classifiers, ord->d, "classifiers");
 
@@ -1336,22 +1483,38 @@ auto symcache::apply_pending_settings(cache_item *item) -> void
 	pending_settings_ops.erase(it);
 }
 
-auto symcache::get_max_timeout(std::vector<std::pair<double, const cache_item *>> &elts) const -> double
+auto symcache::get_max_timeout(std::vector<std::pair<double, const cache_item *>> &elts) -> double
 {
 	auto accumulated_timeout = 0.0;
 	auto log_func = RSPAMD_LOG_FUNC;
 	ankerl::unordered_dense::set<const cache_item *> seen_items;
 
-	auto get_item_timeout = [](cache_item *it) {
+	if (!exec_plan_ready) {
+		/* E.g. called before init: then merely the declared types are used */
+		compute_exec_plan();
+	}
+
+	auto get_item_timeout = [](const cache_item *it) {
 		return it->get_numeric_augmentation("timeout").value_or(0.0);
 	};
 
-	/* This function returns the timeout for an item and all it's dependencies */
-	auto get_filter_timeout = [&](cache_item *it, auto self) -> double {
+	/*
+	 * Returns the timeout of an item plus the longest chain of its dependencies
+	 * that run in the same bucket (the same stage and level): those run
+	 * sequentially, while dependencies from the earlier buckets are accounted
+	 * in their own buckets.
+	 * This function might have O(N^2) complexity if all symbols are in a single
+	 * dependencies chain. But it is not the case in practice
+	 */
+	auto get_chain_timeout = [&](const cache_item *it, auto self) -> double {
 		auto own_timeout = get_item_timeout(it);
 		auto max_child_timeout = 0.0;
 
 		for (const auto &[id, dep]: it->deps) {
+			if (dep.item == nullptr || dep.item->stage != it->stage || dep.item->level != it->level) {
+				continue;
+			}
+
 			auto cld_timeout = self(dep.item, self);
 
 			if (cld_timeout > max_child_timeout) {
@@ -1362,77 +1525,60 @@ auto symcache::get_max_timeout(std::vector<std::pair<double, const cache_item *>
 		return own_timeout + max_child_timeout;
 	};
 
-	/* For prefilters and postfilters, we just care about priorities */
-	auto pre_postfilter_iter = [&](const items_ptr_vec &vec) -> double {
-		auto saved_priority = vec.empty() ? -1 : vec.front()->priority;
-		auto max_timeout = 0.0, added_timeout = 0.0;
-		const cache_item *max_elt = nullptr;
-		for (const auto &it: vec) {
-			if (it->priority != saved_priority && max_elt != nullptr && max_timeout > 0) {
-				if (!seen_items.contains(max_elt)) {
-					accumulated_timeout += max_timeout;
-					added_timeout += max_timeout;
+	/* Buckets run sequentially, items inside a bucket run concurrently */
+	std::vector<const cache_item *> items;
+	items.reserve(items_by_id.size());
 
-					msg_debug_cache_lambda("added %.2f to the timeout (%.2f) as the priority has changed (%d -> %d); "
-										   "symbol: %s",
-										   max_timeout, accumulated_timeout, saved_priority, it->priority,
-										   max_elt->symbol.c_str());
-					elts.emplace_back(max_timeout, max_elt);
-					seen_items.insert(max_elt);
-				}
-				max_timeout = 0;
-				saved_priority = it->priority;
-				max_elt = nullptr;
-			}
-
-			auto timeout = get_item_timeout(it);
-
-			if (timeout > max_timeout) {
-				max_timeout = timeout;
-				max_elt = it;
-			}
-		}
-
-		if (max_elt != nullptr && max_timeout > 0) {
-			if (!seen_items.contains(max_elt)) {
-				accumulated_timeout += max_timeout;
-				added_timeout += max_timeout;
-
-				msg_debug_cache_lambda("added %.2f to the timeout (%.2f) end of processing; "
-									   "symbol: %s",
-									   max_timeout, accumulated_timeout,
-									   max_elt->symbol.c_str());
-				elts.emplace_back(max_timeout, max_elt);
-				seen_items.insert(max_elt);
-			}
-		}
-
-		return added_timeout;
-	};
-
-	auto prefilters_timeout = pre_postfilter_iter(this->prefilters);
-
-	/* For normal filters, we check the maximum chain of the dependencies
-	 * This function might have O(N^2) complexity if all symbols are in a single
-	 * dependencies chain. But it is not the case in practice
-	 */
-	double max_filters_timeout = 0;
-	for (const auto &it: this->filters) {
-		auto timeout = get_filter_timeout(it, get_filter_timeout);
-
-		if (timeout > max_filters_timeout) {
-			max_filters_timeout = timeout;
-			if (!seen_items.contains(it)) {
-				elts.emplace_back(timeout, it);
-				seen_items.insert(it);
-			}
+	for (const auto &[_id, it]: items_by_id) {
+		if (it->is_executable()) {
+			items.push_back(it.get());
 		}
 	}
 
-	accumulated_timeout += max_filters_timeout;
+	std::sort(std::begin(items), std::end(items), [](const auto *it1, const auto *it2) {
+		if (it1->stage != it2->stage) {
+			return it1->stage < it2->stage;
+		}
 
-	auto postfilters_timeout = pre_postfilter_iter(this->postfilters);
-	auto idempotent_timeout = pre_postfilter_iter(this->idempotent);
+		if (it1->level != it2->level) {
+			return it1->level > it2->level;
+		}
+
+		return it1->id < it2->id;
+	});
+
+	std::array<double, exec_stages_count> stage_timeouts{};
+
+	for (auto i = 0ul; i < items.size();) {
+		const auto stage = items[i]->stage;
+		const auto level = items[i]->level;
+		auto max_timeout = 0.0;
+		const cache_item *max_elt = nullptr;
+
+		for (; i < items.size() && items[i]->stage == stage && items[i]->level == level; i++) {
+			auto timeout = get_chain_timeout(items[i], get_chain_timeout);
+
+			if (timeout > 0 && !seen_items.contains(items[i])) {
+				elts.emplace_back(timeout, items[i]);
+				seen_items.insert(items[i]);
+			}
+
+			if (timeout > max_timeout) {
+				max_timeout = timeout;
+				max_elt = items[i];
+			}
+		}
+
+		if (max_elt != nullptr) {
+			accumulated_timeout += max_timeout;
+			stage_timeouts[static_cast<unsigned int>(stage)] += max_timeout;
+
+			msg_debug_cache_lambda("added %.2f to the timeout (%.2f) for the stage %s, level %d; "
+								   "symbol: %s",
+								   max_timeout, accumulated_timeout, exec_stage_to_str(stage), level,
+								   max_elt->symbol.c_str());
+		}
+	}
 
 	/* Sort in decreasing order by timeout */
 	std::stable_sort(std::begin(elts), std::end(elts),
@@ -1440,11 +1586,15 @@ auto symcache::get_max_timeout(std::vector<std::pair<double, const cache_item *>
 						 return p1.first > p2.first;
 					 });
 
-	msg_debug_cache("overall cache timeout: %.2f, %.2f from prefilters,"
+	msg_debug_cache("overall cache timeout: %.2f, %.2f from connfilters, %.2f from prefilters,"
 					" %.2f from postfilters, %.2f from idempotent filters,"
 					" %.2f from normal filters",
-					accumulated_timeout, prefilters_timeout, postfilters_timeout,
-					idempotent_timeout, max_filters_timeout);
+					accumulated_timeout,
+					stage_timeouts[static_cast<unsigned int>(exec_stage::connfilters)],
+					stage_timeouts[static_cast<unsigned int>(exec_stage::prefilters)],
+					stage_timeouts[static_cast<unsigned int>(exec_stage::postfilters)],
+					stage_timeouts[static_cast<unsigned int>(exec_stage::idempotent)],
+					stage_timeouts[static_cast<unsigned int>(exec_stage::filters)]);
 
 	return accumulated_timeout;
 }

--- a/src/libserver/symcache/symcache_impl.cxx
+++ b/src/libserver/symcache/symcache_impl.cxx
@@ -218,6 +218,9 @@ auto symcache::init() -> bool
 		it->process_deps(*this);
 	}
 
+	/* The runtime, the planner and the timeouts all walk the graph: it must be acyclic */
+	break_dependency_cycles();
+
 	/*
 	 * Assign stages and levels once: as the pre/postfilter ordering did before,
 	 * this uses the priorities known at the init time; later adjustments
@@ -574,6 +577,64 @@ auto symcache::add_dependency(int id_from, std::string_view to, int id_to, int v
 		else {
 			msg_debug_cache("duplicate virtual dependency %s -> %s",
 							vsource->symbol.c_str(), to.data());
+		}
+	}
+}
+
+auto symcache::break_dependency_cycles() -> void
+{
+	auto log_func = RSPAMD_LOG_FUNC;
+
+	enum class color : std::uint8_t {
+		grey,
+		black,
+	};
+	/* Items not in the map are white (not visited yet) */
+	ankerl::unordered_dense::map<int, color> colors;
+	std::vector<std::pair<cache_item *, int>> back_edges;
+
+	const auto visit = [&](cache_item *it, auto &&rec) -> void {
+		colors[it->id] = color::grey;
+
+		for (auto &[dep_id, dep]: it->deps) {
+			auto *dit = dep.item;
+
+			if (dit == nullptr) {
+				continue;
+			}
+
+			auto found = colors.find(dit->id);
+
+			if (found == colors.end()) {
+				rec(dit, rec);
+			}
+			else if (found->second == color::grey) {
+				msg_err_cache_lambda("cyclic dependency: %s depends on %s which (indirectly) depends on it; "
+									 "the dependency %s -> %s is dropped",
+									 it->symbol.c_str(), dit->symbol.c_str(),
+									 it->symbol.c_str(), dit->symbol.c_str());
+				back_edges.emplace_back(it, dep_id);
+			}
+		}
+
+		colors[it->id] = color::black;
+	};
+
+	for (const auto &[_id, it]: items_by_id) {
+		if (it->is_executable() && !colors.contains(it->id)) {
+			visit(it.get(), visit);
+		}
+	}
+
+	for (auto &[it, dep_id]: back_edges) {
+		auto found = it->deps.find(dep_id);
+
+		if (found != it->deps.end()) {
+			if (found->second.item != nullptr) {
+				found->second.item->rdeps.erase(it->id);
+			}
+
+			it->deps.erase(found);
 		}
 	}
 }
@@ -1518,12 +1579,23 @@ auto symcache::get_max_timeout(std::vector<std::pair<double, const cache_item *>
 	 * This function might have O(N^2) complexity if all symbols are in a single
 	 * dependencies chain. But it is not the case in practice
 	 */
+	/* Items on the current traversal path: cycles are broken at init, this is a safety net */
+	ankerl::unordered_dense::set<int> path;
+
 	auto get_chain_timeout = [&](const cache_item *it, auto self) -> double {
 		auto own_timeout = get_item_timeout(it);
 		auto max_child_timeout = 0.0;
 
+		path.insert(it->id);
+
 		for (const auto &[id, dep]: it->deps) {
 			if (dep.item == nullptr || dep.item->stage != it->stage || dep.item->level != it->level) {
+				continue;
+			}
+
+			if (path.contains(dep.item->id)) {
+				msg_err_cache_lambda("cyclic dependency %s -> %s when computing timeouts; ignore it",
+									 it->symbol.c_str(), dep.item->symbol.c_str());
 				continue;
 			}
 
@@ -1533,6 +1605,8 @@ auto symcache::get_max_timeout(std::vector<std::pair<double, const cache_item *>
 				max_child_timeout = cld_timeout;
 			}
 		}
+
+		path.erase(it->id);
 
 		return own_timeout + max_child_timeout;
 	};

--- a/src/libserver/symcache/symcache_internal.hxx
+++ b/src/libserver/symcache/symcache_internal.hxx
@@ -27,6 +27,8 @@
 #include <cstdint>
 #include <utility>
 #include <vector>
+#include <array>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <memory>
@@ -60,6 +62,10 @@
 														"symcache", log_tag(), \
 														RSPAMD_LOG_FUNC,       \
 														__VA_ARGS__)
+#define msg_info_cache_lambda(...) rspamd_default_log_function(G_LOG_LEVEL_INFO,      \
+															   "symcache", log_tag(), \
+															   log_func,              \
+															   __VA_ARGS__)
 #define msg_debug_cache(...) rspamd_conditional_debug_fast(NULL, NULL,                                                        \
 														   ::rspamd::symcache::rspamd_symcache_log_id, "symcache", log_tag(), \
 														   RSPAMD_LOG_FUNC,                                                   \
@@ -96,6 +102,58 @@ struct symcache_header {
 struct cache_item;
 using cache_item_ptr = std::shared_ptr<cache_item>;
 
+/*
+ * Execution stage of an item: the task processing stage that runs it.
+ * The declared symbol type gives the default stage (see `declared_exec_stage`),
+ * a dependency from an earlier stage may hoist an item to that stage
+ * (see `symcache::compute_exec_plan`). Composites, classifiers and virtual
+ * symbols are not scheduled by the symcache and have no stage.
+ */
+enum class exec_stage : std::uint8_t {
+	connfilters = 0,
+	prefilters,
+	filters,
+	postfilters,
+	idempotent,
+	none,
+};
+
+constexpr static const auto exec_stages_count = static_cast<unsigned int>(exec_stage::none);
+
+constexpr static auto exec_stage_to_str(exec_stage st) -> const char *
+{
+	switch (st) {
+	case exec_stage::connfilters:
+		return "connfilters";
+	case exec_stage::prefilters:
+		return "prefilters";
+	case exec_stage::filters:
+		return "filters";
+	case exec_stage::postfilters:
+		return "postfilters";
+	case exec_stage::idempotent:
+		return "idempotent";
+	case exec_stage::none:
+		return "none";
+	}
+
+	return "unknown";
+}
+
+/*
+ * A bucket groups the items of one (stage, level) pair. Within a stage, buckets
+ * are ordered by level (higher level first) and an item may not start until all
+ * buckets before its own in the same stage are drained. Items inside a bucket
+ * run concurrently, subject to their explicit dependencies.
+ */
+struct exec_bucket {
+	exec_stage stage;
+	int level;
+	/* Range [first, first + count) in order_generation::d */
+	unsigned int first;
+	unsigned int count;
+};
+
 /**
  * This structure is intended to keep the current ordering for all symbols
  * It is designed to be shared among all tasks and keep references to the real
@@ -106,12 +164,20 @@ using cache_item_ptr = std::shared_ptr<cache_item>;
  * cache runtime.
  */
 struct order_generation {
-	/* All items ordered */
+	static constexpr const unsigned int no_bucket = std::numeric_limits<unsigned int>::max();
+
+	/* All items ordered: executable items first (grouped by stage and level), then the rest */
 	std::vector<cache_item_ptr> d;
 	/* Mapping from symbol name to the position in the order array */
 	ankerl::unordered_dense::map<std::string_view, unsigned int> by_symbol;
 	/* Mapping from symbol id to the position in the order array */
 	ankerl::unordered_dense::map<unsigned int, unsigned int> by_cache_id;
+	/* Execution buckets in the execution order */
+	std::vector<exec_bucket> buckets;
+	/* Bucket index for each position in `d` (no_bucket for non-executable items) */
+	std::vector<unsigned int> item_bucket;
+	/* Bucket ranges [first, last) for each stage */
+	std::array<std::pair<unsigned int, unsigned int>, exec_stages_count> stage_buckets{};
 	/* It matches cache->generation_id; if not, a fresh ordering is required */
 	unsigned int generation_id;
 
@@ -121,6 +187,7 @@ struct order_generation {
 		d.reserve(nelts);
 		by_symbol.reserve(nelts);
 		by_cache_id.reserve(nelts);
+		item_bucket.reserve(nelts);
 	}
 
 	auto size() const -> auto
@@ -265,7 +332,9 @@ private:
 
 	/* Items sorted into some order */
 	order_generation_ptr items_by_order;
-	unsigned int cur_order_gen;
+	unsigned int cur_order_gen = 0;
+	/* Set once `compute_exec_plan` has assigned stages and levels */
+	bool exec_plan_ready = false;
 
 	/* Specific vectors for execution/iteration */
 	items_ptr_vec connfilters;
@@ -314,6 +383,12 @@ private:
 	/* Internal methods */
 	auto load_items() -> bool;
 	auto resort() -> void;
+	/*
+	 * Assigns the execution stage and level to every item: the declared type and
+	 * priority give the defaults, then every dependency inherits the earliest
+	 * (stage, level) among the items that depend on it (hoisting)
+	 */
+	auto compute_exec_plan() -> void;
 	auto get_item_specific_vector(const cache_item &) -> items_ptr_vec &;
 	/* Helper for g_hash_table_foreach */
 	static auto metric_connect_cb(void *k, void *v, void *ud) -> void;
@@ -562,52 +637,6 @@ public:
 	}
 
 	/**
-	 * Iterate over all composites using a specific functor
-	 * @tparam Functor
-	 * @param f
-	 */
-	template<typename Functor>
-	auto connfilters_foreach(Functor f) -> bool
-	{
-		return std::all_of(std::begin(connfilters), std::end(connfilters),
-						   [&](const auto &sym_it) {
-							   return f(sym_it);
-						   });
-	}
-	template<typename Functor>
-	auto prefilters_foreach(Functor f) -> bool
-	{
-		return std::all_of(std::begin(prefilters), std::end(prefilters),
-						   [&](const auto &sym_it) {
-							   return f(sym_it);
-						   });
-	}
-	template<typename Functor>
-	auto postfilters_foreach(Functor f) -> bool
-	{
-		return std::all_of(std::begin(postfilters), std::end(postfilters),
-						   [&](const auto &sym_it) {
-							   return f(sym_it);
-						   });
-	}
-	template<typename Functor>
-	auto idempotent_foreach(Functor f) -> bool
-	{
-		return std::all_of(std::begin(idempotent), std::end(idempotent),
-						   [&](const auto &sym_it) {
-							   return f(sym_it);
-						   });
-	}
-	template<typename Functor>
-	auto filters_foreach(Functor f) -> bool
-	{
-		return std::all_of(std::begin(filters), std::end(filters),
-						   [&](const auto &sym_it) {
-							   return f(sym_it);
-						   });
-	}
-
-	/**
 	 * Resort cache if anything has been changed since last time
 	 * @return
 	 */
@@ -657,7 +686,7 @@ public:
 	 * Returns maximum timeout that is requested by all rules
 	 * @return
 	 */
-	auto get_max_timeout(std::vector<std::pair<double, const cache_item *>> &elts) const -> double;
+	auto get_max_timeout(std::vector<std::pair<double, const cache_item *>> &elts) -> double;
 
 	/**
 	 * Promote cache resort on next use (after dynamic symbol registration)

--- a/src/libserver/symcache/symcache_internal.hxx
+++ b/src/libserver/symcache/symcache_internal.hxx
@@ -387,6 +387,11 @@ private:
 	 * (stage, level) among the items that depend on it (hoisting)
 	 */
 	auto compute_exec_plan() -> void;
+	/*
+	 * Drops the back edges of the dependency cycles (with an error), so the
+	 * graph walked by the planner, the runtime and the timeouts is acyclic
+	 */
+	auto break_dependency_cycles() -> void;
 	auto get_item_specific_vector(const cache_item &) -> items_ptr_vec &;
 	/* Helper for g_hash_table_foreach */
 	static auto metric_connect_cb(void *k, void *v, void *ud) -> void;

--- a/src/libserver/symcache/symcache_internal.hxx
+++ b/src/libserver/symcache/symcache_internal.hxx
@@ -333,8 +333,6 @@ private:
 	/* Items sorted into some order */
 	order_generation_ptr items_by_order;
 	unsigned int cur_order_gen = 0;
-	/* Set once `compute_exec_plan` has assigned stages and levels */
-	bool exec_plan_ready = false;
 
 	/* Specific vectors for execution/iteration */
 	items_ptr_vec connfilters;

--- a/src/libserver/symcache/symcache_item.cxx
+++ b/src/libserver/symcache/symcache_item.cxx
@@ -123,116 +123,61 @@ auto cache_item::process_deps(const symcache &cache) -> void
 		}
 
 		if (dit != nullptr) {
-			if (!dit->is_filter()) {
-				/*
-				 * Check sanity:
-				 * - same stage deps are OK (prefilter -> prefilter, etc.)
-				 * - natural order deps are OK (postfilter -> filter, filter -> prefilter)
-				 *
-				 * Otherwise, emit error
-				 */
-				auto ok_dep = false;
-				auto same_stage = false;
+			/*
+			 * The dependency is attached to the executed item: the parent for a
+			 * virtual symbol. `dit` is already resolved to the parent.
+			 */
+			auto *real_source = this;
 
-				if (dit->get_type() == type) {
-					ok_dep = true;
-					same_stage = true;
-				}
-				else if (type < dit->get_type()) {
-					ok_dep = true;
-				}
+			if (is_virtual()) {
+				real_source = get_parent_mut(cache);
 
-				if (!ok_dep) {
-					msg_err_cache("cannot add dependency from %s (%s) on %s (%s): invalid symbol types",
-								  symbol.c_str(), item_type_to_str(type),
-								  dit->symbol.c_str(), item_type_to_str(dit->get_type()));
-					/* Drop the edge, so it is removed below and never reaches the runtime */
+				if (real_source == nullptr) {
+					msg_err_cache("cannot find parent for virtual symbol %s, when resolving dependency %s",
+								  symbol.c_str(), dep.sym.c_str());
 					dep.item = nullptr;
-
 					continue;
-				}
-
-				dep.item = dit;
-
-				/* Create reverse deps for same-stage deps to enable eager processing */
-				if (same_stage) {
-					if (!dit->rdeps.contains(id)) {
-						dit->rdeps.emplace(id, cache_dependency{this, symbol, -1, dep.hard});
-						msg_debug_cache("added reverse dependency from %d on %d (same stage)",
-										id, dit->id);
-					}
 				}
 			}
+
+			const auto src_type = real_source->get_type();
+			const auto dst_type = dit->get_type();
+
+			if (dit->id == real_source->id) {
+				msg_err_cache("cannot add dependency on self: %s -> %s "
+							  "(resolved to %s)",
+							  symbol.c_str(), dep.sym.c_str(), dit->symbol.c_str());
+				dep.item = nullptr;
+				continue;
+			}
+
+			if (!edge_allowed(src_type, dst_type)) {
+				msg_err_cache("cannot add dependency from %s (%s) on %s (%s): "
+							  "a %s cannot depend on a symbol from a later stage",
+							  symbol.c_str(), item_type_to_str(src_type),
+							  dit->symbol.c_str(), item_type_to_str(dst_type),
+							  item_type_to_str(src_type));
+				/* Drop the edge, so it is removed below and never reaches the runtime */
+				dep.item = nullptr;
+				continue;
+			}
+
+			dep.item = dit;
+
+			/*
+			 * The reverse dependency lets the runtime start the dependent as soon as
+			 * the dependency is finished; the runtime itself checks that the
+			 * dependent may run at that moment (its stage and level)
+			 */
+			if (!dit->rdeps.contains(real_source->id)) {
+				dit->rdeps.emplace(real_source->id,
+								   cache_dependency{real_source, real_source->symbol, -1, dep.hard});
+				msg_debug_cache("added reverse dependency from %d on %d", real_source->id,
+								dit->id);
+			}
 			else {
-				/*
-				 * A filter can be a dependency merely for another filter or for a later
-				 * stage: otherwise the runtime would pull the filter (and its own
-				 * dependencies) into the earlier stage. Virtual symbols are executed
-				 * at their parent's stage.
-				 */
-				auto src_type = type;
-
-				if (is_virtual()) {
-					const auto *parent = get_parent(cache);
-
-					if (parent != nullptr) {
-						src_type = parent->get_type();
-					}
-				}
-
-				if (src_type == symcache_item_type::CONNFILTER ||
-					src_type == symcache_item_type::PREFILTER) {
-					msg_err_cache("cannot add dependency from %s (%s) on %s (filter): "
-								  "a %s cannot depend on a symbol from a later stage",
-								  symbol.c_str(), item_type_to_str(src_type),
-								  dit->symbol.c_str(), item_type_to_str(src_type));
-					/* Drop the edge, so it is removed below and never reaches the runtime */
-					dep.item = nullptr;
-
-					continue;
-				}
-
-				if (dit->id == id) {
-					msg_err_cache("cannot add dependency on self: %s -> %s "
-								  "(resolved to %s)",
-								  symbol.c_str(), dep.sym.c_str(), dit->symbol.c_str());
-					dep.item = nullptr;
-				}
-				else {
-					/* Create a reverse dep */
-					if (is_virtual()) {
-						auto *parent = get_parent_mut(cache);
-
-						if (parent) {
-							if (!dit->rdeps.contains(parent->id)) {
-								dit->rdeps.emplace(parent->id, cache_dependency{parent, parent->symbol, -1});
-								msg_debug_cache("added reverse dependency from %d on %d", parent->id,
-												dit->id);
-							}
-							else {
-								msg_debug_cache("reverse dependency from %d on %d already exists",
-												parent->id, dit->id);
-							}
-							dep.item = dit;
-						}
-						else {
-							msg_err_cache("cannot find parent for virtual symbol %s, when resolving dependency %s",
-										  symbol.c_str(), dep.sym.c_str());
-						}
-					}
-					else {
-						dep.item = dit;
-						if (!dit->rdeps.contains(id)) {
-							dit->rdeps.emplace(id, cache_dependency{this, symbol, -1});
-							msg_debug_cache("added reverse dependency from %d on %d", id,
-											dit->id);
-						}
-						else {
-							msg_debug_cache("reverse dependency from %d on %d already exists",
-											id, dit->id);
-						}
-					}
-				}
+				msg_debug_cache("reverse dependency from %d on %d already exists",
+								real_source->id, dit->id);
 			}
 		}
 		else {
@@ -670,33 +615,55 @@ auto item_type_from_c(int type) -> tl::expected<std::pair<symcache_item_type, in
 	return std::make_pair(symcache_item_type::FILTER, type);
 }
 
-bool operator<(symcache_item_type lhs, symcache_item_type rhs)
+auto edge_allowed(symcache_item_type src, symcache_item_type dst) -> bool
 {
-	auto ret = false;
-	switch (lhs) {
-	case symcache_item_type::CONNFILTER:
-		break;
-	case symcache_item_type::PREFILTER:
-		if (rhs == symcache_item_type::CONNFILTER) {
-			ret = true;
-		}
-		break;
-	case symcache_item_type::FILTER:
-		if (rhs == symcache_item_type::CONNFILTER || rhs == symcache_item_type::PREFILTER) {
-			ret = true;
-		}
-		break;
-	case symcache_item_type::POSTFILTER:
-		if (rhs != symcache_item_type::IDEMPOTENT) {
-			ret = true;
-		}
-		break;
-	case symcache_item_type::IDEMPOTENT:
-	default:
-		break;
+	if (dst == symcache_item_type::COMPOSITE || dst == symcache_item_type::CLASSIFIER) {
+		/*
+		 * Composites and classifiers are resolved by the task stages between
+		 * filters and postfilters, so only later stages (and other composites)
+		 * can wait for them
+		 */
+		return src == symcache_item_type::POSTFILTER || src == symcache_item_type::IDEMPOTENT ||
+			   src == dst;
 	}
 
-	return ret;
+	if (src == symcache_item_type::COMPOSITE || src == symcache_item_type::CLASSIFIER) {
+		/*
+		 * Composites and classifiers are not scheduled by the symcache, so such
+		 * an edge is merely descriptive (e.g. a composite on its atoms)
+		 */
+		return true;
+	}
+
+	const auto src_stage = declared_exec_stage(src);
+	const auto dst_stage = declared_exec_stage(dst);
+
+	if (src_stage == exec_stage::none || dst_stage == exec_stage::none) {
+		return false;
+	}
+
+	if (src_stage >= dst_stage) {
+		/* Same stage, or a later stage depending on an earlier one */
+		return true;
+	}
+
+	/* An earlier stage depending on a later one: merely prefilter -> filter hoisting */
+	constexpr const auto hoisting_enabled = false;
+
+	return hoisting_enabled && src == symcache_item_type::PREFILTER && dst == symcache_item_type::FILTER;
+}
+
+auto cache_item::get_exec_type(const symcache &cache) const -> symcache_item_type
+{
+	if (is_virtual()) {
+		const auto *parent = get_parent(cache);
+
+		if (parent != nullptr) {
+			return parent->get_type();
+		}
+	}
+
+	return type;
 }
 
 item_condition::~item_condition()

--- a/src/libserver/symcache/symcache_item.cxx
+++ b/src/libserver/symcache/symcache_item.cxx
@@ -647,10 +647,12 @@ auto edge_allowed(symcache_item_type src, symcache_item_type dst) -> bool
 		return true;
 	}
 
-	/* An earlier stage depending on a later one: merely prefilter -> filter hoisting */
-	constexpr const auto hoisting_enabled = false;
-
-	return hoisting_enabled && src == symcache_item_type::PREFILTER && dst == symcache_item_type::FILTER;
+	/*
+	 * An earlier stage depending on a later one: merely a prefilter may depend
+	 * on a filter, which hoists the filter (and its dependencies) to the
+	 * prefilter stage at the level of that prefilter
+	 */
+	return src == symcache_item_type::PREFILTER && dst == symcache_item_type::FILTER;
 }
 
 auto cache_item::get_exec_type(const symcache &cache) const -> symcache_item_type

--- a/src/libserver/symcache/symcache_item.hxx
+++ b/src/libserver/symcache/symcache_item.hxx
@@ -52,12 +52,6 @@ enum class symcache_item_type {
 	VIRTUAL,    /* A virtual symbol... */
 };
 
-/*
- * Compare item types: earlier stages symbols are > than later stages symbols
- * Order for virtual stuff is not defined.
- */
-bool operator<(symcache_item_type lhs, symcache_item_type rhs);
-
 constexpr static auto item_type_to_str(symcache_item_type t) -> const char *
 {
 	switch (t) {
@@ -81,6 +75,39 @@ constexpr static auto item_type_to_str(symcache_item_type t) -> const char *
 
 	RSPAMD_UNREACHABLE;
 }
+
+/**
+ * Returns the execution stage implied by the declared item type
+ */
+constexpr static auto declared_exec_stage(symcache_item_type t) -> exec_stage
+{
+	switch (t) {
+	case symcache_item_type::CONNFILTER:
+		return exec_stage::connfilters;
+	case symcache_item_type::PREFILTER:
+		return exec_stage::prefilters;
+	case symcache_item_type::FILTER:
+		return exec_stage::filters;
+	case symcache_item_type::POSTFILTER:
+		return exec_stage::postfilters;
+	case symcache_item_type::IDEMPOTENT:
+		return exec_stage::idempotent;
+	case symcache_item_type::CLASSIFIER:
+	case symcache_item_type::COMPOSITE:
+	case symcache_item_type::VIRTUAL:
+		return exec_stage::none;
+	}
+
+	return exec_stage::none;
+}
+
+/**
+ * Returns true if a dependency edge from an item of type `src` on an item of
+ * type `dst` is accepted: same stage, a later stage depending on an earlier one,
+ * a prefilter depending on a filter (which hoists the filter to the prefilter
+ * stage), or a postfilter/idempotent depending on a composite or a classifier.
+ */
+auto edge_allowed(symcache_item_type src, symcache_item_type dst) -> bool;
 
 /**
  * This is a public helper to convert a legacy C type to a more static type
@@ -236,6 +263,16 @@ struct cache_item : std::enable_shared_from_this<cache_item> {
 	unsigned int order = 0;
 	int frequency_peaks = 0;
 
+	/*
+	 * Execution plan, computed by symcache::compute_exec_plan: the stage that
+	 * runs the item and its level within the stage (higher level runs earlier).
+	 * `hoisted_by` is set when a dependency moved the item from its declared
+	 * stage or level.
+	 */
+	exec_stage stage = exec_stage::none;
+	int level = 0;
+	cache_item *hoisted_by = nullptr;
+
 	/* Specific data for virtual and callback symbols */
 	std::variant<normal_item, virtual_item> specific;
 
@@ -327,6 +364,37 @@ public:
 	{
 		return std::holds_alternative<normal_item>(specific) &&
 			   (type == symcache_item_type::FILTER);
+	}
+
+	/**
+	 * Returns true if the item is scheduled by the symcache runtime (has a callback
+	 * and belongs to one of the execution stages)
+	 */
+	auto is_executable() const -> bool
+	{
+		return std::holds_alternative<normal_item>(specific) &&
+			   declared_exec_stage(type) != exec_stage::none;
+	}
+
+	/**
+	 * Declared type of the item that is executed for this symbol: the parent's
+	 * type for a virtual symbol
+	 */
+	auto get_exec_type(const symcache &cache) const -> symcache_item_type;
+
+	auto get_stage() const -> exec_stage
+	{
+		return stage;
+	}
+
+	auto get_level() const -> int
+	{
+		return level;
+	}
+
+	auto is_hoisted() const -> bool
+	{
+		return hoisted_by != nullptr;
 	}
 
 	/**

--- a/src/libserver/symcache/symcache_item.hxx
+++ b/src/libserver/symcache/symcache_item.hxx
@@ -272,6 +272,8 @@ struct cache_item : std::enable_shared_from_this<cache_item> {
 	exec_stage stage = exec_stage::none;
 	int level = 0;
 	cache_item *hoisted_by = nullptr;
+	/* Set once the plan has been computed for the item (symbols may be registered after init) */
+	bool planned = false;
 
 	/* Specific data for virtual and callback symbols */
 	std::variant<normal_item, virtual_item> specific;

--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -40,10 +40,20 @@ auto symcache_runtime::create(struct rspamd_task *task, symcache &cache) -> symc
 
 	auto cur_order = cache.get_cache_order();
 	auto allocated_size = sizeof(symcache_runtime) +
-						  sizeof(struct cache_dynamic_item) * cur_order->size();
+						  sizeof(struct cache_dynamic_item) * cur_order->size() +
+						  sizeof(std::uint32_t) * cur_order->buckets.size();
 	auto *checkpoint = (symcache_runtime *) rspamd_mempool_alloc0(task->task_pool,
 																  allocated_size);
-	msg_debug_cache_task("create symcache runtime for task: %d bytes, %d items", (int) allocated_size, (int) cur_order->size());
+	msg_debug_cache_task("create symcache runtime for task: %d bytes, %d items, %d buckets",
+						 (int) allocated_size, (int) cur_order->size(), (int) cur_order->buckets.size());
+	/* Buckets counters live right after the dynamic items */
+	checkpoint->bucket_pending = reinterpret_cast<std::uint32_t *>(checkpoint->dynamic_items + cur_order->size());
+
+	for (const auto [i, bucket]: rspamd::enumerate(cur_order->buckets)) {
+		checkpoint->bucket_pending[i] = bucket.count;
+	}
+
+	checkpoint->cur_stage = exec_stage::none;
 	checkpoint->order = std::move(cur_order);
 	checkpoint->slow_status = slow_status::none;
 	/* Calculate profile probability */
@@ -233,14 +243,28 @@ auto symcache_runtime::disable_all_symbols(int skip_mask) -> void
 	for (auto [i, item]: rspamd::enumerate(order->d)) {
 		auto *dyn_item = &dynamic_items[i];
 
-		if (!(item->get_flags() & skip_mask)) {
-			/*
-			 * Use `finished` not `disabled`: this implements the "disable all,
-			 * then enable some" pattern from symbols_enabled/groups_enabled.
-			 * Using `disabled` would cascade-disable hard dependents, which is
-			 * wrong when an enabled symbol depends on a non-enabled one.
-			 */
-			dyn_item->status = cache_item_status::finished;
+		/*
+		 * The mask is checked against the flags and the type: the type bit is
+		 * stripped from the flags at registration, so `SYMBOL_TYPE_IDEMPOTENT`
+		 * in the mask spares the idempotent symbols as intended
+		 */
+		if (item->get_flags() & skip_mask) {
+			continue;
+		}
+
+		if ((skip_mask & SYMBOL_TYPE_IDEMPOTENT) && item->get_type() == symcache_item_type::IDEMPOTENT) {
+			continue;
+		}
+
+		/*
+		 * Use `suppressed` not `disabled`: this implements the "disable all,
+		 * then enable some" pattern from symbols_enabled/groups_enabled.
+		 * Using `disabled` would cascade-disable hard dependents, which is
+		 * wrong when an enabled symbol depends on a non-enabled one.
+		 * Items that are already running are finalised as usual.
+		 */
+		if (dyn_item->status == cache_item_status::not_started) {
+			set_status(dyn_item, cache_item_status::suppressed);
 		}
 	}
 }
@@ -254,7 +278,15 @@ auto symcache_runtime::disable_symbol(struct rspamd_task *task, const symcache &
 		auto *dyn_item = get_dynamic_item(item->id);
 
 		if (dyn_item) {
-			dyn_item->status = cache_item_status::disabled;
+			if (dyn_item->status == cache_item_status::started ||
+				dyn_item->status == cache_item_status::pending) {
+				/* The item is running: it is finalised as usual */
+				msg_debug_cache_task("cannot disable %s: it is already running", name.data());
+
+				return false;
+			}
+
+			set_status(dyn_item, cache_item_status::disabled);
 			msg_debug_cache_task("disable execution of %s", name.data());
 
 			return true;
@@ -279,7 +311,25 @@ auto symcache_runtime::enable_symbol(struct rspamd_task *task, const symcache &c
 		auto *dyn_item = get_dynamic_item(item->id);
 
 		if (dyn_item) {
-			dyn_item->status = cache_item_status::not_started;
+			switch (dyn_item->status) {
+			case cache_item_status::started:
+			case cache_item_status::pending:
+			case cache_item_status::finished:
+				/* Already executed (or being executed): never run an item twice */
+				msg_debug_cache_task("cannot enable %s: it is %s", name.data(),
+									 item_status_to_str(dyn_item->status));
+				return false;
+			default:
+				break;
+			}
+
+			if (cur_stage != exec_stage::none && item->get_stage() < cur_stage) {
+				msg_debug_cache_task("cannot enable %s: its stage (%s) has already passed", name.data(),
+									 exec_stage_to_str(item->get_stage()));
+				return false;
+			}
+
+			set_status(dyn_item, cache_item_status::not_started);
 
 			if (item->get_flags() & SYMBOL_TYPE_EXPLICIT_ENABLE) {
 				/* An explicit enable call unlocks `explicit_enable` symbols */
@@ -362,6 +412,24 @@ auto symcache_runtime::get_dynamic_item(int id) const -> cache_dynamic_item *
 	return nullptr;
 }
 
+static auto exec_stage_from_task_stage(unsigned int stage) -> exec_stage
+{
+	switch (stage) {
+	case RSPAMD_TASK_STAGE_CONNFILTERS:
+		return exec_stage::connfilters;
+	case RSPAMD_TASK_STAGE_PRE_FILTERS:
+		return exec_stage::prefilters;
+	case RSPAMD_TASK_STAGE_FILTERS:
+		return exec_stage::filters;
+	case RSPAMD_TASK_STAGE_POST_FILTERS:
+		return exec_stage::postfilters;
+	case RSPAMD_TASK_STAGE_IDEMPOTENT:
+		return exec_stage::idempotent;
+	default:
+		g_assert_not_reached();
+	}
+}
+
 auto symcache_runtime::process_symbols(struct rspamd_task *task, symcache &cache, unsigned int stage) -> bool
 {
 	msg_debug_cache_task("symbols processing stage at pass: %d", stage);
@@ -370,164 +438,143 @@ auto symcache_runtime::process_symbols(struct rspamd_task *task, symcache &cache
 		return true;
 	}
 
-	switch (stage) {
-	case RSPAMD_TASK_STAGE_CONNFILTERS:
-	case RSPAMD_TASK_STAGE_PRE_FILTERS:
-	case RSPAMD_TASK_STAGE_POST_FILTERS:
-	case RSPAMD_TASK_STAGE_IDEMPOTENT:
-		return process_pre_postfilters(task, cache,
-									   rspamd_session_events_pending(task->s), stage);
-		break;
+	auto st = exec_stage_from_task_stage(stage);
 
-	case RSPAMD_TASK_STAGE_FILTERS:
-		return process_filters(task, cache, rspamd_session_events_pending(task->s));
-		break;
-
-	default:
-		g_assert_not_reached();
-	}
-}
-
-auto symcache_runtime::process_pre_postfilters(struct rspamd_task *task,
-											   symcache &cache,
-											   int start_events,
-											   unsigned int stage) -> bool
-{
-	auto saved_priority = std::numeric_limits<int>::min();
-	auto all_done = true;
-	auto log_func = RSPAMD_LOG_FUNC;
-	auto compare_functor = +[](int a, int b) { return a < b; };
-
-	auto proc_func = [&](cache_item *item) {
+	if (st != cur_stage) {
 		/*
-		 * We can safely ignore all pre/postfilters except idempotent ones and
-		 * those that are marked as ignore passthrough result
+		 * Entering a new stage: whatever has not been started at the previous
+		 * stages will never run (e.g. after a passthrough result or a timeout),
+		 * so mark it as skipped to let the dependents proceed
 		 */
-		if (stage != RSPAMD_TASK_STAGE_IDEMPOTENT &&
-			!(item->flags & SYMBOL_TYPE_IGNORE_PASSTHROUGH)) {
-			if (check_process_status(task) == check_status::passthrough) {
-				msg_debug_cache_task_lambda("task has already the passthrough result being set, ignore further checks");
-
-				return true;
-			}
-		}
-
-		auto dyn_item = get_dynamic_item(item->id);
-
-		if (dyn_item->status == cache_item_status::not_started) {
-			if (slow_status == slow_status::enabled) {
-				return false;
-			}
-
-			if (saved_priority == std::numeric_limits<int>::min()) {
-				saved_priority = item->priority;
-			}
-			else {
-				if (compare_functor(item->priority, saved_priority) &&
-					rspamd_session_events_pending(task->s) > start_events) {
-					/*
-					 * Delay further checks as we have higher
-					 * priority filters to be processed
-					 */
-					return false;
-				}
-			}
-
-			/* Check dependencies for pre/postfilters */
-			if (!item->deps.empty()) {
-				if (!check_item_deps(task, cache, item, dyn_item, false)) {
-					msg_debug_cache_task_lambda("blocked execution of %d(%s) in "
-												"pre/postfilter stage unless deps are resolved",
-												item->id, item->symbol.c_str());
-					return false;
-				}
-			}
-
-			return process_symbol(task, cache, item, dyn_item);
-		}
-
-		/* Continue processing */
-		return true;
-	};
-
-	switch (stage) {
-	case RSPAMD_TASK_STAGE_CONNFILTERS:
-		all_done = cache.connfilters_foreach(proc_func);
-		break;
-	case RSPAMD_TASK_STAGE_PRE_FILTERS:
-		all_done = cache.prefilters_foreach(proc_func);
-		break;
-	case RSPAMD_TASK_STAGE_POST_FILTERS:
-		compare_functor = +[](int a, int b) { return a > b; };
-		all_done = cache.postfilters_foreach(proc_func);
-		break;
-	case RSPAMD_TASK_STAGE_IDEMPOTENT:
-		compare_functor = +[](int a, int b) { return a > b; };
-		all_done = cache.idempotent_foreach(proc_func);
-		break;
-	default:
-		g_error("invalid invocation");
-		break;
+		sweep_earlier_stages(task, st);
+		cur_stage = st;
 	}
 
-	return all_done;
+	return process_stage(task, cache, st);
 }
 
-auto symcache_runtime::process_filters(struct rspamd_task *task, symcache &cache, int start_events) -> bool
+auto symcache_runtime::sweep_earlier_stages(struct rspamd_task *task, exec_stage stage) -> void
 {
-	auto all_done = true;
-	auto log_func = RSPAMD_LOG_FUNC;
-	auto has_passtrough = false;
-
-	for (const auto [idx, item]: rspamd::enumerate(order->d)) {
-		/* Exclude all non filters */
-		if (item->type != symcache_item_type::FILTER) {
-			/*
-			 * We use breaking the loop as we append non-filters to the end of the list
-			 * so, it is safe to stop processing immediately
-			 */
+	for (const auto [i, bucket]: rspamd::enumerate(order->buckets)) {
+		if (bucket.stage >= stage) {
 			break;
 		}
 
-		auto check_result = check_process_status(task);
-
-		if (!(item->flags & (SYMBOL_TYPE_FINE | SYMBOL_TYPE_IGNORE_PASSTHROUGH))) {
-			if (has_passtrough || check_result == check_status::passthrough) {
-				msg_debug_cache_task_lambda("task has already the passthrough result being set, ignore further checks");
-				has_passtrough = true;
-				/* Skip this item */
-				continue;
-			}
-			else if (check_result == check_status::limit_reached) {
-				msg_debug_cache_task_lambda("task has already the limit reached result being set, ignore further checks");
-				/* Skip this item */
-				continue;
-			}
+		if (bucket_pending[i] == 0) {
+			continue;
 		}
 
-		auto dyn_item = &dynamic_items[idx];
+		for (auto idx = bucket.first; idx < bucket.first + bucket.count; idx++) {
+			auto *dyn_item = &dynamic_items[idx];
 
-		if (dyn_item->status == cache_item_status::not_started) {
-			all_done = false;
-
-			if (!check_item_deps(task, cache, item.get(),
-								 dyn_item, false)) {
-				msg_debug_cache_task("blocked execution of %d(%s) unless deps are "
-									 "resolved",
-									 item->id, item->symbol.c_str());
-
-				continue;
-			}
-
-			process_symbol(task, cache, item.get(), dyn_item);
-
-			if (slow_status == slow_status::enabled) {
-				return false;
+			if (dyn_item->status == cache_item_status::not_started) {
+				msg_debug_cache_task("skip %s(%d) as its stage (%s) has passed",
+									 order->d[idx]->symbol.c_str(), order->d[idx]->id,
+									 exec_stage_to_str(bucket.stage));
+				set_status(dyn_item, cache_item_status::skipped);
 			}
 		}
 	}
+}
 
-	return all_done;
+auto symcache_runtime::should_skip(const cache_item *item, check_status status) -> bool
+{
+	if (status == check_status::allow) {
+		return false;
+	}
+
+	switch (item->get_type()) {
+	case symcache_item_type::IDEMPOTENT:
+		/* Idempotent symbols always run */
+		return false;
+	case symcache_item_type::FILTER:
+		/* Filters (hoisted ones included) are also stopped by the score limit */
+		if (item->get_flags() & (SYMBOL_TYPE_FINE | SYMBOL_TYPE_IGNORE_PASSTHROUGH)) {
+			return false;
+		}
+
+		return true;
+	default:
+		/* Connfilters, prefilters and postfilters are stopped by passthrough results only */
+		if (item->get_flags() & SYMBOL_TYPE_IGNORE_PASSTHROUGH) {
+			return false;
+		}
+
+		return status == check_status::passthrough;
+	}
+}
+
+auto symcache_runtime::may_start(const cache_item *item, const cache_dynamic_item *dyn_item) const -> bool
+{
+	if (item->get_stage() != cur_stage) {
+		return false;
+	}
+
+	auto idx = dyn_item - dynamic_items;
+	auto bucket = order->item_bucket[idx];
+
+	return bucket != order_generation::no_bucket && is_bucket_open(bucket);
+}
+
+auto symcache_runtime::process_stage(struct rspamd_task *task, symcache &cache, exec_stage stage) -> bool
+{
+	auto log_func = RSPAMD_LOG_FUNC;
+	const auto [first_bucket, last_bucket] = order->stage_buckets[static_cast<unsigned int>(stage)];
+
+	for (auto b = first_bucket; b < last_bucket; b++) {
+		const auto &bucket = order->buckets[b];
+
+		msg_debug_cache_task_lambda("process bucket %d: stage %s, level %d, %d items, %d pending",
+									(int) b, exec_stage_to_str(bucket.stage), bucket.level,
+									(int) bucket.count, (int) bucket_pending[b]);
+
+		for (auto idx = bucket.first; idx < bucket.first + bucket.count; idx++) {
+			if (RSPAMD_TASK_IS_SKIPPED(task)) {
+				/* E.g. whitelisted by settings */
+				return true;
+			}
+
+			auto *item = order->d[idx].get();
+			auto *dyn_item = &dynamic_items[idx];
+
+			if (dyn_item->status != cache_item_status::not_started) {
+				continue;
+			}
+
+			auto check_result = check_process_status(task);
+
+			if (should_skip(item, check_result)) {
+				msg_debug_cache_task_lambda("skip %s(%d): task has %s",
+											item->symbol.c_str(), item->id,
+											check_result == check_status::passthrough ? "the passthrough result" : "reached the score limit");
+				set_status(dyn_item, cache_item_status::skipped);
+				continue;
+			}
+
+			if (slow_status == slow_status::enabled) {
+				/* Let the slow timer fire before starting anything else */
+				return false;
+			}
+
+			if (!check_item_deps(task, cache, item, dyn_item, false)) {
+				msg_debug_cache_task_lambda("blocked execution of %d(%s) unless deps are "
+											"resolved",
+											item->id, item->symbol.c_str());
+				continue;
+			}
+
+			process_symbol(task, cache, item, dyn_item);
+		}
+
+		if (bucket_pending[b] > 0) {
+			/* The next level may not start until this one is drained */
+			msg_debug_cache_task_lambda("bucket %d is not drained: %d items pending",
+										(int) b, (int) bucket_pending[b]);
+			return false;
+		}
+	}
+
+	return true;
 }
 
 auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache, cache_item *item,
@@ -557,6 +604,19 @@ auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache,
 		return is_item_done(dyn_item->status);
 	}
 
+	if (!may_start(item, dyn_item)) {
+		/*
+		 * Reached from a reverse dependency or an eager dependency check:
+		 * the item belongs to another stage or its level is not open yet,
+		 * so the stage loop starts it when its turn comes
+		 */
+		msg_debug_cache_task("cannot start %s(%d) now: stage %s, level %d",
+							 item->symbol.c_str(), item->id,
+							 exec_stage_to_str(item->get_stage()), item->get_level());
+
+		return false;
+	}
+
 	/* Check has been started */
 	auto check = true;
 
@@ -565,9 +625,10 @@ auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache,
 	}
 
 	if (check) {
-		dyn_item->status = cache_item_status::started;
-		msg_debug_cache_task("execute %s, %d; symbol type = %s", item->symbol.data(),
-							 item->id, item_type_to_str(item->type));
+		set_status(dyn_item, cache_item_status::started);
+		msg_debug_cache_task("execute %s, %d; symbol type = %s, stage = %s, level = %d",
+							 item->symbol.data(), item->id, item_type_to_str(item->type),
+							 exec_stage_to_str(item->get_stage()), item->get_level());
 
 		/*
 		 * Stamp the start under the SAME condition finalize_item measures
@@ -587,31 +648,32 @@ auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache,
 								   1e3;
 		}
 		dyn_item->async_events = 0;
+		/* Nested starts (from finalisation of another item) must not clobber the caller's item */
+		auto *saved_cur_item = cur_item;
 		cur_item = dyn_item;
 		items_inflight++;
 		/* Callback now must finalize itself */
 
 
 		if (item->call(task, dyn_item)) {
-			cur_item = nullptr;
+			cur_item = saved_cur_item;
 
-			if (items_inflight == 0) {
+			if (is_item_done(dyn_item->status)) {
+				/* Finalised synchronously */
 				msg_debug_cache_task("item %s, %d is now finished (no async events)", item->symbol.data(),
 									 item->id);
-				dyn_item->status = cache_item_status::finished;
 				return true;
 			}
 
-			if (dyn_item->async_events == 0 && dyn_item->status != cache_item_status::finished) {
+			if (dyn_item->async_events == 0) {
 				msg_err_cache_task("critical error: item %s has no async events pending, "
 								   "but it is not finalised",
 								   item->symbol.data());
 				g_assert_not_reached();
 			}
-			else if (dyn_item->async_events > 0) {
-				msg_debug_cache_task("item %s, %d is now pending with %d async events", item->symbol.data(),
-									 item->id, dyn_item->async_events);
-			}
+
+			msg_debug_cache_task("item %s, %d is now pending with %d async events", item->symbol.data(),
+								 item->id, dyn_item->async_events);
 
 			return false;
 		}
@@ -619,14 +681,16 @@ auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache,
 			/* We were not able to call item, so we assume it is not callable */
 			msg_debug_cache_task("cannot call %s, %d; symbol type = %s", item->symbol.data(),
 								 item->id, item_type_to_str(item->type));
-			dyn_item->status = cache_item_status::finished;
+			cur_item = saved_cur_item;
+			items_inflight--;
+			set_status(dyn_item, cache_item_status::finished);
 			return true;
 		}
 	}
 	else {
 		msg_debug_cache_task("do not check %s, %d", item->symbol.data(),
 							 item->id);
-		dyn_item->status = cache_item_status::finished;
+		set_status(dyn_item, cache_item_status::finished);
 	}
 
 	return true;
@@ -642,8 +706,8 @@ auto symcache_runtime::check_process_status(struct rspamd_task *task) -> symcach
 			struct rspamd_action_config *act_config =
 				rspamd_find_action_config_for_action(task->result, pr->action);
 
-			/* Skip least results */
-			if (pr->flags & RSPAMD_PASSTHROUGH_LEAST) {
+			/* Skip least results and the results that explicitly allow further processing */
+			if (pr->flags & (RSPAMD_PASSTHROUGH_LEAST | RSPAMD_PASSTHROUGH_PROCESS_ALL)) {
 				continue;
 			}
 
@@ -701,25 +765,60 @@ auto symcache_runtime::check_item_deps(struct rspamd_task *task, symcache &cache
 
 			auto *dep_dyn_item = get_dynamic_item(dep.item->id);
 
-			if (dep_dyn_item->status == cache_item_status::disabled) {
-				/* Dependency was disabled by settings */
-				if (dep.hard) {
-					/* Hard dependency disabled: cascade-disable this item */
-					dyn_item->status = cache_item_status::disabled;
-					msg_debug_cache_task_lambda("cascade disable %d(%s) because hard dependency "
-												"%d(%s) is disabled",
-												item->id, item->symbol.c_str(),
-												dest_id, dep.sym.c_str());
-					return true; /* Item is "done" (disabled) */
-				}
-				/* Normal (weak) dependency disabled: proceed without it (backward compat) */
-				msg_debug_cache_task_lambda("dependency %d(%s) for symbol %d(%s) is "
-											"disabled, proceeding (not a hard dep)",
-											dest_id, dep.sym.c_str(), item->id, item->symbol.c_str());
+			if (dep_dyn_item == nullptr) {
+				/* Composites and classifiers of another order generation, or virtual */
+				msg_debug_cache_task_lambda("symbol %d(%s) has a dependency %d(%s) without a dynamic item",
+											item->id, item->symbol.c_str(), dest_id, dep.sym.c_str());
 				continue;
 			}
 
-			if (dep_dyn_item->status != cache_item_status::finished) {
+			if (dep_dyn_item->status == cache_item_status::not_started &&
+				dep.item->get_stage() < cur_stage) {
+				/*
+				 * The dependency stage has passed (e.g. it was enabled too late),
+				 * so it will never run
+				 */
+				msg_debug_cache_task_lambda("dependency %d(%s) for symbol %d(%s) belongs to the "
+											"passed stage %s: skip it",
+											dest_id, dep.sym.c_str(), item->id, item->symbol.c_str(),
+											exec_stage_to_str(dep.item->get_stage()));
+				set_status(dep_dyn_item, cache_item_status::skipped);
+			}
+
+			/*
+			 * Cascade `disabled` and `skipped` to the hard dependents: their
+			 * dependency will never produce a result. `suppressed` (not enabled by
+			 * settings) does not cascade, as an enabled symbol may legitimately
+			 * depend on a non-enabled one.
+			 */
+			const auto cascade = [&](cache_item_status dep_status) -> bool {
+				if (dep_status == cache_item_status::disabled || dep_status == cache_item_status::skipped) {
+					if (dep.hard) {
+						set_status(dyn_item, dep_status);
+						msg_debug_cache_task_lambda("cascade %s %d(%s) because hard dependency "
+													"%d(%s) is %s",
+													item_status_to_str(dep_status),
+													item->id, item->symbol.c_str(),
+													dest_id, dep.sym.c_str(),
+													item_status_to_str(dep_status));
+						return true;
+					}
+
+					/* Normal (weak) dependency: proceed without it (backward compat) */
+					msg_debug_cache_task_lambda("dependency %d(%s) for symbol %d(%s) is "
+												"%s, proceeding (not a hard dep)",
+												dest_id, dep.sym.c_str(), item->id, item->symbol.c_str(),
+												item_status_to_str(dep_status));
+				}
+
+				return false;
+			};
+
+			if (cascade(dep_dyn_item->status)) {
+				return true; /* Item is "done" */
+			}
+
+			if (!is_item_done(dep_dyn_item->status)) {
 				if (dep_dyn_item->status == cache_item_status::not_started) {
 					/* Not started */
 					if (!check_only) {
@@ -733,17 +832,15 @@ auto symcache_runtime::check_item_deps(struct rspamd_task *task, symcache &cache
 														"symbol %d(%s)",
 														dest_id, dep.sym.c_str(), item->id, item->symbol.c_str());
 						}
-						else if (dep_dyn_item->status == cache_item_status::disabled) {
-							/* Dep was cascade-disabled during recursive check */
-							if (dep.hard) {
-								dyn_item->status = cache_item_status::disabled;
-								msg_debug_cache_task_lambda("cascade disable %d(%s) because hard dependency "
-															"%d(%s) was cascade-disabled",
-															item->id, item->symbol.c_str(),
-															dest_id, dep.sym.c_str());
-								return true;
-							}
-							/* Weak dep: proceed */
+						else if (cascade(dep_dyn_item->status)) {
+							/* Dep was cascade-disabled or skipped during recursive check */
+							return true;
+						}
+						else if (is_item_done(dep_dyn_item->status)) {
+							msg_debug_cache_task_lambda("dependency %d(%s) for symbol %d(%s) is "
+														"%s",
+														dest_id, dep.sym.c_str(), item->id, item->symbol.c_str(),
+														item_status_to_str(dep_dyn_item->status));
 						}
 						else if (!process_symbol(task, cache, dep.item, dep_dyn_item)) {
 							/* Now started, but has events pending */
@@ -864,7 +961,7 @@ auto symcache_runtime::finalize_item(struct rspamd_task *task, cache_dynamic_ite
 	}
 
 	msg_debug_cache_task("process finalize for item %s(%d)", item->symbol.c_str(), item->id);
-	dyn_item->status = cache_item_status::finished;
+	set_status(dyn_item, cache_item_status::finished);
 	items_inflight--;
 	cur_item = nullptr;
 
@@ -987,8 +1084,13 @@ auto symcache_runtime::process_item_rdeps(struct rspamd_task *task, cache_item *
 
 	for (const auto &[id, rdep]: item->rdeps.values()) {
 		if (rdep.item) {
+			if (rdep.item->get_stage() != cur_stage) {
+				/* The stage loop deals with it when its stage comes */
+				continue;
+			}
+
 			auto *dyn_item = get_dynamic_item(rdep.item->id);
-			if (dyn_item->status == cache_item_status::not_started) {
+			if (dyn_item && dyn_item->status == cache_item_status::not_started) {
 				msg_debug_cache_task("check item %d(%s) rdep of %s ",
 									 rdep.item->id, rdep.item->symbol.c_str(), item->symbol.c_str());
 
@@ -1033,7 +1135,8 @@ auto symcache_runtime::describe_inflight_symbols() const -> GString *
 	for (auto [i, item]: rspamd::enumerate(order->d)) {
 		auto *dyn_item = &dynamic_items[i];
 
-		if (dyn_item->status != cache_item_status::started) {
+		if (dyn_item->status != cache_item_status::started &&
+			dyn_item->status != cache_item_status::pending) {
 			continue;
 		}
 

--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -698,27 +698,9 @@ auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache,
 
 auto symcache_runtime::check_process_status(struct rspamd_task *task) -> symcache_runtime::check_status
 {
-	if (task->result->passthrough_result != nullptr) {
-		/* We also need to check passthrough results */
-		auto *pr = task->result->passthrough_result;
-		DL_FOREACH(task->result->passthrough_result, pr)
-		{
-			struct rspamd_action_config *act_config =
-				rspamd_find_action_config_for_action(task->result, pr->action);
-
-			/* Skip least results and the results that explicitly allow further processing */
-			if (pr->flags & (RSPAMD_PASSTHROUGH_LEAST | RSPAMD_PASSTHROUGH_PROCESS_ALL)) {
-				continue;
-			}
-
-			/* Skip disabled actions */
-			if (act_config && (act_config->flags & RSPAMD_ACTION_RESULT_DISABLED)) {
-				continue;
-			}
-
-			/* Immediately stop on non least passthrough action */
-			return check_status::passthrough;
-		}
+	/* Stop on a passthrough result (least and process_all results do not count) */
+	if (rspamd_scan_result_has_passthrough(task->result)) {
+		return check_status::passthrough;
 	}
 
 	if (task->flags & RSPAMD_TASK_FLAG_PASS_ALL) {

--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -504,7 +504,31 @@ auto symcache_runtime::should_skip(const cache_item *item, check_status status) 
 	}
 }
 
-auto symcache_runtime::may_start(const cache_item *item, const cache_dynamic_item *dyn_item) const -> bool
+static inline auto session_has_events(struct rspamd_task *task) -> bool
+{
+	return task->s != nullptr && rspamd_session_events_pending(task->s) > 0;
+}
+
+auto symcache_runtime::is_bucket_open(struct rspamd_task *task, unsigned int bucket) const -> bool
+{
+	const auto stage = order->buckets[bucket].stage;
+	const auto first = order->stage_buckets[static_cast<unsigned int>(stage)].first;
+
+	for (auto i = first; i < bucket; i++) {
+		if (bucket_pending[i] > 0) {
+			/*
+			 * Items are pending, but when the session has no events nothing is
+			 * going to finish them (a leaked async counter): proceed, as the
+			 * priority based scheduler used to do
+			 */
+			return !session_has_events(task);
+		}
+	}
+
+	return true;
+}
+
+auto symcache_runtime::may_start(struct rspamd_task *task, const cache_item *item, const cache_dynamic_item *dyn_item) const -> bool
 {
 	if (item->get_stage() != cur_stage) {
 		return false;
@@ -513,13 +537,18 @@ auto symcache_runtime::may_start(const cache_item *item, const cache_dynamic_ite
 	auto idx = dyn_item - dynamic_items;
 	auto bucket = order->item_bucket[idx];
 
-	return bucket != order_generation::no_bucket && is_bucket_open(bucket);
+	return bucket != order_generation::no_bucket && is_bucket_open(task, bucket);
 }
 
 auto symcache_runtime::process_stage(struct rspamd_task *task, symcache &cache, exec_stage stage) -> bool
 {
 	auto log_func = RSPAMD_LOG_FUNC;
 	const auto [first_bucket, last_bucket] = order->stage_buckets[static_cast<unsigned int>(stage)];
+	/*
+	 * True when nothing is left to start at this stage; the items in flight are
+	 * awaited by the task processing via the session events
+	 */
+	auto all_done = true;
 
 	for (auto b = first_bucket; b < last_bucket; b++) {
 		const auto &bucket = order->buckets[b];
@@ -527,6 +556,12 @@ auto symcache_runtime::process_stage(struct rspamd_task *task, symcache &cache, 
 		msg_debug_cache_task_lambda("process bucket %d: stage %s, level %d, %d items, %d pending",
 									(int) b, exec_stage_to_str(bucket.stage), bucket.level,
 									(int) bucket.count, (int) bucket_pending[b]);
+
+		if (b > first_bucket && !is_bucket_open(task, b)) {
+			/* The previous level is being drained: wait for its events */
+			msg_debug_cache_task_lambda("bucket %d is not open yet: wait for the previous levels", (int) b);
+			return false;
+		}
 
 		for (auto idx = bucket.first; idx < bucket.first + bucket.count; idx++) {
 			if (RSPAMD_TASK_IS_SKIPPED(task)) {
@@ -560,6 +595,7 @@ auto symcache_runtime::process_stage(struct rspamd_task *task, symcache &cache, 
 				msg_debug_cache_task_lambda("blocked execution of %d(%s) unless deps are "
 											"resolved",
 											item->id, item->symbol.c_str());
+				all_done = false;
 				continue;
 			}
 
@@ -567,14 +603,63 @@ auto symcache_runtime::process_stage(struct rspamd_task *task, symcache &cache, 
 		}
 
 		if (bucket_pending[b] > 0) {
-			/* The next level may not start until this one is drained */
-			msg_debug_cache_task_lambda("bucket %d is not drained: %d items pending",
-										(int) b, (int) bucket_pending[b]);
-			return false;
+			if (session_has_events(task)) {
+				/* The next level may not start until this one is drained */
+				msg_debug_cache_task_lambda("bucket %d is not drained: %d items pending",
+											(int) b, (int) bucket_pending[b]);
+				return false;
+			}
+
+			auto *inflight = describe_inflight_symbols();
+
+			if (inflight != nullptr) {
+				msg_warn_task("symbols are pending without any async events at the %s stage (level %d), "
+							  "probably a leaked async counter: %v; proceed with the next level",
+							  exec_stage_to_str(bucket.stage), bucket.level, inflight);
+				g_string_free(inflight, TRUE);
+			}
 		}
 	}
 
-	return true;
+	if (!all_done && !session_has_events(task)) {
+		/*
+		 * The remaining items wait for dependencies that nothing is going to
+		 * finish: skip them instead of spinning in the task processing loop
+		 */
+		auto nskipped = 0;
+
+		for (auto b = first_bucket; b < last_bucket; b++) {
+			const auto &bucket = order->buckets[b];
+
+			for (auto idx = bucket.first; idx < bucket.first + bucket.count; idx++) {
+				auto *dyn_item = &dynamic_items[idx];
+
+				if (dyn_item->status == cache_item_status::not_started) {
+					msg_debug_cache_task_lambda("skip %s(%d): its dependencies cannot be finished",
+												order->d[idx]->symbol.c_str(), order->d[idx]->id);
+					set_status(dyn_item, cache_item_status::skipped);
+					nskipped++;
+				}
+			}
+		}
+
+		auto *inflight = describe_inflight_symbols();
+
+		if (inflight != nullptr) {
+			msg_warn_task("skipped %d symbols at the %s stage as their dependencies are pending "
+						  "without any async events, probably a leaked async counter: %v",
+						  nskipped, exec_stage_to_str(stage), inflight);
+			g_string_free(inflight, TRUE);
+		}
+		else {
+			msg_warn_task("skipped %d symbols at the %s stage as their dependencies cannot be started",
+						  nskipped, exec_stage_to_str(stage));
+		}
+
+		all_done = true;
+	}
+
+	return all_done;
 }
 
 auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache, cache_item *item,
@@ -604,7 +689,7 @@ auto symcache_runtime::process_symbol(struct rspamd_task *task, symcache &cache,
 		return is_item_done(dyn_item->status);
 	}
 
-	if (!may_start(item, dyn_item)) {
+	if (!may_start(task, item, dyn_item)) {
 		/*
 		 * Reached from a reverse dependency or an eager dependency check:
 		 * the item belongs to another stage or its level is not open yet,

--- a/src/libserver/symcache/symcache_runtime.cxx
+++ b/src/libserver/symcache/symcache_runtime.cxx
@@ -1094,6 +1094,14 @@ auto symcache_runtime::process_item_rdeps(struct rspamd_task *task, cache_item *
 				msg_debug_cache_task("check item %d(%s) rdep of %s ",
 									 rdep.item->id, rdep.item->symbol.c_str(), item->symbol.c_str());
 
+				if (should_skip(rdep.item, check_process_status(task))) {
+					/* The same rule as in the stage loop: e.g. the score limit has been reached */
+					msg_debug_cache_task("skip %d(%s) rdep of %s: passthrough or limit",
+										 rdep.item->id, rdep.item->symbol.c_str(), item->symbol.c_str());
+					set_status(dyn_item, cache_item_status::skipped);
+					continue;
+				}
+
 				if (!check_item_deps(task, *cache_ptr, rdep.item, dyn_item, false)) {
 					msg_debug_cache_task("blocked execution of %d(%s) rdep of %s "
 										 "unless deps are resolved",

--- a/src/libserver/symcache/symcache_runtime.hxx
+++ b/src/libserver/symcache/symcache_runtime.hxx
@@ -35,13 +35,40 @@ enum class cache_item_status : std::uint16_t {
 	started = 1,
 	pending = 2,
 	finished = 3,
-	disabled = 4, /* Disabled by settings; triggers cascade-disable for hard deps */
+	disabled = 4,   /* Disabled by settings; triggers cascade-disable for hard deps */
+	suppressed = 5, /* Not enabled (symbols_enabled, disable_all_symbols, pre-result): no cascade, can be re-enabled */
+	skipped = 6,    /* Skipped by the scheduler (passthrough, score limit, stage passed): cascades to hard deps */
 };
 
-/* Check if an item status means "done" (finished or disabled) */
+/* Check if an item status means "done": it will not run (anymore) */
 static inline auto is_item_done(cache_item_status status) -> bool
 {
-	return status == cache_item_status::finished || status == cache_item_status::disabled;
+	return status == cache_item_status::finished ||
+		   status == cache_item_status::disabled ||
+		   status == cache_item_status::suppressed ||
+		   status == cache_item_status::skipped;
+}
+
+static inline auto item_status_to_str(cache_item_status status) -> const char *
+{
+	switch (status) {
+	case cache_item_status::not_started:
+		return "not started";
+	case cache_item_status::started:
+		return "started";
+	case cache_item_status::pending:
+		return "pending";
+	case cache_item_status::finished:
+		return "finished";
+	case cache_item_status::disabled:
+		return "disabled";
+	case cache_item_status::suppressed:
+		return "suppressed";
+	case cache_item_status::skipped:
+		return "skipped";
+	}
+
+	return "unknown";
 }
 /**
  * These items are saved within task structure and are used to track
@@ -81,6 +108,13 @@ class symcache_runtime {
 	order_generation_ptr order;
 	/* Symbol IDs force-enabled by merged settings (overrides settings_elt forbidden_ids) */
 	id_list *force_enabled_ids;
+	/* The stage being processed (exec_stage::none before the first stage) */
+	exec_stage cur_stage;
+	/*
+	 * Number of items that are not done yet for each bucket of the order;
+	 * allocated right after `dynamic_items` in the same memory block
+	 */
+	std::uint32_t *bucket_pending;
 	/* Dynamically expanded as needed */
 	mutable struct cache_dynamic_item dynamic_items[];
 	/* We allocate this structure merely in memory pool, so destructor is absent */
@@ -88,12 +122,72 @@ class symcache_runtime {
 
 	auto process_symbol(struct rspamd_task *task, symcache &cache, cache_item *item,
 						cache_dynamic_item *dyn_item) -> bool;
-	/* Specific stages of the processing */
-	auto process_pre_postfilters(struct rspamd_task *task, symcache &cache, int start_events, unsigned int stage) -> bool;
-	auto process_filters(struct rspamd_task *task, symcache &cache, int start_events) -> bool;
+	/* Processes all buckets of a stage in their order */
+	auto process_stage(struct rspamd_task *task, symcache &cache, exec_stage stage) -> bool;
 	auto check_process_status(struct rspamd_task *task) -> check_status;
 	auto check_item_deps(struct rspamd_task *task, symcache &cache, cache_item *item,
 						 cache_dynamic_item *dyn_item, bool check_only) -> bool;
+	/* True if the item is subject to skipping for the current passthrough/limit status */
+	static auto should_skip(const cache_item *item, check_status status) -> bool;
+	/* Marks every not started item of the stages before `stage` as skipped */
+	auto sweep_earlier_stages(struct rspamd_task *task, exec_stage stage) -> void;
+
+public:
+	/**
+	 * The only way to change an item status: keeps the buckets accounting consistent
+	 * @param dyn_item
+	 * @param status
+	 */
+	auto set_status(cache_dynamic_item *dyn_item, cache_item_status status) -> void
+	{
+		auto was_done = is_item_done(dyn_item->status);
+		auto now_done = is_item_done(status);
+
+		if (was_done != now_done) {
+			auto idx = dyn_item - dynamic_items;
+			auto bucket = order->item_bucket[idx];
+
+			if (bucket != order_generation::no_bucket) {
+				if (now_done) {
+					g_assert(bucket_pending[bucket] > 0);
+					bucket_pending[bucket]--;
+				}
+				else {
+					bucket_pending[bucket]++;
+				}
+			}
+		}
+
+		dyn_item->status = status;
+	}
+
+	/**
+	 * A bucket is open when all buckets before it at the same stage are drained
+	 * @param bucket
+	 * @return
+	 */
+	auto is_bucket_open(unsigned int bucket) const -> bool
+	{
+		const auto stage = order->buckets[bucket].stage;
+		const auto first = order->stage_buckets[static_cast<unsigned int>(stage)].first;
+
+		for (auto i = first; i < bucket; i++) {
+			if (bucket_pending[i] > 0) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if an item may be started now: its stage is the current one and its
+	 * level is open
+	 * @param item
+	 * @param dyn_item
+	 * @return
+	 */
+	auto may_start(const cache_item *item, const cache_dynamic_item *dyn_item) const -> bool;
 
 public:
 	/* Dropper for a shared ownership */

--- a/src/libserver/symcache/symcache_runtime.hxx
+++ b/src/libserver/symcache/symcache_runtime.hxx
@@ -162,32 +162,23 @@ public:
 	}
 
 	/**
-	 * A bucket is open when all buckets before it at the same stage are drained
+	 * A bucket is open when all buckets before it at the same stage are drained,
+	 * or when nothing can drain them anymore (the session has no events left)
+	 * @param task
 	 * @param bucket
 	 * @return
 	 */
-	auto is_bucket_open(unsigned int bucket) const -> bool
-	{
-		const auto stage = order->buckets[bucket].stage;
-		const auto first = order->stage_buckets[static_cast<unsigned int>(stage)].first;
-
-		for (auto i = first; i < bucket; i++) {
-			if (bucket_pending[i] > 0) {
-				return false;
-			}
-		}
-
-		return true;
-	}
+	auto is_bucket_open(struct rspamd_task *task, unsigned int bucket) const -> bool;
 
 	/**
 	 * Checks if an item may be started now: its stage is the current one and its
 	 * level is open
+	 * @param task
 	 * @param item
 	 * @param dyn_item
 	 * @return
 	 */
-	auto may_start(const cache_item *item, const cache_dynamic_item *dyn_item) const -> bool;
+	auto may_start(struct rspamd_task *task, const cache_item *item, const cache_dynamic_item *dyn_item) const -> bool;
 
 public:
 	/* Dropper for a shared ownership */

--- a/src/libserver/task.c
+++ b/src/libserver/task.c
@@ -1179,12 +1179,16 @@ rspamd_task_process(struct rspamd_task *task, unsigned int stages)
 	case RSPAMD_TASK_STAGE_CLASSIFIERS:
 	case RSPAMD_TASK_STAGE_CLASSIFIERS_PRE:
 	case RSPAMD_TASK_STAGE_CLASSIFIERS_POST:
-		if (!RSPAMD_TASK_IS_EMPTY(task)) {
+		/* A passthrough result (e.g. a pre-result from a prefilter) makes classification pointless */
+		if (!RSPAMD_TASK_IS_EMPTY(task) && !rspamd_scan_result_has_passthrough(task->result)) {
 			if (rspamd_stat_classify(task, task->cfg->lua_state, st, &stat_error) ==
 				RSPAMD_STAT_PROCESS_ERROR) {
 				msg_err_task("classify error: %e", stat_error);
 				g_error_free(stat_error);
 			}
+		}
+		else if (!RSPAMD_TASK_IS_EMPTY(task)) {
+			msg_debug_task("skip classification: the task has a passthrough result");
 		}
 		break;
 

--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -209,7 +209,9 @@ LUA_FUNCTION_DEF(config, get_classifier);
  * - `name`: name of symbol (can be missing for callback symbols)
  * - `callback`: function to be called for symbol's check (can be absent for virtual symbols)
  * - `weight`: weight of symbol (should normally be 1 or missing)
- * - `priority`: priority of symbol (normally 0 or missing)
+ * - `priority`: priority of symbol (normally 0 or missing); for prefilters, connfilters,
+ *   postfilters and idempotent symbols it defines the execution level within the stage
+ *   (see below), for normal symbols it is merely a soft ordering hint
  * - `type`: type of symbol:
  *   + `normal`: executed after prefilters, according to dependency graph or in undefined order
  *   + `callback`: a check that merely inserts virtual symbols
@@ -218,6 +220,14 @@ LUA_FUNCTION_DEF(config, get_classifier);
  *   + `postfilter`: executed after most other checks
  *   + `prefilter`: executed before most other checks
  *   + `virtual`: a symbol inserted by its parent check
+ *
+ *   All types share one dependency graph. Prefilters (and connfilters) with a higher
+ *   priority run before the ones with a lower priority, and a prefilter may not start
+ *   until every prefilter with a higher priority has finished; prefilters of the same
+ *   priority run concurrently. Postfilters and idempotent symbols are ordered the other
+ *   way round: a higher priority runs later. A prefilter may depend on a normal symbol
+ *   (see `register_dependency`): that symbol, with its own dependencies, is then executed
+ *   at the prefilter stage at the level of the depending prefilter.
  * - `flags`: various flags split by commas or spaces:
  *   + `nice` if symbol can produce negative score;
  *   + `empty` if symbol can be called for empty messages
@@ -266,11 +276,21 @@ LUA_FUNCTION_DEF(config, register_callback_symbol);
 LUA_FUNCTION_DEF(config, register_callback_symbol_priority);
 
 /***
- * @method rspamd_config:register_dependency(id|name, depname)
+ * @method rspamd_config:register_dependency(id|name, depname[, hard])
  * Create a dependency on symbol identified by name for symbol identified by ID or name.
- * This affects order of checks only (a symbol is still checked if its dependencies are disabled).
+ * This affects order of checks only (a symbol is still checked if its dependencies are
+ * disabled), unless `hard` is set: then the dependent symbol is not executed when its
+ * dependency has been disabled or skipped.
+ *
+ * A dependency may point to the same stage or to an earlier one (e.g. a normal symbol
+ * depending on a prefilter, a postfilter depending on a normal symbol). A prefilter
+ * may also depend on a normal symbol: that symbol is then hoisted to the prefilter
+ * stage together with its own dependencies, so the cost of the dependency is paid
+ * before the prefilter decision. Other edges to a later stage are rejected at the
+ * configuration time; `rspamadm configdump -e` shows the resulting execution plan.
  * @param {number|string} id id or name of source (numeric id is returned by all register_*_symbol)
  * @param {string} depname dependency name
+ * @param {boolean} hard if true, the source is skipped when the dependency is disabled or skipped
  * @example
 local function cb(task)
 ...

--- a/src/lua/lua_config.c
+++ b/src/lua/lua_config.c
@@ -293,6 +293,19 @@ LUA_FUNCTION_DEF(config, register_dependency);
 LUA_FUNCTION_DEF(config, get_symbol_flags);
 
 /***
+ * @method rspamd_config:get_symbol_type(name)
+ * Returns the declared type of a symbol and its execution plan. The type is one
+ * of `connfilter`, `prefilter`, `filter`, `postfilter`, `idempotent`,
+ * `composite`, `classifier` or `virtual`. For the executed symbols (and for the
+ * virtual symbols of executed parents) the stage that runs the symbol
+ * (`connfilters`, `prefilters`, `filters`, `postfilters`, `idempotent`) and its
+ * level within the stage are also returned.
+ * @param {string} name symbol's name
+ * @return {string,string,number} type, stage, level (or nil if the symbol is unknown)
+ */
+LUA_FUNCTION_DEF(config, get_symbol_type);
+
+/***
  * @method rspamd_config:add_symbol_flags(name, flags)
  * Adds flags to a symbol
  * @param {string} name symbols's name
@@ -1047,6 +1060,7 @@ static const struct luaL_reg configlib_m[] = {
 	LUA_INTERFACE_DEF(config, promote_symbols_cache_resort),
 	LUA_INTERFACE_DEF(config, register_settings_id),
 	LUA_INTERFACE_DEF(config, get_symbol_flags),
+	LUA_INTERFACE_DEF(config, get_symbol_type),
 	LUA_INTERFACE_DEF(config, set_metric_symbol),
 	{"set_symbol", lua_config_set_metric_symbol},
 	LUA_INTERFACE_DEF(config, set_metric_action),
@@ -2159,6 +2173,71 @@ lua_config_get_symbol_flags(lua_State *L)
 	}
 
 	return 1;
+}
+
+static int
+lua_config_get_symbol_type(lua_State *L)
+{
+	struct rspamd_config *cfg = lua_check_config(L, 1);
+	const char *name = luaL_checkstring(L, 2);
+
+	if (cfg && name) {
+		unsigned int stage = rspamd_symcache_get_symbol_stage(cfg->cache, name);
+		const char *type_str = NULL;
+
+		switch (stage) {
+		case SYMBOL_TYPE_CONNFILTER:
+			type_str = "connfilter";
+			break;
+		case SYMBOL_TYPE_PREFILTER:
+			type_str = "prefilter";
+			break;
+		case SYMBOL_TYPE_NORMAL:
+			type_str = "filter";
+			break;
+		case SYMBOL_TYPE_POSTFILTER:
+			type_str = "postfilter";
+			break;
+		case SYMBOL_TYPE_IDEMPOTENT:
+			type_str = "idempotent";
+			break;
+		case SYMBOL_TYPE_COMPOSITE:
+			type_str = "composite";
+			break;
+		case SYMBOL_TYPE_CLASSIFIER:
+			type_str = "classifier";
+			break;
+		case SYMBOL_TYPE_VIRTUAL:
+			type_str = "virtual";
+			break;
+		default:
+			break;
+		}
+
+		if (type_str == NULL) {
+			lua_pushnil(L);
+
+			return 1;
+		}
+
+		lua_pushstring(L, type_str);
+
+		struct rspamd_symcache_exec_info info;
+
+		if (rspamd_symcache_get_symbol_exec_info(cfg->cache, name, &info)) {
+			lua_pushstring(L, info.stage);
+			lua_pushinteger(L, info.level);
+		}
+		else {
+			lua_pushnil(L);
+			lua_pushnil(L);
+		}
+
+		return 3;
+	}
+	else {
+		return luaL_error(L, "invalid arguments");
+	}
 }
 
 static bool

--- a/src/lua/lua_http.c
+++ b/src/lua/lua_http.c
@@ -709,15 +709,16 @@ lua_http_dns_handler(struct rdns_reply *reply, gpointer ud)
 		else {
 			REF_RETAIN(cbd);
 			if (!lua_http_make_connection(cbd)) {
+				/*
+				 * E.g. the resolved address is denied by `forbid_local`; the
+				 * symbol's async counter taken for the DNS request is released
+				 * below as in the other error paths
+				 */
 				lua_http_push_error(cbd, "unable to make connection to the host");
 
 				if (cbd->ref.refcount > 1) {
 					REF_RELEASE(cbd);
 				}
-
-				REF_RELEASE(cbd);
-
-				return;
 			}
 			REF_RELEASE(cbd);
 		}

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -2638,12 +2638,13 @@ lua_task_set_pre_result(lua_State *L)
 									  flags,
 									  rspamd_find_metric_result(task, res_name));
 
-		/* Don't classify or filter message if pre-filter sets results */
+		/*
+		 * Do not run further checks if a pre-filter sets the result: the symbols
+		 * that ignore passthrough results and the idempotent ones still run, and
+		 * the classification is skipped by the task processing itself
+		 */
 
 		if (res_name == NULL && !(flags & (RSPAMD_PASSTHROUGH_LEAST | RSPAMD_PASSTHROUGH_PROCESS_ALL))) {
-			task->processed_stages |= (RSPAMD_TASK_STAGE_CLASSIFIERS |
-									   RSPAMD_TASK_STAGE_CLASSIFIERS_PRE |
-									   RSPAMD_TASK_STAGE_CLASSIFIERS_POST);
 			rspamd_symcache_disable_all_symbols(task, task->cfg->cache,
 												SYMBOL_TYPE_IDEMPOTENT | SYMBOL_TYPE_IGNORE_PASSTHROUGH);
 		}

--- a/src/plugins/lua/multimap.lua
+++ b/src/plugins/lua/multimap.lua
@@ -2036,6 +2036,8 @@ local function add_multimap_rule(key, newrule)
         end
       end
 
+      -- Keep the selector string: symbols it needs are registered as dependencies
+      newrule.selector_str = newrule.selector
       newrule.selector = selector
     end
   end
@@ -2088,6 +2090,7 @@ local function add_multimap_rule(key, newrule)
     end
 
     newrule['redis_key'] = selector
+    newrule.redis_selector_str = selector_str
     ret = true
   elseif newrule.type == 'combined' then
     local lua_maps_expressions = require "lua_maps_expressions"
@@ -2410,6 +2413,11 @@ if opts and type(opts) == 'table' then
     })
 
     rule.callback_id = id
+
+    -- Symbols used by the selectors of the rule must be checked before it
+    for _, selector_str in pairs({ rule.selector_str, rule.redis_selector_str }) do
+      lua_selectors.register_dependencies(rspamd_config, rule['symbol'], selector_str)
+    end
 
     if rule['symbols'] then
       -- Find allowed symbols by this map

--- a/src/plugins/lua/ratelimit.lua
+++ b/src/plugins/lua/ratelimit.lua
@@ -652,6 +652,7 @@ if opts then
           end
 
           settings.limits[t].selector = selector
+          settings.limits[t].selector_str = lim.selector
         end
       else
         rspamd_logger.warnx(rspamd_config, 'old syntax for ratelimits: %s', lim)
@@ -749,6 +750,15 @@ if opts then
     }
 
     local id = rspamd_config:register_symbol(s)
+
+    -- Symbols used by the selectors (e.g. `symbol(DKIM_CHECK)`) are checked
+    -- before the ratelimit check; when it is a prefilter, they are hoisted to
+    -- the prefilter stage
+    for _, lim in pairs(settings.limits) do
+      if lim.selector_str then
+        lua_selectors.register_dependencies(rspamd_config, 'RATELIMIT_CHECK', lim.selector_str)
+      end
+    end
 
     -- Register per bucket symbols
     -- Display what's enabled

--- a/src/plugins/lua/rbl.lua
+++ b/src/plugins/lua/rbl.lua
@@ -1061,11 +1061,14 @@ local function add_rbl(key, rbl, global_opts)
   if rbl.selector then
 
     rbl.selectors = {}
+    -- Selector strings: the symbols they need are registered as dependencies
+    rbl.selector_strings = {}
     if type(rbl.selector) ~= 'table' then
       rbl.selector = { ['selector'] = rbl.selector }
     end
 
     for selector_label, selector in pairs(rbl.selector) do
+      table.insert(rbl.selector_strings, selector)
       if known_selectors[selector] then
         lua_util.debugm(N, rspamd_config, 'reuse selector id %s',
             known_selectors[selector].id)
@@ -1209,6 +1212,11 @@ local function add_rbl(key, rbl, global_opts)
         rbl.symbol, rbl)
 
     local check_sym = rbl.symbols_prefixes and rbl.symbol .. '_CHECK' or rbl.symbol
+
+    for _, selector_str in ipairs(rbl.selector_strings or {}) do
+      -- Symbols used by the selector must be checked before the rule
+      selectors.register_dependencies(rspamd_config, check_sym, selector_str)
+    end
 
     if rbl.dkim then
       -- Weak: RBL has other query sources; DKIM-domain queries just won't happen

--- a/src/plugins/lua/reputation.lua
+++ b/src/plugins/lua/reputation.lua
@@ -1493,6 +1493,11 @@ local function parse_rule(name, tbl)
     augmentations = { string.format("timeout=%f", redis_params.timeout or 0.0) },
   }
 
+  if sel_type == 'generic' and rule.selector.config.selector then
+    -- Symbols used by the selector must be checked before this one
+    lua_selectors.register_dependencies(rspamd_config, rule.symbol, rule.selector.config.selector)
+  end
+
   if rule.selector.config.split_symbols then
     rspamd_config:register_symbol {
       name = rule.symbol .. '_HAM',

--- a/src/rspamadm/configdump.c
+++ b/src/rspamadm/configdump.c
@@ -29,6 +29,7 @@ static gboolean show_comments = FALSE;
 static gboolean modules_state = FALSE;
 static gboolean symbol_groups_only = FALSE;
 static gboolean symbol_full_details = FALSE;
+static gboolean symbols_exec_plan = FALSE;
 static gboolean skip_template = FALSE;
 static char *config = NULL;
 static gboolean local_conf_only = FALSE;
@@ -66,6 +67,8 @@ static GOptionEntry entries[] = {
 	 "Show symbols groups only", NULL},
 	{"symbol-details", 'd', 0, G_OPTION_ARG_NONE, &symbol_full_details,
 	 "Show full symbol details only", NULL},
+	{"exec-plan", 'e', 0, G_OPTION_ARG_NONE, &symbols_exec_plan,
+	 "Show symbols execution plan only (stages, levels and dependencies)", NULL},
 	{"skip-template", 'T', 0, G_OPTION_ARG_NONE, &skip_template,
 	 "Do not apply Jinja templates", NULL},
 	{"local", 0, 0, G_OPTION_ARG_NONE, &local_conf_only, "Show only local and override configuration", NULL},
@@ -386,6 +389,16 @@ rspamadm_configdump(int argc, char **argv, const struct rspamadm_command *cmd)
 										  "plugins_stats",
 										  FALSE);
 
+			exit(EXIT_SUCCESS);
+		}
+
+		if (symbols_exec_plan) {
+			/* Dump the execution plan of the symbols cache in the execution order */
+			ucl_object_t *out = ucl_object_typed_new(UCL_OBJECT);
+
+			ucl_object_insert_key(out, rspamd_symcache_dump_exec_plan(cfg->cache),
+								  "exec_plan", strlen("exec_plan"), false);
+			rspamadm_dump_section_obj(cfg, out, NULL);
 			exit(EXIT_SUCCESS);
 		}
 

--- a/test/functional/cases/102_symcache_order.robot
+++ b/test/functional/cases/102_symcache_order.robot
@@ -1,0 +1,66 @@
+*** Settings ***
+Suite Setup     Rspamd Setup
+Suite Teardown  Rspamd Teardown
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}              ${RSPAMD_TESTDIR}/configs/lua_test.conf
+${MESSAGE}             ${RSPAMD_TESTDIR}/messages/spam_message.eml
+${RSPAMD_LUA_SCRIPT}   ${RSPAMD_TESTDIR}/lua/symcache_order.lua
+${RSPAMD_SCOPE}        Suite
+${RSPAMD_URL_TLD}      ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+
+*** Test Cases ***
+Prefilter Levels And Hoisted Filters
+  Scan File  ${MESSAGE}
+  # The top level prefilter finished before the medium ones started
+  Expect Symbol  ORD_PRE_TOP
+  Expect Symbol  ORD_PRE_MED_A
+  # The filters needed by ORD_PRE_MED_B ran at the prefilter stage, before it
+  Expect Symbol With Option  ORD_FILTER_DEP  before_pre
+  Expect Symbol  ORD_FILTER_DEP2
+  Expect Symbol  ORD_PRE_MED_B
+  # The lower level prefilter saw the whole medium level done
+  Expect Symbol  ORD_PRE_LOW
+  # A plain filter saw all prefilters and the hoisted filters done
+  Expect Symbol  ORD_FILTER_PLAIN
+  Expect Symbol  ORD_FILTER_IGNORE
+  Expect Symbol  ORD_FILTER_AFTER
+  Do Not Expect Symbol  ORD_FILTER_BIG
+  # Postfilters: lower priority first, dependencies satisfied
+  Expect Symbol  ORD_POST_LOW
+  Expect Symbol  ORD_POST_HIGH
+  Expect Symbol  ORD_POST_WEAK
+  Expect Symbol  ORD_POST_HARD
+
+Passthrough Stops Filters But Not Hoisted Or Exempt Ones
+  Scan File  ${MESSAGE}  X-Passthrough=yes
+  Expect Action  soft reject
+  Expect Symbol  ORD_PRE_TOP
+  Expect Symbol  ORD_PRE_MED_A
+  # Hoisted filters ran at the prefilter stage, before the pre-result was set
+  Expect Symbol With Option  ORD_FILTER_DEP  before_pre
+  Expect Symbol  ORD_FILTER_DEP2
+  Expect Symbol  ORD_PRE_MED_B
+  Expect Symbol  ORD_PRE_LOW
+  # A pre-result from a prefilter skips the filters stage as a whole
+  Do Not Expect Symbol  ORD_FILTER_PLAIN
+  Do Not Expect Symbol  ORD_FILTER_AFTER
+  Do Not Expect Symbol  ORD_FILTER_IGNORE
+  Do Not Expect Symbol  ORD_POST_LOW
+  Do Not Expect Symbol  ORD_POST_HIGH
+
+Score Limit Skips Dependents And Cascades To Hard Dependencies
+  Scan File  ${MESSAGE}  X-Limit=yes
+  Expect Action  reject
+  Expect Symbol  ORD_FILTER_BIG
+  # Not started after the limit has been reached, so its dependents see it as skipped
+  Do Not Expect Symbol  ORD_FILTER_AFTER
+  # The exempt filter still runs
+  Expect Symbol  ORD_FILTER_IGNORE
+  Expect Symbol  ORD_POST_WEAK
+  Do Not Expect Symbol  ORD_POST_HARD
+  Expect Symbol  ORD_POST_LOW
+  Expect Symbol  ORD_POST_HIGH

--- a/test/functional/cases/102_symcache_order.robot
+++ b/test/functional/cases/102_symcache_order.robot
@@ -45,10 +45,10 @@ Passthrough Stops Filters But Not Hoisted Or Exempt Ones
   Expect Symbol  ORD_FILTER_DEP2
   Expect Symbol  ORD_PRE_MED_B
   Expect Symbol  ORD_PRE_LOW
-  # A pre-result from a prefilter skips the filters stage as a whole
+  # Everything else at the filter stage is stopped, except the exempt filter
   Do Not Expect Symbol  ORD_FILTER_PLAIN
   Do Not Expect Symbol  ORD_FILTER_AFTER
-  Do Not Expect Symbol  ORD_FILTER_IGNORE
+  Expect Symbol  ORD_FILTER_IGNORE
   Do Not Expect Symbol  ORD_POST_LOW
   Do Not Expect Symbol  ORD_POST_HIGH
 

--- a/test/functional/lua/symcache_order.lua
+++ b/test/functional/lua/symcache_order.lua
@@ -1,0 +1,215 @@
+-- Symbols cache ordering: prefilter levels, filters hoisted by prefilter
+-- dependencies, passthrough handling and the score limit.
+-- Every symbol inserts its result only when the ordering it relies on holds,
+-- so the robot suite merely checks for the presence of symbols.
+
+local function resolve_then(task, cb)
+  -- An asynchronous operation attached to the current symbol (the test config
+  -- has a fake DNS record for this name)
+  task:get_resolver():resolve_a({
+    task = task,
+    name = 'example.com',
+    callback = function()
+      cb()
+    end,
+  })
+end
+
+local function has_all(task, ...)
+  for _, sym in ipairs({ ... }) do
+    if not task:has_symbol(sym) then
+      return false
+    end
+  end
+
+  return true
+end
+
+-- Top priority prefilter finishes (asynchronously) before the medium ones start
+rspamd_config:register_symbol({
+  name = 'ORD_PRE_TOP',
+  type = 'prefilter',
+  priority = 10,
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    resolve_then(task, function()
+      task:insert_result('ORD_PRE_TOP', 1.0)
+    end)
+  end,
+})
+
+-- Medium prefilter: observes the top one
+rspamd_config:register_symbol({
+  name = 'ORD_PRE_MED_A',
+  type = 'prefilter',
+  priority = 5,
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    if has_all(task, 'ORD_PRE_TOP') then
+      task:insert_result('ORD_PRE_MED_A', 1.0)
+    end
+  end,
+})
+
+-- Runs after the whole medium level (hoisted filters included); sets a
+-- pre-result when asked, which stops the filters stage
+rspamd_config:register_symbol({
+  name = 'ORD_PRE_LOW',
+  type = 'prefilter',
+  priority = 4,
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    if has_all(task, 'ORD_PRE_MED_A', 'ORD_PRE_MED_B', 'ORD_FILTER_DEP', 'ORD_FILTER_DEP2') then
+      task:insert_result('ORD_PRE_LOW', 1.0)
+    end
+
+    if task:get_request_header('X-Passthrough') then
+      task:set_pre_result('soft reject', 'ordering test passthrough', 'symcache_order')
+    end
+  end,
+})
+
+-- Two chained filters: ORD_PRE_MED_B depends on ORD_FILTER_DEP, so both are
+-- hoisted to the prefilter stage (medium level)
+rspamd_config:register_symbol({
+  name = 'ORD_FILTER_DEP2',
+  type = 'normal',
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    resolve_then(task, function()
+      task:insert_result('ORD_FILTER_DEP2', 1.0)
+    end)
+  end,
+})
+
+rspamd_config:register_symbol({
+  name = 'ORD_FILTER_DEP',
+  type = 'normal',
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    resolve_then(task, function()
+      -- The option tells whether the depending prefilter has already run
+      local opt = task:has_symbol('ORD_PRE_MED_B') and 'after_pre' or 'before_pre'
+      task:insert_result('ORD_FILTER_DEP', 1.0, opt)
+    end)
+  end,
+})
+rspamd_config:register_dependency('ORD_FILTER_DEP', 'ORD_FILTER_DEP2')
+
+rspamd_config:register_symbol({
+  name = 'ORD_PRE_MED_B',
+  type = 'prefilter',
+  priority = 5,
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    if has_all(task, 'ORD_PRE_TOP', 'ORD_FILTER_DEP', 'ORD_FILTER_DEP2') then
+      task:insert_result('ORD_PRE_MED_B', 1.0)
+    end
+  end,
+})
+rspamd_config:register_dependency('ORD_PRE_MED_B', 'ORD_FILTER_DEP')
+
+-- A plain filter starts after all prefilters, hoisted filters included
+rspamd_config:register_symbol({
+  name = 'ORD_FILTER_PLAIN',
+  type = 'normal',
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    if has_all(task, 'ORD_PRE_MED_A', 'ORD_PRE_MED_B', 'ORD_FILTER_DEP', 'ORD_FILTER_DEP2') then
+      task:insert_result('ORD_FILTER_PLAIN', 1.0)
+    end
+  end,
+})
+
+-- Runs even after a pre-result
+rspamd_config:register_symbol({
+  name = 'ORD_FILTER_IGNORE',
+  type = 'normal',
+  score = 1.0,
+  flags = 'nostat,ignore_passthrough',
+  callback = function(task)
+    task:insert_result('ORD_FILTER_IGNORE', 1.0)
+  end,
+})
+
+-- Score limit: ORD_FILTER_BIG exceeds the reject threshold when asked, so
+-- ORD_FILTER_AFTER (which waits for it) must be skipped
+rspamd_config:register_symbol({
+  name = 'ORD_FILTER_BIG',
+  type = 'normal',
+  score = 200000.0,
+  flags = 'nostat',
+  callback = function(task)
+    if task:get_request_header('X-Limit') then
+      task:insert_result('ORD_FILTER_BIG', 1.0)
+    end
+  end,
+})
+
+rspamd_config:register_symbol({
+  name = 'ORD_FILTER_AFTER',
+  type = 'normal',
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    task:insert_result('ORD_FILTER_AFTER', 1.0)
+  end,
+})
+rspamd_config:register_dependency('ORD_FILTER_AFTER', 'ORD_FILTER_BIG')
+
+-- Postfilters: a lower priority runs first; a weak dependency on a skipped
+-- symbol proceeds while a hard one is skipped as well
+rspamd_config:register_symbol({
+  name = 'ORD_POST_LOW',
+  type = 'postfilter',
+  priority = 1,
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    task:insert_result('ORD_POST_LOW', 1.0)
+  end,
+})
+
+rspamd_config:register_symbol({
+  name = 'ORD_POST_HIGH',
+  type = 'postfilter',
+  priority = 9,
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    if has_all(task, 'ORD_POST_LOW') then
+      task:insert_result('ORD_POST_HIGH', 1.0)
+    end
+  end,
+})
+
+rspamd_config:register_symbol({
+  name = 'ORD_POST_WEAK',
+  type = 'postfilter',
+  priority = 1,
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    task:insert_result('ORD_POST_WEAK', 1.0)
+  end,
+})
+rspamd_config:register_dependency('ORD_POST_WEAK', 'ORD_FILTER_AFTER')
+
+rspamd_config:register_symbol({
+  name = 'ORD_POST_HARD',
+  type = 'postfilter',
+  priority = 1,
+  score = 1.0,
+  flags = 'nostat',
+  callback = function(task)
+    task:insert_result('ORD_POST_HARD', 1.0)
+  end,
+})
+rspamd_config:register_dependency('ORD_POST_HARD', 'ORD_FILTER_AFTER', true)

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -45,6 +45,7 @@
 #include "rspamd_cxx_unit_settings_merge.hxx"
 #include "rspamd_cxx_unit_fpconv.hxx"
 #include "rspamd_cxx_unit_symcache_timeout.hxx"
+#include "rspamd_cxx_unit_symcache_order.hxx"
 #include "rspamd_cxx_unit_text_stats.hxx"
 #include "rspamd_cxx_unit_multipattern.hxx"
 #include "rspamd_cxx_unit_regexp.hxx"

--- a/test/rspamd_cxx_unit_symcache_order.hxx
+++ b/test/rspamd_cxx_unit_symcache_order.hxx
@@ -417,6 +417,39 @@ TEST_SUITE("symcache_order")
 
 		CHECK(max_timeout() == doctest::Approx(4.0 + 3.0 + 1.5 + 2.5));
 	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "symbols registered after init are planned on resort")
+	{
+		add("PRE", 5, SYMBOL_TYPE_PREFILTER);
+		add("F", 0, SYMBOL_TYPE_NORMAL);
+		init();
+
+		/* E.g. regexp rules loaded from a map */
+		add("LATE_PRE", 9, SYMBOL_TYPE_PREFILTER);
+		add("LATE_F", 0, SYMBOL_TYPE_NORMAL);
+		add("LATE_POST", 1, SYMBOL_TYPE_POSTFILTER);
+		rspamd_symcache_promote_resort(cache);
+
+		/* The dump resorts the cache, which plans the new symbols */
+		auto p = plan();
+		CHECK(p.size() == 5);
+		CHECK(position(p, "LATE_PRE") < position(p, "PRE"));
+		CHECK(position(p, "PRE") < position(p, "F"));
+		CHECK(position(p, "F") < position(p, "LATE_POST"));
+
+		auto i = info("LATE_PRE");
+		CHECK(std::string(i.stage) == "prefilters");
+		CHECK(i.level == 9);
+		i = info("LATE_F");
+		CHECK(std::string(i.stage) == "filters");
+		i = info("LATE_POST");
+		CHECK(std::string(i.stage) == "postfilters");
+		CHECK(i.level == -1);
+
+		/* The old symbols keep their plan */
+		i = info("PRE");
+		CHECK(i.level == 5);
+	}
 }
 
 #endif

--- a/test/rspamd_cxx_unit_symcache_order.hxx
+++ b/test/rspamd_cxx_unit_symcache_order.hxx
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Unit tests for the symbols cache execution plan: stages, levels, hoisting
+ * of dependencies, rejected edges and the timeout accounting that follows
+ * the plan.
+ */
+
+#ifndef RSPAMD_CXX_UNIT_SYMCACHE_ORDER_HXX
+#define RSPAMD_CXX_UNIT_SYMCACHE_ORDER_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+#include "libserver/cfg_file.h"
+#include "libserver/rspamd_symcache.h"
+#include "libutil/util.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace {
+
+static void
+order_dummy_callback(struct rspamd_task *task, struct rspamd_symcache_dynamic_item *item, gpointer ud)
+{
+}
+
+struct symcache_order_fixture {
+	struct rspamd_config *cfg = nullptr;
+	struct rspamd_symcache *cache = nullptr;
+
+	symcache_order_fixture()
+	{
+		cfg = rspamd_config_new(RSPAMD_CONFIG_INIT_DEFAULT);
+		REQUIRE(cfg != nullptr);
+		cache = rspamd_symcache_new(cfg);
+		REQUIRE(cache != nullptr);
+	}
+
+	~symcache_order_fixture()
+	{
+		if (cache != nullptr) {
+			rspamd_symcache_destroy(cache);
+		}
+		if (cfg != nullptr) {
+			rspamd_config_free(cfg);
+		}
+	}
+
+	int add(const char *name, int priority, int type_flags, double timeout = 0.0)
+	{
+		int id = rspamd_symcache_add_symbol(cache, name, priority,
+											order_dummy_callback, nullptr, type_flags, -1);
+		REQUIRE(id >= 0);
+
+		if (timeout > 0.0) {
+			char timeout_str[64];
+			snprintf(timeout_str, sizeof(timeout_str), "timeout=%f", timeout);
+			REQUIRE(rspamd_symcache_add_symbol_augmentation(cache, id, timeout_str, nullptr));
+		}
+
+		return id;
+	}
+
+	int add_virtual(const char *name, int parent)
+	{
+		int id = rspamd_symcache_add_symbol(cache, name, 0, nullptr, nullptr,
+											SYMBOL_TYPE_VIRTUAL, parent);
+		REQUIRE(id >= 0);
+
+		return id;
+	}
+
+	void depends(const char *from, const char *to, bool hard = false)
+	{
+		rspamd_symcache_add_delayed_dependency(cache, from, to, hard);
+	}
+
+	void init()
+	{
+		REQUIRE(rspamd_symcache_init(cache));
+	}
+
+	struct rspamd_symcache_exec_info info(const char *name)
+	{
+		struct rspamd_symcache_exec_info i{};
+		REQUIRE(rspamd_symcache_get_symbol_exec_info(cache, name, &i));
+
+		return i;
+	}
+
+	/* Symbols in the execution order */
+	std::vector<std::string> plan()
+	{
+		std::vector<std::string> out;
+		auto *obj = rspamd_symcache_dump_exec_plan(cache);
+		ucl_object_iter_t it = nullptr;
+		const ucl_object_t *bucket;
+
+		while ((bucket = ucl_object_iterate(obj, &it, true)) != nullptr) {
+			const auto *syms = ucl_object_lookup(bucket, "symbols");
+			ucl_object_iter_t sit = nullptr;
+			const ucl_object_t *sym;
+
+			while ((sym = ucl_object_iterate(syms, &sit, true)) != nullptr) {
+				out.emplace_back(ucl_object_tostring(ucl_object_lookup(sym, "symbol")));
+			}
+		}
+
+		ucl_object_unref(obj);
+
+		return out;
+	}
+
+	/* Dependencies of a symbol as they are known to the runtime */
+	std::vector<std::string> deps_of(const char *name)
+	{
+		std::vector<std::string> out;
+		auto *obj = rspamd_symcache_dump_exec_plan(cache);
+		ucl_object_iter_t it = nullptr;
+		const ucl_object_t *bucket;
+
+		while ((bucket = ucl_object_iterate(obj, &it, true)) != nullptr) {
+			const auto *syms = ucl_object_lookup(bucket, "symbols");
+			ucl_object_iter_t sit = nullptr;
+			const ucl_object_t *sym;
+
+			while ((sym = ucl_object_iterate(syms, &sit, true)) != nullptr) {
+				if (strcmp(ucl_object_tostring(ucl_object_lookup(sym, "symbol")), name) == 0) {
+					const auto *deps = ucl_object_lookup(sym, "dependencies");
+
+					if (deps != nullptr) {
+						ucl_object_iter_t dit = nullptr;
+						const ucl_object_t *dep;
+
+						while ((dep = ucl_object_iterate(deps, &dit, true)) != nullptr) {
+							out.emplace_back(ucl_object_tostring(dep));
+						}
+					}
+				}
+			}
+		}
+
+		ucl_object_unref(obj);
+
+		return out;
+	}
+
+	static int position(const std::vector<std::string> &p, const char *name)
+	{
+		auto it = std::find(p.begin(), p.end(), name);
+		REQUIRE(it != p.end());
+
+		return static_cast<int>(it - p.begin());
+	}
+
+	double max_timeout()
+	{
+		auto *tres = rspamd_symcache_get_max_timeout(cache);
+		REQUIRE(tres != nullptr);
+		double result = tres->max_timeout;
+		rspamd_symcache_timeout_result_free(tres);
+
+		return result;
+	}
+};
+
+}// namespace
+
+TEST_SUITE("symcache_order")
+{
+	TEST_CASE_FIXTURE(symcache_order_fixture, "declared types define stages and levels")
+	{
+		add("CONN", 1, SYMBOL_TYPE_CONNFILTER);
+		add("PRE", 9, SYMBOL_TYPE_PREFILTER);
+		add("FILT", 5, SYMBOL_TYPE_NORMAL);
+		add("POST", 9, SYMBOL_TYPE_POSTFILTER);
+		add("IDEM", 3, SYMBOL_TYPE_IDEMPOTENT);
+		init();
+
+		auto i = info("CONN");
+		CHECK(std::string(i.stage) == "connfilters");
+		CHECK(i.level == 1);
+		CHECK(i.hoisted_by == nullptr);
+
+		i = info("PRE");
+		CHECK(std::string(i.stage) == "prefilters");
+		CHECK(i.level == 9);
+
+		/* Priority of filters is a soft key only */
+		i = info("FILT");
+		CHECK(std::string(i.stage) == "filters");
+		CHECK(i.level == 0);
+
+		/* Higher priority runs later for postfilters and idempotent symbols */
+		i = info("POST");
+		CHECK(std::string(i.stage) == "postfilters");
+		CHECK(i.level == -9);
+
+		i = info("IDEM");
+		CHECK(std::string(i.stage) == "idempotent");
+		CHECK(i.level == -3);
+	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "prefilters run by level, postfilters in the inverted order")
+	{
+		add("PRE_MED_A", 5, SYMBOL_TYPE_PREFILTER);
+		add("PRE_HIGH", 9, SYMBOL_TYPE_PREFILTER);
+		add("PRE_MED_B", 5, SYMBOL_TYPE_PREFILTER);
+		add("PRE_LOW", 1, SYMBOL_TYPE_PREFILTER);
+		add("POST_LOW", 1, SYMBOL_TYPE_POSTFILTER);
+		add("POST_HIGH", 9, SYMBOL_TYPE_POSTFILTER);
+		add("FILT", 0, SYMBOL_TYPE_NORMAL);
+		init();
+
+		auto p = plan();
+		CHECK(position(p, "PRE_HIGH") < position(p, "PRE_MED_A"));
+		/* Registration order inside a level */
+		CHECK(position(p, "PRE_MED_A") < position(p, "PRE_MED_B"));
+		CHECK(position(p, "PRE_MED_B") < position(p, "PRE_LOW"));
+		CHECK(position(p, "PRE_LOW") < position(p, "FILT"));
+		CHECK(position(p, "FILT") < position(p, "POST_LOW"));
+		CHECK(position(p, "POST_LOW") < position(p, "POST_HIGH"));
+	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "a prefilter dependency hoists a filter with its chain")
+	{
+		add("PRE", 5, SYMBOL_TYPE_PREFILTER);
+		add("F", 0, SYMBOL_TYPE_NORMAL);
+		add("G", 0, SYMBOL_TYPE_NORMAL);
+		add("H", 0, SYMBOL_TYPE_NORMAL);
+		add("PLAIN", 0, SYMBOL_TYPE_NORMAL);
+		depends("PRE", "F");
+		depends("F", "G");
+		depends("H", "F");
+		init();
+
+		auto i = info("F");
+		CHECK(std::string(i.stage) == "prefilters");
+		CHECK(i.level == 5);
+		REQUIRE(i.hoisted_by != nullptr);
+		CHECK(std::string(i.hoisted_by) == "PRE");
+
+		/* Transitive: the dependency of the hoisted filter follows it */
+		i = info("G");
+		CHECK(std::string(i.stage) == "prefilters");
+		CHECK(i.level == 5);
+		REQUIRE(i.hoisted_by != nullptr);
+		CHECK(std::string(i.hoisted_by) == "PRE");
+
+		/* A filter that depends on the hoisted one stays a filter */
+		i = info("H");
+		CHECK(std::string(i.stage) == "filters");
+		CHECK(i.hoisted_by == nullptr);
+
+		i = info("PLAIN");
+		CHECK(std::string(i.stage) == "filters");
+
+		/* Dependencies first inside the bucket, and everything before the plain filters */
+		auto p = plan();
+		CHECK(position(p, "G") < position(p, "F"));
+		CHECK(position(p, "F") < position(p, "PRE"));
+		CHECK(position(p, "PRE") < position(p, "H"));
+		CHECK(position(p, "PRE") < position(p, "PLAIN"));
+	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "the earliest dependent wins")
+	{
+		add("PRE_MED", 5, SYMBOL_TYPE_PREFILTER);
+		add("PRE_HIGH", 9, SYMBOL_TYPE_PREFILTER);
+		add("F", 0, SYMBOL_TYPE_NORMAL);
+		depends("PRE_MED", "F");
+		depends("PRE_HIGH", "F");
+		/* A prefilter depending on a lower level prefilter raises it */
+		add("PRE_LOW", 1, SYMBOL_TYPE_PREFILTER);
+		add("PRE_MED2", 5, SYMBOL_TYPE_PREFILTER);
+		depends("PRE_MED2", "PRE_LOW");
+		init();
+
+		auto i = info("F");
+		CHECK(std::string(i.stage) == "prefilters");
+		CHECK(i.level == 9);
+		REQUIRE(i.hoisted_by != nullptr);
+		CHECK(std::string(i.hoisted_by) == "PRE_HIGH");
+
+		i = info("PRE_LOW");
+		CHECK(std::string(i.stage) == "prefilters");
+		CHECK(i.level == 5);
+		REQUIRE(i.hoisted_by != nullptr);
+		CHECK(std::string(i.hoisted_by) == "PRE_MED2");
+
+		auto p = plan();
+		CHECK(position(p, "F") < position(p, "PRE_HIGH"));
+		CHECK(position(p, "PRE_LOW") < position(p, "PRE_MED2"));
+	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "dependencies through virtual symbols hoist the parent")
+	{
+		auto fid = add("F", 0, SYMBOL_TYPE_NORMAL);
+		add_virtual("F_VIRT", fid);
+		add("PRE", 5, SYMBOL_TYPE_PREFILTER);
+		depends("PRE", "F_VIRT");
+
+		auto pid = add("P2", 5, SYMBOL_TYPE_PREFILTER);
+		add_virtual("P2_VIRT", pid);
+		add("F2", 0, SYMBOL_TYPE_NORMAL);
+		depends("P2_VIRT", "F2");
+		init();
+
+		auto i = info("F");
+		CHECK(std::string(i.stage) == "prefilters");
+		CHECK(i.level == 5);
+
+		/* Virtual symbols report the plan of their parents */
+		i = info("F_VIRT");
+		CHECK(std::string(i.stage) == "prefilters");
+		CHECK(i.level == 5);
+
+		i = info("F2");
+		CHECK(std::string(i.stage) == "prefilters");
+		REQUIRE(i.hoisted_by != nullptr);
+		CHECK(std::string(i.hoisted_by) == "P2");
+	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "edges to a later stage are dropped")
+	{
+		add("CONN", 1, SYMBOL_TYPE_CONNFILTER);
+		add("F", 0, SYMBOL_TYPE_NORMAL);
+		add("PRE", 5, SYMBOL_TYPE_PREFILTER);
+		add("POST", 5, SYMBOL_TYPE_POSTFILTER);
+		add("IDEM", 0, SYMBOL_TYPE_IDEMPOTENT);
+		add("SELF", 0, SYMBOL_TYPE_NORMAL);
+		/* Rejected: the message is not read at the connfilters stage */
+		depends("CONN", "F");
+		depends("PRE", "POST");
+		depends("F", "POST");
+		depends("POST", "IDEM");
+		depends("SELF", "SELF");
+		/* Accepted: later stages depend on earlier ones */
+		depends("POST", "F");
+		depends("IDEM", "PRE");
+		depends("F", "CONN");
+		init();
+
+		CHECK(deps_of("CONN").empty());
+		CHECK(deps_of("PRE").empty());
+		CHECK(deps_of("SELF").empty());
+		CHECK(deps_of("F") == std::vector<std::string>{"CONN"});
+		CHECK(deps_of("POST") == std::vector<std::string>{"F"});
+		CHECK(deps_of("IDEM") == std::vector<std::string>{"PRE"});
+
+		/* Nothing has moved */
+		CHECK(std::string(info("F").stage) == "filters");
+		CHECK(std::string(info("POST").stage) == "postfilters");
+		CHECK(std::string(info("IDEM").stage) == "idempotent");
+		CHECK(std::string(info("CONN").stage) == "connfilters");
+	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "cycles do not break the plan")
+	{
+		add("A", 0, SYMBOL_TYPE_NORMAL);
+		add("B", 0, SYMBOL_TYPE_NORMAL);
+		depends("A", "B");
+		depends("B", "A");
+		add("PRE", 5, SYMBOL_TYPE_PREFILTER);
+		depends("PRE", "A");
+		init();
+
+		CHECK(std::string(info("A").stage) == "prefilters");
+		CHECK(std::string(info("B").stage) == "prefilters");
+		CHECK(info("A").level == 5);
+		CHECK(info("B").level == 5);
+
+		auto p = plan();
+		CHECK(p.size() == 3);
+		CHECK(position(p, "PRE") > position(p, "A"));
+	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "hoisted chains are accounted in the prefilter stage timeout")
+	{
+		add("PRE", 5, SYMBOL_TYPE_PREFILTER, 2.0);
+		add("F", 0, SYMBOL_TYPE_NORMAL, 3.0);
+		add("OTHER", 0, SYMBOL_TYPE_NORMAL, 1.0);
+		depends("PRE", "F");
+		init();
+
+		/* Prefilters level 5: PRE waits for F (2 + 3); filters: OTHER (1) */
+		CHECK(max_timeout() == doctest::Approx(6.0));
+	}
+
+	TEST_CASE_FIXTURE(symcache_order_fixture, "levels are summed and buckets take the longest chain")
+	{
+		add("PRE_HIGH", 9, SYMBOL_TYPE_PREFILTER, 4.0);
+		add("PRE_MED_A", 5, SYMBOL_TYPE_PREFILTER, 2.0);
+		add("PRE_MED_B", 5, SYMBOL_TYPE_PREFILTER, 1.0);
+		/* Sequential inside the bucket: 1 + 2 */
+		depends("PRE_MED_B", "PRE_MED_A");
+		add("POST_LOW", 1, SYMBOL_TYPE_POSTFILTER, 1.5);
+		add("POST_HIGH", 9, SYMBOL_TYPE_POSTFILTER, 2.5);
+		init();
+
+		CHECK(max_timeout() == doctest::Approx(4.0 + 3.0 + 1.5 + 2.5));
+	}
+}
+
+#endif

--- a/test/rspamd_cxx_unit_symcache_order.hxx
+++ b/test/rspamd_cxx_unit_symcache_order.hxx
@@ -372,15 +372,26 @@ TEST_SUITE("symcache_order")
 		CHECK(std::string(info("CONN").stage) == "connfilters");
 	}
 
-	TEST_CASE_FIXTURE(symcache_order_fixture, "cycles do not break the plan")
+	TEST_CASE_FIXTURE(symcache_order_fixture, "cycles are broken at init")
 	{
-		add("A", 0, SYMBOL_TYPE_NORMAL);
-		add("B", 0, SYMBOL_TYPE_NORMAL);
+		add("A", 0, SYMBOL_TYPE_NORMAL, 1.0);
+		add("B", 0, SYMBOL_TYPE_NORMAL, 2.0);
 		depends("A", "B");
 		depends("B", "A");
-		add("PRE", 5, SYMBOL_TYPE_PREFILTER);
+		add("PRE", 5, SYMBOL_TYPE_PREFILTER, 0.5);
 		depends("PRE", "A");
+		/* A longer cycle through a filter chain */
+		add("C", 0, SYMBOL_TYPE_NORMAL, 1.0);
+		add("D", 0, SYMBOL_TYPE_NORMAL, 1.0);
+		add("E", 0, SYMBOL_TYPE_NORMAL, 1.0);
+		depends("C", "D");
+		depends("D", "E");
+		depends("E", "C");
 		init();
+
+		/* One edge of each cycle has been dropped */
+		CHECK(deps_of("A").size() + deps_of("B").size() == 1);
+		CHECK(deps_of("C").size() + deps_of("D").size() + deps_of("E").size() == 2);
 
 		CHECK(std::string(info("A").stage) == "prefilters");
 		CHECK(std::string(info("B").stage) == "prefilters");
@@ -388,8 +399,16 @@ TEST_SUITE("symcache_order")
 		CHECK(info("B").level == 5);
 
 		auto p = plan();
-		CHECK(p.size() == 3);
+		CHECK(p.size() == 6);
 		CHECK(position(p, "PRE") > position(p, "A"));
+
+		/*
+		 * The timeouts traversal terminates: the prefilter bucket is either
+		 * PRE -> A -> B (3.5) or max(PRE -> A, B) (2.0), the filters chain is 3.0
+		 */
+		auto t = max_timeout();
+		CHECK(t >= 2.0 + 3.0);
+		CHECK(t <= 3.5 + 3.0);
 	}
 
 	TEST_CASE_FIXTURE(symcache_order_fixture, "hoisted chains are accounted in the prefilter stage timeout")


### PR DESCRIPTION
## Motivation

Symbols were scheduled by three unrelated mechanisms: prefilters and postfilters were serialised by priority class, filters followed a topological sort plus a cost heuristic, and the only cross-class rule was "a later stage waits for the whole earlier stage". Dependencies were meaningful only among filters, which made natural configurations impossible: a ratelimit (prefilter) keyed by the DKIM domain (filter) could not be expressed, and until #6224 such an edge was executed by accident from the wrong stage.

## The model

All executable symbols now share one execution plan, computed once at init:

| declared type | stage | level |
|---|---|---|
| connfilter | connfilters | priority |
| prefilter | prefilters | priority |
| normal / callback | filters | 0 (priority stays a soft ordering key) |
| postfilter | postfilters | -priority (higher runs later, as before) |
| idempotent | idempotent | -priority (as before) |

* Inside a stage, a symbol may not start until every symbol of a higher level in that stage is done; symbols of the same level run concurrently. This reproduces the previous priority serialisation exactly, without the "session events pending" heuristic.
* A dependency inherits the earliest (stage, level) among its dependents. A prefilter may now depend on a normal symbol: the symbol and its own dependencies are **hoisted** to the prefilter stage at the prefilter's level. Hoists are logged at info level so the cost is visible.
* Edge rules are table driven: same stage, later stage on earlier stage, prefilter on filter (hoisting), postfilter/idempotent on composites or classifiers. Everything else is rejected at init with the stages of both symbols, as before.

The public vocabulary (`prefilter`, `postfilter`, `idempotent`, `priority`, `SYMBOL_TYPE_*`) does not change; plugins and the C API need no modification.

## Runtime

* One `process_stage()` loop replaces `process_pre_postfilters()` and `process_filters()`. The order generation groups items into (stage, level) buckets and each task keeps a pending counter per bucket. The same start gate applies to the stage loop, to eager dependency execution and to reverse dependencies, which could previously start a postfilter from the filters stage.
* All status changes go through one transition function that maintains the counters. Two new done-without-running states: `suppressed` (settings, `disable_all_symbols`, pre-result: no cascade, can be re-enabled) and `skipped` (passthrough, score limit, passed stage: cascades to hard dependents). Entering a stage sweeps the not-started symbols of earlier stages, so a dependent never restarts them.
* Timeout accounting follows the plan: longest dependency chain inside a bucket, buckets summed within a stage, stages summed.

Behaviour changes, all deliberate:

* `ignore_passthrough` symbols always run. `task:set_pre_result()` marked the classifier stages as processed, and as the task resumes from the highest processed stage that also skipped the filters stage. Classification is now skipped explicitly when the result has a passthrough result that stops further checks (`least`, `process_all` and disabled actions do not count), shared with the symbols cache via `rspamd_scan_result_has_passthrough()`. Classification is therefore also skipped after a C-side passthrough such as the timeout soft reject.
* `process_all` pre-results allow further processing, as documented (the flag only prevented `disable_all_symbols` before).
* The idempotent bit in the pre-result skip mask is honoured (the type bit is stripped from the flags at registration, so it was dead).
* A symbol that already ran is not re-executed by `task:enable_symbol()` or `symbols_enabled`; running symbols are not clobbered by disable calls.
* A reverse dependency woken by a finished symbol is not started after the score limit has been reached.
* Connfilters count toward the announced maximum timeout, and same-level dependency chains among prefilters are summed.

## Selector dependencies

Extractors may declare the symbols they need: `asn` and `country` need `ASN_CHECK`, `symbol(NAME)` needs `NAME`. `lua_selectors.get_dependencies()` collects them for a selector string and `lua_selectors.register_dependencies()` registers them for the symbol that evaluates it (composites, classifiers and later-stage symbols are skipped with a warning). Ratelimit, multimap, rbl and generic reputation rules register the dependencies of their selectors, so e.g. a ratelimit bucket with `selector = "symbol(DKIM_CHECK)"` gets DKIM checked at the prefilter stage before the ratelimit decision.

## Introspection

* `rspamadm configdump -e` dumps the execution plan: buckets in execution order with stage, level, symbols, hoisting cause and dependencies.
* `rspamadm configdump -d` adds `stage`, `level`, `priority`, `hoisted_by` and `dependencies` per symbol.
* `rspamd_config:get_symbol_type(name)` returns the declared type, the stage and the level.
* `rspamd_symcache_get_symbol_exec_info()` and `rspamd_symcache_dump_exec_plan()` in the C API.

## Tests

* New unit tests (`test/rspamd_cxx_unit_symcache_order.hxx`): stage and level assignment, prefilter and postfilter ordering, hoisting through chains and virtual symbols, the earliest dependent winning, rejected edges, cycles, plan-based timeouts. The existing timeout tests pass unchanged.
* New functional suite (`102_symcache_order.robot`): the top level prefilter finishes before the medium ones start; filters needed by a prefilter run at the prefilter stage before it and before the plain filters; a pre-result from a prefilter stops the filters except the `ignore_passthrough` one; postfilters run in priority order; a symbol not started because of the score limit is skipped so that its weak dependents run and its hard dependents are skipped too.
* Existing suites run locally on the new scheduler: 101, 108, 109 (settings merge), 121 (preresult), 123, 150, 330, 360, 450, 500 and the whole merged 001 suite, all green.
