### PR TITLE
[Fix] lua_maps: include the map type in the cache key of url lists

### DIFF
--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -391,7 +391,8 @@ local function rspamd_map_add_from_ucl(opt, mtype, description, callback)
       return ret
     end
   elseif type(opt) == 'table' then
-    local cache_key = lua_util.unordered_table_digest(opt)
+    -- Type is a part of the key: the same urls can back maps of different types
+    local cache_key = map_hash_key(lua_util.unordered_table_digest(opt), mtype)
     if not callback and maps_cache[cache_key] then
       rspamd_logger.infox(rspamd_config, 'reuse url for complex map definition %s: %s',
           cache_key:sub(1, 8), description)

--- a/lualib/lua_maps.lua
+++ b/lualib/lua_maps.lua
@@ -391,6 +391,29 @@ local function rspamd_map_add_from_ucl(opt, mtype, description, callback)
       return ret
     end
   elseif type(opt) == 'table' then
+    -- Strip type prefixes (e.g. `glob;`) before hashing, so the cache key
+    -- reflects the effective map type rather than the one the caller asked for
+    if opt[1] then
+      local adjusted
+      for i, source in ipairs(opt) do
+        local nsrc, ntype = maybe_adjust_type(source, mtype)
+
+        if mtype ~= ntype then
+          if not adjusted then
+            mtype = ntype
+          end
+          adjusted = true
+        end
+        opt[i] = nsrc
+      end
+    elseif not opt.external and type(opt.url) == 'string' then
+      local nsrc, ntype = maybe_adjust_type(opt.url, mtype)
+      if nsrc and ntype then
+        opt.url = nsrc
+        mtype = ntype
+      end
+    end
+
     -- Type is a part of the key: the same urls can back maps of different types
     local cache_key = map_hash_key(lua_util.unordered_table_digest(opt), mtype)
     if not callback and maps_cache[cache_key] then
@@ -419,20 +442,6 @@ local function rspamd_map_add_from_ucl(opt, mtype, description, callback)
             or lua_util.str_startswith(line, 'file:')
             or lua_util.str_startswith(line, '/')
       end
-      -- Adjust each element if needed
-      local adjusted
-      for i, source in ipairs(opt) do
-        local nsrc, ntype = maybe_adjust_type(source, mtype)
-
-        if mtype ~= ntype then
-          if not adjusted then
-            mtype = ntype
-          end
-          adjusted = true
-        end
-        opt[i] = nsrc
-      end
-
       if mtype == 'radix' then
 
         if string.find(opt[1], '^%d') then
@@ -619,14 +628,6 @@ local function rspamd_map_add_from_ucl(opt, mtype, description, callback)
               parse_err)
         end
       else
-        -- Adjust lua specific augmentations in a trivial case
-        if type(opt.url) == 'string' then
-          local nsrc, ntype = maybe_adjust_type(opt.url, mtype)
-          if nsrc and ntype then
-            opt.url = nsrc
-            mtype = ntype
-          end
-        end
         -- We have some non-trivial object so let C code to deal with it somehow...
         local map = rspamd_config:add_map {
           type = mtype,

--- a/test/lua/unit/lua_maps.cache_key.lua
+++ b/test/lua/unit/lua_maps.cache_key.lua
@@ -1,0 +1,44 @@
+-- Maps built from the same url list must not be shared across map types:
+-- the cache key has to include the effective type of the map.
+context("lua_maps - map cache key", function()
+  local lua_maps = require "lua_maps"
+
+  local function url_list()
+    return { 'key value', 'other' }
+  end
+
+  test("same url list with different types yields different maps", function()
+    local m_set = lua_maps.map_add_from_ucl(url_list(), 'set', 'cache key set map')
+    local m_hash = lua_maps.map_add_from_ucl(url_list(), 'hash', 'cache key hash map')
+
+    assert_not_nil(m_set)
+    assert_not_nil(m_hash)
+    assert_not_equal(m_set, m_hash)
+    -- A hash map splits 'key value' into a kv pair, a set keeps the whole line
+    assert_equal(m_hash:get_key('key'), 'value')
+    assert_nil(m_set:get_key('key'))
+    assert_true(m_set:get_key('key value'))
+  end)
+
+  test("same url list with the same type reuses the map", function()
+    local first = lua_maps.map_add_from_ucl(url_list(), 'set', 'cache key set map')
+    local second = lua_maps.map_add_from_ucl(url_list(), 'set', 'cache key set map again')
+
+    assert_not_nil(first)
+    assert_equal(first, second)
+  end)
+
+  test("type prefix inside the list defines the effective type", function()
+    -- `hash;` overrides whatever type the caller asked for, so requests for
+    -- different types on the same prefixed list must converge on one map
+    local function prefixed()
+      return { 'hash;key value' }
+    end
+    local m_set = lua_maps.map_add_from_ucl(prefixed(), 'set', 'cache key prefixed map')
+    local m_glob = lua_maps.map_add_from_ucl(prefixed(), 'glob', 'cache key prefixed map again')
+
+    assert_not_nil(m_set)
+    assert_equal(m_set, m_glob)
+    assert_equal(m_set:get_key('key'), 'value')
+  end)
+end)


### PR DESCRIPTION
map_add_from_ucl() caches maps so that modules pointed at the same feed share one object. A map given as a single string is keyed by its url and its type, but a map given as a list of urls is keyed by the digest of the list alone, so the type requested by the first caller wins and every later caller silently gets a map of a foreign type.

url_redirector asks for a glob map of redirector_hosts_map while the multimap `redirector` rule asks for a hash map of the same two urls. multimap registers first, so url_redirector runs on a hash map and no glob pattern in the feed can ever match.

The collision is visible at startup: the module that did not get its own map logs the one it was handed instead.

```
lua_maps.lua:396: reuse url for complex map definition f4fbdf5a: Redirectors definitions (glob: bare names match exactly, *.foo matches subs)
```

Checked on a running instance with both modules enabled over one shared list: a `*.sub.example` entry never matched while an exact host did, and the same message with the patch applied resolves through the glob, with the reuse line gone.
