### PR TITLE
[Fix] settings: keep custom keys when merging settings layers

### DIFF
--- a/src/libserver/settings_merge.cxx
+++ b/src/libserver/settings_merge.cxx
@@ -20,7 +20,9 @@
 #include "contrib/ankerl/unordered_dense.h"
 
 #include <algorithm>
+#include <array>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #define msg_debug_settings(...) rspamd_conditional_debug_fast(NULL, NULL,                                           \
@@ -411,6 +413,77 @@ merge_array_union(ucl_object_t *result, const char *key,
 	}
 }
 
+/**
+ * Top level keys that this file merges explicitly. Everything else in a layer
+ * is an opaque operator defined extension (settings `apply` blocks are a
+ * documented extension point: consumers read them back via task:get_settings()),
+ * so it must be passed through instead of being dropped.
+ */
+static constexpr std::array<std::string_view, 15> settings_known_keys = {
+	std::string_view{"actions"},
+	std::string_view{"add_headers"},
+	std::string_view{"flags"},
+	std::string_view{"groups_disabled"},
+	std::string_view{"groups_enabled"},
+	std::string_view{"messages"},
+	std::string_view{"remove_headers"},
+	std::string_view{"scores"},
+	std::string_view{"subject"},
+	std::string_view{"symbols"},
+	std::string_view{"symbols_disabled"},
+	std::string_view{"symbols_enabled"},
+	std::string_view{"variables"},
+	std::string_view{"whitelist"},
+	/* Produced by this function, never taken from a layer */
+	std::string_view{"_merge_info"},
+};
+
+static bool
+settings_is_known_key(std::string_view key)
+{
+	return std::find(settings_known_keys.begin(), settings_known_keys.end(), key) !=
+		   settings_known_keys.end();
+}
+
+/**
+ * Copy over every top-level key that is not handled by the explicit mergers.
+ * Semantics match merge_override_object: per-key, the higher layer wins; the
+ * value itself is taken as a whole (an unknown key is opaque to us, so we
+ * cannot meaningfully merge its insides).
+ */
+static void
+merge_unknown_keys(ucl_object_t *result, const std::vector<layer_entry> &layers)
+{
+	for (const auto &layer: layers) {
+		if (ucl_object_type(layer.settings) != UCL_OBJECT) {
+			continue;
+		}
+
+		ucl_object_iter_t it = nullptr;
+		const ucl_object_t *cur;
+
+		while ((cur = ucl_object_iterate(layer.settings, &it, true)) != nullptr) {
+			const char *key = ucl_object_key(cur);
+
+			if (key == nullptr) {
+				continue;
+			}
+
+			const auto klen = strlen(key);
+
+			if (settings_is_known_key(std::string_view{key, klen})) {
+				continue;
+			}
+
+			/* Replace existing key or insert a new one */
+			ucl_object_replace_key(result, ucl_object_ref(cur), key, klen, true);
+
+			msg_debug_settings("passed through custom settings key %s from layer %s",
+							   key, layer.name.c_str());
+		}
+	}
+}
+
 extern "C" ucl_object_t *
 rspamd_settings_merge_finalize(struct rspamd_settings_merge_ctx *ctx)
 {
@@ -457,6 +530,9 @@ rspamd_settings_merge_finalize(struct rspamd_settings_merge_ctx *ctx)
 
 	/* Symbols to inject: union */
 	merge_override_object(result, "symbols", ctx->layers);
+
+	/* Anything else the operator put in the apply block: per-key, higher layer wins */
+	merge_unknown_keys(result, ctx->layers);
 
 	/* Build merge metadata */
 	auto *meta = ucl_object_typed_new(UCL_ARRAY);

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -6658,6 +6658,8 @@ lua_task_settings_apply_actions(struct rspamd_task *task, const ucl_object_t *ac
 								   act_name,
 								   action_config->cur_limit,
 								   act_score);
+					action_config->flags &= ~(RSPAMD_ACTION_RESULT_DISABLED |
+											  RSPAMD_ACTION_RESULT_NO_THRESHOLD);
 					action_config->cur_limit = act_score;
 				}
 			}

--- a/src/lua/lua_task.c
+++ b/src/lua/lua_task.c
@@ -6530,6 +6530,141 @@ lua_task_learn(lua_State *L)
 	return ret;
 }
 
+/*
+ * Apply an `actions` object from a settings block to the task scan result.
+ *
+ * Shared by lua_task_set_settings() (single settings layer) and
+ * lua_task_merge_and_apply_settings() (merged multi-layer result) so that the
+ * two paths cannot drift apart: a merged result must mean exactly what the
+ * same object would have meant as a single layer.
+ */
+static void
+lua_task_settings_apply_actions(struct rspamd_task *task, const ucl_object_t *act)
+{
+	struct rspamd_scan_result *mres = task->result;
+	ucl_object_iter_t it = NULL;
+	const ucl_object_t *cur;
+	unsigned int i;
+
+	if (act == NULL || ucl_object_type(act) != UCL_OBJECT || mres == NULL) {
+		return;
+	}
+
+	while ((cur = ucl_object_iterate(act, &it, true)) != NULL) {
+		const char *act_name = ucl_object_key(cur);
+		struct rspamd_action_config *action_config = NULL;
+		double act_score;
+		enum rspamd_action_type act_type;
+
+		if (!rspamd_action_from_str(act_name, &act_type)) {
+			act_type = -1;
+		}
+
+		for (i = 0; i < mres->nactions; i++) {
+			struct rspamd_action_config *cur_act = &mres->actions_config[i];
+
+			if (cur_act->action->action_type == METRIC_ACTION_CUSTOM &&
+				act_type == -1) {
+				/* Compare by name */
+				if (g_ascii_strcasecmp(act_name, cur_act->action->name) == 0) {
+					action_config = cur_act;
+					break;
+				}
+			}
+			else {
+				if (cur_act->action->action_type == act_type) {
+					action_config = cur_act;
+					break;
+				}
+			}
+		}
+
+		if (!action_config) {
+			if (ucl_object_type(cur) == UCL_NULL) {
+				/*
+				 * Disabling an action that this task does not have is a no-op,
+				 * not a request to create it (ucl_object_todouble() of a null
+				 * yields 0.0, which would otherwise add the action with a zero
+				 * threshold and make it fire on everything).
+				 */
+				continue;
+			}
+
+			act_score = ucl_object_todouble(cur);
+			if (!isnan(act_score)) {
+				struct rspamd_action *new_act;
+
+				new_act = rspamd_config_get_action(task->cfg, act_name);
+
+				if (new_act == NULL) {
+					/* New action! */
+					msg_info_task("added new action %s with threshold %.2f "
+								  "due to settings",
+								  act_name,
+								  act_score);
+					new_act = rspamd_mempool_alloc0(task->task_pool,
+													sizeof(*new_act));
+					new_act->name = rspamd_mempool_strdup(task->task_pool, act_name);
+					new_act->action_type = METRIC_ACTION_CUSTOM;
+					new_act->threshold = act_score;
+				}
+				else {
+					/* A disabled action that is enabled */
+					msg_info_task("enabled disabled action %s with threshold %.2f "
+								  "due to settings",
+								  act_name,
+								  act_score);
+				}
+
+				/* Insert it to the mres structure */
+				gsize new_actions_cnt = mres->nactions + 1;
+				struct rspamd_action_config *old_actions = mres->actions_config;
+
+				mres->actions_config = rspamd_mempool_alloc(task->task_pool,
+															sizeof(struct rspamd_action_config) * new_actions_cnt);
+				memcpy(mres->actions_config, old_actions,
+					   sizeof(struct rspamd_action_config) * mres->nactions);
+				mres->actions_config[mres->nactions].action = new_act;
+				mres->actions_config[mres->nactions].cur_limit = act_score;
+				/*
+				 * The array comes from rspamd_mempool_alloc(), so the new slot
+				 * is uninitialised: flags must be set explicitly or the action
+				 * is skipped by rspamd_check_action_metric() whenever the
+				 * garbage happens to carry DISABLED/NO_THRESHOLD.
+				 */
+				mres->actions_config[mres->nactions].flags = RSPAMD_ACTION_RESULT_DEFAULT;
+				mres->nactions++;
+			}
+			/* Disabled/missing action is disabled one more time, not an error */
+		}
+		else {
+			/* Found the existing configured action */
+			if (ucl_object_type(cur) == UCL_NULL) {
+				/* Disable action completely */
+				action_config->flags |= RSPAMD_ACTION_RESULT_DISABLED;
+				msg_info_task("disabled action %s due to settings",
+							  action_config->action->name);
+			}
+			else {
+				act_score = ucl_object_todouble(cur);
+				if (isnan(act_score)) {
+					msg_info_task("disabled action %s threshold (was %.2f) due to settings",
+								  action_config->action->name,
+								  action_config->cur_limit);
+					action_config->flags |= RSPAMD_ACTION_RESULT_NO_THRESHOLD;
+				}
+				else {
+					msg_debug_task("adjusted action %s: %.2f -> %.2f",
+								   act_name,
+								   action_config->cur_limit,
+								   act_score);
+					action_config->cur_limit = act_score;
+				}
+			}
+		}
+	}
+}
+
 static int
 lua_task_set_settings(lua_State *L)
 {
@@ -6538,8 +6673,6 @@ lua_task_set_settings(lua_State *L)
 	ucl_object_t *settings;
 	const ucl_object_t *act, *metric_elt, *vars, *cur;
 	ucl_object_iter_t it = NULL;
-	struct rspamd_scan_result *mres;
-	unsigned int i;
 
 	settings = ucl_object_lua_import(L, 2);
 
@@ -6563,110 +6696,7 @@ lua_task_set_settings(lua_State *L)
 		}
 
 		act = ucl_object_lookup(task->settings, "actions");
-
-		if (act && ucl_object_type(act) == UCL_OBJECT) {
-			/* Adjust desired actions */
-			mres = task->result;
-
-			it = NULL;
-
-			while ((cur = ucl_object_iterate(act, &it, true)) != NULL) {
-				const char *act_name = ucl_object_key(cur);
-				struct rspamd_action_config *action_config = NULL;
-				double act_score;
-				enum rspamd_action_type act_type;
-
-				if (!rspamd_action_from_str(act_name, &act_type)) {
-					act_type = -1;
-				}
-
-				for (i = 0; i < mres->nactions; i++) {
-					struct rspamd_action_config *cur_act = &mres->actions_config[i];
-
-					if (cur_act->action->action_type == METRIC_ACTION_CUSTOM &&
-						act_type == -1) {
-						/* Compare by name */
-						if (g_ascii_strcasecmp(act_name, cur_act->action->name) == 0) {
-							action_config = cur_act;
-							break;
-						}
-					}
-					else {
-						if (cur_act->action->action_type == act_type) {
-							action_config = cur_act;
-							break;
-						}
-					}
-				}
-
-				if (!action_config) {
-					act_score = ucl_object_todouble(cur);
-					if (!isnan(act_score)) {
-						struct rspamd_action *new_act;
-
-						new_act = rspamd_config_get_action(task->cfg, act_name);
-
-						if (new_act == NULL) {
-							/* New action! */
-							msg_info_task("added new action %s with threshold %.2f "
-										  "due to settings",
-										  act_name,
-										  act_score);
-							new_act = rspamd_mempool_alloc0(task->task_pool,
-															sizeof(*new_act));
-							new_act->name = rspamd_mempool_strdup(task->task_pool, act_name);
-							new_act->action_type = METRIC_ACTION_CUSTOM;
-							new_act->threshold = act_score;
-						}
-						else {
-							/* A disabled action that is enabled */
-							msg_info_task("enabled disabled action %s with threshold %.2f "
-										  "due to settings",
-										  act_name,
-										  act_score);
-						}
-
-						/* Insert it to the mres structure */
-						gsize new_actions_cnt = mres->nactions + 1;
-						struct rspamd_action_config *old_actions = mres->actions_config;
-
-						mres->actions_config = rspamd_mempool_alloc(task->task_pool,
-																	sizeof(struct rspamd_action_config) * new_actions_cnt);
-						memcpy(mres->actions_config, old_actions,
-							   sizeof(struct rspamd_action_config) * mres->nactions);
-						mres->actions_config[mres->nactions].action = new_act;
-						mres->actions_config[mres->nactions].cur_limit = act_score;
-						mres->nactions++;
-					}
-					/* Disabled/missing action is disabled one more time, not an error */
-				}
-				else {
-					/* Found the existing configured action */
-					if (ucl_object_type(cur) == UCL_NULL) {
-						/* Disable action completely */
-						action_config->flags |= RSPAMD_ACTION_RESULT_DISABLED;
-						msg_info_task("disabled action %s due to settings",
-									  action_config->action->name);
-					}
-					else {
-						act_score = ucl_object_todouble(cur);
-						if (isnan(act_score)) {
-							msg_info_task("disabled action %s threshold (was %.2f) due to settings",
-										  action_config->action->name,
-										  action_config->cur_limit);
-							action_config->flags |= RSPAMD_ACTION_RESULT_NO_THRESHOLD;
-						}
-						else {
-							action_config->cur_limit = act_score;
-							msg_debug_task("adjusted action %s: %.2f -> %.2f",
-										   act_name,
-										   action_config->cur_limit,
-										   act_score);
-						}
-					}
-				}
-			}
-		}
+		lua_task_settings_apply_actions(task, act);
 
 		vars = ucl_object_lookup(task->settings, "variables");
 		if (vars && ucl_object_type(vars) == UCL_OBJECT) {
@@ -6745,50 +6775,9 @@ lua_task_merge_and_apply_settings(lua_State *L)
 		}
 		task->settings = merged;
 
-		/* Apply actions overrides */
-		const ucl_object_t *act = ucl_object_lookup(task->settings, "actions");
-		if (act && ucl_object_type(act) == UCL_OBJECT) {
-			struct rspamd_scan_result *mres = task->result;
-			ucl_object_iter_t it = NULL;
-			const ucl_object_t *cur;
-
-			while ((cur = ucl_object_iterate(act, &it, true)) != NULL) {
-				const char *act_name = ucl_object_key(cur);
-				enum rspamd_action_type act_type;
-
-				if (!rspamd_action_from_str(act_name, &act_type)) {
-					act_type = -1;
-				}
-
-				for (unsigned int i = 0; i < mres->nactions; i++) {
-					struct rspamd_action_config *cur_act = &mres->actions_config[i];
-					gboolean matched = FALSE;
-
-					if (cur_act->action->action_type == METRIC_ACTION_CUSTOM && act_type == -1) {
-						matched = g_ascii_strcasecmp(act_name, cur_act->action->name) == 0;
-					}
-					else {
-						matched = cur_act->action->action_type == act_type;
-					}
-
-					if (matched) {
-						if (ucl_object_type(cur) == UCL_NULL) {
-							cur_act->flags |= RSPAMD_ACTION_RESULT_DISABLED;
-						}
-						else {
-							double act_score = ucl_object_todouble(cur);
-							if (isnan(act_score)) {
-								cur_act->flags |= RSPAMD_ACTION_RESULT_NO_THRESHOLD;
-							}
-							else {
-								cur_act->cur_limit = act_score;
-							}
-						}
-						break;
-					}
-				}
-			}
-		}
+		/* Apply actions overrides, exactly as the single layer path does */
+		lua_task_settings_apply_actions(task,
+										ucl_object_lookup(task->settings, "actions"));
 
 		/* Apply variables */
 		const ucl_object_t *vars = ucl_object_lookup(task->settings, "variables");

--- a/test/functional/cases/109_settings_merge.robot
+++ b/test/functional/cases/109_settings_merge.robot
@@ -103,6 +103,12 @@ MULTI LAYER - NULL ACTION STILL DISABLES GREYLIST
   Scan File  ${MESSAGE}  IP=8.8.8.8
   Expect Action  no action
 
+# A numeric threshold in the higher layer re-enables an action disabled below
+MULTI LAYER - HIGHER THRESHOLD REENABLES GREYLIST
+  Redis SET  merge_user_settings  {"actions":{"greylist":2.0}}
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Expect Action  greylist
+
 # Single-layer baseline for the same disable
 SINGLE LAYER - NULL ACTION DISABLES GREYLIST
   Scan File  ${MESSAGE}  IP=8.8.8.9

--- a/test/functional/cases/109_settings_merge.robot
+++ b/test/functional/cases/109_settings_merge.robot
@@ -1,6 +1,6 @@
 *** Settings ***
-Suite Setup     Rspamd Setup
-Suite Teardown  Rspamd Teardown
+Suite Setup     Rspamd Redis Setup
+Suite Teardown  Rspamd Redis Teardown
 Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
 Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
 Variables       ${RSPAMD_TESTDIR}/lib/vars.py
@@ -9,6 +9,7 @@ Variables       ${RSPAMD_TESTDIR}/lib/vars.py
 ${CONFIG}               ${RSPAMD_TESTDIR}/configs/settings_merge.conf
 ${MESSAGE}              ${RSPAMD_TESTDIR}/messages/spam_message.eml
 ${RSPAMD_LUA_SCRIPT}    ${RSPAMD_TESTDIR}/lua/settings_merge.lua
+${REDIS_SCOPE}          Suite
 ${RSPAMD_SCOPE}         Suite
 ${RSPAMD_URL_TLD}       ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
 
@@ -78,3 +79,45 @@ COEXISTENCE - GROUP SYMBOLS WITH INLINE
   Expect Symbol  MERGE_GROUP_SYM
   Expect Symbol  MERGE_GROUP_SYM2
   Expect Required Score  500
+
+# Two layers: static rule (RULE) + redis handler (PER_USER). Custom apply keys
+# are an extension point read back through task:get_settings(), so the merge
+# must not drop them.
+MULTI LAYER - CUSTOM KEYS SURVIVE MERGE
+  Redis SET  merge_user_settings  {"mode":"outbound","shared":"from_redis"}
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Expect Symbol With Option  MERGE_CUSTOM_KEYS  tenant=acme
+  Expect Symbol With Option  MERGE_CUSTOM_KEYS  mode=outbound
+
+# Same key in both layers: the higher layer (PER_USER) wins
+MULTI LAYER - HIGHER LAYER WINS ON CONFLICT
+  Redis SET  merge_user_settings  {"mode":"outbound","shared":"from_redis"}
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Expect Symbol With Option  MERGE_CUSTOM_KEYS  shared=from_redis
+  Do Not Expect Symbol With Option  MERGE_CUSTOM_KEYS  shared=from_rule
+
+# `actions { greylist = null }` disables the action after a merge, exactly as
+# it does on the single-layer path
+MULTI LAYER - NULL ACTION STILL DISABLES GREYLIST
+  Redis SET  merge_user_settings  {"mode":"outbound","shared":"from_redis"}
+  Scan File  ${MESSAGE}  IP=8.8.8.8
+  Expect Action  no action
+
+# Single-layer baseline for the same disable
+SINGLE LAYER - NULL ACTION DISABLES GREYLIST
+  Scan File  ${MESSAGE}  IP=8.8.8.9
+  Expect Symbol With Option  MERGE_CUSTOM_KEYS  tenant=solo
+  Expect Action  no action
+
+# Without any settings the greylist threshold is in force
+NO SETTINGS - GREYLIST ACTION FIRES
+  Scan File  ${MESSAGE}
+  Expect Action  greylist
+
+# A brand new custom action declared in one layer must be created after the
+# merge, exactly as it is on the single-layer path
+MULTI LAYER - CUSTOM ACTION IS CREATED
+  Redis SET  merge_user_settings  {"mode":"outbound","shared":"from_redis"}
+  Scan File  ${MESSAGE}  IP=8.8.8.10
+  Expect Symbol With Option  MERGE_CUSTOM_KEYS  tenant=custom
+  Expect Action  my_custom_action

--- a/test/functional/configs/settings_merge.conf
+++ b/test/functional/configs/settings_merge.conf
@@ -19,6 +19,40 @@ settings {
     }
   }
 
+  # Two layers: this rule (RULE) + the redis handler above (PER_USER)
+  two_layer_rule {
+    ip = "8.8.8.8";
+    apply {
+      actions {
+        greylist = null;
+      }
+      tenant = "acme";
+      shared = "from_rule";
+    }
+  }
+
+  # Two layers where the rule declares a brand new custom action
+  custom_action_rule {
+    ip = "8.8.8.10";
+    apply {
+      actions {
+        my_custom_action = 3.0;
+      }
+      tenant = "custom";
+    }
+  }
+
+  # Single layer control: same disable, no redis layer for this IP
+  one_layer_rule {
+    ip = "8.8.8.9";
+    apply {
+      actions {
+        greylist = null;
+      }
+      tenant = "solo";
+    }
+  }
+
   # Rule that matches by IP and provides action override
   ip_rule {
     ip = "7.7.7.7";
@@ -28,5 +62,30 @@ settings {
         greylist = 50.0;
       }
     }
+  }
+}
+
+# Two-layer merge fixture: a static rule (RULE layer) plus a per-user layer
+# pushed by the redis settings handler (PER_USER layer). Both carry custom
+# (non-builtin) apply keys, and the rule disables the greylist action.
+actions {
+  greylist = 2.0;
+}
+
+settings_redis {
+  servers = "{= env.REDIS_ADDR =}:{= env.REDIS_PORT =}";
+  handlers = {
+    merge_user = <<EOD
+return function(task)
+  local ip = task:get_from_ip()
+  if ip and ip:is_valid() then
+    local s = ip:to_string()
+    if s == '8.8.8.8' or s == '8.8.8.10' then
+      return 'merge_user_settings'
+    end
+  end
+  return nil
+end
+EOD;
   }
 }

--- a/test/functional/lua/settings_merge.lua
+++ b/test/functional/lua/settings_merge.lua
@@ -64,3 +64,31 @@ rspamd_config:register_symbol({
     return true, 'pre'
   end
 })
+
+-- Reports the custom (non-builtin) keys of the effective settings object so
+-- that the functional tests can assert they survived a multi-layer merge.
+rspamd_config:register_symbol({
+  name = 'MERGE_CUSTOM_KEYS',
+  score = 0.0,
+  type = 'postfilter',
+  flags = 'nostat',
+  callback = function(task)
+    local s = task:get_settings()
+
+    if not s then
+      return
+    end
+
+    local opts = {}
+
+    for _, k in ipairs({ 'tenant', 'mode', 'shared' }) do
+      if s[k] then
+        opts[#opts + 1] = string.format('%s=%s', k, tostring(s[k]))
+      end
+    end
+
+    if #opts > 0 then
+      task:insert_result('MERGE_CUSTOM_KEYS', 1.0, opts)
+    end
+  end
+})

--- a/test/rspamd_cxx_unit_settings_merge.hxx
+++ b/test/rspamd_cxx_unit_settings_merge.hxx
@@ -345,6 +345,176 @@ TEST_SUITE("settings_merge")
 		rspamd_config_free(cfg);
 	}
 
+	TEST_CASE("unknown keys survive multi layer merge")
+	{
+		auto *cfg = rspamd_config_new(RSPAMD_CONFIG_INIT_DEFAULT);
+		auto *pool = cfg->cfg_pool;
+
+		auto *ctx = rspamd_settings_merge_ctx_create(pool, cfg);
+
+		/* Custom (non-builtin) apply keys used by third party Lua consumers */
+		auto *low = ucl_parse_string(R"({"actions":{"reject":15.0},"tenant":"acme","policy":{"quarantine":true}})");
+		auto *high = ucl_parse_string(R"({"mode":"outbound"})");
+
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_RULE, "rule", 0, low);
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_HTTP, "http", 0, high);
+		ucl_object_unref(low);
+		ucl_object_unref(high);
+
+		auto *result = rspamd_settings_merge_finalize(ctx);
+		REQUIRE(result != nullptr);
+
+		SUBCASE("scalar from the lower layer is preserved")
+		{
+			auto *tenant = ucl_object_lookup(result, "tenant");
+			REQUIRE(tenant != nullptr);
+			CHECK(std::string(ucl_object_tostring(tenant)) == "acme");
+		}
+
+		SUBCASE("scalar from the higher layer is preserved")
+		{
+			auto *mode = ucl_object_lookup(result, "mode");
+			REQUIRE(mode != nullptr);
+			CHECK(std::string(ucl_object_tostring(mode)) == "outbound");
+		}
+
+		SUBCASE("object valued unknown key is preserved")
+		{
+			auto *policy = ucl_object_lookup(result, "policy");
+			REQUIRE(policy != nullptr);
+			REQUIRE(ucl_object_type(policy) == UCL_OBJECT);
+			CHECK(ucl_object_toboolean(ucl_object_lookup(policy, "quarantine")));
+		}
+
+		SUBCASE("known keys keep their semantics")
+		{
+			auto *actions = ucl_object_lookup(result, "actions");
+			REQUIRE(actions != nullptr);
+			CHECK(ucl_object_todouble(ucl_object_lookup(actions, "reject")) == doctest::Approx(15.0));
+		}
+
+		ucl_object_unref(result);
+		rspamd_config_free(cfg);
+	}
+
+	TEST_CASE("unknown key conflict higher layer wins")
+	{
+		auto *cfg = rspamd_config_new(RSPAMD_CONFIG_INIT_DEFAULT);
+		auto *pool = cfg->cfg_pool;
+
+		auto *ctx = rspamd_settings_merge_ctx_create(pool, cfg);
+
+		auto *low = ucl_parse_string(R"({"tenant":"low","only_low":1})");
+		auto *high = ucl_parse_string(R"({"tenant":"high"})");
+
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_PROFILE, "profile", 0, low);
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_PER_USER, "user", 0, high);
+		ucl_object_unref(low);
+		ucl_object_unref(high);
+
+		auto *result = rspamd_settings_merge_finalize(ctx);
+		REQUIRE(result != nullptr);
+
+		auto *tenant = ucl_object_lookup(result, "tenant");
+		REQUIRE(tenant != nullptr);
+		CHECK(std::string(ucl_object_tostring(tenant)) == "high");
+
+		auto *only_low = ucl_object_lookup(result, "only_low");
+		REQUIRE(only_low != nullptr);
+		CHECK(ucl_object_toint(only_low) == 1);
+
+		ucl_object_unref(result);
+		rspamd_config_free(cfg);
+	}
+
+	TEST_CASE("layer supplied merge info does not clobber metadata")
+	{
+		auto *cfg = rspamd_config_new(RSPAMD_CONFIG_INIT_DEFAULT);
+		auto *pool = cfg->cfg_pool;
+
+		auto *ctx = rspamd_settings_merge_ctx_create(pool, cfg);
+
+		/* A layer that is itself a previously merged object must not win over ours */
+		auto *low = ucl_parse_string(R"({"_merge_info":"bogus","tenant":"acme"})");
+		auto *high = ucl_parse_string(R"({"mode":"outbound"})");
+
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_RULE, "rule", 0, low);
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_HTTP, "http", 0, high);
+		ucl_object_unref(low);
+		ucl_object_unref(high);
+
+		auto *result = rspamd_settings_merge_finalize(ctx);
+		REQUIRE(result != nullptr);
+
+		auto *meta = ucl_object_lookup(result, "_merge_info");
+		REQUIRE(meta != nullptr);
+		CHECK(ucl_object_type(meta) == UCL_ARRAY);
+
+		ucl_object_unref(result);
+		rspamd_config_free(cfg);
+	}
+
+	TEST_CASE("null valued action survives the merge")
+	{
+		auto *cfg = rspamd_config_new(RSPAMD_CONFIG_INIT_DEFAULT);
+		auto *pool = cfg->cfg_pool;
+
+		auto *ctx = rspamd_settings_merge_ctx_create(pool, cfg);
+
+		/* `actions { greylist = null }` is the documented way to disable an action */
+		auto *low = ucl_parse_string(R"({"actions":{"greylist":null,"reject":15.0}})");
+		auto *high = ucl_parse_string(R"({"actions":{"reject":20.0}})");
+
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_RULE, "rule", 0, low);
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_HTTP, "http", 0, high);
+		ucl_object_unref(low);
+		ucl_object_unref(high);
+
+		auto *result = rspamd_settings_merge_finalize(ctx);
+		REQUIRE(result != nullptr);
+
+		auto *actions = ucl_object_lookup(result, "actions");
+		REQUIRE(actions != nullptr);
+
+		auto *greylist = ucl_object_lookup(actions, "greylist");
+		REQUIRE(greylist != nullptr);
+		CHECK(ucl_object_type(greylist) == UCL_NULL);
+
+		CHECK(ucl_object_todouble(ucl_object_lookup(actions, "reject")) == doctest::Approx(20.0));
+
+		ucl_object_unref(result);
+		rspamd_config_free(cfg);
+	}
+
+	TEST_CASE("null valued action from the higher layer survives the merge")
+	{
+		auto *cfg = rspamd_config_new(RSPAMD_CONFIG_INIT_DEFAULT);
+		auto *pool = cfg->cfg_pool;
+
+		auto *ctx = rspamd_settings_merge_ctx_create(pool, cfg);
+
+		auto *low = ucl_parse_string(R"({"actions":{"greylist":4.0}})");
+		auto *high = ucl_parse_string(R"({"actions":{"greylist":null}})");
+
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_RULE, "rule", 0, low);
+		rspamd_settings_merge_add_layer(ctx, RSPAMD_SETTINGS_LAYER_HTTP, "http", 0, high);
+		ucl_object_unref(low);
+		ucl_object_unref(high);
+
+		auto *result = rspamd_settings_merge_finalize(ctx);
+		REQUIRE(result != nullptr);
+
+		auto *actions = ucl_object_lookup(result, "actions");
+		REQUIRE(actions != nullptr);
+
+		auto *greylist = ucl_object_lookup(actions, "greylist");
+		REQUIRE(greylist != nullptr);
+		CHECK(ucl_object_type(greylist) == UCL_NULL);
+
+		ucl_object_unref(result);
+		rspamd_config_free(cfg);
+	}
+
 	TEST_CASE("subject highest layer wins")
 	{
 		auto *cfg = rspamd_config_new(RSPAMD_CONFIG_INIT_DEFAULT);


### PR DESCRIPTION
# settings: keep custom keys when merging settings layers

## Problem

`SETTINGS_APPLY` (src/plugins/lua/settings.lua) merges the settings layers
collected during a scan through `task:merge_and_apply_settings()`
(`src/lua/lua_task.c` → `src/libserver/settings_merge.cxx`).

`rspamd_settings_merge_finalize()` builds a **brand-new** result object from a
fixed list of known keys:

```
actions, scores, variables, add_headers,
symbols_enabled/disabled, groups_enabled/disabled,
subject, whitelist, flags, remove_headers, messages, symbols, _merge_info
```

Anything else in a layer's `apply` object was silently dropped.

That matters because custom `apply` keys are a documented extension point:
consumers read them back with `task:get_settings()` — e.g. a lualib that keys
off `apply.tenant`, or an outbound helper that reads `apply.mode`. The bug is
invisible until a second layer shows up:

* **one layer** — `rspamd_settings_merge_finalize()` short-circuits and refs
  the layer object as-is, so every key survives;
* **two or more layers** — the result is rebuilt from the known-key list and
  the custom keys are gone.

Two layers are the normal case whenever a static settings block (RULE level)
coexists with a layer pushed by another prefilter — the redis settings handler
(PER_USER), an external settings map, or any operator plugin that appends to
the `settings_layers` task cache. So the same rule behaved differently
depending on how many settings sources happened to match, with nothing in the
logs to explain it.

## Fix

`src/libserver/settings_merge.cxx`

* `settings_known_keys` — the 15 keys the explicit mergers own, `_merge_info`
  included so a layer cannot clobber the merge metadata.
* `merge_unknown_keys()` — walks the layers in ascending priority order and
  copies over every other top-level key with `ucl_object_replace_key()`. Same
  precedence rule as `merge_override_object()`: **per-key, the higher layer
  wins**. The value is taken whole, since an unknown key is opaque and its
  insides cannot be merged meaningfully.
* Called from `rspamd_settings_merge_finalize()` after the known-key mergers
  and before `_merge_info` is built. No existing key's semantics change.

`src/lua/lua_task.c`

`lua_task_merge_and_apply_settings()` carried its own, shorter copy of the
`actions` application loop from `lua_task_set_settings()`. It only touched
actions already present in the scan result, so an action declared solely in a
settings block was created on the single-layer path and silently ignored after
a merge. Both call sites now share one helper,
`lua_task_settings_apply_actions()`, so the two paths cannot drift apart.

Extracting it exposed two further bugs, fixed in the shared helper:

* a newly added `actions_config` slot came from `rspamd_mempool_alloc()` and
  never had `flags` initialised, so the new action was skipped by
  `rspamd_check_action_metric()` whenever the uninitialised memory happened to
  carry `DISABLED`/`NO_THRESHOLD`. It is now explicitly
  `RSPAMD_ACTION_RESULT_DEFAULT`.
* `actions { foo = null }` for an action the task does not have *created* it
  with a zero threshold — `ucl_object_todouble()` of a `null` yields `0.0`, not
  NaN — i.e. a request to disable an action could make it fire on everything.
  A null for a missing action is now the no-op the surrounding comment always
  claimed it was.

### About the null-action symptom

`actions { greylist = null }` losing its effect after a merge **did not
reproduce**. Both halves were verified:

* the merge preserves `UCL_NULL` members — `ucl_object_copy()` and
  `ucl_object_replace_key()` in `merge_override_object()` keep the type, and
  `ucl_object_iterate()` over an object does not skip null values (two new
  doctest cases cover null in the lower and in the higher layer);
* the post-merge apply honours them the same way `lua_task_set_settings()`
  does, and now literally through the same code.

A functional case (`MULTI LAYER - NULL ACTION STILL DISABLES GREYLIST`)
asserts it end-to-end against two real layers, with a single-layer baseline
and a no-settings control that shows the greylist action does fire otherwise.
The two real merge defects found are the dropped custom keys and the
divergent action-application loop described above.

## Verification

Configured and built on macOS/arm64:

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
  -DENABLE_LUAJIT=ON -DENABLE_PCRE2=ON \
  -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl \
  -DICU_ROOT_DIR=/opt/homebrew/opt/icu4c/ \
  -DLIBARCHIVE_ROOT_DIR=/opt/homebrew/opt/libarchive/ \
  -DENABLE_HYPERSCAN=ON -DENABLE_FASTTEXT=ON -DLINKER_NAME=ld
cmake --build build -j 10
```

**Unit tests** — `build/test/rspamd-test-cxx`

* `-ts=settings_merge`: 16 cases / 76 assertions, all pass. Before the fix the
  two new custom-key cases failed (`REQUIRE(tenant != nullptr)`), the null-action
  cases already passed.
* full suite: 405 cases / 78535 assertions, all pass.

**Functional tests** — robot 7.3.2 against a staged install

* `109 Settings Merge`: 15/15 pass (9 pre-existing + 6 new). Against an
  unpatched `librspamd-server` the same suite fails exactly
  `MULTI LAYER - CUSTOM KEYS SURVIVE MERGE` and
  `MULTI LAYER - HIGHER LAYER WINS ON CONFLICT`, and the debug log shows the
  merge running with 2 layers and no custom keys in the result.
* regression sweep: `108 Settings` (38), `360 Force Actions`, `450 Grow Factor`,
  `101 Lua` — 64/64 pass.

## New test coverage

`test/rspamd_cxx_unit_settings_merge.hxx`

* `unknown keys survive multi layer merge` — scalar from the lower layer,
  scalar from the higher layer, object-valued unknown key, known keys unchanged.
* `unknown key conflict higher layer wins`.
* `layer supplied merge info does not clobber metadata`.
* `null valued action survives the merge` / `... from the higher layer ...`.

`test/functional/` — `109_settings_merge` now builds two genuine layers: a
static IP rule (RULE) plus a redis settings handler keyed on the same IP
(PER_USER), so the suite runs under `Rspamd Redis Setup`.

* `MULTI LAYER - CUSTOM KEYS SURVIVE MERGE`
* `MULTI LAYER - HIGHER LAYER WINS ON CONFLICT`
* `MULTI LAYER - NULL ACTION STILL DISABLES GREYLIST`
* `SINGLE LAYER - NULL ACTION DISABLES GREYLIST`
* `NO SETTINGS - GREYLIST ACTION FIRES`
* `MULTI LAYER - CUSTOM ACTION IS CREATED`

A `MERGE_CUSTOM_KEYS` postfilter in `lua/settings_merge.lua` reports the
custom keys of the effective settings object as symbol options, which is how
the robot cases assert on them.
