### PR TITLE
[Feature] WebUI: informative All SERVERS cluster row

### DIFF
--- a/interface/css/rspamd.css
+++ b/interface/css/rspamd.css
@@ -627,20 +627,23 @@ input.action-scores {
 #clusterTable.cluster-hide-git .cluster-git {
     display: none;
 }
-/* "seen <time> ago": on narrow screens the note wraps under the status glyph
-   to save horizontal space; on large screens it stays on the glyph's line,
-   keeping server rows single-line (the table is otherwise text-nowrap) */
+/* "seen <time> ago" and the "up/total" counter: on narrow screens the note
+   wraps under the status glyph to save horizontal space; on large screens it
+   stays on the glyph's line, keeping server rows single-line (the table is
+   otherwise text-nowrap) */
 #clusterTable td.cluster-status {
     white-space: normal;
 }
-#clusterTable td.cluster-status .cluster-last-seen {
+#clusterTable td.cluster-status .cluster-last-seen,
+#clusterTable td.cluster-status .cluster-count {
     display: block;
 }
 @media (min-width: 992px) {
     #clusterTable td.cluster-status {
         white-space: nowrap;
     }
-    #clusterTable td.cluster-status .cluster-last-seen {
+    #clusterTable td.cluster-status .cluster-last-seen,
+    #clusterTable td.cluster-status .cluster-count {
         display: inline;
         margin-left: 0.25rem;
     }

--- a/interface/js/app/common.js
+++ b/interface/js/app/common.js
@@ -86,6 +86,8 @@ define(["nprogress"],
             return value === null || typeof value === "undefined";
         }
 
+        ui.isNil = isNil;
+
         // Resolve a string selector, Element, NodeList, Array, or jQuery wrapper
         // into a plain Array of Element. Accepts jQuery objects during the staged
         // removal so callers still passing $(...) keep working.

--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -62,6 +62,16 @@ define(["app/common", "app/libft", "d3pie", "d3"],
         const MIN_RATE_WINDOW_MS = 1000;
         const STALE_RATE_WINDOW_MS = 2 * 60 * 60 * 1000;
 
+        // /stat counters summed across up servers for the "All SERVERS" row:
+        // traffic and memory totals of the whole cluster (per-server detail
+        // stays available in each server's own details row)
+        const CLUSTER_SUM_FIELDS = [
+            "scanned", "learned", "spam_count", "ham_count", "connections",
+            "control_connections", "bytes_allocated", "fragmented", "pools_allocated",
+            "pools_freed", "chunks_allocated", "chunks_freed", "shared_chunks_allocated",
+            "chunks_oversized"
+        ];
+
         // Servers whose details row is expanded (module state: survives the
         // periodic tbody re-render, intentionally not a page reload)
         const expandedServers = new Set();
@@ -100,9 +110,61 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             return seconds + "\u00a0s ago";
         }
 
+        // "All SERVERS" row cells: the aggregates computed in statWidgets and
+        // stored on the synthetic Credentials entry
+        function aggregateRowState(state, val, cluster) {
+            if (!common.isNil(val.data.config_id)) {
+                state.short_id = val.data.config_id.substring(0, 8);
+            }
+            if (val.data.scan_times) {
+                const {min, avg, max} = val.data.scan_times;
+                if (max) {
+                    const f = d3.format(".3f");
+                    state.scan_times = {
+                        data: "<small>" + f(min) + "/</small>" + f(avg) +
+                            "<small>/" + f(max) + "</small>",
+                        title: ' title="min/avg/max across servers"'
+                    };
+                } else {
+                    state.scan_times = {
+                        data: "-",
+                        title: ' title="No messages scanned yet"'
+                    };
+                }
+            }
+            if (cluster) {
+                const allUp = cluster.upCount === cluster.total;
+                const healthy = allUp && !cluster.degraded.length;
+                state.row_class = healthy ? "success" : "warning";
+                state.glyph_status = healthy
+                    ? "fas fa-check"
+                    : "fas fa-exclamation-triangle";
+                // A single-server install gains no counter noise
+                if (cluster.total > 1) {
+                    state.status_extra = '<span class="small text-secondary cluster-count" title="' +
+                        common.escapeHTML(cluster.upCount + " of " + cluster.total + " servers up") +
+                        '">' + cluster.upCount + "/" + cluster.total + "</span>";
+                }
+                const notes = [];
+                if (!allUp) {
+                    notes.push((cluster.total - cluster.upCount) + " of " +
+                        cluster.total + " servers down");
+                }
+                if (cluster.degraded.length) {
+                    notes.push("degraded: " + cluster.degraded.join(", "));
+                }
+                if (notes.length) {
+                    state.status_title = ' title="' +
+                        common.escapeHTML(notes.join("; ")) + '"';
+                }
+            }
+        }
+
         // Derive the display state (row class, status glyph, cell values) of
-        // one cluster-table row from its Credentials snapshot entry.
-        function serverRowState(key, val, statHistory) {
+        // one cluster-table row from its Credentials snapshot entry. `cluster`
+        // (the up/degraded counter for the aggregate row, see
+        // displayStatWidgets) is used only for the "All SERVERS" row.
+        function serverRowState(key, val, statHistory, cluster) {
             const state = {
                 row_class: "danger",
                 glyph_status: "fas fa-times",
@@ -145,17 +207,16 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             if (Number.isFinite(val.data.uptime)) {
                 state.uptime = msToTime(val.data.uptime);
             }
-            if ("version" in val.data) {
+            if (!common.isNil(val.data.version)) {
                 state.version = val.data.version;
             }
-            if ("git_id" in val.data) {
+            if (!common.isNil(val.data.git_id)) {
                 state.git_id = val.data.git_id;
             }
             if (key === "All SERVERS") {
-                state.short_id = "";
-                state.scan_times.data = "";
+                aggregateRowState(state, val, cluster);
             } else {
-                if ("config_id" in val.data) {
+                if (!common.isNil(val.data.config_id)) {
                     state.short_id = val.data.config_id.substring(0, 8);
                 }
                 if ("scan_times" in val.data) {
@@ -209,37 +270,60 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             });
         }
 
+        // Tally distinct values of `key` among the servers reporting one
+        // (down servers carry data:{}, a legacy /auth patch may leave the
+        // value nil)
+        function tallyValues(servers, key) {
+            const present = servers.filter(({data}) => !common.isNil(data[key]));
+            const counts = new Map();
+            present.forEach(({data}) => counts.set(data[key], (counts.get(data[key]) || 0) + 1));
+            return {counts, present};
+        }
+
+        // Largest group of the tally: its value is null on a tie or when
+        // nobody reports the key
+        function largestGroup(counts) {
+            let size = 0;
+            counts.forEach((count) => {
+                if (count > size) size = count;
+            });
+            let value = null;
+            let winners = 0;
+            counts.forEach((count, candidate) => {
+                if (count === size) {
+                    value = candidate;
+                    winners++;
+                }
+            });
+            if (winners !== 1) value = null;
+            return {value, size, winners};
+        }
+
+        // The value the largest group of servers reports: a unanimous or
+        // plurality winner; null on a tie or when nobody reports it
+        function majorityValue(servers, key) {
+            const {counts} = tallyValues(servers, key);
+            return largestGroup(counts).value;
+        }
+
         // Majority-based cluster drift detection: flag servers whose value
         // differs from the largest group, but only when 2+ servers share a
         // value (a real cluster). All-unique values (centrally managed
         // standalone servers) and majority ties are not flagged. Returns
         // {majorityValue, majorityCount, total, deviants} or null.
         function findDeviants(servers, key) {
-            const present = servers.filter(({data}) => key in data);
-            const counts = new Map();
-            present.forEach(({data}) => counts.set(data[key], (counts.get(data[key]) || 0) + 1));
+            const {counts, present} = tallyValues(servers, key);
             if (counts.size < 2) return null;
 
-            let maxCount = 0;
-            counts.forEach((count) => {
-                if (count > maxCount) maxCount = count;
-            });
+            const largest = largestGroup(counts);
             // No group of 2+, or a split with no identifiable majority
-            if (maxCount < 2 ||
-                Array.from(counts.values()).filter((count) => count === maxCount).length > 1) {
-                return null;
-            }
-
-            let majorityValue = null;
-            counts.forEach((count, value) => {
-                if (count === maxCount) majorityValue = value;
-            });
+            if (largest.size < 2 || largest.winners > 1) return null;
 
             return {
-                majorityValue,
-                majorityCount: maxCount,
+                majorityValue: largest.value,
+                majorityCount: largest.size,
                 total: present.length,
-                deviants: new Set(present.filter(({data}) => data[key] !== majorityValue)
+                deviants: new Set(present.filter(({data}) => data[key] !== largest.value)
                     .map(({name}) => name))
             };
         }
@@ -478,7 +562,9 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                         d3.format(".3~s")(v) + "</strong>" + k + "</div></div>";
                 }
 
-                if (i === "auth" || i === "error") return; // Skip to the next iteration
+                // Skip to the next iteration; scan_times is an aggregate
+                // object (or a per-server array) shown in the table instead
+                if (i === "auth" || i === "error" || i === "scan_times") return;
                 if (i === "uptime" || i === "version") {
                     let cls = "border-end ";
                     let val = item;
@@ -486,8 +572,16 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                         cls = "";
                         val = msToTime(item);
                     }
+                    // Aggregate semantics of the "All SERVERS" selection:
+                    // minimum uptime and majority version
+                    const title = (checked_server === "All SERVERS")
+                        ? ' title="' + (i === "uptime"
+                            ? "Minimum uptime across servers"
+                            : "Most common version across servers") + '"'
+                        : "";
                     statWidgets.insertAdjacentHTML("beforeend",
-                        '<div class="' + cls + 'float-start px-3"><strong class="d-block mt-2 mb-1 fw-bold">' +
+                        '<div class="' + cls + 'float-start px-3"' + title + ">" +
+                        '<strong class="d-block mt-2 mb-1 fw-bold">' +
                         val + "</strong>" + i + "</div>");
                 } else if (i === "actions") {
                     Object.entries(item).forEach(([action, count]) => {
@@ -531,6 +625,20 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             const versionDrift = findDeviants(realServers, "version");
             const gitDrift = findDeviants(realServers, "git_id");
 
+            // "All SERVERS" status cell: up-counter over all real servers plus
+            // the aggregated degraded state. Health lands after the first
+            // render (probe pass), so this reads the Credentials snapshot and
+            // settles on the second pass
+            const clusterEntries = Object.entries(servers)
+                .filter(([name]) => name !== "All SERVERS");
+            const cluster = {
+                degraded: clusterEntries
+                    .filter(([, val]) => val.health?.state === "degraded")
+                    .map(([name]) => name),
+                total: clusterEntries.length,
+                upCount: clusterEntries.filter(([, val]) => val.status).length
+            };
+
             // @ warning triangle marking a server deviating from the cluster majority
             function driftBadge(drift, what, value) {
                 return ' <span class="icon cluster-drift" title="' +
@@ -539,8 +647,32 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                     '"><i class="fas fa-exclamation-triangle"></i></span>';
             }
 
+            // The badge marks deviating servers and the aggregate row alike:
+            // the majority value the latter shows is not cluster-wide
+            function hasDriftBadge(drift, key) {
+                return Boolean(drift) && (drift.deviants.has(key) || key === "All SERVERS");
+            }
+
+            // Uptime cell state: the recent-restart warning, or the aggregate
+            // semantics on the "All SERVERS" row
+            function uptimeCellState(key, uptime) {
+                const young = Number.isFinite(uptime) && uptime < 3600;
+                if (key !== "All SERVERS") {
+                    return {
+                        title: young ? "Has been restarted within the last hour" : "",
+                        young
+                    };
+                }
+                return {
+                    title: young
+                        ? "Youngest server has been restarted within the last hour"
+                        : "Minimum uptime across servers",
+                    young
+                };
+            }
+
             Object.entries(servers).forEach(([key, val]) => {
-                const rowState = serverRowState(key, val, statHistory);
+                const rowState = serverRowState(key, val, statHistory, cluster);
 
                 const checked = checked_server === key;
                 const disabled = !checked && !val.status;
@@ -549,17 +681,20 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                 const radioAttrs = 'value="' + escKey + '"' +
                     (checked ? " checked" : "") + (disabled ? " disabled" : "");
 
-                const realUp = val.status && key !== "All SERVERS";
+                // The aggregate row expands into cluster totals as well
+                const hasDetails = Boolean(val.status);
                 const expanded = expandedServers.has(key);
-                const toggle = realUp
+                const toggle = hasDetails
                     ? '<td class="cluster-toggle" role="button" aria-expanded="' + expanded +
                         '" title="Show/hide details"><span class="cluster-toggle-icon">' +
                             '<i class="fas fa-chevron-down"></i></span></td>'
                     : "<td></td>";
-                let latency = "";
-                if (key !== "All SERVERS") {
-                    latency = val.status ? formatLatency(val.latency) : "-";
-                }
+                // Aggregated as the slowest responding up server
+                const latency = val.status ? formatLatency(val.latency) : "-";
+                const latencyTitle = (key === "All SERVERS")
+                    ? ' title="Slowest server response"'
+                    : "";
+                const uptimeCell = uptimeCellState(key, val.data.uptime);
                 // Same badge as the Configuration tab: shown when writable,
                 // nothing in read-only mode; right-aligned within the cell
                 const writable_badge = (val.data.read_only === false)
@@ -578,31 +713,31 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                         rowState.status_extra + "</td>" +
                     '<td class="text-center"' + rowState.scan_times.title + ">" +
                         rowState.scan_times.data + "</td>" +
-                    '<td class="text-end" title="Messages scanned per minute">' +
+                    '<td class="text-end" title="' + (key === "All SERVERS"
+                        ? "Sum of messages scanned per minute across servers"
+                        : "Messages scanned per minute") + '">' +
                         formatRate(val.rate) + "</td>" +
-                    '<td class="text-end">' + latency + "</td>" +
-                    '<td class="text-end' +
-                      ((Number.isFinite(val.data.uptime) && val.data.uptime < 3600)
-                          ? ' warning" title="Has been restarted within the last hour"'
-                          : "") +
-                      '">' + rowState.uptime + "</td>" +
+                    '<td class="text-end"' + latencyTitle + ">" + latency + "</td>" +
+                    '<td class="text-end' + (uptimeCell.young ? " warning" : "") + '"' +
+                      (uptimeCell.title ? ' title="' + uptimeCell.title + '"' : "") + ">" +
+                      rowState.uptime + "</td>" +
                     "<td>" + common.escapeHTML(rowState.version) +
-                        (versionDrift?.deviants.has(key)
+                        (hasDriftBadge(versionDrift, key)
                             ? driftBadge(versionDrift, "Version", "run " + versionDrift.majorityValue)
                             : "") +
                     "</td>" +
                     '<td class="cluster-git">' + common.escapeHTML(rowState.git_id) +
-                        (gitDrift?.deviants.has(key)
+                        (hasDriftBadge(gitDrift, key)
                             ? driftBadge(gitDrift, "Git ID", "run " + gitDrift.majorityValue)
                             : "") +
                     "</td>" +
                     "<td>" + common.escapeHTML(rowState.short_id) +
-                        (configDrift?.deviants.has(key)
+                        (hasDriftBadge(configDrift, key)
                             ? driftBadge(configDrift, "Configuration ID",
                                 "share " + String(configDrift.majorityValue).substring(0, 8))
                             : "") +
                     "</td></tr>" +
-                    (realUp ? buildDetailsRow(val.data, expanded, detailCols) : "")
+                    (hasDetails ? buildDetailsRow(val.data, expanded, detailCols) : "")
                 );
 
                 selSrv.insertAdjacentHTML("beforeend",
@@ -782,11 +917,11 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                 common.query("stat", {
                     success: function (neighbours_status) {
                         const statHistory = parseJsonOrEmpty(sessionStorage.getItem(STAT_HISTORY_KEY));
+                        // Youngest up server defines the cluster uptime:
+                        // Infinity until a finite value is seen (deleted
+                        // before serialization if never replaced)
                         const neighbours_sum = {
-                            version: neighbours_status[0].data.version,
-                            uptime: 0,
-                            scanned: 0,
-                            learned: 0,
+                            uptime: Infinity,
                             actions: {
                                 "no action": 0,
                                 "add header": 0,
@@ -796,7 +931,9 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                                 "soft reject": 0,
                             }
                         };
-                        let status_count = 0;
+                        CLUSTER_SUM_FIELDS.forEach((p) => {
+                            neighbours_sum[p] = 0;
+                        });
                         const promises = [];
                         const healthPromises = [];
                         const to_Credentials = {
@@ -812,17 +949,65 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                         function process_node_stat(e) {
                             const {data} = neighbours_status[e];
                             // Controller doesn't return the 'actions' object until at least one message is scanned
-                            if (data.scanned) {
+                            if (data.scanned && data.actions) {
                                 for (const action in neighbours_sum.actions) {
                                     if ({}.hasOwnProperty.call(neighbours_sum.actions, action)) {
-                                        neighbours_sum.actions[action] += data.actions[action];
+                                        neighbours_sum.actions[action] += data.actions[action] || 0;
                                     }
                                 }
                             }
-                            ["learned", "scanned", "uptime"].forEach((p) => {
-                                neighbours_sum[p] += data[p];
+                            CLUSTER_SUM_FIELDS.forEach((p) => {
+                                if (Number.isFinite(data[p])) neighbours_sum[p] += data[p];
                             });
-                            status_count++;
+                            if (Number.isFinite(data.uptime)) {
+                                neighbours_sum.uptime = Math.min(neighbours_sum.uptime, data.uptime);
+                            }
+                        }
+
+                        // Identity and envelope aggregates of the "All SERVERS"
+                        // row. Runs once all legacy /auth patches have settled,
+                        // so majority values see the patched fields
+                        function finalizeClusterAggregates() {
+                            const upServers = neighbours_status.filter((n) => n.status === true);
+                            // Cluster identity: the value the largest group of
+                            // up servers runs (null on ties or when nobody
+                            // reports it — then nothing is shown)
+                            ["config_id", "git_id", "version"].forEach((p) => {
+                                const value = majorityValue(upServers, p);
+                                if (!common.isNil(value)) neighbours_sum[p] = value;
+                            });
+                            // Scan-time envelope: min of mins, max of maxes,
+                            // average of per-server averages (all servers report
+                            // an equal-length slot array, so this equals the
+                            // pooled mean and stays server-equal-weighted)
+                            const scanTimes = upServers
+                                .map((n) => n.data.scan_times)
+                                .filter(Array.isArray);
+                            if (scanTimes.length) {
+                                const [min, max] = d3.extent(scanTimes.flat());
+                                neighbours_sum.scan_times = {
+                                    avg: d3.mean(scanTimes.map((slots) => d3.mean(slots))),
+                                    max,
+                                    min
+                                };
+                            }
+                            if (Number.isFinite(neighbours_sum.uptime)) {
+                                neighbours_sum.uptime = Math.floor(neighbours_sum.uptime);
+                            } else {
+                                // Never serialize Infinity (JSON.stringify turns it into null)
+                                delete neighbours_sum.uptime;
+                            }
+                            // Slowest responding up server (an up server always
+                            // carries a finite latency; with none up the
+                            // success callback never fires, so this row — and
+                            // its latency cell — never renders. formatLatency
+                            // would still degrade an absent value to "-")
+                            const latencies = upServers
+                                .map((n) => n.latency)
+                                .filter(Number.isFinite);
+                            if (latencies.length) {
+                                to_Credentials["All SERVERS"].latency = Math.max(...latencies);
+                            }
                         }
 
                         // Get config_id, version and uptime using /auth query for Rspamd 2.5 and earlier
@@ -918,7 +1103,7 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                                     // A newer refresh cycle superseded this one:
                                     // drop its (stale) state entirely
                                     if (cycleId === statCycleId) {
-                                        neighbours_sum.uptime = Math.floor(neighbours_sum.uptime / status_count);
+                                        finalizeClusterAggregates();
                                         neighbours_sum.rate = updateStatHistory(neighbours_status, statHistory);
                                         sessionStorage.setItem(STAT_HISTORY_KEY, JSON.stringify(statHistory));
                                         to_Credentials["All SERVERS"].data = neighbours_sum;

--- a/test/playwright/tests/charts.spec.mjs
+++ b/test/playwright/tests/charts.spec.mjs
@@ -40,18 +40,19 @@ test.describe.serial("WebUI Status / Throughput / History rendering", () => {
         // CI builds pass no -DGIT_ID, so no server reports git_id and the
         // Git ID column stays hidden
         await expect(page.locator("#clusterTable thead th.cluster-git")).toBeHidden();
-        await expect(page.locator("#clusterTable tbody td[title='Messages scanned per minute']").first())
+        await expect(page.locator(
+            "#clusterTable tbody tr:not([data-server='All SERVERS']) td[title='Messages scanned per minute']"))
             .toHaveText(/-|[\d.]+\/min/);
 
         // Clicking anywhere on a server row (except the radio) expands its
         // details row built from the already-fetched /stat snapshot (traffic
         // and memory counters). The row also carries the Writable badge when
         // the server is not in read-only mode.
-        const row = page.locator("#clusterTable tbody tr[data-server]")
+        const row = page.locator("#clusterTable tbody tr[data-server]:not([data-server='All SERVERS'])")
             .filter({has: page.locator("td.cluster-toggle")}).first();
         await expect(row).toContainText("Writable");
         const serverNameCell = row.locator("td").nth(2); // Server name
-        const details = page.locator("#clusterTable tr.cluster-details").first();
+        const details = row.locator("xpath=following-sibling::tr[contains(@class, 'cluster-details')][1]");
         await serverNameCell.click();
         await expect(details).toBeVisible();
         await expect(details).toContainText("Memory");
@@ -67,6 +68,17 @@ test.describe.serial("WebUI Status / Throughput / History rendering", () => {
         ]);
         await expect(details).toBeVisible();
 
+        // The aggregate row is expandable too (cluster totals; on a
+        // single-server install they equal the local server's own) and
+        // carries the aggregate-semantics tooltips instead of the badge.
+        const allRow = page.locator("#clusterTable tbody tr[data-server='All SERVERS']");
+        const allNameCell = allRow.locator("td").nth(2); // Server name
+        const allDetails = allRow.locator("xpath=following-sibling::tr[contains(@class, 'cluster-details')][1]");
+        await allNameCell.click();
+        await expect(allDetails).toBeVisible();
+        await expect(allDetails).toContainText("Memory");
+        await expect(allRow).not.toContainText("Writable");
+
         // Three-state health: simulate a /healthy failure (HTTP 500 with the
         // reason in the JSON body) and check the degraded row state.
         await page.route("**/healthy", (route) => route.fulfill({
@@ -81,6 +93,10 @@ test.describe.serial("WebUI Status / Throughput / History rendering", () => {
         await expect(row).toHaveClass(/\bwarning\b/);
         await expect(row.locator("td").nth(4)).toHaveAttribute("title",
             "Degraded: 2 workers are not responding");
+        // The aggregate row aggregates the degraded state (no up/total
+        // counter noise on a single-server install)
+        await expect(allRow).toHaveClass(/\bwarning\b/);
+        await expect(allRow.locator("td").nth(4)).toHaveAttribute("title", "degraded: local");
 
         // Back to the healthy state once /healthy answers again.
         await page.unroute("**/healthy");
@@ -89,6 +105,7 @@ test.describe.serial("WebUI Status / Throughput / History rendering", () => {
             page.locator("#refresh").click(),
         ]);
         await expect(row).toHaveClass(/\bsuccess\b/);
+        await expect(allRow).toHaveClass(/\bsuccess\b/);
     });
 
     test("Throughput tab renders the graph and reloads on dataset change", async () => {

--- a/test/playwright/tests/cluster.spec.mjs
+++ b/test/playwright/tests/cluster.spec.mjs
@@ -53,13 +53,224 @@ test("Git ID column: values, drift badge, details colspan", async ({page, reques
     await expect(page.locator('tr[data-server="srv1"] td.cluster-git')).toHaveText("a1b2c3d");
     await expect(page.locator('tr[data-server="srv3"] td.cluster-git')).toContainText("e5f6a7b<b>x</b>");
 
-    // Identical versions and config ids: the git deviant carries the only badge
-    await expect(page.locator("#clusterTable .cluster-drift")).toHaveCount(1);
+    // Identical versions and config ids: the git drift badge marks the
+    // deviant and the aggregate row alike (its majority value is not
+    // cluster-wide)
+    await expect(page.locator("#clusterTable .cluster-drift")).toHaveCount(2);
     await expect(page.locator('tr[data-server="srv3"] td.cluster-git .cluster-drift'))
         .toHaveAttribute("title", "Git ID differs: 2 of 3 servers run a1b2c3d");
+    await expect(page.locator('tr[data-server="All SERVERS"] td.cluster-git .cluster-drift'))
+        .toHaveAttribute("title", "Git ID differs: 2 of 3 servers run a1b2c3d");
+
+    // All up: green aggregate row carrying the up-counter and the majority
+    // git value
+    await expect(page.locator('tr[data-server="All SERVERS"]')).toHaveClass(/\bsuccess\b/);
+    await expect(page.locator('tr[data-server="All SERVERS"] td.cluster-status'))
+        .toContainText("3/3");
+    await expect(page.locator('tr[data-server="All SERVERS"] td.cluster-git'))
+        .toContainText("a1b2c3d");
 
     // The details row spans all 12 visible columns
     await page.locator('tr[data-server="srv1"] td').nth(2).click();
     await expect(page.locator("#clusterTable tr.cluster-details td").first())
         .toHaveAttribute("colspan", "12");
+});
+
+// The "All SERVERS" row shows majority identity values (not the first
+// neighbour's), the youngest uptime, the cluster-wide scan-time envelope and
+// the slowest server latency, and expands into summed traffic/memory totals.
+// Same mocking scheme as the Git ID test above.
+test("All SERVERS row aggregates identity, uptime, scan time and latency", async ({page, request}, testInfo) => {
+    const {enablePassword, readOnlyPassword} = testInfo.project.use.rspamdPasswords;
+    const baseStat = await (await request.get("/stat", {headers: {Password: readOnlyPassword}})).json();
+
+    // n3 deviates on version and config id; its uptime is the youngest
+    const variations = {
+        n1: {config_id: "cafebabedeadbeef", scan_times: Array(31).fill(1.0), uptime: 7200, version: "9.9.9"},
+        n2: {config_id: "cafebabedeadbeef", scan_times: Array(31).fill(2.0), uptime: 90000, version: "9.9.9"},
+        n3: {config_id: "0123456789abcdef", scan_times: Array(31).fill(3.0), uptime: 60, version: "8.8.8"},
+    };
+    await page.route("**/neighbours", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            srv1: {host: "127.0.0.1", url: "http://localhost:11334/n1/"},
+            srv2: {host: "127.0.0.1", url: "http://localhost:11334/n2/"},
+            srv3: {host: "127.0.0.1", url: "http://localhost:11334/n3/"},
+        }),
+    }));
+    for (const [n, stat] of Object.entries(variations)) {
+        const statBody = {...baseStat, ...stat};
+        // No git_id: the Git ID column stays hidden regardless of the
+        // underlying build, so the details row spans a fixed 11 columns
+        delete statBody.git_id;
+        await page.route(`**/${n}/stat`, (route) => route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(statBody),
+        }));
+        // The login-time auth fan-out and the health probes must not 404
+        for (const ep of ["auth", "healthy", "ready"]) {
+            await page.route(`**/${n}/${ep}`, (route) => route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify(ep === "auth"
+                    ? {auth: "ok", version: stat.version}
+                    : {}),
+            }));
+        }
+    }
+
+    await login(page, enablePassword);
+    await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    await Promise.all([
+        page.waitForResponse((r) => r.url().includes("/n3/stat")),
+        page.locator("#status_nav").click(),
+    ]);
+
+    const allRow = page.locator('tr[data-server="All SERVERS"]');
+
+    // Majority version and configuration id, each with the drift badge
+    await expect(allRow.locator("td").nth(9)).toHaveText("9.9.9");
+    await expect(allRow.locator("td").nth(9).locator(".cluster-drift"))
+        .toHaveAttribute("title", "Version differs: 2 of 3 servers run 9.9.9");
+    await expect(allRow.locator("td").nth(11)).toHaveText("cafebabe");
+    await expect(allRow.locator("td").nth(11).locator(".cluster-drift"))
+        .toHaveAttribute("title", "Configuration ID differs: 2 of 3 servers share cafebabe");
+
+    // Youngest uptime (n3: 60 s), flagged as a recent restart
+    await expect(allRow.locator("td").nth(8)).toHaveText("1min");
+    await expect(allRow.locator("td").nth(8)).toHaveClass(/\bwarning\b/);
+    await expect(allRow.locator("td").nth(8))
+        .toHaveAttribute("title", "Youngest server has been restarted within the last hour");
+
+    // Cluster scan-time envelope: min of mins / mean of means / max of maxes
+    await expect(allRow.locator("td").nth(5)).toHaveText("1.000/2.000/3.000");
+    await expect(allRow.locator("td").nth(5)).toHaveAttribute("title", "min/avg/max across servers");
+
+    // Slowest server latency and the summed load tooltip
+    await expect(allRow.locator("td").nth(7)).toHaveText(/^[\d.]+ (ms|s)$/);
+    await expect(allRow.locator("td").nth(7)).toHaveAttribute("title", "Slowest server response");
+    await expect(allRow.locator("td").nth(6))
+        .toHaveAttribute("title", "Sum of messages scanned per minute across servers");
+
+    // The uptime/version widgets mirror the aggregate semantics
+    await expect(page.locator('#statWidgets [title="Minimum uptime across servers"]'))
+        .toContainText("1min");
+    await expect(page.locator('#statWidgets [title="Most common version across servers"]'))
+        .toContainText("9.9.9");
+
+    // The aggregate row expands into summed traffic and memory totals
+    await allRow.locator("td").nth(2).click();
+    const details = page.locator("#clusterTable tr.cluster-details").first();
+    await expect(details).toBeVisible();
+    await expect(details.locator("td")).toHaveAttribute("colspan", "11");
+    await expect(details).toContainText("Traffic");
+    await expect(details).toContainText("Memory");
+    await expect(details).toContainText(
+        (baseStat.scanned * 3).toLocaleString("en-US"));
+});
+
+// A down neighbour turns the "All SERVERS" row amber with an up/total counter,
+// while the aggregates stay over the servers that still answer.
+test("All SERVERS row reflects a down neighbour", async ({page, request}, testInfo) => {
+    const {enablePassword, readOnlyPassword} = testInfo.project.use.rspamdPasswords;
+    const baseStat = await (await request.get("/stat", {headers: {Password: readOnlyPassword}})).json();
+
+    const variations = {
+        n1: {config_id: "cafebabedeadbeef", uptime: 7200, version: "9.9.9"},
+        n2: {config_id: "cafebabedeadbeef", uptime: 90000, version: "9.9.9"},
+    };
+    await page.route("**/neighbours", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            srv1: {host: "127.0.0.1", url: "http://localhost:11334/n1/"},
+            srv2: {host: "127.0.0.1", url: "http://localhost:11334/n2/"},
+            srv3: {host: "127.0.0.1", url: "http://localhost:11334/n3/"},
+        }),
+    }));
+    for (const [n, stat] of Object.entries(variations)) {
+        await page.route(`**/${n}/stat`, (route) => route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({...baseStat, ...stat}),
+        }));
+        for (const ep of ["auth", "healthy", "ready"]) {
+            await page.route(`**/${n}/${ep}`, (route) => route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify(ep === "auth"
+                    ? {auth: "ok", version: stat.version}
+                    : {}),
+            }));
+        }
+    }
+    await page.route("**/n3/stat", (route) => route.fulfill({status: 503}));
+    await page.route("**/n3/auth", (route) => route.fulfill({status: 503}));
+
+    await login(page, enablePassword);
+    await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    await Promise.all([
+        page.waitForResponse((r) => r.url().includes("/n2/stat")),
+        page.locator("#status_nav").click(),
+    ]);
+
+    // srv3 renders as down
+    await expect(page.locator('tr[data-server="srv3"]')).toHaveClass(/\bdanger\b/);
+
+    // The aggregate row: amber, counter, reason in the tooltip
+    const allRow = page.locator('tr[data-server="All SERVERS"]');
+    await expect(allRow).toHaveClass(/\bwarning\b/);
+    await expect(allRow.locator("td.cluster-status")).toContainText("2/3");
+    await expect(allRow.locator("td.cluster-status"))
+        .toHaveAttribute("title", "1 of 3 servers down");
+
+    // Aggregates span the up servers only: unanimous version, youngest of
+    // the two uptimes (2 h), no drift badges
+    await expect(allRow.locator("td").nth(9)).toHaveText("9.9.9");
+    await expect(allRow.locator("td").nth(8)).toHaveText("2hr 0min");
+    await expect(allRow.locator("td").nth(8)).toHaveAttribute("title", "Minimum uptime across servers");
+    await expect(page.locator("#clusterTable .cluster-drift")).toHaveCount(0);
+});
+
+// A fully down cluster never renders the aggregate row: the fan-out fires
+// success only when at least one neighbour answers, so the table keeps its
+// initial empty state instead of a fake-green "All SERVERS" row. The waits
+// run before the assertion so the completed failure path, not a slow fan-out,
+// is what gets checked.
+test("All SERVERS row not rendered when all neighbours are down", async ({page}, testInfo) => {
+    const {enablePassword} = testInfo.project.use.rspamdPasswords;
+
+    await page.route("**/neighbours", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            srv1: {host: "127.0.0.1", url: "http://localhost:11334/n1/"},
+            srv2: {host: "127.0.0.1", url: "http://localhost:11334/n2/"},
+            srv3: {host: "127.0.0.1", url: "http://localhost:11334/n3/"},
+        }),
+    }));
+    for (const n of ["n1", "n2", "n3"]) {
+        await page.route(`**/${n}/stat`, (route) => route.fulfill({status: 503}));
+        for (const ep of ["auth", "healthy", "ready"]) {
+            await page.route(`**/${n}/${ep}`, (route) => route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: "{}",
+            }));
+        }
+    }
+
+    await login(page, enablePassword);
+    await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    await Promise.all([
+        page.waitForResponse((r) => r.url().includes("/n1/stat")),
+        page.waitForResponse((r) => r.url().includes("/n2/stat")),
+        page.waitForResponse((r) => r.url().includes("/n3/stat")),
+        page.locator("#status_nav").click(),
+    ]);
+
+    // Every neighbour failed: nothing renders, the synthetic row included
+    await expect(page.locator("#clusterTable tbody tr")).toHaveCount(0);
 });


### PR DESCRIPTION
Derive the aggregate row from cluster data instead of a mix of the first neighbour's values, averages and blanks: majority version, configuration and git ids (with drift badges), youngest uptime, cluster-wide scan-time envelope, slowest-server latency, an up/total health counter, and an expandable details row with summed traffic and memory totals. Fixes the literal "undefined" version shown when the first neighbour is down or legacy (<= 2.5).