### PR TITLE
[Fix] forged_recipients: compare addresses by mailbox identity

### DIFF
--- a/conf/maps.d/equivalent_domains.inc
+++ b/conf/maps.d/equivalent_domains.inc
@@ -1,0 +1,31 @@
+# Domains that deliver to the same mailbox namespace as another domain:
+# user@<alias> and user@<canonical> reach one and the same account.
+# Format: <alias domain> <canonical domain>
+#
+# This list is used to compare mailbox identities only (e.g. envelope vs
+# header addresses in forged_recipients). The domains stay distinct for
+# DNS-based checks (SPF, DKIM, DMARC), so nothing here rewrites addresses.
+#
+# Only providers documenting that the same local part is reachable under
+# every listed domain belong here. Providers where the user picks one of
+# several domains per address (yahoo.com/ymail.com, outlook.com/hotmail.com,
+# mail.ru/bk.ru/list.ru/inbox.ru, gmx.*) do not.
+
+# Google
+googlemail.com gmail.com
+
+# Proton
+protonmail.com proton.me
+protonmail.ch proton.me
+pm.me proton.me
+
+# Apple
+me.com icloud.com
+mac.com icloud.com
+
+# Yandex
+yandex.com yandex.ru
+yandex.by yandex.ru
+yandex.kz yandex.ru
+yandex.ua yandex.ru
+ya.ru yandex.ru

--- a/conf/modules.d/forged_recipients.conf
+++ b/conf/modules.d/forged_recipients.conf
@@ -16,6 +16,16 @@ forged_recipients {
   symbol_sender = "FORGED_SENDER";
   symbol_rcpt = "FORGED_RECIPIENTS";
 
+  # Domains that deliver to one and the same mailbox namespace (e.g.
+  # googlemail.com and gmail.com): envelope and header addresses are compared
+  # with these domains folded, so such a pair is not reported as forged.
+  # Format: "<alias domain> <canonical domain>" per line
+  equivalent_domains = [
+    "{= env.MAPS_MIRROR | default "https://maps.rspamd.com" =}/rspamd/equivalent_domains.inc.zst",
+    "$LOCAL_CONFDIR/local.d/maps.d/equivalent_domains.inc",
+    "fallback+file://${CONFDIR}/maps.d/equivalent_domains.inc"
+  ];
+
   .include(try=true,priority=5) "${DBDIR}/dynamic/forged_recipients.conf"
   .include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/forged_recipients.conf"
   .include(try=true,priority=10) "$LOCAL_CONFDIR/override.d/forged_recipients.conf"

--- a/lualib/lua_aliases.lua
+++ b/lualib/lua_aliases.lua
@@ -607,6 +607,119 @@ local function apply_service_rules(email_addr)
 end
 exports.apply_service_rules = apply_service_rules
 
+--[[ Equivalent domains and mailbox identity ]]--
+
+-- Domains that deliver to the same mailbox namespace as another domain:
+-- user@<alias> and user@<canonical> reach one and the same account. They are
+-- used only to compare mailbox identities (see mailbox_identity); the rewrite
+-- path (apply_service_rules) keeps the transmitted domain on purpose, since
+-- the domains stay distinct for SPF, DKIM and DMARC.
+-- The builtin table is the fallback when no source is configured; the normal
+-- source is rspamd/equivalent_domains.inc registered via init_equivalent_domains
+local builtin_equivalent_domains = {
+  ['googlemail.com'] = 'gmail.com',
+}
+-- lua_maps kv maps (alias domain -> canonical domain), consulted in order
+local equivalent_domains_maps = {}
+-- alias -> canonical pairs given inline in the configuration
+local equivalent_domains_inline = {}
+
+--- Register a source of equivalent domains
+-- Several modules may call this: identical map definitions are shared by
+-- lua_maps, different ones are all consulted
+-- @param rspamd_config config object
+-- @param def map definition (url, list of urls or map object) or an inline
+--   table { ["alias.domain"] = "canonical.domain" }
+-- @return {boolean} true if the source was accepted
+local function init_equivalent_domains(rspamd_config, def)
+  if not def then
+    return false
+  end
+
+  if type(def) == 'table' and not def[1] and not def.url and not def.urls
+      and not def.external then
+    for alias, canonical in pairs(def) do
+      if type(alias) == 'string' and type(canonical) == 'string' then
+        equivalent_domains_inline[alias:lower()] = canonical:lower()
+      end
+    end
+
+    return true
+  end
+
+  local map = lua_maps.map_add_from_ucl(def, 'map', 'Equivalent mailbox domains')
+  if not map then
+    rspamd_logger.errx(rspamd_config, 'cannot add equivalent domains map: %s', def)
+    return false
+  end
+
+  for _, existing in ipairs(equivalent_domains_maps) do
+    if existing == map then
+      return true
+    end
+  end
+  table.insert(equivalent_domains_maps, map)
+
+  return true
+end
+exports.init_equivalent_domains = init_equivalent_domains
+
+--- Fold a domain to the canonical domain of its mailbox namespace
+-- @param domain domain string
+-- @return {string} lowercased canonical domain (the domain itself when it has no alias)
+local function canonical_domain(domain)
+  if not domain or domain == '' then
+    return domain
+  end
+
+  local d = domain:lower()
+
+  for _, map in ipairs(equivalent_domains_maps) do
+    local canonical = map:get_key(d)
+    if type(canonical) == 'string' and canonical ~= '' then
+      return canonical:lower()
+    end
+  end
+
+  return equivalent_domains_inline[d] or builtin_equivalent_domains[d] or d
+end
+exports.canonical_domain = canonical_domain
+
+--- Identity of a mailbox for comparison purposes
+-- Lowercases the address, folds the domain through canonical_domain and
+-- canonicalizes the user part with apply_service_rules (gmail dots and tags,
+-- plus tags elsewhere). The result is a comparison key: it must never be
+-- written back to a task as an address.
+-- @param addr email address table (user/domain fields) or a 'user@domain' string
+-- @return {string} identity and its canonical domain, or nil without a user part
+local function mailbox_identity(addr)
+  local user, domain
+
+  if type(addr) == 'string' then
+    user, domain = addr:match('^(.*)@([^@]*)$')
+    if not user then
+      user, domain = addr, ''
+    end
+  elseif type(addr) == 'table' then
+    user, domain = addr.user, addr.domain
+  end
+
+  if not user or user == '' then
+    return nil
+  end
+
+  user = user:lower()
+  domain = canonical_domain(domain or '')
+
+  local nu = apply_service_rules({ user = user, domain = domain })
+  if nu and nu ~= '' then
+    user = nu
+  end
+
+  return user .. '@' .. domain, domain
+end
+exports.mailbox_identity = mailbox_identity
+
 --- Resolve one step of aliasing
 -- @param email_str normalized email string
 -- @return result (string, array of strings, or nil), rule_type

--- a/src/plugins/lua/forged_recipients.lua
+++ b/src/plugins/lua/forged_recipients.lua
@@ -24,6 +24,9 @@ if confighelp then
   forged_recipients {
     symbol_sender = "FORGED_SENDER"; # Symbol for a forged sender
     symbol_rcpt = "FORGED_RECIPIENTS"; # Symbol for a forged recipients
+    # Domains delivering to one mailbox namespace (e.g. googlemail.com and
+    # gmail.com) are compared as equal; a map of "<alias> <canonical>" lines
+    equivalent_domains = "https://maps.rspamd.com/rspamd/equivalent_domains.inc.zst";
   }
   ]])
 end
@@ -31,15 +34,47 @@ end
 local symbol_rcpt = 'FORGED_RECIPIENTS'
 local symbol_sender = 'FORGED_SENDER'
 local rspamd_util = require "rspamd_util"
+local lua_aliases = require "lua_aliases"
 
 local E = {}
 
+-- Identity of a bare address string (authenticated user, Delivered-To):
+-- the same comparison key that addresses parsed from the task get
+local function string_identity(str)
+  if type(str) ~= 'string' or str == '' then
+    return nil
+  end
+
+  str = str:match('<([^>]*)>') or str
+  str = str:match('^%s*(.-)%s*$')
+
+  return lua_aliases.mailbox_identity(str)
+end
+
+-- Same mailbox up to case, equivalent domains and service-specific aliasing
+local function same_mailbox(a, b)
+  if not a or not b then
+    return false
+  end
+
+  local ia, ib = lua_aliases.mailbox_identity(a), lua_aliases.mailbox_identity(b)
+
+  if ia and ib then
+    return rspamd_util.strequal_caseless_utf8(ia, ib)
+  end
+
+  return rspamd_util.strequal_caseless_utf8(a.addr or '', b.addr or '')
+end
+
 local function check_forged_headers(task)
-  local auser = task:get_user()
-  local delivered_to = task:get_header('Delivered-To')
+  local auser = string_identity(task:get_user())
+  local delivered_to = string_identity(task:get_header('Delivered-To'))
   -- Compare the envelope and the headers as they were transmitted: alias
   -- rewrites (e.g. a cross-domain virtual alias applied to the envelope
-  -- recipients) must not make the wire To/Cc headers look forged
+  -- recipients) must not make the wire To/Cc headers look forged.
+  -- Addresses are matched by mailbox identity (lua_aliases.mailbox_identity),
+  -- so the same account reached under an equivalent domain or through a
+  -- dotted/tagged local part is not a mismatch either
   local smtp_rcpts = task:get_recipients({ 'smtp', 'orig' })
   local smtp_from = task:get_from({ 'smtp', 'orig' })
 
@@ -65,30 +100,29 @@ local function check_forged_headers(task)
     mime_rcpts[100] = nil
   end
 
-  -- map smtp recipient domains to a list of addresses for this domain
+  local smtp_from_id = lua_aliases.mailbox_identity((smtp_from or E)[1])
+
+  -- map canonical smtp recipient domains to the identities seen in this domain
   local smtp_rcpt_domain_map = {}
   local smtp_rcpt_map = {}
   for _, smtp_rcpt in ipairs(smtp_rcpts) do
-    local addr = smtp_rcpt.addr
+    local id, dom = lua_aliases.mailbox_identity(smtp_rcpt)
 
-    if addr and addr ~= '' then
-      local dom = string.lower(smtp_rcpt.domain)
-      addr = addr:lower()
-
+    if id then
       local dom_map = smtp_rcpt_domain_map[dom]
       if not dom_map then
         dom_map = {}
         smtp_rcpt_domain_map[dom] = dom_map
       end
 
-      dom_map[addr] = smtp_rcpt
-      smtp_rcpt_map[addr] = smtp_rcpt
+      dom_map[id] = smtp_rcpt
+      smtp_rcpt_map[id] = smtp_rcpt
+      smtp_rcpt.dom_map = dom_map
 
-      if auser and auser == addr then
+      if auser and auser == id then
         smtp_rcpt.matched = true
       end
-      if ((smtp_from or E)[1] or E).addr and
-          smtp_from[1]['addr'] == addr then
+      if smtp_from_id and smtp_from_id == id then
         -- allow sender to BCC themselves
         smtp_rcpt.matched = true
       end
@@ -96,17 +130,17 @@ local function check_forged_headers(task)
   end
 
   for _, mime_rcpt in ipairs(mime_rcpts) do
-    if mime_rcpt.addr and mime_rcpt.addr ~= '' then
-      local addr = string.lower(mime_rcpt.addr)
-      local dom = string.lower(mime_rcpt.domain)
-      local matched_smtp_addr = smtp_rcpt_map[addr]
+    local id, dom = lua_aliases.mailbox_identity(mime_rcpt)
+
+    if id then
+      local matched_smtp_addr = smtp_rcpt_map[id]
       if matched_smtp_addr then
         -- Direct match, go forward
         matched_smtp_addr.matched = true
         mime_rcpt.matched = true
-      elseif delivered_to and delivered_to == addr then
+      elseif delivered_to and delivered_to == id then
         mime_rcpt.matched = true
-      elseif auser and auser == addr then
+      elseif auser and auser == id then
         -- allow user to BCC themselves
         mime_rcpt.matched = true
       else
@@ -129,14 +163,14 @@ local function check_forged_headers(task)
   for _, mime_rcpt in ipairs(mime_rcpts) do
     if not mime_rcpt.matched then
       seen_mime_unmatched = true
-      table.insert(opts, 'm:' .. mime_rcpt.addr)
+      table.insert(opts, 'm:' .. (mime_rcpt.addr or ''))
     end
   end
   for _, smtp_rcpt in ipairs(smtp_rcpts) do
     if not smtp_rcpt.matched then
-      if not smtp_rcpt_domain_map[smtp_rcpt.domain:lower()]._seen_mime_domain then
+      if not (smtp_rcpt.dom_map or E)._seen_mime_domain then
         seen_smtp_unmatched = true
-        table.insert(opts, 's:' .. smtp_rcpt.addr)
+        table.insert(opts, 's:' .. (smtp_rcpt.addr or ''))
       end
     end
   end
@@ -148,8 +182,7 @@ local function check_forged_headers(task)
   -- Check sender
   if smtp_from and smtp_from[1] and smtp_from[1]['addr'] ~= '' then
     local mime_from = task:get_from({ 'mime', 'orig' })
-    if not mime_from or not mime_from[1] or
-        not rspamd_util.strequal_caseless_utf8(mime_from[1]['addr'], smtp_from[1]['addr']) then
+    if not same_mailbox((mime_from or E)[1], smtp_from[1]) then
       task:insert_result(symbol_sender, 1, ((mime_from or E)[1] or E).addr or '', smtp_from[1].addr)
     end
   end
@@ -159,6 +192,10 @@ end
 local opts = rspamd_config:get_all_opt('forged_recipients')
 if opts then
   if opts['symbol_rcpt'] or opts['symbol_sender'] then
+    if opts.equivalent_domains then
+      lua_aliases.init_equivalent_domains(rspamd_config, opts.equivalent_domains)
+    end
+
     local id = rspamd_config:register_symbol({
       name = 'FORGED_CALLBACK',
       callback = check_forged_headers,

--- a/test/functional/cases/001_merged/370_forged_recipients.robot
+++ b/test/functional/cases/001_merged/370_forged_recipients.robot
@@ -1,0 +1,83 @@
+*** Settings ***
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Test Cases ***
+
+# forged_recipients matches envelope and header addresses by mailbox
+# identity: equivalent domains (googlemail.com = gmail.com, the shipped map
+# and a test-only class), gmail dots and plus tags are not a mismatch.
+# Every test carries its own envelope sender so greylisting sees no repeat.
+
+RCPT GMAIL DOTS - NOT FORGED
+  [Documentation]  Dotted To header vs undotted envelope recipient in gmail.com
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_rcpt_gmail_dotted.eml
+  ...  From=sender1@forged.example.test
+  ...  Rcpt=johndoe@gmail.com
+  Do Not Expect Symbol  FORGED_RECIPIENTS
+
+RCPT GOOGLEMAIL TO GMAIL - NOT FORGED
+  [Documentation]  To: johndoe@googlemail.com, RCPT TO johndoe@gmail.com
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_rcpt_googlemail.eml
+  ...  From=sender2@forged.example.test
+  ...  Rcpt=johndoe@gmail.com
+  Do Not Expect Symbol  FORGED_RECIPIENTS
+
+RCPT GMAIL TO GOOGLEMAIL - NOT FORGED
+  [Documentation]  To: johndoe@gmail.com, RCPT TO johndoe@googlemail.com
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_rcpt_gmail.eml
+  ...  From=sender3@forged.example.test
+  ...  Rcpt=johndoe@googlemail.com
+  Do Not Expect Symbol  FORGED_RECIPIENTS
+
+RCPT GOOGLEMAIL DOTS TO GMAIL - NOT FORGED
+  [Documentation]  To: j.o.h.n.doe@googlemail.com, RCPT TO johndoe@gmail.com
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_rcpt_googlemail_dotted.eml
+  ...  From=sender4@forged.example.test
+  ...  Rcpt=johndoe@gmail.com
+  Do Not Expect Symbol  FORGED_RECIPIENTS
+
+RCPT SHIPPED MAP CLASS - NOT FORGED
+  [Documentation]  me.com -> icloud.com comes only from the shipped map file
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_rcpt_me_com.eml
+  ...  From=sender5@forged.example.test
+  ...  Rcpt=user@icloud.com
+  Do Not Expect Symbol  FORGED_RECIPIENTS
+
+RCPT TEST MAP CLASS - NOT FORGED
+  [Documentation]  A domain pair known only from the second configured map
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_rcpt_equiv.eml
+  ...  From=sender6@forged.example.test
+  ...  Rcpt=user@equiv-primary.test
+  Do Not Expect Symbol  FORGED_RECIPIENTS
+
+RCPT OTHER DOMAIN - FORGED
+  [Documentation]  A real mismatch is still reported with the wire addresses
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_rcpt_gmail.eml
+  ...  From=sender7@forged.example.test
+  ...  Rcpt=someone@else.example.test
+  Expect Symbol With Exact Options  FORGED_RECIPIENTS  m:johndoe@gmail.com  s:someone@else.example.test
+
+SENDER GOOGLEMAIL VS GMAIL - NOT FORGED
+  [Documentation]  From: johndoe@googlemail.com with MAIL FROM johndoe@gmail.com;
+  ...  the task still carries the transmitted From domain
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_from_googlemail.eml
+  ...  From=johndoe@gmail.com
+  ...  Rcpt=rcpt8@forged.example.test
+  Do Not Expect Symbol  FORGED_SENDER
+  Expect Symbol With Exact Options  GET_FROM  John Doe,johndoe@googlemail.com,johndoe,googlemail.com
+
+SENDER PLUS TAG - NOT FORGED
+  [Documentation]  MAIL FROM johndoe+tag@gmail.com is the From: johndoe@gmail.com mailbox
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_from_gmail.eml
+  ...  From=johndoe+tag@gmail.com
+  ...  Rcpt=rcpt9@forged.example.test
+  Do Not Expect Symbol  FORGED_SENDER
+
+SENDER OTHER USER - FORGED
+  [Documentation]  Another user in the same domain is still a forged sender
+  Scan File  ${RSPAMD_TESTDIR}/messages/forged_from_gmail.eml
+  ...  From=janedoe@gmail.com
+  ...  Rcpt=rcpt10@forged.example.test
+  Expect Symbol With Exact Options  FORGED_SENDER  johndoe@gmail.com  janedoe@gmail.com

--- a/test/functional/configs/maps/equivalent_domains.map
+++ b/test/functional/configs/maps/equivalent_domains.map
@@ -1,0 +1,2 @@
+# Test-only equivalent domain class for the forged_recipients suite
+equiv-alias.test equiv-primary.test

--- a/test/functional/configs/merged-local.conf
+++ b/test/functional/configs/merged-local.conf
@@ -116,6 +116,14 @@ multimap {
   }
 }
 
+# 370_forged_recipients: shipped equivalent domains plus a test-only class
+forged_recipients {
+  equivalent_domains = [
+    "file://{= env.TESTDIR =}/../../conf/maps.d/equivalent_domains.inc",
+    "file://{= env.TESTDIR =}/configs/maps/equivalent_domains.map"
+  ];
+}
+
 mid = {
     source = {
         url = [

--- a/test/functional/messages/forged_from_gmail.eml
+++ b/test/functional/messages/forged_from_gmail.eml
@@ -1,0 +1,10 @@
+From: John Doe <johndoe@gmail.com>
+To: rcpt@forged.example.test
+Subject: forged_recipients mailbox identity probe
+Message-ID: <forged_from_gmail.eml@forged.example.test>
+Date: Wed, 02 Sep 2026 22:58:27 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Envelope and header addresses that reach the same mailbox must not be
+reported as forged.

--- a/test/functional/messages/forged_from_googlemail.eml
+++ b/test/functional/messages/forged_from_googlemail.eml
@@ -1,0 +1,10 @@
+From: John Doe <johndoe@googlemail.com>
+To: rcpt@forged.example.test
+Subject: forged_recipients mailbox identity probe
+Message-ID: <forged_from_googlemail.eml@forged.example.test>
+Date: Wed, 02 Sep 2026 22:58:27 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Envelope and header addresses that reach the same mailbox must not be
+reported as forged.

--- a/test/functional/messages/forged_rcpt_equiv.eml
+++ b/test/functional/messages/forged_rcpt_equiv.eml
@@ -1,0 +1,10 @@
+From: Sender <sender@forged.example.test>
+To: user@equiv-alias.test
+Subject: forged_recipients mailbox identity probe
+Message-ID: <forged_rcpt_equiv.eml@forged.example.test>
+Date: Wed, 02 Sep 2026 22:58:27 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Envelope and header addresses that reach the same mailbox must not be
+reported as forged.

--- a/test/functional/messages/forged_rcpt_gmail.eml
+++ b/test/functional/messages/forged_rcpt_gmail.eml
@@ -1,0 +1,10 @@
+From: Sender <sender@forged.example.test>
+To: johndoe@gmail.com
+Subject: forged_recipients mailbox identity probe
+Message-ID: <forged_rcpt_gmail.eml@forged.example.test>
+Date: Wed, 02 Sep 2026 22:58:27 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Envelope and header addresses that reach the same mailbox must not be
+reported as forged.

--- a/test/functional/messages/forged_rcpt_gmail_dotted.eml
+++ b/test/functional/messages/forged_rcpt_gmail_dotted.eml
@@ -1,0 +1,10 @@
+From: Sender <sender@forged.example.test>
+To: j.o.h.n.doe@gmail.com
+Subject: forged_recipients mailbox identity probe
+Message-ID: <forged_rcpt_gmail_dotted.eml@forged.example.test>
+Date: Wed, 02 Sep 2026 22:58:27 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Envelope and header addresses that reach the same mailbox must not be
+reported as forged.

--- a/test/functional/messages/forged_rcpt_googlemail.eml
+++ b/test/functional/messages/forged_rcpt_googlemail.eml
@@ -1,0 +1,10 @@
+From: Sender <sender@forged.example.test>
+To: johndoe@googlemail.com
+Subject: forged_recipients mailbox identity probe
+Message-ID: <forged_rcpt_googlemail.eml@forged.example.test>
+Date: Wed, 02 Sep 2026 22:58:27 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Envelope and header addresses that reach the same mailbox must not be
+reported as forged.

--- a/test/functional/messages/forged_rcpt_googlemail_dotted.eml
+++ b/test/functional/messages/forged_rcpt_googlemail_dotted.eml
@@ -1,0 +1,10 @@
+From: Sender <sender@forged.example.test>
+To: j.o.h.n.doe@googlemail.com
+Subject: forged_recipients mailbox identity probe
+Message-ID: <forged_rcpt_googlemail_dotted.eml@forged.example.test>
+Date: Wed, 02 Sep 2026 22:58:27 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Envelope and header addresses that reach the same mailbox must not be
+reported as forged.

--- a/test/functional/messages/forged_rcpt_me_com.eml
+++ b/test/functional/messages/forged_rcpt_me_com.eml
@@ -1,0 +1,10 @@
+From: Sender <sender@forged.example.test>
+To: user@me.com
+Subject: forged_recipients mailbox identity probe
+Message-ID: <forged_rcpt_me_com.eml@forged.example.test>
+Date: Wed, 02 Sep 2026 22:58:27 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Envelope and header addresses that reach the same mailbox must not be
+reported as forged.

--- a/test/lua/unit/lua_aliases.lua
+++ b/test/lua/unit/lua_aliases.lua
@@ -58,3 +58,65 @@ context("Lua aliases - apply_service_rules", function()
     assert_nil(nu)
   end)
 end)
+
+context("Lua aliases - mailbox_identity", function()
+  local lua_aliases = require 'lua_aliases'
+
+  local function mk_addr(user, domain)
+    return {
+      user = user,
+      domain = domain,
+      addr = string.format('%s@%s', user, domain),
+    }
+  end
+
+  test('canonical_domain folds the builtin google class', function()
+    assert_equal(lua_aliases.canonical_domain('googlemail.com'), 'gmail.com')
+    assert_equal(lua_aliases.canonical_domain('GoogleMail.COM'), 'gmail.com')
+    assert_equal(lua_aliases.canonical_domain('gmail.com'), 'gmail.com')
+    assert_equal(lua_aliases.canonical_domain('example.com'), 'example.com')
+    assert_equal(lua_aliases.canonical_domain(''), '')
+    assert_nil(lua_aliases.canonical_domain(nil))
+  end)
+
+  test('google: one identity for both domains and dotted/tagged forms', function()
+    local ref = lua_aliases.mailbox_identity(mk_addr('johndoe', 'gmail.com'))
+    assert_equal(ref, 'johndoe@gmail.com')
+    assert_equal(lua_aliases.mailbox_identity(mk_addr('johndoe', 'googlemail.com')), ref)
+    assert_equal(lua_aliases.mailbox_identity(mk_addr('j.o.h.n.doe', 'googlemail.com')), ref)
+    assert_equal(lua_aliases.mailbox_identity(mk_addr('John.Doe+news', 'GMAIL.com')), ref)
+    assert_not_equal(lua_aliases.mailbox_identity(mk_addr('janedoe', 'googlemail.com')), ref)
+  end)
+
+  test('returns the canonical domain as the second value', function()
+    local id, dom = lua_aliases.mailbox_identity(mk_addr('user', 'googlemail.com'))
+    assert_equal(id, 'user@gmail.com')
+    assert_equal(dom, 'gmail.com')
+  end)
+
+  test('generic domain: plus tag and case folded, dots kept', function()
+    local ref = lua_aliases.mailbox_identity(mk_addr('first.last', 'example.com'))
+    assert_equal(ref, 'first.last@example.com')
+    assert_equal(lua_aliases.mailbox_identity(mk_addr('First.Last+tag', 'Example.COM')), ref)
+    assert_not_equal(lua_aliases.mailbox_identity(mk_addr('firstlast', 'example.com')), ref)
+  end)
+
+  test('accepts a bare address string', function()
+    assert_equal(lua_aliases.mailbox_identity('J.Doe+x@googlemail.com'), 'jdoe@gmail.com')
+    assert_equal(lua_aliases.mailbox_identity('nodomain'), 'nodomain@')
+  end)
+
+  test('no user part yields nil', function()
+    assert_nil(lua_aliases.mailbox_identity(mk_addr('', 'example.com')))
+    assert_nil(lua_aliases.mailbox_identity(nil))
+    assert_nil(lua_aliases.mailbox_identity(''))
+  end)
+
+  test('inline equivalent domains extend the builtin classes', function()
+    assert_true(lua_aliases.init_equivalent_domains(nil, { ['Alias.Test'] = 'Primary.test' }))
+    assert_equal(lua_aliases.canonical_domain('alias.test'), 'primary.test')
+    assert_equal(lua_aliases.mailbox_identity(mk_addr('user+tag', 'alias.test')), 'user@primary.test')
+    assert_equal(lua_aliases.canonical_domain('googlemail.com'), 'gmail.com')
+    assert_false(lua_aliases.init_equivalent_domains(nil, nil))
+  end)
+end)


### PR DESCRIPTION
Fixes #6227

## Problem

`forged_recipients` compared the envelope and header addresses as raw lowercase strings. A message whose envelope carries one form of a Google address and whose `To:`/`From:` header carries the other form of the very same mailbox was reported as forged:

| `To:` header | envelope `RCPT TO` | before | after |
|---|---|---|---|
| `j.o.h.n.doe@gmail.com` | `johndoe@gmail.com` | no symbol (same-domain fallback) | no symbol |
| `johndoe@googlemail.com` | `johndoe@gmail.com` | FORGED_RECIPIENTS | no symbol |
| `johndoe@gmail.com` | `johndoe@googlemail.com` | FORGED_RECIPIENTS | no symbol |
| `j.o.h.n.doe@googlemail.com` | `johndoe@gmail.com` | FORGED_RECIPIENTS | no symbol |

`FORGED_SENDER` had the same problem and no fallback at all: `From: j.o.h.n@gmail.com` with `MAIL FROM:<john@gmail.com>` fired too.

Some history: #6141 switched the module to the `orig` address flavour, which is right for cross-domain virtual aliases, but it also dropped the canonicalisation the default-on aliases plugin used to provide by rewriting both views.

## Fix

- `lua_aliases` gains a comparison-only view of an address: `mailbox_identity()` (lowercased, plus tags stripped, gmail dots removed, domain folded through equivalent domain classes), `canonical_domain()` and `init_equivalent_domains()`. Domain folding lives only here. The rewrite path keeps the transmitted domain, so SPF/DKIM/DMARC alignment and the guarantees from #6141 are unchanged; a test asserts the task's From domain still reads `googlemail.com`.
- `forged_recipients` matches both sides by identity, including the authenticated-user and `Delivered-To` checks, and compares the sender pair the same way. Symbol options still show the wire addresses. Also fixes a nil index in the unmatched-recipients pass for an envelope recipient without an address.
- Equivalent domain classes are data: a new map `rspamd/equivalent_domains.inc` (`<alias> <canonical>` per line) with Google, Proton, Apple and Yandex, wired like `mime_types`: fetched from maps.rspamd.com, `local.d/maps.d/equivalent_domains.inc` for local additions, and a shipped snapshot in `conf/maps.d/` as `fallback+file`. Only providers documenting that the same local part is reachable under every listed domain are included; the file header explains the rule. An inline table also works: `equivalent_domains = { "corp.example" = "example.com" }`.

Plus tags are folded for every domain, not only Google, which matches what the aliases plugin already does to the rewritten views.

## Tests

- 7 new unit tests for `mailbox_identity` / `canonical_domain` / inline classes.
- New functional suite `001_merged/370_forged_recipients.robot` (10 cases): the matrix above, the sender case, one case that only passes when the shipped map loaded (`me.com` -> `icloud.com`), one that only passes when a second configured map loaded, and two controls showing real forgeries still fire. `360_aliases` still passes.

## Deployment note

The map is already live at https://maps.rspamd.com/rspamd/equivalent_domains.inc.zst (rspamd/maps commit 4b5bea0); a daemon smoke test on the stock config loads 11 entries over HTTP. Hosts without access to maps.rspamd.com use the shipped snapshot in `conf/maps.d/`.

Docs for the new `equivalent_domains` option will follow on rspamd.com.
