### PR TITLE
[Feature] Experimental MTA Hooks proxy frontend

### DIFF
--- a/src/libserver/CMakeLists.txt
+++ b/src/libserver/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(LIBRSPAMDSERVERSRC
         ${CMAKE_CURRENT_SOURCE_DIR}/fuzzy_storage_stat.c
         ${CMAKE_CURRENT_SOURCE_DIR}/fuzzy_wire.c
         ${CMAKE_CURRENT_SOURCE_DIR}/milter.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/mta_hooks.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/monitored.c
         ${CMAKE_CURRENT_SOURCE_DIR}/multipart_form.cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/multipart_response.cxx

--- a/src/libserver/MTA_HOOKS.md
+++ b/src/libserver/MTA_HOOKS.md
@@ -1,0 +1,70 @@
+# Experimental MTA Hooks frontend
+
+The proxy worker supports an opt-in inbound DATA / JSON profile of
+draft-degennaro-mta-hooks-01. Use a dedicated HTTP proxy listener and Redis.
+Native milter listeners and mirrors cannot share this worker. Nothing is enabled
+in the stock configuration.
+
+The frontend translates `no action`, greylist pass-through, reject, soft reject,
+discard, quarantine, `add header`, and `rewrite subject`. It supports named
+header removals (all occurrences or selected one-based occurrences), additive
+headers with insertion order, and single or multiple DKIM signing results.
+The proxy worker's `spam_header` setting is also used by the Hooks frontend.
+Replacement Subject values affect the first surviving Subject, as in native milter.
+
+Header-only changes use structured Hooks operations. Header indexes refer to the
+MTA-visible original field sequence; additions and descending deletions are
+ordered according to Hooks' set/add/delete processing order. Values may contain
+folding whitespace, but a newline introducing another field is rejected.
+
+When a scanner rewrites the body, the frontend returns a base64 `/rawMessage`
+replacement containing the original field bytes, requested header edits and the
+new body. Empty bodies are supported. This follows native milter semantics:
+header changes must be expressed in the milter result; rewriting the scan buffer
+does not by itself replace the envelope or original headers. The complete response
+is validated before any edits are returned. Invalid or unsupported results return
+HTTP 503, allowing the bridge's default temporary SMTP failure policy to apply.
+
+Use a bridge version supporting raw-message replacements and folded output
+headers. Early SMTP stages, outbound events, CBOR, envelope edits and per-result
+milter action overrides remain outside this frontend's profile.
+
+## Bounds and state
+
+Messages are limited by `max_message`, capped at 25 MiB. Header-only replies are
+limited to 1 MiB; body-replacement replies allow bounded base64 expansion of the
+message limit. At most 256 added headers are emitted. Redis is required for shared
+registration/revocation and five-minute retry deduplication; completed results
+are cached, including replacements. Plan Redis memory for these response sizes.
+The current ledger admits 1,024 new request IDs per credential and policy namespace
+in five minutes; this is a capacity limit, not just an in-flight concurrency bound.
+
+The expanded profile uses a separate Redis namespace from the preliminary
+add-only profile. Workers should share the same profile, settings ID and spam
+header. Registrations from the old profile must be recreated; the bridge handles
+not-found registration recovery. No old state is deleted during startup.
+
+## Tests
+
+`test/functional/util/mta_hooks_test.py` runs isolated Redis and multi-worker
+self-scan/upstream tests. Pass `--milter /path/to/mta-hooks-milter` to test the real
+bridge, including folded DKIM signatures, duplicate removals, Subject/spam-header
+actions, empty and large body replacements, failures and recovery.
+
+`--postfix` additionally submits synthetic SMTP transactions and inspects queued
+messages, including independent verification of both DKIM signatures and a
+tampered-body negative control. This option is restricted to Docker and requires
+Postfix and Python dkimpy. All delivery transports are deferred.
+
+To build the disposable Linux test image, assemble a build context containing
+`rspamd/` and `milter/` source directories (without their `.git` or build output),
+then run:
+
+```sh
+docker build -f rspamd/test/functional/util/mta_hooks.Dockerfile -t rspamd-hooks-parity .
+docker run --rm --network none rspamd-hooks-parity
+```
+
+The image compiles both actual implementations. Its runtime has no published
+ports, host mounts or external network access. Test messages and queues exist
+only inside the disposable container.

--- a/src/libserver/mta_hooks.cxx
+++ b/src/libserver/mta_hooks.cxx
@@ -1,0 +1,1249 @@
+/* Copyright 2026 Vsevolod Stakhov. SPDX-License-Identifier: Apache-2.0 */
+#include "mta_hooks.h"
+#include "cfg_file.h"
+#include "http/http_private.h"
+#include "libcryptobox/cryptobox.h"
+#include "libutil/str_util.h"
+#include "libutil/rspamd_simdutf.h"
+#include "libutil/addr.h"
+#include "libmime/email_addr.h"
+#include "contrib/hiredis/async.h"
+#include "contrib/expected/expected.hpp"
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <chrono>
+#include <ctime>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+using object = std::unique_ptr<ucl_object_t, decltype(&ucl_object_unref)>;
+using message = std::unique_ptr<rspamd_http_message, decltype(&rspamd_http_message_unref)>;
+using fstring = std::unique_ptr<rspamd_fstring_t, decltype(&rspamd_fstring_free)>;
+using sv = std::string_view;
+/* Errors are static literals; they remain valid across C and async boundaries. */
+template<typename T>
+using result = tl::expected<T, const char *>;
+constexpr std::array properties = {"/stage", "/action", "/timestamp", "/protocol",
+								   "/rawMessage", "/envelope", "/queue", "/client"};
+constexpr unsigned registration_ttl = 3600, replay_ttl = 300;
+
+object obj(ucl_type_t type = UCL_OBJECT)
+{
+	return {ucl_object_typed_new(type), ucl_object_unref};
+}
+
+const ucl_object_t *get(const ucl_object_t *o, const char *key)
+{
+	return ucl_object_lookup(o, key);
+}
+
+/* Views borrow the UCL tree, which must outlive the synchronous codec call. */
+result<sv> str(const ucl_object_t *o)
+{
+	if (!o || ucl_object_type(o) != UCL_STRING) {
+		return tl::make_unexpected("expected string");
+	}
+	size_t len;
+	const char *s = ucl_object_tolstring(o, &len);
+	return sv{s, len};
+}
+
+bool string_is(const ucl_object_t *o, sv value)
+{
+	auto s = str(o);
+	return s && *s == value;
+}
+
+sv key_view(const ucl_object_t *o)
+{
+	size_t len;
+	const char *key = ucl_object_keyl(o, &len);
+	return {key, len};
+}
+
+void put(ucl_object_t *o, const char *key, ucl_object_t *value)
+{
+	ucl_object_insert_key(o, value, key, 0, true);
+}
+
+void put(ucl_object_t *o, const char *key, sv value)
+{
+	put(o, key, ucl_object_fromlstring(value.data(), value.size()));
+}
+
+fstring emit(const ucl_object_t *o)
+{
+	auto *buffer = rspamd_fstring_sized_new(256);
+	rspamd_ucl_emit_fstring(o, UCL_EMIT_JSON_COMPACT, &buffer);
+	return {buffer, rspamd_fstring_free};
+}
+
+sv view(const fstring &s)
+{
+	return {s->str, s->len};
+}
+
+bool clean(sv s, size_t limit = 4096)
+{
+	return s.size() <= limit && std::none_of(s.begin(), s.end(), [](unsigned char c) {
+			   return c < 32 || c == 127;
+		   });
+}
+
+bool valid_utf8(sv s)
+{
+	return rspamd_fast_utf8_validate(reinterpret_cast<const unsigned char *>(s.data()), s.size()) == 0;
+}
+
+bool ascii_alnum(unsigned char c)
+{
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+}
+
+bool identifier(sv s, size_t limit, bool registration = false)
+{
+	return !s.empty() && s.size() <= limit && std::all_of(s.begin(), s.end(), [=](unsigned char c) {
+		return ascii_alnum(c) || c == '-' || c == '_' ||
+			   (registration ? c == ':' : c == '.' || c == '~');
+	});
+}
+
+result<object> parse_borrowed(sv s)
+{
+	if (s.empty() || !valid_utf8(s)) {
+		return tl::make_unexpected("missing body or invalid UTF-8");
+	}
+	/* Same safe flags and explicit limits as ucl.untrusted_parser(). No
+	 * secondary grammar: accepting the UCL syntax superset is intentional.
+	 * The caller keeps the HTTP body or Redis reply alive until this tree is
+	 * destroyed. UCL only copies values that need decoding, such as escapes. */
+	auto parser = std::unique_ptr<ucl_parser, decltype(&ucl_parser_free)>(
+		ucl_parser_new(UCL_PARSER_SAFE_FLAGS | UCL_PARSER_ZEROCOPY), ucl_parser_free);
+	ucl_parser_limits limits{16, 20000, s.size() * 3 + 2 * 1024 * 1024, 256, s.size()};
+	ucl_parser_set_limits(parser.get(), &limits);
+	if (!ucl_parser_add_chunk_full(parser.get(), reinterpret_cast<const unsigned char *>(s.data()),
+								   s.size(), 0, UCL_DUPLICATE_ERROR, UCL_PARSE_UCL)) {
+		return tl::make_unexpected("invalid or over-budget request body");
+	}
+	object root{ucl_parser_get_object(parser.get()), ucl_object_unref};
+	if (!root || ucl_object_type(root.get()) != UCL_OBJECT) {
+		return tl::make_unexpected("expected object");
+	}
+	return root;
+}
+
+std::string digest(sv s)
+{
+	unsigned char hash[crypto_hash_sha256_BYTES];
+	crypto_hash_sha256(hash, reinterpret_cast<const unsigned char *>(s.data()), s.size());
+	std::string encoded(sizeof(hash) * 2, '\0');
+	rspamd_encode_hex_buf(hash, sizeof(hash), encoded.data(), encoded.size());
+	return encoded;
+}
+
+std::string utc(time_t when)
+{
+	tm date{};
+	gmtime_r(&when, &date);
+	char buffer[32];
+	auto len = std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &date);
+	return {buffer, len};
+}
+
+bool valid_timestamp(sv s)
+{
+	/* RFC3339 UTC, with optional fractional seconds. Parse directly from the
+	 * borrowed value; no NUL-terminated copy or heap-allocated date object. */
+	if (s.size() < 20 || s.size() > 64 || s[4] != '-' || s[7] != '-' ||
+		s[10] != 'T' || s[13] != ':' || s[16] != ':' || s.back() != 'Z') {
+		return false;
+	}
+	auto number = [&](size_t offset, size_t len) {
+		int value = -1;
+		auto part = s.substr(offset, len);
+		if (!std::all_of(part.begin(), part.end(), [](char c) { return c >= '0' && c <= '9'; })) {
+			return -1;
+		}
+		std::from_chars(part.data(), part.data() + part.size(), value);
+		return value;
+	};
+	using namespace std::chrono;
+	int year_value = number(0, 4);
+	auto date = year_month_day{year{year_value}, month{unsigned(number(5, 2))}, day{unsigned(number(8, 2))}};
+	int hour = number(11, 2), minute = number(14, 2), second = number(17, 2);
+	if (year_value < 1 || !date.ok() || hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 60) {
+		return false;
+	}
+	if (s.size() == 20) {
+		return true;
+	}
+	return s.size() > 21 && s[19] == '.' &&
+		   std::all_of(s.begin() + 20, s.end() - 1, [](char c) { return c >= '0' && c <= '9'; });
+}
+
+message reply(int status, sv body)
+{
+	message m{rspamd_http_new_message(HTTP_RESPONSE), rspamd_http_message_unref};
+	m->code = status;
+	rspamd_http_message_set_body(m.get(), body.data(), body.size());
+	rspamd_http_message_add_header(m.get(), "Cache-Control", "no-store");
+	return m;
+}
+
+message json_reply(int status, const ucl_object_t *o)
+{
+	auto m = reply(status, {});
+	auto body = emit(o);
+	rspamd_http_message_set_body_from_fstring_steal(m.get(), body.release());
+	return m;
+}
+
+/* The header value borrows the input HTTP message, never an async request. */
+result<sv> header(rspamd_http_message *m, const char *name)
+{
+	rspamd_ftok_t key{.len = strlen(name), .begin = name};
+	auto k = kh_get(rspamd_http_headers_hash, m->headers, &key);
+	if (k == kh_end(m->headers)) {
+		return sv{};
+	}
+	auto *h = kh_val(m->headers, k);
+	if (h->next != nullptr) {
+		return tl::make_unexpected("duplicate HTTP protocol header");
+	}
+	return sv{h->value.begin, h->value.len};
+}
+
+result<void> add_header(rspamd_http_message *m, const char *name, sv value)
+{
+	if (!clean(value)) {
+		return tl::make_unexpected("invalid SMTP metadata");
+	}
+	rspamd_http_message_add_header_len(m, name, value.data(), value.size());
+	return {};
+}
+
+result<void> add_optional_header(rspamd_http_message *m, const ucl_object_t *o,
+								 const char *field, const char *name)
+{
+	auto *v = get(o, field);
+	if (!v || ucl_object_type(v) == UCL_NULL) {
+		return {};
+	}
+	return str(v).and_then([&](sv s) { return add_header(m, name, s); });
+}
+
+object subscription()
+{
+	auto o = obj(), stages = obj(UCL_ARRAY), props = obj(UCL_ARRAY);
+	ucl_array_append(stages.get(), ucl_object_fromstring("data"));
+	for (auto p: properties) {
+		ucl_array_append(props.get(), ucl_object_fromstring(p));
+	}
+	put(o.get(), "stages", stages.release());
+	put(o.get(), "properties", props.release());
+	return o;
+}
+
+result<void> validate_subscription(const ucl_object_t *o)
+{
+	if (!o || ucl_object_type(o) != UCL_OBJECT) {
+		return tl::make_unexpected("inbound subscription required");
+	}
+	auto *stages = get(o, "stages");
+	if (!stages || ucl_object_type(stages) != UCL_ARRAY || stages->len != 1 ||
+		!string_is(ucl_array_find_index(stages, 0), "data")) {
+		return tl::make_unexpected("only inbound data is supported");
+	}
+	auto *props = get(o, "properties");
+	if (!props || ucl_object_type(props) == UCL_NULL) {
+		return {};
+	}
+	if (ucl_object_type(props) != UCL_ARRAY || props->len != properties.size()) {
+		return tl::make_unexpected("DATA profile requires all eight properties");
+	}
+	std::array<bool, properties.size()> seen{};
+	ucl_object_iter_t it = nullptr;
+	while (auto *v = ucl_object_iterate(props, &it, true)) {
+		auto p = str(v);
+		if (!p) {
+			return tl::make_unexpected(p.error());
+		}
+		auto found = std::find(properties.begin(), properties.end(), *p);
+		if (found == properties.end() || seen[found - properties.begin()]) {
+			return tl::make_unexpected("unsupported or duplicate property");
+		}
+		seen[found - properties.begin()] = true;
+	}
+	return {};
+}
+
+result<void> validate_event(const ucl_object_t *o)
+{
+	if (!string_is(get(o, "stage"), "data")) {
+		return tl::make_unexpected("unsupported stage");
+	}
+	auto action = str(get(o, "action"));
+	if (!action || (*action != "accept" && *action != "reject" && *action != "discard" &&
+					*action != "quarantine" && *action != "disconnect")) {
+		return tl::make_unexpected("invalid action");
+	}
+	auto timestamp = str(get(o, "timestamp"));
+	if (!timestamp || !valid_timestamp(*timestamp)) {
+		return tl::make_unexpected("invalid UTC timestamp");
+	}
+	auto *protocol = get(o, "protocol");
+	if (!protocol || ucl_object_type(protocol) != UCL_OBJECT ||
+		!string_is(get(protocol, "version"), "1.0")) {
+		return tl::make_unexpected("unsupported protocol version");
+	}
+	return {};
+}
+
+result<fstring> decode_body(const ucl_object_t *o, size_t max_message)
+{
+	auto raw = str(get(o, "rawMessage"));
+	if (!raw) {
+		return tl::make_unexpected(raw.error());
+	}
+	if (raw->empty() || raw->size() % 4 != 0 || raw->size() > ((max_message + 2) / 3) * 4) {
+		return tl::make_unexpected("invalid base64 size");
+	}
+	fstring body{rspamd_fstring_sized_new(raw->size() / 4 * 3), rspamd_fstring_free};
+	gsize len = body->allocated;
+	if (!rspamd_cryptobox_base64_decode(raw->data(), raw->size(),
+										reinterpret_cast<unsigned char *>(body->str), &len) ||
+		len == 0 || len > max_message) {
+		return tl::make_unexpected("invalid base64 message");
+	}
+	/* The fast decoder is permissive about whitespace and padding bits.
+	 * Re-encoding enforces the canonical wire profile, without copying raw. */
+	gsize encoded_len;
+	std::unique_ptr<char, decltype(&g_free)> encoded{
+		rspamd_encode_base64(reinterpret_cast<unsigned char *>(body->str), len, 0, &encoded_len), g_free};
+	if (!encoded || *raw != sv{encoded.get(), encoded_len}) {
+		return tl::make_unexpected("noncanonical base64 message");
+	}
+	body->len = len;
+	return body;
+}
+
+result<sv> envelope_address(const ucl_object_t *o, bool sender)
+{
+	if (!o || ucl_object_type(o) != UCL_OBJECT) {
+		return tl::make_unexpected("invalid envelope address");
+	}
+	auto *v = get(o, "address");
+	if (v && ucl_object_type(v) == UCL_NULL) {
+		if (sender) {
+			return sv{"<>"};
+		}
+		return tl::make_unexpected("null recipient");
+	}
+	auto text = str(v);
+	if (!text || text->empty() || !clean(*text, 1024)) {
+		return tl::make_unexpected("invalid address");
+	}
+	auto parsed = std::unique_ptr<rspamd_email_address, decltype(&rspamd_email_address_free)>{
+		rspamd_email_address_from_smtp(text->data(), text->size()), rspamd_email_address_free};
+	if (!parsed || (parsed->flags & RSPAMD_EMAIL_ADDR_EMPTY)) {
+		return tl::make_unexpected("invalid SMTP address; null reverse path must use JSON null");
+	}
+	return *text;
+}
+
+result<void> add_esmtp_parameters(rspamd_http_message *m, const ucl_object_t *o, int index)
+{
+	auto *params = get(o, "parameters");
+	if (!params || ucl_object_type(params) != UCL_OBJECT || params->len > 32) {
+		return tl::make_unexpected("invalid ESMTP parameters");
+	}
+	ucl_object_iter_t it = nullptr;
+	while (auto *p = ucl_object_iterate(params, &it, true)) {
+		auto key = key_view(p);
+		if (key.empty() || key.size() > 64 ||
+			!std::all_of(key.begin(), key.end(), [](unsigned char c) { return ascii_alnum(c) || c == '-'; })) {
+			return tl::make_unexpected("invalid ESMTP key");
+		}
+		auto value = str(p);
+		if (!value || !clean(*value)) {
+			return tl::make_unexpected("invalid ESMTP value");
+		}
+		/* Combining the recipient index, key and value requires owned storage. */
+		std::string field = index < 0 ? "" : std::to_string(index) + ":";
+		field.append(key).append("=").append(*value);
+		auto added = add_header(m, index < 0 ? "X-Rspamd-Mail-Esmtp-Args" : "X-Rspamd-Rcpt-Esmtp-Args", field);
+		if (!added) {
+			return added;
+		}
+	}
+	return {};
+}
+
+result<void> add_envelope_address(rspamd_http_message *m, const ucl_object_t *o, int index)
+{
+	return envelope_address(o, index < 0)
+		.and_then([&](sv address) { return add_header(m, index < 0 ? "From" : "Rcpt", address); })
+		.and_then([&] { return add_esmtp_parameters(m, o, index); });
+}
+
+result<void> decode_envelope(rspamd_http_message *m, const ucl_object_t *o)
+{
+	auto *envelope = get(o, "envelope");
+	if (!envelope || ucl_object_type(envelope) != UCL_OBJECT) {
+		return tl::make_unexpected("missing envelope");
+	}
+	auto sender = add_envelope_address(m, get(envelope, "from"), -1);
+	if (!sender) {
+		return sender;
+	}
+	auto *to = get(envelope, "to");
+	if (!to || ucl_object_type(to) != UCL_ARRAY || to->len == 0 || to->len > 1000) {
+		return tl::make_unexpected("invalid recipients");
+	}
+	ucl_object_iter_t it = nullptr;
+	int index = 0;
+	while (auto *recipient = ucl_object_iterate(to, &it, true)) {
+		auto added = add_envelope_address(m, recipient, index++);
+		if (!added) {
+			return added;
+		}
+	}
+	return {};
+}
+
+result<void> decode_client(rspamd_http_message *m, const ucl_object_t *o)
+{
+	auto *client = get(o, "client");
+	if (!client || ucl_object_type(client) == UCL_NULL) {
+		return {};
+	}
+	if (ucl_object_type(client) != UCL_OBJECT) {
+		return tl::make_unexpected("invalid client");
+	}
+	if (auto *ip = get(client, "ip"); ip && ucl_object_type(ip) != UCL_NULL) {
+		auto text = str(ip);
+		if (!text) {
+			return tl::make_unexpected(text.error());
+		}
+		rspamd_inet_addr_t *addr = nullptr;
+		if (!rspamd_parse_inet_address(&addr, text->data(), text->size(),
+									   static_cast<rspamd_inet_address_parse_flags>(
+										   RSPAMD_INET_ADDRESS_PARSE_NO_UNIX | RSPAMD_INET_ADDRESS_PARSE_NO_PORT))) {
+			return tl::make_unexpected("invalid client IP");
+		}
+		rspamd_inet_address_free(addr);
+		auto added = add_header(m, "IP", *text);
+		if (!added) {
+			return added;
+		}
+	}
+	return add_optional_header(m, client, "ehlo", "Helo")
+		.and_then([&] { return add_optional_header(m, client, "ptr", "Hostname"); });
+}
+
+result<void> decode_queue(rspamd_http_message *m, const ucl_object_t *o)
+{
+	auto *queue = get(o, "queue");
+	if (!queue || ucl_object_type(queue) == UCL_NULL) {
+		return {};
+	}
+	if (ucl_object_type(queue) != UCL_OBJECT) {
+		return tl::make_unexpected("invalid queue");
+	}
+	if (auto *id = get(queue, "id")) {
+		return str(id).and_then([&](sv s) { return add_header(m, "Queue-ID", s); });
+	}
+	return {};
+}
+
+result<message> decode_request(sv data, size_t max_message)
+{
+	if (data.size() > max_message * 4 / 3 + 128 * 1024) {
+		return tl::make_unexpected("request too large");
+	}
+	auto root = parse_borrowed(data);
+	if (!root) {
+		return tl::make_unexpected(root.error());
+	}
+	const auto *event = root->get();
+	auto valid = validate_event(event);
+	if (!valid) {
+		return tl::make_unexpected(valid.error());
+	}
+	auto body = decode_body(event, max_message);
+	if (!body) {
+		return tl::make_unexpected(body.error());
+	}
+
+	message m{rspamd_http_new_message(HTTP_REQUEST), rspamd_http_message_unref};
+	m->method = HTTP_POST;
+	m->url = rspamd_fstring_append(m->url, "/checkv2", 8);
+	rspamd_http_message_set_body_from_fstring_steal(m.get(), body->release());
+	rspamd_http_message_add_header(m.get(), "Content-Type", "message/rfc822");
+	rspamd_http_message_add_header(m.get(), "Flags", "body_block");
+	rspamd_http_message_add_header(m.get(), "Milter", "yes");
+
+	auto metadata = decode_envelope(m.get(), event)
+						.and_then([&] { return decode_client(m.get(), event); })
+						.and_then([&] { return decode_queue(m.get(), event); });
+	if (!metadata) {
+		return tl::make_unexpected(metadata.error());
+	}
+	return m;
+}
+
+void set_operation(ucl_object_t *sets, const char *path, ucl_object_t *value)
+{
+	auto op = obj();
+	put(op.get(), "path", path);
+	put(op.get(), "value", value);
+	ucl_array_append(sets, op.release());
+}
+
+result<void> add_output_header(ucl_object_t *adds, sv name, const ucl_object_t *value)
+{
+	int order = -1;
+	if (ucl_object_type(value) == UCL_OBJECT) {
+		if (auto *o = ucl_object_lookup_any(value, "order", "index", nullptr)) {
+			if (ucl_object_type(o) != UCL_INT || ucl_object_toint(o) < -1 || ucl_object_toint(o) > 100000) {
+				return tl::make_unexpected("invalid header order");
+			}
+			order = ucl_object_toint(o);
+		}
+		if (get(value, "order") && get(value, "index") &&
+			(ucl_object_type(get(value, "index")) != UCL_INT || ucl_object_toint(get(value, "index")) != order)) {
+			return tl::make_unexpected("conflicting header order");
+		}
+		value = get(value, "value");
+	}
+	auto text = str(value);
+	if (!text || !clean(*text, 64 * 1024) || !valid_utf8(*text)) {
+		return tl::make_unexpected("invalid output header value");
+	}
+	if (name.empty() || name.size() > 998 ||
+		!std::all_of(name.begin(), name.end(), [](unsigned char c) { return c > 32 && c < 127 && c != ':'; })) {
+		return tl::make_unexpected("invalid output header name");
+	}
+	if (adds->len >= 256) {
+		return tl::make_unexpected("too many output headers");
+	}
+	auto op = obj(), h = obj();
+	put(h.get(), "name", name);
+	put(h.get(), "value", *text);
+	put(op.get(), "path", "/message/headers");
+	put(op.get(), "value", h.release());
+	if (order >= 0) {
+		put(op.get(), "index", ucl_object_fromint(order));
+	}
+	ucl_array_append(adds, op.release());
+	return {};
+}
+
+result<void> encode_headers(ucl_object_t *adds, const ucl_object_t *milter)
+{
+	if (!milter) {
+		return {};
+	}
+	if (ucl_object_type(milter) != UCL_OBJECT) {
+		return tl::make_unexpected("invalid milter result");
+	}
+	ucl_object_iter_t it = nullptr;
+	while (auto *v = ucl_object_iterate(milter, &it, true)) {
+		auto key = key_view(v);
+		if (key == "remove_headers" && ucl_object_type(v) == UCL_OBJECT && v->len == 0) {
+			continue;
+		}
+		if (key != "add_headers" || ucl_object_type(v) != UCL_OBJECT) {
+			return tl::make_unexpected("unsupported milter modification");
+		}
+		ucl_object_iter_t headers = nullptr;
+		while (auto *h = ucl_object_iterate(v, &headers, true)) {
+			auto name = key_view(h);
+			if (ucl_object_type(h) == UCL_ARRAY) {
+				ucl_object_iter_t values = nullptr;
+				while (auto *value = ucl_object_iterate(h, &values, true)) {
+					auto added = add_output_header(adds, name, value);
+					if (!added) {
+						return added;
+					}
+				}
+			}
+			else {
+				auto added = add_output_header(adds, name, h);
+				if (!added) {
+					return added;
+				}
+			}
+		}
+	}
+	return {};
+}
+
+result<void> encode_action(ucl_object_t *sets, const ucl_object_t *results)
+{
+	auto action = str(get(results, "action"));
+	if (!action) {
+		return tl::make_unexpected(action.error());
+	}
+	if (*action == "reject" || *action == "soft reject") {
+		bool soft = *action == "soft reject";
+		sv reason = soft ? "Try again later" : "Message rejected";
+		if (auto *v = get(get(results, "messages"), "smtp_message")) {
+			auto text = str(v);
+			if (!text) {
+				return tl::make_unexpected(text.error());
+			}
+			reason = *text;
+		}
+		if (!clean(reason, 400)) {
+			return tl::make_unexpected("invalid SMTP response");
+		}
+		auto smtp = obj();
+		put(smtp.get(), "code", ucl_object_fromint(soft ? 451 : 550));
+		put(smtp.get(), "enhancedCode", soft ? "4.7.1" : "5.7.1");
+		put(smtp.get(), "message", reason);
+		set_operation(sets, "/action", ucl_object_fromstring("reject"));
+		set_operation(sets, "/response", smtp.release());
+	}
+	else if (*action == "discard" || *action == "quarantine") {
+		set_operation(sets, "/action", ucl_object_fromlstring(action->data(), action->size()));
+	}
+	else if (*action != "no action" && *action != "greylist") {
+		return tl::make_unexpected("unsupported delivery action");
+	}
+	return {};
+}
+
+result<message> encode_result(const ucl_object_t *results, bool rewritten)
+{
+	if (!results || ucl_object_type(results) != UCL_OBJECT || get(results, "error")) {
+		return tl::make_unexpected("scan failed");
+	}
+	if (rewritten || get(results, "dkim-signature")) {
+		return tl::make_unexpected("body rewriting and DKIM signing are outside the add-only profile");
+	}
+	auto root = obj(), sets = obj(UCL_ARRAY), adds = obj(UCL_ARRAY);
+	auto encoded = encode_headers(adds.get(), get(results, "milter"))
+					   .and_then([&] { return encode_action(sets.get(), results); });
+	if (!encoded) {
+		return tl::make_unexpected(encoded.error());
+	}
+	/* No-action preserves the MTA's incoming action (including earlier policy). */
+	if (sets->len == 0 && adds->len == 0) {
+		return reply(204, {});
+	}
+	if (sets->len) {
+		put(root.get(), "set", sets.release());
+	}
+	if (adds->len) {
+		put(root.get(), "add", adds.release());
+	}
+	auto m = json_reply(200, root.get());
+	gsize len;
+	rspamd_http_message_get_body(m.get(), &len);
+	if (len > 64 * 1024) {
+		return tl::make_unexpected("response too large");
+	}
+	return m;
+}
+}// namespace
+
+extern "C" rspamd_http_message *rspamd_mta_hooks_error(int status, const char *code, const char *why)
+{
+	auto root = obj(), error = obj();
+	put(error.get(), "code", code);
+	put(error.get(), "message", why);
+	put(root.get(), "error", error.release());
+	auto m = json_reply(status, root.get());
+	if (status == 401) {
+		rspamd_http_message_add_header(m.get(), "WWW-Authenticate", "Bearer");
+	}
+	if (status == 503 || status == 429) {
+		rspamd_http_message_add_header(m.get(), "Retry-After", "1");
+	}
+	return m.release();
+}
+
+extern "C" rspamd_http_message *rspamd_mta_hooks_decode(const char *data, gsize len, gsize max_message, GError **err)
+{
+	auto decoded = decode_request({data, len}, max_message);
+	if (!decoded) {
+		g_set_error_literal(err, g_quark_from_static_string("mta-hooks"), 400, decoded.error());
+		return nullptr;
+	}
+	return decoded->release();
+}
+
+extern "C" rspamd_http_message *rspamd_mta_hooks_encode(const ucl_object_t *results, gboolean rewritten)
+{
+	auto encoded = encode_result(results, rewritten);
+	if (!encoded) {
+		return rspamd_mta_hooks_error(503, "SCANNER_UNAVAILABLE", encoded.error());
+	}
+	return encoded->release();
+}
+
+struct rspamd_mta_hooks_config {
+	rspamd_config *cfg;
+	std::string token, owner, redis_host, redis_password, redis_db, prefix, settings_id;
+	int redis_port = 6379;
+	bool insecure_loopback = false;
+	size_t max_message;
+};
+
+struct rspamd_mta_hooks_request {
+	rspamd_mta_hooks_config *config;
+	message input{nullptr, rspamd_http_message_unref}, output{nullptr, rspamd_http_message_unref};
+	/* These values survive the input HTTP message and asynchronous callbacks. */
+	std::string id, fingerprint;
+	fstring registration{nullptr, rspamd_fstring_free};
+	std::string registration_key, invocation_key;
+	int method;
+	double started = g_get_monotonic_time() / 1e6, budget = 20.0;
+	bool owns_invocation = false;
+};
+
+namespace {
+/* Atomic state transitions shared by all workers. Pending requests are not
+ * re-executed during the replay window, even after an uncertain worker failure.
+ * Redis never stores the message or bearer credential. */
+constexpr auto state_script = R"lua(
+local op = ARGV[1]
+local now = tonumber(redis.call('TIME')[1])
+if op == 'register' then
+  redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', now)
+  if redis.call('ZCARD', KEYS[2]) >= 64 then return {409, ''} end
+  if not redis.call('SET', KEYS[1], ARGV[3], 'EX', ARGV[4], 'NX') then return {503, ''} end
+  redis.call('ZADD', KEYS[2], now + tonumber(ARGV[4]), KEYS[1])
+  redis.call('EXPIRE', KEYS[2], ARGV[4])
+  return {201, ''}
+end
+local reg = redis.call('GET', KEYS[1])
+if not reg then return {404, ''} end
+reg = cjson.decode(reg)
+if reg.owner ~= ARGV[2] then return {403, ''} end
+if op == 'delete' then
+  reg.response.status = 'deregistered'
+  redis.call('SET', KEYS[1], cjson.encode(reg), 'KEEPTTL')
+  -- Tombstones count towards the quota until expiry, preventing churn from
+  -- growing the registry without bound.
+  return {200, cjson.encode(reg)}
+end
+if op == 'status' then return {200, cjson.encode(reg)} end
+if reg.response.status ~= 'active' then return {410, ''} end
+if op == 'get' then return {200, cjson.encode(reg)} end
+if op == 'invoke' then
+  local cached = redis.call('GET', KEYS[2])
+  if cached then
+    cached = cjson.decode(cached)
+    if cached.fingerprint ~= ARGV[3] then return {409, ''} end
+    if not cached.body then return {503, ''} end
+    return {cached.status, cached.body}
+  end
+  redis.call('ZREMRANGEBYSCORE', KEYS[3], '-inf', now)
+  if redis.call('ZCARD', KEYS[3]) >= 1024 then return {429, ''} end
+  redis.call('SET', KEYS[2], cjson.encode({fingerprint=ARGV[3]}), 'EX', ARGV[4])
+  redis.call('ZADD', KEYS[3], now + tonumber(ARGV[4]), KEYS[2])
+  redis.call('EXPIRE', KEYS[3], ARGV[4])
+  return {100, ''}
+end
+return {503, ''}
+)lua";
+constexpr auto complete_script = R"lua(
+local previous = redis.call('GET', KEYS[1])
+if not previous then return 0 end
+previous = cjson.decode(previous)
+if previous.fingerprint ~= ARGV[1] or previous.body then return 0 end
+redis.call('SET', KEYS[1], cjson.encode({fingerprint=ARGV[1], status=tonumber(ARGV[2]), body=ARGV[3]}), 'KEEPTTL')
+return 1
+)lua";
+using redis_cb = std::function<void(const redisReply *)>;
+struct redis_operation {
+	rspamd_mta_hooks_config *config;
+	redis_cb done;
+};
+void redis_done(redisAsyncContext *ctx, void *reply, void *ud)
+{
+	auto op = std::unique_ptr<redis_operation>(static_cast<redis_operation *>(ud));
+	rspamd_redis_pool_release_connection(op->config->cfg->redis_pool, ctx,
+										 reply ? RSPAMD_REDIS_RELEASE_DEFAULT : RSPAMD_REDIS_RELEASE_FATAL);
+	op->done(static_cast<redisReply *>(reply));
+}
+void command(rspamd_mta_hooks_config *c, std::initializer_list<sv> args, redis_cb done)
+{
+	auto *ctx = rspamd_redis_pool_connect(c->cfg->redis_pool, c->redis_db.c_str(), nullptr,
+										  c->redis_password.empty() ? nullptr : c->redis_password.c_str(), c->redis_host.c_str(), c->redis_port);
+	if (!ctx) {
+		done(nullptr);
+		return;
+	}
+	redisAsyncSetTimeout(ctx, timeval{1, 0});
+	std::vector<const char *> argv;
+	std::vector<size_t> lengths;
+	argv.reserve(args.size());
+	lengths.reserve(args.size());
+	for (auto &s: args) {
+		argv.push_back(s.data());
+		lengths.push_back(s.size());
+	}
+	auto *op = new redis_operation{c, std::move(done)};
+	/* Hiredis formats and copies the arguments before returning. Only the
+	 * callback, not these borrowed views, survives this call. */
+	if (redisAsyncCommandArgv(ctx, redis_done, op, argv.size(), argv.data(), lengths.data()) != REDIS_OK) {
+		redis_done(ctx, nullptr, op);
+	}
+}
+void state(rspamd_mta_hooks_request *r, const char *op, sv key2, sv arg3,
+		   unsigned ttl, std::function<void(int, sv)> cb)
+{
+	command(r->config, {"EVAL", state_script, "3", r->registration_key, key2, r->config->prefix + "invocations:" + r->config->owner, op, r->config->owner, arg3, std::to_string(ttl)}, [cb = std::move(cb)](const redisReply *rep) {
+		if (!rep || rep->type != REDIS_REPLY_ARRAY || rep->elements != 2 ||
+			rep->element[0]->type != REDIS_REPLY_INTEGER || rep->element[1]->type != REDIS_REPLY_STRING) {
+			cb(503, {});
+			return;
+		}
+		cb(rep->element[0]->integer, {rep->element[1]->str, rep->element[1]->len});
+	});
+}
+rspamd_http_message *state_error(int code)
+{
+	const char *name = "SCANNER_UNAVAILABLE";
+	if (code == 404) name = "REGISTRATION_NOT_FOUND";
+	else if (code == 403)
+		name = "REGISTRATION_MISMATCH";
+	else if (code == 410)
+		name = "REGISTRATION_DEREGISTERED";
+	else if (code == 409)
+		name = "INVALID_REQUEST";
+	else if (code == 429)
+		name = "RATE_LIMITED";
+	return rspamd_mta_hooks_error(code, name, "Registration or invocation state is unavailable or conflicts");
+}
+std::string quota_key(rspamd_mta_hooks_request *r)
+{
+	return r->config->prefix + "quota:" + r->config->owner;
+}
+void return_output(rspamd_mta_hooks_request *r, rspamd_mta_hooks_callback cb, gpointer ud)
+{
+	cb(r->output.release(), FALSE, ud);
+}
+}// namespace
+
+namespace {
+result<std::unique_ptr<rspamd_mta_hooks_config>> parse_config(const ucl_object_t *o, rspamd_config *cfg)
+{
+	if (!o || ucl_object_type(o) != UCL_OBJECT) {
+		return tl::make_unexpected("mta_hooks must be an object");
+	}
+	auto *enabled = get(o, "enabled");
+	if (!enabled || ucl_object_type(enabled) != UCL_BOOLEAN) {
+		return tl::make_unexpected("mta_hooks requires explicit enabled boolean");
+	}
+	if (!ucl_object_toboolean(enabled)) {
+		return std::unique_ptr<rspamd_mta_hooks_config>{};
+	}
+	auto token = str(get(o, "token"));
+	if (!token || token->size() < 32 || !clean(*token, 1024)) {
+		return tl::make_unexpected("token must be 32-1024 printable bytes");
+	}
+	auto host = str(get(o, "redis_host"));
+	if (!host || host->empty() || !clean(*host, 256)) {
+		return tl::make_unexpected("redis_host required");
+	}
+	auto c = std::make_unique<rspamd_mta_hooks_config>();
+	c->cfg = cfg;
+	c->max_message = std::min<size_t>(cfg->max_message, 25 * 1024 * 1024);
+	/* Config owns values across worker startup, reload and async operations. */
+	c->token = *token;
+	c->owner = digest(*token);
+	c->redis_host = *host;
+	c->prefix = "mta-hooks:draft01:";
+	for (auto pair: {std::pair{"redis_password", &c->redis_password}, std::pair{"redis_db", &c->redis_db},
+					 std::pair{"prefix", &c->prefix}, std::pair{"settings_id", &c->settings_id}}) {
+		if (auto *v = get(o, pair.first)) {
+			auto value = str(v);
+			if (!value || !clean(*value, 1024)) {
+				return tl::make_unexpected("invalid configuration string");
+			}
+			*pair.second = *value;
+		}
+	}
+	if (auto *v = get(o, "redis_port")) {
+		if (ucl_object_type(v) != UCL_INT || ucl_object_toint(v) <= 0 || ucl_object_toint(v) > 65535) {
+			return tl::make_unexpected("invalid redis_port");
+		}
+		c->redis_port = ucl_object_toint(v);
+	}
+	if (auto *v = get(o, "insecure_loopback")) {
+		if (ucl_object_type(v) != UCL_BOOLEAN) {
+			return tl::make_unexpected("insecure_loopback must be boolean");
+		}
+		c->insecure_loopback = ucl_object_toboolean(v);
+	}
+	/* Profile changes must not reuse state from another scanning policy. */
+	c->prefix += digest(c->settings_id + ":add-only-v1:") + ":";
+	return c;
+}
+
+message discovery(const rspamd_mta_hooks_config *c)
+{
+	auto root = obj(), endpoints = obj(), caps = obj(), inbound = obj(), limits = obj();
+	put(root.get(), "version", "1.0");
+	put(endpoints.get(), "registration", "/v1/hooks/register");
+	put(endpoints.get(), "deregistration", "/v1/hooks/register/{registration_id}");
+	put(root.get(), "endpoints", endpoints.release());
+	auto formats = obj(UCL_ARRAY);
+	ucl_array_append(formats.get(), ucl_object_fromstring("json"));
+	put(root.get(), "serialization", formats.release());
+	auto sub = subscription();
+	put(inbound.get(), "stages", ucl_object_ref(get(sub.get(), "stages")));
+	put(inbound.get(), "fetchProperties", ucl_object_ref(get(sub.get(), "properties")));
+	auto actions = obj(UCL_ARRAY), updates = obj(UCL_ARRAY);
+	for (auto a: {"accept", "reject", "discard", "quarantine"}) {
+		ucl_array_append(actions.get(), ucl_object_fromstring(a));
+	}
+	for (auto p: {"/action", "/response", "/message/headers"}) {
+		ucl_array_append(updates.get(), ucl_object_fromstring(p));
+	}
+	put(inbound.get(), "actions", actions.release());
+	put(inbound.get(), "updateProperties", updates.release());
+	put(caps.get(), "inbound", inbound.release());
+	put(root.get(), "capabilities", caps.release());
+	put(limits.get(), "maxMessageSize", ucl_object_fromint(c->max_message));
+	put(limits.get(), "maxRegistrations", ucl_object_fromint(64));
+	put(limits.get(), "timeoutMs", ucl_object_fromint(20000));
+	put(root.get(), "limits", limits.release());
+	return json_reply(200, root.get());
+}
+
+result<void> validate_content_type(rspamd_http_message *msg)
+{
+	auto type = header(msg, "Content-Type");
+	if (!type) {
+		return tl::make_unexpected(type.error());
+	}
+	if (*type != "application/json" && *type != "application/json; charset=utf-8") {
+		return tl::make_unexpected("application/json required");
+	}
+	for (auto name: {"Content-Encoding", "Compression"}) {
+		auto encoding = header(msg, name);
+		if (!encoding) {
+			return tl::make_unexpected(encoding.error());
+		}
+		if (!encoding->empty()) {
+			return tl::make_unexpected("compressed requests unsupported");
+		}
+	}
+	return {};
+}
+
+result<void> prepare_registration(rspamd_mta_hooks_request *r, sv data)
+{
+	if (data.size() > 16384) {
+		return tl::make_unexpected("registration too large");
+	}
+	auto request = parse_borrowed(data);
+	if (!request) {
+		return tl::make_unexpected(request.error());
+	}
+	const auto *o = request->get();
+	auto name = str(get(o, "name"));
+	if (!name || name->empty() || !clean(*name, 255)) {
+		return tl::make_unexpected("MTA name required");
+	}
+	if (!string_is(get(o, "serialization"), "json")) {
+		return tl::make_unexpected("only JSON is supported");
+	}
+	if (auto *out = get(o, "outbound"); out && ucl_object_type(out) != UCL_NULL) {
+		return tl::make_unexpected("outbound unsupported");
+	}
+	if (auto *filter = get(o, "filter"); filter && ucl_object_type(filter) != UCL_NULL) {
+		r->output.reset(rspamd_mta_hooks_error(422, "UNSUPPORTED_FILTER", "Filters are not supported"));
+		return {};
+	}
+	auto subscription_valid = validate_subscription(get(o, "inbound"));
+	if (!subscription_valid) {
+		return subscription_valid;
+	}
+	int timeout_ms = 20000;
+	if (auto *v = get(o, "timeoutMs"); v && ucl_object_type(v) != UCL_NULL) {
+		if (ucl_object_type(v) != UCL_INT || ucl_object_toint(v) < 1000 || ucl_object_toint(v) > 3600000) {
+			return tl::make_unexpected("invalid timeoutMs");
+		}
+		timeout_ms = std::min<int64_t>(20000, ucl_object_toint(v));
+	}
+	char *id = g_uuid_string_random();
+	r->id = id;
+	g_free(id);
+	auto response = obj(), negotiated = obj(), endpoints = obj(), record = obj();
+	put(response.get(), "registrationId", r->id);
+	put(response.get(), "status", "active");
+	auto now = time(nullptr);
+	put(response.get(), "createdAt", utc(now));
+	put(response.get(), "expiresAt", utc(now + registration_ttl));
+	put(response.get(), "hookEndpoint", "/v1/hooks/invoke/" + r->id);
+	put(negotiated.get(), "serialization", "json");
+	put(negotiated.get(), "inbound", subscription().release());
+	put(negotiated.get(), "outbound", ucl_object_typed_new(UCL_NULL));
+	put(response.get(), "negotiated", negotiated.release());
+	put(endpoints.get(), "status", "/v1/hooks/register/" + r->id + "/status");
+	put(endpoints.get(), "deregistration", "/v1/hooks/register/" + r->id);
+	put(response.get(), "endpoints", endpoints.release());
+	r->output = json_reply(201, response.get());
+	rspamd_http_message_add_header(r->output.get(), "Location", ("/v1/hooks/register/" + r->id).c_str());
+	put(record.get(), "owner", r->config->owner);
+	put(record.get(), "timeoutMs", ucl_object_fromint(timeout_ms));
+	put(record.get(), "response", response.release());
+	r->registration = emit(record.get());
+	return {};
+}
+
+result<void> prepare_invocation(rspamd_mta_hooks_request *r, rspamd_http_message *msg, sv id, sv data)
+{
+	auto registration = header(msg, "X-MTA-Hooks-Registration");
+	if (!registration) {
+		return tl::make_unexpected(registration.error());
+	}
+	if (!identifier(id, 255, true) || *registration != id) {
+		return tl::make_unexpected("invalid registration header");
+	}
+	auto request_id = header(msg, "X-MTA-Hooks-Request-Id");
+	if (!request_id) {
+		return tl::make_unexpected(request_id.error());
+	}
+	if (!identifier(*request_id, 128)) {
+		return tl::make_unexpected("invalid request ID");
+	}
+	auto input = decode_request(data, r->config->max_message);
+	if (!input) {
+		return tl::make_unexpected(input.error());
+	}
+	if (!r->config->settings_id.empty()) {
+		auto added = add_header(input->get(), "Settings-ID", r->config->settings_id);
+		if (!added) {
+			return added;
+		}
+	}
+	r->id = id;
+	r->fingerprint = digest(data);
+	r->invocation_key = r->config->prefix + "request:" + r->config->owner + ":";
+	r->invocation_key.append(*request_id);
+	r->input = std::move(*input);
+	return {};
+}
+
+result<void> prepare_request(rspamd_mta_hooks_request *r, rspamd_http_message *msg, bool tls, bool loopback)
+{
+	auto *c = r->config;
+	if (!tls && !(loopback && c->insecure_loopback)) {
+		r->output.reset(rspamd_mta_hooks_error(403, "REGISTRATION_DENIED", "HTTPS required"));
+		return {};
+	}
+	sv path = msg->url ? sv{msg->url->str, msg->url->len} : sv{};
+	if (path == "/.well-known/mta-hooks" && msg->method == HTTP_GET) {
+		r->output = discovery(c);
+		return {};
+	}
+	auto authorization = header(msg, "Authorization");
+	if (!authorization) {
+		return tl::make_unexpected(authorization.error());
+	}
+	constexpr sv bearer = "Bearer ";
+	if (authorization->size() != bearer.size() + c->token.size() ||
+		!authorization->starts_with(bearer) ||
+		rspamd_cryptobox_memcmp(authorization->data() + bearer.size(), c->token.data(), c->token.size()) != 0) {
+		r->output.reset(rspamd_mta_hooks_error(401, "INVALID_CREDENTIALS", "Valid bearer credential required"));
+		return {};
+	}
+	gsize len;
+	const char *data = rspamd_http_message_get_body(msg, &len);
+	if (len > rspamd_mta_hooks_max_request(c)) {
+		r->output.reset(rspamd_mta_hooks_error(413, "REQUEST_TOO_LARGE", "Request limit exceeded"));
+		return {};
+	}
+	if (msg->method == HTTP_POST) {
+		auto content = validate_content_type(msg);
+		if (!content) {
+			return content;
+		}
+	}
+	constexpr sv registration_path = "/v1/hooks/register/";
+	constexpr sv invocation_path = "/v1/hooks/invoke/";
+	if (path == "/v1/hooks/register" && msg->method == HTTP_POST) {
+		auto prepared = prepare_registration(r, {data, len});
+		if (!prepared) {
+			return prepared;
+		}
+	}
+	else if (path.starts_with(invocation_path) && msg->method == HTTP_POST) {
+		auto prepared = prepare_invocation(r, msg, path.substr(invocation_path.size()), {data, len});
+		if (!prepared) {
+			return prepared;
+		}
+	}
+	else if (path.starts_with(registration_path) && (msg->method == HTTP_GET || msg->method == HTTP_DELETE)) {
+		auto id = path.substr(registration_path.size());
+		if (msg->method == HTTP_GET) {
+			if (!id.ends_with("/status")) {
+				return tl::make_unexpected("invalid status endpoint");
+			}
+			id.remove_suffix(7);
+		}
+		if (!identifier(id, 255, true)) {
+			return tl::make_unexpected("invalid registration ID");
+		}
+		r->id = id;
+	}
+	else {
+		r->output.reset(rspamd_mta_hooks_error(404, "INVALID_REQUEST", "Unknown Hooks endpoint or method"));
+		return {};
+	}
+	r->registration_key = c->prefix + "registration:" + r->id;
+	return {};
+}
+}// namespace
+
+extern "C" rspamd_mta_hooks_config *rspamd_mta_hooks_config_new(const ucl_object_t *o, rspamd_config *cfg, GError **err)
+{
+	auto parsed = parse_config(o, cfg);
+	if (!parsed) {
+		g_set_error_literal(err, g_quark_from_static_string("mta-hooks"), EINVAL, parsed.error());
+		return nullptr;
+	}
+	return parsed->release();
+}
+
+extern "C" void rspamd_mta_hooks_config_free(rspamd_mta_hooks_config *c)
+{
+	delete c;
+}
+
+extern "C" gsize rspamd_mta_hooks_max_request(rspamd_mta_hooks_config *c)
+{
+	return c->max_message * 4 / 3 + 128 * 1024;
+}
+
+extern "C" void rspamd_mta_hooks_request_free(rspamd_mta_hooks_request *r)
+{
+	delete r;
+}
+
+extern "C" double rspamd_mta_hooks_remaining(rspamd_mta_hooks_request *r)
+{
+	return std::max(0.001, r->budget - (g_get_monotonic_time() / 1e6 - r->started));
+}
+
+extern "C" rspamd_mta_hooks_request *rspamd_mta_hooks_request_new(rspamd_mta_hooks_config *c,
+																  rspamd_http_message *msg, gboolean tls, gboolean loopback)
+{
+	auto r = std::make_unique<rspamd_mta_hooks_request>();
+	r->config = c;
+	r->method = msg->method;
+	auto prepared = prepare_request(r.get(), msg, tls, loopback);
+	if (!prepared) {
+		r->registration.reset();
+		r->output.reset(rspamd_mta_hooks_error(400, "INVALID_REQUEST", prepared.error()));
+	}
+	return r.release();
+}
+
+extern "C" void rspamd_mta_hooks_begin(rspamd_mta_hooks_request *r, rspamd_mta_hooks_callback cb, gpointer ud)
+{
+	if (r->registration) {
+		state(r, "register", quota_key(r), view(r->registration), registration_ttl, [=](int status, sv) {
+			if (status != 201) {
+				r->output.reset(status == 409 ? rspamd_mta_hooks_error(409, "REGISTRATION_LIMIT_REACHED", "Registration quota exceeded") : state_error(status));
+			}
+			return_output(r, cb, ud);
+		});
+		return;
+	}
+	if (r->output) {
+		return_output(r, cb, ud);
+		return;
+	}
+	const char *op = r->method == HTTP_DELETE ? "delete" : r->method == HTTP_GET ? "status"
+																				 : "get";
+	state(r, op, quota_key(r), "", registration_ttl, [=](int status, sv payload) {
+		if (status != 200) {
+			cb(state_error(status), FALSE, ud);
+			return;
+		}
+		auto record = parse_borrowed(payload);
+		if (!record) {
+			cb(state_error(503), FALSE, ud);
+			return;
+		}
+		if (!r->input) {
+			auto *response = get(record->get(), "response");
+			if (r->method == HTTP_DELETE) {
+				auto out = obj();
+				put(out.get(), "registrationId", r->id);
+				put(out.get(), "status", "deregistered");
+				put(out.get(), "deregisteredAt", utc(time(nullptr)));
+				cb(json_reply(200, out.get()).release(), FALSE, ud);
+			}
+			else if (!response || ucl_object_type(response) != UCL_OBJECT) {
+				cb(state_error(503), FALSE, ud);
+			}
+			else {
+				cb(json_reply(200, response).release(), FALSE, ud);
+			}
+			return;
+		}
+		auto *timeout = get(record->get(), "timeoutMs");
+		if (!timeout || ucl_object_type(timeout) != UCL_INT ||
+			ucl_object_toint(timeout) < 1000 || ucl_object_toint(timeout) > 20000) {
+			cb(state_error(503), FALSE, ud);
+			return;
+		}
+		r->budget = ucl_object_toint(timeout) / 1000.0;
+		if (rspamd_mta_hooks_remaining(r) <= 0.001) {
+			cb(state_error(503), FALSE, ud);
+			return;
+		}
+		state(r, "invoke", r->invocation_key, r->fingerprint, replay_ttl, [=](int code, sv body) {
+			if (code == 100) {
+				r->owns_invocation = true;
+				if (rspamd_mta_hooks_remaining(r) <= 0.001) {
+					cb(state_error(503), FALSE, ud);
+				}
+				else {
+					cb(r->input.release(), TRUE, ud);
+				}
+			}
+			else if (!body.empty() || code == 204) {
+				cb(reply(code, body).release(), FALSE, ud);
+			}
+			else {
+				cb(state_error(code), FALSE, ud);
+			}
+		});
+	});
+}
+
+extern "C" void rspamd_mta_hooks_finish(rspamd_mta_hooks_request *r, const ucl_object_t *results,
+										gboolean rewritten, rspamd_mta_hooks_callback cb, gpointer ud)
+{
+	r->output.reset(rspamd_mta_hooks_encode(results, rewritten));
+	if (rspamd_mta_hooks_remaining(r) <= 0.001) {
+		r->output.reset(state_error(503));
+	}
+	if (!r->owns_invocation) {
+		return_output(r, cb, ud);
+		return;
+	}
+	gsize len;
+	auto *body = rspamd_http_message_get_body(r->output.get(), &len);
+	command(r->config, {"EVAL", complete_script, "1", r->invocation_key, r->fingerprint, std::to_string(r->output->code), sv{body, len}}, [=](const redisReply *rep) {
+		if (!rep || rep->type != REDIS_REPLY_INTEGER || rep->integer != 1) {
+			r->output.reset(state_error(503));
+		}
+		return_output(r, cb, ud);
+	});
+}

--- a/src/libserver/mta_hooks.cxx
+++ b/src/libserver/mta_hooks.cxx
@@ -12,7 +12,6 @@
 #include <algorithm>
 #include <array>
 #include <charconv>
-#include <chrono>
 #include <ctime>
 #include <functional>
 #include <memory>
@@ -172,11 +171,14 @@ bool valid_timestamp(sv s)
 		std::from_chars(part.data(), part.data() + part.size(), value);
 		return value;
 	};
-	using namespace std::chrono;
 	int year_value = number(0, 4);
-	auto date = year_month_day{year{year_value}, month{unsigned(number(5, 2))}, day{unsigned(number(8, 2))}};
+	int month_value = number(5, 2), day_value = number(8, 2);
 	int hour = number(11, 2), minute = number(14, 2), second = number(17, 2);
-	if (year_value < 1 || !date.ok() || hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 60) {
+	/* GLib's calendar validation also works with older C++20 libraries that
+	 * do not yet provide std::chrono calendar types. */
+	if (year_value < 1 || month_value < 1 || month_value > 12 || day_value < 1 || day_value > 31 ||
+		!g_date_valid_dmy(day_value, static_cast<GDateMonth>(month_value), year_value) ||
+		hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 60) {
 		return false;
 	}
 	if (s.size() == 20) {
@@ -263,21 +265,28 @@ result<void> validate_subscription(const ucl_object_t *o)
 	if (!props || ucl_object_type(props) == UCL_NULL) {
 		return {};
 	}
-	if (ucl_object_type(props) != UCL_ARRAY || props->len != properties.size()) {
+	if (ucl_object_type(props) != UCL_ARRAY || props->len < properties.size() || props->len > 64) {
 		return tl::make_unexpected("DATA profile requires all eight properties");
 	}
 	std::array<bool, properties.size()> seen{};
+	std::vector<sv> offered;
+	offered.reserve(props->len);
 	ucl_object_iter_t it = nullptr;
 	while (auto *v = ucl_object_iterate(props, &it, true)) {
 		auto p = str(v);
-		if (!p) {
-			return tl::make_unexpected(p.error());
+		if (!p || p->empty() || p->front() != '/' || !clean(*p, 256) ||
+			std::find(offered.begin(), offered.end(), *p) != offered.end()) {
+			return tl::make_unexpected("invalid or duplicate property");
 		}
+		offered.push_back(*p);
 		auto found = std::find(properties.begin(), properties.end(), *p);
-		if (found == properties.end() || seen[found - properties.begin()]) {
-			return tl::make_unexpected("unsupported or duplicate property");
+		/* Confirm only our DATA profile, allowing MTAs to offer more fields. */
+		if (found != properties.end()) {
+			seen[found - properties.begin()] = true;
 		}
-		seen[found - properties.begin()] = true;
+	}
+	if (!std::all_of(seen.begin(), seen.end(), [](bool present) { return present; })) {
+		return tl::make_unexpected("DATA profile requires all eight properties");
 	}
 	return {};
 }
@@ -505,12 +514,36 @@ void set_operation(ucl_object_t *sets, const char *path, ucl_object_t *value)
 	ucl_array_append(sets, op.release());
 }
 
+bool header_name(sv name)
+{
+	return !name.empty() && name.size() <= 998 &&
+		   std::all_of(name.begin(), name.end(), [](unsigned char c) { return c > 32 && c < 127 && c != ':'; });
+}
+
+bool header_value(sv value)
+{
+	if (value.size() > 64 * 1024 || !valid_utf8(value)) return false;
+	for (size_t i = 0; i < value.size(); ++i) {
+		auto c = static_cast<unsigned char>(value[i]);
+		if (c == '\r') {
+			if (++i == value.size() || value[i] != '\n') return false;
+			c = '\n';
+		}
+		if (c == '\n') {
+			if (i + 1 == value.size() || (value[i + 1] != ' ' && value[i + 1] != '\t')) return false;
+		}
+		else if ((c < 32 && c != '\t') || c == 127)
+			return false;
+	}
+	return true;
+}
+
 result<void> add_output_header(ucl_object_t *adds, sv name, const ucl_object_t *value)
 {
 	int order = -1;
 	if (ucl_object_type(value) == UCL_OBJECT) {
 		if (auto *o = ucl_object_lookup_any(value, "order", "index", nullptr)) {
-			if (ucl_object_type(o) != UCL_INT || ucl_object_toint(o) < -1 || ucl_object_toint(o) > 100000) {
+			if (ucl_object_type(o) != UCL_INT || ucl_object_toint(o) < -100000 || ucl_object_toint(o) > 100000) {
 				return tl::make_unexpected("invalid header order");
 			}
 			order = ucl_object_toint(o);
@@ -522,11 +555,10 @@ result<void> add_output_header(ucl_object_t *adds, sv name, const ucl_object_t *
 		value = get(value, "value");
 	}
 	auto text = str(value);
-	if (!text || !clean(*text, 64 * 1024) || !valid_utf8(*text)) {
+	if (!text || !header_value(*text)) {
 		return tl::make_unexpected("invalid output header value");
 	}
-	if (name.empty() || name.size() > 998 ||
-		!std::all_of(name.begin(), name.end(), [](unsigned char c) { return c > 32 && c < 127 && c != ':'; })) {
+	if (!header_name(name)) {
 		return tl::make_unexpected("invalid output header name");
 	}
 	if (adds->len >= 256) {
@@ -537,7 +569,7 @@ result<void> add_output_header(ucl_object_t *adds, sv name, const ucl_object_t *
 	put(h.get(), "value", *text);
 	put(op.get(), "path", "/message/headers");
 	put(op.get(), "value", h.release());
-	if (order >= 0) {
+	if (order != -1) {
 		put(op.get(), "index", ucl_object_fromint(order));
 	}
 	ucl_array_append(adds, op.release());
@@ -555,7 +587,7 @@ result<void> encode_headers(ucl_object_t *adds, const ucl_object_t *milter)
 	ucl_object_iter_t it = nullptr;
 	while (auto *v = ucl_object_iterate(milter, &it, true)) {
 		auto key = key_view(v);
-		if (key == "remove_headers" && ucl_object_type(v) == UCL_OBJECT && v->len == 0) {
+		if (key == "remove_headers" || key == "spam_header") {
 			continue;
 		}
 		if (key != "add_headers" || ucl_object_type(v) != UCL_OBJECT) {
@@ -613,28 +645,219 @@ result<void> encode_action(ucl_object_t *sets, const ucl_object_t *results)
 	else if (*action == "discard" || *action == "quarantine") {
 		set_operation(sets, "/action", ucl_object_fromlstring(action->data(), action->size()));
 	}
-	else if (*action != "no action" && *action != "greylist") {
+	else if (*action != "no action" && *action != "greylist" && *action != "add header" && *action != "rewrite subject") {
 		return tl::make_unexpected("unsupported delivery action");
 	}
 	return {};
 }
 
-result<message> encode_result(const ucl_object_t *results, bool rewritten)
+struct output_header {
+	sv name, value, raw;
+	size_t original;
+	bool changed = false;
+};
+constexpr size_t added_header = SIZE_MAX;
+
+/* Preserve the original field bytes, including folding, for raw replacements.
+ * This only identifies field boundaries; it does not decode MIME values. */
+result<std::vector<output_header>> original_headers(sv raw)
+{
+	std::vector<output_header> headers;
+	size_t offset = 0;
+	while (offset < raw.size()) {
+		auto end = raw.find('\n', offset);
+		if (end == sv::npos) return tl::make_unexpected("unterminated message headers");
+		auto line = raw.substr(offset, end - offset);
+		if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+		if (line.empty()) return headers;
+		if (line.front() == ' ' || line.front() == '\t') {
+			if (headers.empty()) return tl::make_unexpected("orphan header continuation");
+			auto &h = headers.back();
+			h.raw = sv{h.raw.data(), static_cast<size_t>(raw.data() + end + 1 - h.raw.data())};
+		}
+		else {
+			auto colon = line.find(':');
+			if (colon == sv::npos || !header_name(line.substr(0, colon)) || headers.size() >= 10000)
+				return tl::make_unexpected("invalid original header");
+			headers.push_back({line.substr(0, colon), {}, raw.substr(offset, end + 1 - offset), headers.size()});
+		}
+		offset = end + 1;
+	}
+	return tl::make_unexpected("missing header separator");
+}
+
+bool same_header(sv a, sv b)
+{
+	return a.size() == b.size() && g_ascii_strncasecmp(a.data(), b.data(), a.size()) == 0;
+}
+
+result<void> encode_message_edits(ucl_object_t *sets, ucl_object_t *adds, ucl_object_t *deletes,
+								  const ucl_object_t *results, sv original, const char *body, size_t body_len, sv spam_header, size_t max_message)
+{
+	auto parsed = original_headers(original);
+	if (!parsed) return tl::make_unexpected(parsed.error());
+	auto headers = *parsed;
+	auto *milter = get(results, "milter");
+	if (auto *remove = get(milter, "remove_headers")) {
+		if (ucl_object_type(remove) != UCL_OBJECT) return tl::make_unexpected("invalid header removals");
+		std::vector<bool> removed(headers.size());
+		ucl_object_iter_t it = nullptr;
+		while (auto *h = ucl_object_iterate(remove, &it, true)) {
+			auto mark = [&](const ucl_object_t *n) -> result<void> {
+				if (ucl_object_type(n) != UCL_INT || ucl_object_toint(n) < 0)
+					return tl::make_unexpected("invalid header occurrence");
+				size_t occurrence = 0;
+				for (size_t i = 0; i < headers.size(); ++i) {
+					if (same_header(headers[i].name, key_view(h)) &&
+						(++occurrence == static_cast<uint64_t>(ucl_object_toint(n)) || ucl_object_toint(n) == 0)) removed[i] = true;
+				}
+				return {};
+			};
+			if (ucl_object_type(h) == UCL_ARRAY) {
+				ucl_object_iter_t values = nullptr;
+				while (auto *n = ucl_object_iterate(h, &values, true)) {
+					auto ok = mark(n);
+					if (!ok) return ok;
+				}
+			}
+			else {
+				auto ok = mark(h);
+				if (!ok) return ok;
+			}
+		}
+		headers.erase(std::remove_if(headers.begin(), headers.end(), [&](const auto &h) { return removed[h.original]; }), headers.end());
+	}
+	auto collected = obj(UCL_ARRAY);
+	auto ok = encode_headers(collected.get(), milter);
+	if (!ok) return ok;
+	ucl_object_iter_t it = nullptr;
+	while (auto *op = ucl_object_iterate(collected.get(), &it, true)) {
+		auto *h = get(op, "value");
+		auto *index = get(op, "index");
+		auto requested = index ? ucl_object_toint(index) : static_cast<int64_t>(headers.size());
+		if (requested < 0) requested += static_cast<int64_t>(headers.size()) + 2;
+		auto position = static_cast<size_t>(std::clamp<int64_t>(requested, 0, headers.size()));
+		headers.insert(headers.begin() + position, {*str(get(h, "name")), *str(get(h, "value")), {}, added_header, true});
+	}
+	auto replace = [&](sv name, const ucl_object_t *value, bool all) -> result<void> {
+		auto text = str(value);
+		if (!header_name(name) || !text || !header_value(*text)) return tl::make_unexpected("invalid replacement header");
+		auto found = std::find_if(headers.begin(), headers.end(), [&](const auto &h) { return same_header(h.name, name); });
+		if (all) {
+			headers.erase(std::remove_if(headers.begin(), headers.end(), [&](const auto &h) { return same_header(h.name, name); }), headers.end());
+			found = headers.end();
+		}
+		if (found == headers.end()) headers.push_back({name, *text, {}, added_header, true});
+		else {
+			found->value = *text;
+			found->changed = true;
+		}
+		return {};
+	};
+	auto default_spam = object{ucl_object_fromstring("Yes"), ucl_object_unref};
+	if (string_is(get(results, "action"), "add header")) {
+		auto *spam = get(milter, "spam_header");
+		if (spam && ucl_object_type(spam) == UCL_OBJECT) {
+			ucl_object_iter_t fields = nullptr;
+			while (auto *h = ucl_object_iterate(spam, &fields, true)) {
+				auto r = replace(key_view(h), h, true);
+				if (!r) return r;
+			}
+		}
+		else {
+			auto r = replace(spam_header, spam ? spam : default_spam.get(), true);
+			if (!r) return r;
+		}
+	}
+	if (string_is(get(results, "action"), "rewrite subject")) {
+		auto r = replace("Subject", get(results, "subject"), false);
+		if (!r) return r;
+	}
+	if (auto *dkim = get(results, "dkim-signature")) {
+		size_t position = std::min<size_t>(1, headers.size());
+		auto insert = [&](const ucl_object_t *signature) -> result<void> {
+			auto value = str(signature);
+			if (!value || !header_value(*value)) return tl::make_unexpected("invalid DKIM signature");
+			headers.insert(headers.begin() + position++, {"DKIM-Signature", *value, {}, added_header, true});
+			return {};
+		};
+		if (ucl_object_type(dkim) == UCL_ARRAY) {
+			ucl_object_iter_t signatures = nullptr;
+			while (auto *signature = ucl_object_iterate(dkim, &signatures, true)) {
+				auto r = insert(signature);
+				if (!r) return r;
+			}
+		}
+		else {
+			auto r = insert(dkim);
+			if (!r) return r;
+		}
+	}
+	if (body) {
+		if (body_len > max_message) return tl::make_unexpected("replacement body too large");
+		std::string raw;
+		for (const auto &h: headers) {
+			if (!h.changed) raw.append(h.raw);
+			else
+				raw.append(h.name).append(": ").append(h.value).append("\r\n");
+			if (raw.size() > max_message) return tl::make_unexpected("replacement message too large");
+		}
+		if (raw.size() + 2 + body_len > max_message) return tl::make_unexpected("replacement message too large");
+		raw.append("\r\n").append(body, body_len);
+		gsize len;
+		std::unique_ptr<char, decltype(&g_free)> encoded{rspamd_encode_base64(reinterpret_cast<const unsigned char *>(raw.data()), raw.size(), 0, &len), g_free};
+		set_operation(sets, "/rawMessage", ucl_object_fromlstring(encoded.get(), len));
+		return {};
+	}
+	/* Hooks applies set, then add, then delete. Keep removed originals as
+	 * placeholders until the final descending deletions so indexes stay valid. */
+	std::vector<size_t> wire;
+	for (size_t i = 0; i < parsed->size(); ++i) wire.push_back(i);
+	std::vector<bool> retained(parsed->size());
+	for (size_t i = 0; i < headers.size(); ++i) {
+		const auto &h = headers[i];
+		if (h.original != added_header) {
+			retained[h.original] = true;
+			if (h.changed) {
+				auto path = "/message/headers/" + std::to_string(h.original) + "/value";
+				set_operation(sets, path.c_str(), ucl_object_fromlstring(h.value.data(), h.value.size()));
+			}
+		}
+		else {
+			auto next = std::find_if(headers.begin() + i + 1, headers.end(), [](const auto &v) { return v.original != added_header; });
+			auto pos = next == headers.end() ? wire.end() : std::find(wire.begin(), wire.end(), next->original);
+			auto index = pos - wire.begin();
+			wire.insert(pos, added_header);
+			auto value = obj();
+			put(value.get(), "value", h.value);
+			put(value.get(), "order", ucl_object_fromint(index));
+			auto r = add_output_header(adds, h.name, value.get());
+			if (!r) return r;
+		}
+	}
+	for (size_t i = wire.size(); i-- > 0;) {
+		if (wire[i] != added_header && !retained[wire[i]]) {
+			auto op = obj();
+			put(op.get(), "path", "/message/headers/" + std::to_string(i));
+			ucl_array_append(deletes, op.release());
+		}
+	}
+	return {};
+}
+
+result<message> encode_result(const ucl_object_t *results, sv original, const char *body, size_t body_len, sv spam_header, size_t max_message)
 {
 	if (!results || ucl_object_type(results) != UCL_OBJECT || get(results, "error")) {
 		return tl::make_unexpected("scan failed");
 	}
-	if (rewritten || get(results, "dkim-signature")) {
-		return tl::make_unexpected("body rewriting and DKIM signing are outside the add-only profile");
-	}
-	auto root = obj(), sets = obj(UCL_ARRAY), adds = obj(UCL_ARRAY);
-	auto encoded = encode_headers(adds.get(), get(results, "milter"))
+	auto root = obj(), sets = obj(UCL_ARRAY), adds = obj(UCL_ARRAY), deletes = obj(UCL_ARRAY);
+	auto encoded = encode_message_edits(sets.get(), adds.get(), deletes.get(), results, original, body, body_len, spam_header, max_message)
 					   .and_then([&] { return encode_action(sets.get(), results); });
 	if (!encoded) {
 		return tl::make_unexpected(encoded.error());
 	}
 	/* No-action preserves the MTA's incoming action (including earlier policy). */
-	if (sets->len == 0 && adds->len == 0) {
+	if (sets->len == 0 && adds->len == 0 && deletes->len == 0) {
 		return reply(204, {});
 	}
 	if (sets->len) {
@@ -643,10 +866,11 @@ result<message> encode_result(const ucl_object_t *results, bool rewritten)
 	if (adds->len) {
 		put(root.get(), "add", adds.release());
 	}
+	if (deletes->len) put(root.get(), "delete", deletes.release());
 	auto m = json_reply(200, root.get());
 	gsize len;
 	rspamd_http_message_get_body(m.get(), &len);
-	if (len > 64 * 1024) {
+	if (len > (body ? max_message * 4 / 3 + 128 * 1024 : 1024 * 1024)) {
 		return tl::make_unexpected("response too large");
 	}
 	return m;
@@ -679,9 +903,10 @@ extern "C" rspamd_http_message *rspamd_mta_hooks_decode(const char *data, gsize 
 	return decoded->release();
 }
 
-extern "C" rspamd_http_message *rspamd_mta_hooks_encode(const ucl_object_t *results, gboolean rewritten)
+extern "C" rspamd_http_message *rspamd_mta_hooks_encode(const ucl_object_t *results,
+														const char *original, gsize original_len, const char *body, gsize body_len, const char *spam_header, gsize max_message)
 {
-	auto encoded = encode_result(results, rewritten);
+	auto encoded = encode_result(results, {original, original_len}, body, body_len, spam_header, max_message);
 	if (!encoded) {
 		return rspamd_mta_hooks_error(503, "SCANNER_UNAVAILABLE", encoded.error());
 	}
@@ -691,6 +916,8 @@ extern "C" rspamd_http_message *rspamd_mta_hooks_encode(const ucl_object_t *resu
 struct rspamd_mta_hooks_config {
 	rspamd_config *cfg;
 	std::string token, owner, redis_host, redis_password, redis_db, prefix, settings_id;
+	std::string spam_header = "X-Spam";
+	std::string prefix_base;
 	int redis_port = 6379;
 	bool insecure_loopback = false;
 	size_t max_message;
@@ -699,6 +926,7 @@ struct rspamd_mta_hooks_config {
 struct rspamd_mta_hooks_request {
 	rspamd_mta_hooks_config *config;
 	message input{nullptr, rspamd_http_message_unref}, output{nullptr, rspamd_http_message_unref};
+	message original{nullptr, rspamd_http_message_unref};
 	/* These values survive the input HTTP message and asynchronous callbacks. */
 	std::string id, fingerprint;
 	fstring registration{nullptr, rspamd_fstring_free};
@@ -886,7 +1114,8 @@ result<std::unique_ptr<rspamd_mta_hooks_config>> parse_config(const ucl_object_t
 		c->insecure_loopback = ucl_object_toboolean(v);
 	}
 	/* Profile changes must not reuse state from another scanning policy. */
-	c->prefix += digest(c->settings_id + ":add-only-v1:") + ":";
+	c->prefix_base = c->prefix;
+	c->prefix += digest(c->settings_id + ":data-edits-v2:" + c->spam_header) + ":";
 	return c;
 }
 
@@ -907,7 +1136,7 @@ message discovery(const rspamd_mta_hooks_config *c)
 	for (auto a: {"accept", "reject", "discard", "quarantine"}) {
 		ucl_array_append(actions.get(), ucl_object_fromstring(a));
 	}
-	for (auto p: {"/action", "/response", "/message/headers"}) {
+	for (auto p: {"/action", "/response", "/message/headers", "/rawMessage"}) {
 		ucl_array_append(updates.get(), ucl_object_fromstring(p));
 	}
 	put(inbound.get(), "actions", actions.release());
@@ -1034,6 +1263,7 @@ result<void> prepare_invocation(rspamd_mta_hooks_request *r, rspamd_http_message
 	r->invocation_key = r->config->prefix + "request:" + r->config->owner + ":";
 	r->invocation_key.append(*request_id);
 	r->input = std::move(*input);
+	r->original.reset(rspamd_http_message_ref(r->input.get()));
 	return {};
 }
 
@@ -1121,6 +1351,14 @@ extern "C" rspamd_mta_hooks_config *rspamd_mta_hooks_config_new(const ucl_object
 extern "C" void rspamd_mta_hooks_config_free(rspamd_mta_hooks_config *c)
 {
 	delete c;
+}
+
+extern "C" gboolean rspamd_mta_hooks_set_spam_header(rspamd_mta_hooks_config *c, const char *name)
+{
+	if (!name || !header_name(name)) return FALSE;
+	c->spam_header = name;
+	c->prefix = c->prefix_base + digest(c->settings_id + ":data-edits-v2:" + c->spam_header) + ":";
+	return TRUE;
 }
 
 extern "C" gsize rspamd_mta_hooks_max_request(rspamd_mta_hooks_config *c)
@@ -1228,9 +1466,11 @@ extern "C" void rspamd_mta_hooks_begin(rspamd_mta_hooks_request *r, rspamd_mta_h
 }
 
 extern "C" void rspamd_mta_hooks_finish(rspamd_mta_hooks_request *r, const ucl_object_t *results,
-										gboolean rewritten, rspamd_mta_hooks_callback cb, gpointer ud)
+										const char *body, gsize body_len, rspamd_mta_hooks_callback cb, gpointer ud)
 {
-	r->output.reset(rspamd_mta_hooks_encode(results, rewritten));
+	gsize original_len = 0;
+	const char *original = r->original ? rspamd_http_message_get_body(r->original.get(), &original_len) : "";
+	r->output.reset(rspamd_mta_hooks_encode(results, original, original_len, body, body_len, r->config->spam_header.c_str(), r->config->max_message));
 	if (rspamd_mta_hooks_remaining(r) <= 0.001) {
 		r->output.reset(state_error(503));
 	}
@@ -1239,8 +1479,8 @@ extern "C" void rspamd_mta_hooks_finish(rspamd_mta_hooks_request *r, const ucl_o
 		return;
 	}
 	gsize len;
-	auto *body = rspamd_http_message_get_body(r->output.get(), &len);
-	command(r->config, {"EVAL", complete_script, "1", r->invocation_key, r->fingerprint, std::to_string(r->output->code), sv{body, len}}, [=](const redisReply *rep) {
+	auto *reply_body = rspamd_http_message_get_body(r->output.get(), &len);
+	command(r->config, {"EVAL", complete_script, "1", r->invocation_key, r->fingerprint, std::to_string(r->output->code), sv{reply_body, len}}, [=](const redisReply *rep) {
 		if (!rep || rep->type != REDIS_REPLY_INTEGER || rep->integer != 1) {
 			r->output.reset(state_error(503));
 		}

--- a/src/libserver/mta_hooks.h
+++ b/src/libserver/mta_hooks.h
@@ -1,0 +1,46 @@
+/* Copyright 2026 Vsevolod Stakhov. SPDX-License-Identifier: Apache-2.0 */
+#ifndef RSPAMD_MTA_HOOKS_H
+#define RSPAMD_MTA_HOOKS_H
+
+#include "config.h"
+#include "ucl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+struct rspamd_http_message;
+struct rspamd_config;
+struct rspamd_mta_hooks_config;
+struct rspamd_mta_hooks_request;
+
+/* Experimental draft-01 DATA/add-only frontend. All callbacks may run inline.
+ * A callback receives ownership of exactly one message: native scan input or
+ * HTTP response. The caller keeps the request and its callback data alive until
+ * the callback has completed, including when the peer disconnects. */
+typedef void (*rspamd_mta_hooks_callback)(struct rspamd_http_message *message,
+										  gboolean scan, gpointer ud);
+struct rspamd_mta_hooks_config *rspamd_mta_hooks_config_new(
+	const ucl_object_t *obj, struct rspamd_config *cfg, GError **err);
+void rspamd_mta_hooks_config_free(struct rspamd_mta_hooks_config *cfg);
+gsize rspamd_mta_hooks_max_request(struct rspamd_mta_hooks_config *cfg);
+struct rspamd_mta_hooks_request *rspamd_mta_hooks_request_new(
+	struct rspamd_mta_hooks_config *cfg, struct rspamd_http_message *msg,
+	gboolean tls, gboolean loopback);
+void rspamd_mta_hooks_request_free(struct rspamd_mta_hooks_request *request);
+void rspamd_mta_hooks_begin(struct rspamd_mta_hooks_request *request,
+							rspamd_mta_hooks_callback callback, gpointer ud);
+void rspamd_mta_hooks_finish(struct rspamd_mta_hooks_request *request,
+							 const ucl_object_t *results, gboolean rewritten,
+							 rspamd_mta_hooks_callback callback, gpointer ud);
+double rspamd_mta_hooks_remaining(struct rspamd_mta_hooks_request *request);
+struct rspamd_http_message *rspamd_mta_hooks_error(int status,
+												   const char *code, const char *message);
+/* Pure codec entry points also used by unit tests. */
+struct rspamd_http_message *rspamd_mta_hooks_decode(const char *data, gsize len,
+													gsize max_message, GError **err);
+struct rspamd_http_message *rspamd_mta_hooks_encode(const ucl_object_t *results,
+													gboolean rewritten);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/libserver/mta_hooks.h
+++ b/src/libserver/mta_hooks.h
@@ -13,7 +13,7 @@ struct rspamd_config;
 struct rspamd_mta_hooks_config;
 struct rspamd_mta_hooks_request;
 
-/* Experimental draft-01 DATA/add-only frontend. All callbacks may run inline.
+/* Experimental draft-01 DATA frontend. All callbacks may run inline.
  * A callback receives ownership of exactly one message: native scan input or
  * HTTP response. The caller keeps the request and its callback data alive until
  * the callback has completed, including when the peer disconnects. */
@@ -22,6 +22,8 @@ typedef void (*rspamd_mta_hooks_callback)(struct rspamd_http_message *message,
 struct rspamd_mta_hooks_config *rspamd_mta_hooks_config_new(
 	const ucl_object_t *obj, struct rspamd_config *cfg, GError **err);
 void rspamd_mta_hooks_config_free(struct rspamd_mta_hooks_config *cfg);
+/* Set the worker's spam header before accepting requests. */
+gboolean rspamd_mta_hooks_set_spam_header(struct rspamd_mta_hooks_config *cfg, const char *name);
 gsize rspamd_mta_hooks_max_request(struct rspamd_mta_hooks_config *cfg);
 struct rspamd_mta_hooks_request *rspamd_mta_hooks_request_new(
 	struct rspamd_mta_hooks_config *cfg, struct rspamd_http_message *msg,
@@ -30,7 +32,7 @@ void rspamd_mta_hooks_request_free(struct rspamd_mta_hooks_request *request);
 void rspamd_mta_hooks_begin(struct rspamd_mta_hooks_request *request,
 							rspamd_mta_hooks_callback callback, gpointer ud);
 void rspamd_mta_hooks_finish(struct rspamd_mta_hooks_request *request,
-							 const ucl_object_t *results, gboolean rewritten,
+							 const ucl_object_t *results, const char *body, gsize body_len,
 							 rspamd_mta_hooks_callback callback, gpointer ud);
 double rspamd_mta_hooks_remaining(struct rspamd_mta_hooks_request *request);
 struct rspamd_http_message *rspamd_mta_hooks_error(int status,
@@ -39,7 +41,8 @@ struct rspamd_http_message *rspamd_mta_hooks_error(int status,
 struct rspamd_http_message *rspamd_mta_hooks_decode(const char *data, gsize len,
 													gsize max_message, GError **err);
 struct rspamd_http_message *rspamd_mta_hooks_encode(const ucl_object_t *results,
-													gboolean rewritten);
+													const char *original, gsize original_len, const char *body, gsize body_len,
+													const char *spam_header, gsize max_message);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libserver/protocol.c
+++ b/src/libserver/protocol.c
@@ -2037,10 +2037,9 @@ rspamd_protocol_update_stats(struct rspamd_task *task)
  * For milter protocol, skip past the raw headers to return only the body.
  * Shared between v2 and v3 reply handlers.
  */
-static void
-rspamd_protocol_get_rewritten_body(struct rspamd_task *task,
-								   const char **body_start,
-								   gsize *body_len)
+void rspamd_protocol_get_rewritten_body(struct rspamd_task *task,
+										const char **body_start,
+										gsize *body_len)
 {
 	*body_start = task->msg.begin;
 	*body_len = task->msg.len;

--- a/src/libserver/protocol.h
+++ b/src/libserver/protocol.h
@@ -78,6 +78,10 @@ struct ucl_parser *rspamd_ucl_parser_new_untrusted(gsize inlen);
 gboolean rspamd_protocol_handle_headers(struct rspamd_task *task,
 										struct rspamd_http_message *msg);
 
+/* Borrow the rewritten body using the native milter/v2/v3 semantics. */
+void rspamd_protocol_get_rewritten_body(struct rspamd_task *task,
+										const char **body_start, gsize *body_len);
+
 /**
  * Process control chunk and update task structure accordingly
  * @param task

--- a/src/rspamd_proxy.c
+++ b/src/rspamd_proxy.c
@@ -39,6 +39,7 @@
 #include "libmime/lang_detection.h"
 #include "libmime/content_type.h"
 #include "libserver/multipart_form.h"
+#include "libserver/mta_hooks.h"
 
 #include <math.h>
 #include <string.h>
@@ -165,6 +166,8 @@ struct rspamd_proxy_ctx {
 	gboolean has_self_scan;
 	/* It is not HTTP but milter proxy */
 	gboolean milter;
+	/* Dedicated experimental HTTP frontend; mutually exclusive with milter. */
+	struct rspamd_mta_hooks_config *mta_hooks;
 	/* Discard messages instead of rejecting them */
 	gboolean discard_on_reject;
 	/* Quarantine messages instead of rejecting them */
@@ -241,6 +244,9 @@ struct rspamd_proxy_session {
 	rspamd_inet_addr_t *client_addr;
 	struct rspamd_http_connection *client_conn;
 	struct rspamd_milter_session *client_milter_conn;
+	struct rspamd_mta_hooks_request *hooks_request;
+	gboolean hooks_tls;
+	gboolean hooks_disconnected;
 	struct rspamd_http_upstream *backend;
 	gpointer map;
 	char *fname;
@@ -300,7 +306,7 @@ proxy_add_client_ip_header(struct rspamd_http_message *msg,
 		rspamd_http_message_add_header_len(msg, IP_ADDR_HEADER,
 										   existing_ip_hdr->begin, existing_ip_hdr->len);
 	}
-	else if (session->client_addr) {
+	else if (session->client_addr && !session->hooks_request) {
 		/* For direct HTTP connections, use the client address */
 		if (rspamd_inet_address_get_af(session->client_addr) != AF_UNIX) {
 			rspamd_http_message_add_header(msg, IP_ADDR_HEADER,
@@ -1036,6 +1042,27 @@ rspamd_proxy_parse_log_tag_worker_option(rspamd_mempool_t *pool,
 	return TRUE;
 }
 
+static gboolean
+rspamd_proxy_parse_mta_hooks(rspamd_mempool_t *pool,
+							 const ucl_object_t *obj, gpointer ud,
+							 struct rspamd_rcl_section *section, GError **err)
+{
+	struct rspamd_rcl_struct_parser *pd = ud;
+	struct rspamd_proxy_ctx *ctx = pd->user_struct;
+	struct rspamd_mta_hooks_config *hooks;
+
+	hooks = rspamd_mta_hooks_config_new(obj, ctx->cfg, err);
+	if (err && *err) {
+		return FALSE;
+	}
+	ctx->mta_hooks = hooks;
+	if (hooks) {
+		rspamd_mempool_add_destructor(pool,
+									  (rspamd_mempool_destruct_t) rspamd_mta_hooks_config_free, hooks);
+	}
+	return TRUE;
+}
+
 gpointer
 init_rspamd_proxy(struct rspamd_config *cfg)
 {
@@ -1069,6 +1096,9 @@ init_rspamd_proxy(struct rspamd_config *cfg)
 	ctx->allow_file_and_shm_inputs = TRUE;
 	ctx->max_connections = 0;            /* Unlimited by default */
 	ctx->max_connections_per_source = 0; /* Unlimited by default */
+	rspamd_rcl_register_worker_option(cfg, type, "mta_hooks",
+									  rspamd_proxy_parse_mta_hooks, ctx, 0, 0,
+									  "Experimental draft-01 DATA/add-only HTTP frontend (requires Redis)");
 
 	rspamd_rcl_register_worker_option(cfg,
 									  type,
@@ -1678,6 +1708,7 @@ proxy_session_dtor(struct rspamd_proxy_session *session)
 	g_ptr_array_free(session->mirror_conns, TRUE);
 	rspamd_http_message_shmem_unref(session->shmem_ref);
 	rspamd_http_message_unref(session->client_message);
+	rspamd_mta_hooks_request_free(session->hooks_request);
 
 	if (session->client_addr) {
 		rspamd_inet_address_free(session->client_addr);
@@ -2710,11 +2741,49 @@ proxy_open_mirror_connections(struct rspamd_proxy_session *session)
 	}
 }
 
+/* A Redis operation owns an additional session reference, including after the
+ * HTTP peer disconnects. Neither the request nor its callback data can dangle. */
+static void
+proxy_hooks_ready(struct rspamd_http_message *msg, gboolean scan, gpointer ud)
+{
+	struct rspamd_proxy_session *session = ud;
+
+	if (session->hooks_disconnected) {
+		rspamd_http_message_unref(msg);
+	}
+	else if (scan) {
+		session->client_message = msg;
+		session->allow_file_shm = FALSE;
+		/* The authenticated frontend does not confer local scan privileges. */
+		session->local_client = FALSE;
+		proxy_send_master_message(session);
+	}
+	else {
+		rspamd_http_connection_reset(session->client_conn);
+		rspamd_http_connection_write_message(session->client_conn, msg, NULL,
+											 "application/json", session, 2.0);
+	}
+	REF_RELEASE(session);
+}
+
+static void
+proxy_hooks_finish(struct rspamd_proxy_session *session,
+				   const ucl_object_t *results, gboolean rewritten)
+{
+	REF_RETAIN(session);
+	rspamd_mta_hooks_finish(session->hooks_request, results, rewritten,
+							proxy_hooks_ready, session);
+}
+
 static void
 proxy_client_write_error(struct rspamd_proxy_session *session, int code,
 						 const char *status)
 {
 	struct rspamd_http_message *reply;
+	if (session->hooks_request) {
+		proxy_hooks_finish(session, NULL, FALSE);
+		return;
+	}
 
 	if (session->client_milter_conn) {
 		rspamd_milter_send_action(session->client_milter_conn,
@@ -2803,6 +2872,13 @@ proxy_backend_master_error_handler(struct rspamd_http_connection *conn, GError *
 
 	rspamd_upstream_fail(bk_conn->up, FALSE, err ? err->message : "unknown");
 	proxy_backend_close_connection(session->master_conn);
+
+	/* Retrying a possibly processed scan could duplicate learning or other
+	 * backend side effects. Hooks retries are handled by the shared ledger. */
+	if (session->hooks_request) {
+		proxy_client_write_error(session, 503, "Backend failed");
+		return;
+	}
 
 	if (session->ctx->max_retries > 0 &&
 		session->retries >= session->ctx->max_retries) {
@@ -2929,6 +3005,13 @@ proxy_backend_master_finish_handler(struct rspamd_http_connection *conn,
 		}
 	}
 
+	if (session->hooks_request) {
+		proxy_hooks_finish(session, msg->code == 200 ? bk_conn->results : NULL,
+						   bk_conn->body_data != NULL || body_offset > 0);
+		rspamd_http_message_unref(msg);
+		return 0;
+	}
+
 	if (session->client_milter_conn) {
 		nsession = proxy_session_refresh(session);
 
@@ -3029,6 +3112,20 @@ rspamd_proxy_scan_self_reply(struct rspamd_task *task)
 	msg = rspamd_http_new_message(HTTP_RESPONSE);
 	msg->date = time(NULL);
 	msg->code = 200;
+	if (session->hooks_request) {
+		if (!task->err) {
+			rspamd_protocol_http_reply(msg, task, &rep, out_type);
+			rspamd_protocol_write_log_pipe(task);
+		}
+		if (rep) {
+			session->master_conn->results = ucl_object_ref(rep);
+		}
+		session->master_conn->flags |= RSPAMD_BACKEND_CLOSED;
+		proxy_hooks_finish(session, rep,
+						   (task->flags & RSPAMD_TASK_FLAG_MESSAGE_REWRITE) != 0);
+		rspamd_http_message_unref(msg);
+		return;
+	}
 
 	switch (task->cmd) {
 	case CMD_CHECK:
@@ -3155,6 +3252,24 @@ rspamd_proxy_task_fin(void *ud)
 	return FALSE;
 }
 
+static void
+proxy_hooks_task_timeout(EV_P_ ev_timer *w, int revents)
+{
+	struct rspamd_task *task = w->data;
+	/* Unlike the native soft timeout, the negotiated hook budget must not
+	 * restart for postfilters. Cancel remaining work and return an HTTP error. */
+	ev_timer_stop(EV_A_ w);
+	msg_info_task("MTA Hooks scan deadline exceeded");
+	if (task->err == NULL) {
+		g_set_error_literal(&task->err, rspamd_proxy_quark(), ETIMEDOUT,
+							"MTA Hooks scan deadline exceeded");
+	}
+	task->processed_stages |= RSPAMD_TASK_STAGE_DONE;
+	task->flags |= RSPAMD_TASK_FLAG_SKIP;
+	rspamd_session_cleanup(task->s, true);
+	rspamd_session_pending(task->s);
+}
+
 static gboolean
 rspamd_proxy_self_scan(struct rspamd_proxy_session *session)
 {
@@ -3251,11 +3366,16 @@ rspamd_proxy_self_scan(struct rspamd_proxy_session *session)
 	 * cfg->task_timeout) rather than default_upstream->timeout, which is the
 	 * milter/HTTP wire timeout and can be much larger (e.g. 120s) than the
 	 * intended task processing limit. */
-	if (!isnan(session->ctx->task_timeout) && session->ctx->task_timeout > 0.0) {
+	double task_timeout = session->ctx->task_timeout;
+	if (session->hooks_request) {
+		double remaining = rspamd_mta_hooks_remaining(session->hooks_request);
+		task_timeout = isnan(task_timeout) || task_timeout <= 0 ? remaining : MIN(task_timeout, remaining);
+	}
+	if (!isnan(task_timeout) && task_timeout > 0.0) {
 		task->timeout_ev.data = task;
-		ev_timer_init(&task->timeout_ev, rspamd_task_timeout,
-					  session->ctx->task_timeout,
-					  session->ctx->task_timeout);
+		ev_timer_init(&task->timeout_ev,
+					  session->hooks_request ? proxy_hooks_task_timeout : rspamd_task_timeout,
+					  task_timeout, task_timeout);
 		ev_timer_start(task->event_loop, &task->timeout_ev);
 	}
 
@@ -3368,6 +3488,10 @@ proxy_send_master_message(struct rspamd_proxy_session *session)
 		}
 
 		session->master_conn->timeout = backend->timeout;
+		if (session->hooks_request) {
+			session->master_conn->timeout = MIN(backend->timeout,
+												rspamd_mta_hooks_remaining(session->hooks_request));
+		}
 
 		if (session->master_conn->up == NULL) {
 			msg_err_session("cannot select upstream for %s",
@@ -3555,6 +3679,7 @@ static void
 proxy_client_error_handler(struct rspamd_http_connection *conn, GError *err)
 {
 	struct rspamd_proxy_session *session = conn->ud;
+	session->hooks_disconnected = TRUE;
 
 	msg_info_session("abnormally closing connection from: %s, error: %s",
 					 rspamd_inet_address_to_string(session->client_addr), err->message);
@@ -3576,6 +3701,16 @@ proxy_client_finish_handler(struct rspamd_http_connection *conn,
 													 sizeof(*session->master_conn));
 		session->master_conn->s = session;
 		session->master_conn->name = "master";
+		if (session->ctx->mta_hooks) {
+			session->hooks_request = rspamd_mta_hooks_request_new(
+				session->ctx->mta_hooks, msg, session->hooks_tls, session->local_client);
+			rspamd_http_connection_steal_msg(conn);
+			rspamd_http_message_unref(msg);
+			rspamd_http_connection_reset(conn);
+			REF_RETAIN(session);
+			rspamd_mta_hooks_begin(session->hooks_request, proxy_hooks_ready, session);
+			return 0;
+		}
 
 		/* Reset spamc legacy */
 		if (msg->method >= HTTP_SYMBOLS) {
@@ -3856,7 +3991,7 @@ proxy_accept_socket(EV_P_ ev_io *w, int revents)
 			http_opts);
 
 		rspamd_http_connection_set_max_size(session->client_conn,
-											ctx->cfg->max_message);
+											ctx->mta_hooks ? rspamd_mta_hooks_max_request(ctx->mta_hooks) : ctx->cfg->max_message);
 
 		if (ctx->key) {
 			rspamd_http_connection_set_key(session->client_conn, ctx->key);
@@ -3867,6 +4002,7 @@ proxy_accept_socket(EV_P_ ev_io *w, int revents)
 						 rspamd_inet_address_get_port(addr));
 
 		if (ctx->server_ssl_ctx && rspamd_worker_is_ssl_socket(worker, w->fd)) {
+			session->hooks_tls = TRUE;
 			rspamd_http_connection_accept_ssl_shared(session->client_conn,
 													 ctx->server_ssl_ctx,
 													 session,
@@ -3951,6 +4087,15 @@ start_rspamd_proxy(struct rspamd_worker *worker)
 	ctx->cfg = worker->srv->cfg;
 	CFG_REF_RETAIN(ctx->cfg);
 	ctx->srv = worker->srv;
+	if (ctx->mta_hooks) {
+		if (ctx->milter || ctx->mirrors->len != 0 || ctx->discard_on_reject || ctx->quarantine_on_reject) {
+			msg_err("mta_hooks requires a dedicated HTTP proxy without mirrors or milter action overrides");
+			exit(EXIT_FAILURE);
+		}
+		if (ctx->max_connections == 0) ctx->max_connections = 256;
+		ctx->timeout = MIN(ctx->timeout, 20.0);
+		ctx->allow_file_and_shm_inputs = FALSE;
+	}
 	ctx->event_loop = rspamd_prepare_worker(worker, "rspamd_proxy",
 											proxy_accept_socket);
 	rspamd_worker_warn_file_shm_inputs(worker, "rspamd_proxy",

--- a/src/rspamd_proxy.c
+++ b/src/rspamd_proxy.c
@@ -1098,7 +1098,7 @@ init_rspamd_proxy(struct rspamd_config *cfg)
 	ctx->max_connections_per_source = 0; /* Unlimited by default */
 	rspamd_rcl_register_worker_option(cfg, type, "mta_hooks",
 									  rspamd_proxy_parse_mta_hooks, ctx, 0, 0,
-									  "Experimental draft-01 DATA/add-only HTTP frontend (requires Redis)");
+									  "Experimental draft-01 DATA HTTP frontend (requires Redis)");
 
 	rspamd_rcl_register_worker_option(cfg,
 									  type,
@@ -1328,7 +1328,8 @@ proxy_backend_parse_results(struct rspamd_proxy_session *session,
 	if (offset_hdr) {
 		gulong val;
 
-		if (rspamd_strtoul(offset_hdr->begin, offset_hdr->len, &val) && val < inlen) {
+		/* An offset at the end explicitly replaces the body with zero bytes. */
+		if (rspamd_strtoul(offset_hdr->begin, offset_hdr->len, &val) && val > 0 && val <= inlen) {
 
 			if (body_offset) {
 				*body_offset = val;
@@ -2768,10 +2769,10 @@ proxy_hooks_ready(struct rspamd_http_message *msg, gboolean scan, gpointer ud)
 
 static void
 proxy_hooks_finish(struct rspamd_proxy_session *session,
-				   const ucl_object_t *results, gboolean rewritten)
+				   const ucl_object_t *results, const char *body, gsize body_len)
 {
 	REF_RETAIN(session);
-	rspamd_mta_hooks_finish(session->hooks_request, results, rewritten,
+	rspamd_mta_hooks_finish(session->hooks_request, results, body, body_len,
 							proxy_hooks_ready, session);
 }
 
@@ -2781,7 +2782,7 @@ proxy_client_write_error(struct rspamd_proxy_session *session, int code,
 {
 	struct rspamd_http_message *reply;
 	if (session->hooks_request) {
-		proxy_hooks_finish(session, NULL, FALSE);
+		proxy_hooks_finish(session, NULL, NULL, 0);
 		return;
 	}
 
@@ -3006,8 +3007,16 @@ proxy_backend_master_finish_handler(struct rspamd_http_connection *conn,
 	}
 
 	if (session->hooks_request) {
+		gsize len;
+		const char *data = rspamd_http_message_get_body(msg, &len);
+		const char *body = bk_conn->body_data;
+		gsize body_len = bk_conn->body_len;
+		if (!body && body_offset > 0 && (gsize) body_offset <= len) {
+			body = data + body_offset;
+			body_len = len - body_offset;
+		}
 		proxy_hooks_finish(session, msg->code == 200 ? bk_conn->results : NULL,
-						   bk_conn->body_data != NULL || body_offset > 0);
+						   body, body_len);
 		rspamd_http_message_unref(msg);
 		return 0;
 	}
@@ -3121,8 +3130,12 @@ rspamd_proxy_scan_self_reply(struct rspamd_task *task)
 			session->master_conn->results = ucl_object_ref(rep);
 		}
 		session->master_conn->flags |= RSPAMD_BACKEND_CLOSED;
-		proxy_hooks_finish(session, rep,
-						   (task->flags & RSPAMD_TASK_FLAG_MESSAGE_REWRITE) != 0);
+		const char *body = NULL;
+		gsize body_len = 0;
+		if (task->flags & RSPAMD_TASK_FLAG_MESSAGE_REWRITE) {
+			rspamd_protocol_get_rewritten_body(task, &body, &body_len);
+		}
+		proxy_hooks_finish(session, rep, body, body_len);
 		rspamd_http_message_unref(msg);
 		return;
 	}
@@ -4088,6 +4101,10 @@ start_rspamd_proxy(struct rspamd_worker *worker)
 	CFG_REF_RETAIN(ctx->cfg);
 	ctx->srv = worker->srv;
 	if (ctx->mta_hooks) {
+		if (!rspamd_mta_hooks_set_spam_header(ctx->mta_hooks, ctx->spam_header)) {
+			msg_err("invalid spam_header for MTA Hooks");
+			exit(EXIT_FAILURE);
+		}
 		if (ctx->milter || ctx->mirrors->len != 0 || ctx->discard_on_reject || ctx->quarantine_on_reject) {
 			msg_err("mta_hooks requires a dedicated HTTP proxy without mirrors or milter action overrides");
 			exit(EXIT_FAILURE);

--- a/test/functional/lua/mta_hooks.lua
+++ b/test/functional/lua/mta_hooks.lua
@@ -1,0 +1,56 @@
+-- Deterministic test policy; deliberately no network lookups or learning.
+local ucl = require 'ucl'
+local rspamd_util = require 'rspamd_util'
+local rspamd_http = require 'rspamd_http'
+
+local function slow_request(task)
+  rspamd_http.request({
+    task = task,
+    url = 'http://127.0.0.1:' .. task:get_header('X-Hooks-Slow-Port') .. '/',
+    timeout = 10,
+    callback = function() end,
+  })
+end
+
+rspamd_config:register_symbol({
+  name = 'MTA_HOOKS_SLOW_PREFILTER',
+  type = 'prefilter',
+  callback = function(task)
+    if task:get_header('X-Hooks-Test') == 'slow' then
+      slow_request(task)
+    end
+    return false
+  end,
+})
+
+rspamd_config:register_symbol({
+  name = 'MTA_HOOKS_TEST',
+  type = 'postfilter',
+  flags = 'empty,ignore_passthrough',
+  callback = function(task)
+    local mode = task:get_header('X-Hooks-Test') or 'accept'
+    if mode == 'slow' then
+      slow_request(task)
+    elseif mode == 'reject' or mode == 'soft reject' or mode == 'discard' or mode == 'quarantine' then
+      task:set_pre_result(mode, 'Hooks test policy', 'mta_hooks_test')
+    elseif mode == 'remove' then
+      task:set_milter_reply({add_headers = {['X-Good'] = 'yes'}, remove_headers = {['X-Old'] = 0}})
+    elseif mode == 'headers' then
+      local ip = task:get_ip()
+      local from = task:get_from('smtp') or {}
+      local rcpt = task:get_recipients('smtp') or {}
+      local metadata = {
+        nonce = rspamd_util.random_hex(16),
+        ip = ip and ip:is_valid() and ip:to_string() or 'none',
+        from = from[1] and from[1].addr or '',
+        rcpt = rcpt[1] and rcpt[1].addr or '',
+        helo = task:get_helo(),
+        queue = task:get_queue_id(),
+        mail_args = task:get_mail_esmtp_args(),
+        privileged = task:get_request_header('Settings') or task:get_request_header('Authorization'),
+      }
+      task:set_milter_reply({add_headers = {['X-Hooks-Metadata'] = ucl.to_format(metadata, 'json-compact')}})
+    end
+    return false
+  end,
+})

--- a/test/functional/lua/mta_hooks.lua
+++ b/test/functional/lua/mta_hooks.lua
@@ -35,6 +35,19 @@ rspamd_config:register_symbol({
       task:set_pre_result(mode, 'Hooks test policy', 'mta_hooks_test')
     elseif mode == 'remove' then
       task:set_milter_reply({add_headers = {['X-Good'] = 'yes'}, remove_headers = {['X-Old'] = 0}})
+    elseif mode == 'invalid' then
+      task:set_milter_reply({add_headers = {['X-Good'] = 'yes', ['X-Bad'] = 'bad\r\nInjected: yes'}})
+    elseif mode == 'subject' then
+      task:set_pre_result('rewrite subject', 'Hooks test policy', 'mta_hooks_test')
+    elseif mode == 'spam' then
+      task:set_pre_result('add header', 'Hooks test policy', 'mta_hooks_test')
+    elseif mode == 'body' or mode == 'empty-body' or mode == 'large-body' or mode == 'body-dkim' then
+      local raw = tostring(task:get_content())
+      local headers = raw:match('^(.-)\r?\n\r?\n')
+      local body = mode == 'empty-body' and '' or 'replacement\r\n'
+      if mode == 'large-body' then body = string.rep('x', 1500000) .. '\r\n' end
+      assert(task:set_message(headers .. '\r\n\r\n' .. body))
+      task:set_milter_reply({add_headers = {['X-Rewritten'] = 'yes'}})
     elseif mode == 'headers' then
       local ip = task:get_ip()
       local from = task:get_from('smtp') or {}
@@ -50,6 +63,14 @@ rspamd_config:register_symbol({
         privileged = task:get_request_header('Settings') or task:get_request_header('Authorization'),
       }
       task:set_milter_reply({add_headers = {['X-Hooks-Metadata'] = ucl.to_format(metadata, 'json-compact')}})
+    end
+    if mode == 'dkim' or mode == 'body-dkim' then
+      for _, selector in ipairs({'one', 'two'}) do
+        assert(rspamd_plugins.dkim.sign(task, {
+          key = os.getenv('RSPAMD_HOOKS_TEST_KEY'), domain = 'example.com', selector = selector,
+          headers = 'from:to:subject:x-hooks-test',
+        }))
+      end
     end
     return false
   end,

--- a/test/functional/util/mta_hooks.Dockerfile
+++ b/test/functional/util/mta_hooks.Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.90-bookworm AS bridge
+WORKDIR /build
+COPY milter/Cargo.toml milter/Cargo.lock ./
+COPY milter/src ./src
+RUN cargo build --locked
+
+FROM debian:bookworm-slim
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    cmake ninja-build g++ pkg-config ragel libglib2.0-dev libssl-dev libsodium-dev \
+    libpcre2-dev libicu-dev libsqlite3-dev libarchive-dev libluajit-5.1-dev \
+    zlib1g-dev libzstd-dev redis-server postfix python3 python3-dkim ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY rspamd /src
+RUN cmake -S /src -B /build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_INSTALL_PREFIX=/opt/rspamd -DENABLE_HYPERSCAN=OFF -DENABLE_BLAS=OFF \
+    -DENABLE_LIBUNWIND=OFF -DENABLE_JEMALLOC=OFF \
+    && ninja -C /build -j2 install
+COPY --from=bridge /build/target/debug/mta-hooks-milter /usr/local/bin/mta-hooks-milter
+ENTRYPOINT ["python3", "-u", "/src/test/functional/util/mta_hooks_test.py", "--rspamd", "/opt/rspamd/bin/rspamd", "--milter", "/usr/local/bin/mta-hooks-milter", "--postfix"]

--- a/test/functional/util/mta_hooks_test.py
+++ b/test/functional/util/mta_hooks_test.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Isolated draft-01 integration test: real Redis, four proxy workers, self/upstream.
+
+Run with --rspamd /path/to/rspamd; use RSPAMD_INSTALLROOT for a staged install.
+Only subprocesses and temporary files created by this test are modified.
+"""
+import argparse
+import base64
+import concurrent.futures
+import copy
+import hashlib
+from http.client import HTTPConnection
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import threading
+import uuid
+
+TOKEN = 'mta-hooks-test-only-credential-0123456789'
+PROPERTIES = ['/stage', '/action', '/timestamp', '/protocol', '/rawMessage',
+              '/envelope', '/queue', '/client']
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def port():
+    with socket.socket() as sock:
+        sock.bind(('127.0.0.1', 0))
+        return sock.getsockname()[1]
+
+
+def wait_port(p, process):
+    until = time.monotonic() + 20
+    while time.monotonic() < until:
+        if process.poll() is not None:
+            raise AssertionError(f'process exited {process.returncode}')
+        try:
+            with socket.create_connection(('127.0.0.1', p), timeout=.2):
+                return
+        except OSError:
+            time.sleep(.05)
+    raise AssertionError(f'port {p} not ready')
+
+
+def http(p, path, body=None, method='POST', headers=None):
+    conn = HTTPConnection('127.0.0.1', p, timeout=25)
+    h = {'Authorization': f'Bearer {TOKEN}', 'Content-Type': 'application/json'}
+    h.update(headers or {})
+    data = json.dumps(body).encode() if body is not None else None
+    try:
+        conn.request(method, path, data, h)
+        res = conn.getresponse()
+        raw = res.read()
+        return res.status, json.loads(raw) if raw else None
+    finally:
+        conn.close()
+
+
+def registration(p, timeout=20000):
+    status, r = http(p, '/v1/hooks/register', {
+        'name': 'interop-test', 'serialization': 'json', 'timeoutMs': timeout,
+        'inbound': {'stages': ['data'], 'properties': PROPERTIES}, 'outbound': None})
+    assert status == 201, (status, r)
+    assert r['negotiated']['inbound']['properties'] == PROPERTIES, r
+    return r
+
+
+def payload(mode='accept'):
+    raw = f'From: sender@example.com\r\nTo: rcpt@example.com\r\nSubject: test\r\nX-Hooks-Test: {mode}\r\n\r\nhello\r\n'
+    return {'stage': 'data', 'action': 'accept', 'timestamp': '2026-09-05T12:00:00Z',
+            'protocol': {'version': '1.0'}, 'rawMessage': base64.b64encode(raw.encode()).decode(),
+            'envelope': {'from': {'address': None, 'parameters': {'SIZE': str(len(raw))}},
+                         'to': [{'address': 'rcpt@example.com', 'parameters': {}}]},
+            'client': {'ip': '192.0.2.42', 'port': 34567, 'ehlo': 'mx.example.com'},
+            'queue': {'id': 'TESTQ'}}
+
+
+def invoke(p, r, data=None, request_id=None, extra=None):
+    headers = {'X-MTA-Hooks-Registration': r['registrationId'],
+               'X-MTA-Hooks-Request-Id': request_id or str(uuid.uuid4())}
+    headers.update(extra or {})
+    return http(p, r['hookEndpoint'], data or payload(), headers=headers)
+
+
+def check(p):
+    r = registration(p)
+    assert http(p, '/.well-known/mta-hooks', method='GET')[0] == 200
+    assert http(p, '/checkv2', payload())[0] == 404
+    assert http(p, r['hookEndpoint'], payload(), headers={'Authorization': 'Bearer wrong'})[0] == 401
+    status, _ = http(p, r['endpoints']['status'], method='GET')
+    assert status == 200
+    assert invoke(p, r)[0] == 204
+    for mode in ['reject', 'soft reject', 'discard', 'quarantine']:
+        status, response = invoke(p, r, payload(mode))
+        assert status == 200, (mode, status, response)
+        edits = {x['path']: x['value'] for x in response['set']}
+        assert edits['/action'] == ('reject' if mode == 'soft reject' else mode)
+        if 'reject' in mode:
+            assert edits['/response']['code'] == (451 if mode == 'soft reject' else 550)
+    status, response = invoke(p, r, payload('headers'), extra={
+        'Settings': '{actions {reject = -100}}', 'File': '/not/to/be/opened', 'IP': '127.0.0.1'})
+    assert status == 200, (status, response)
+    meta = json.loads(response['add'][0]['value']['value'])
+    assert meta['ip'] == '192.0.2.42' and meta['from'] == '' and meta['rcpt'] == 'rcpt@example.com', meta
+    assert meta['helo'] == 'mx.example.com' and meta['queue'] == 'TESTQ', meta
+    assert not meta.get('privileged'), meta
+    assert meta['mail_args']['SIZE'], meta
+    missing = payload('headers'); missing['client'] = None
+    status, response = invoke(p, r, missing)
+    assert status == 200, (status, response)
+    assert json.loads(response['add'][0]['value']['value'])['ip'] == 'none', response
+    status, response = invoke(p, r, payload('remove'))
+    assert status == 503 and 'add' not in response, response
+    bad = payload(); bad['rawMessage'] = '!!!!'
+    assert invoke(p, r, bad)[0] == 400
+    bad = payload(); bad['client']['ehlo'] = 'mx\r\nSettings: evil'
+    assert invoke(p, r, bad)[0] == 400
+    uid = str(uuid.uuid4()); original = payload('headers')
+    first = invoke(p, r, original, uid)
+    assert first[0] == 200, first
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        replies = list(pool.map(lambda _: invoke(p, r, original, uid), range(16)))
+    assert all(reply == first for reply in replies), replies
+    # Race initial requests too: one scan wins; other requests replay or wait.
+    racing_id = str(uuid.uuid4())
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        racing = list(pool.map(lambda _: invoke(p, r, original, racing_id), range(16)))
+    completed = [reply for reply in racing if reply[0] == 200]
+    assert completed and all(reply == completed[0] for reply in completed), racing
+    assert all(reply[0] in (200, 503) for reply in racing), racing
+    assert invoke(p, r, payload('reject'), uid)[0] == 409
+    renewed = registration(p)
+    assert invoke(p, renewed, original, uid) == first
+    assert http(p, r['endpoints']['deregistration'], method='DELETE')[0] == 200
+    assert invoke(p, r)[0] == 410
+    assert invoke(p, renewed)[0] == 204
+    unknown = copy.deepcopy(r); unknown['registrationId'] = str(uuid.uuid4())
+    unknown['hookEndpoint'] = '/v1/hooks/invoke/' + unknown['registrationId']
+    assert invoke(p, unknown)[0] == 404
+    return renewed
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--rspamd', required=True)
+    ap.add_argument('--redis', default='redis-server')
+    args = ap.parse_args()
+    work = Path(tempfile.mkdtemp(prefix='rspamd-mta-hooks-test-'))
+    print(f'Logs: {work}', flush=True)
+    processes = []
+    logs = []
+    class SlowHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            time.sleep(3)
+            try:
+                self.send_response(204)
+                self.end_headers()
+            except OSError:
+                pass
+
+        def log_message(self, *_args):
+            pass
+
+    slow = ThreadingHTTPServer(('127.0.0.1', 0), SlowHandler)
+    threading.Thread(target=slow.serve_forever, daemon=True).start()
+
+    def launch(name, command):
+        log = open(work / f'{name}.log', 'wb')
+        logs.append(log)
+        process = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+        processes.append(process)
+        return process
+
+    def scanner(name, p, backend=None, hooks=False):
+        cfg = work / f'{name}.conf'
+        cache = work / f'{name}-cache'
+        cache.mkdir()
+        hooks_config = f'''mta_hooks {{ enabled = true; token = "{TOKEN}";
+          redis_host = "127.0.0.1"; redis_port = {rp}; prefix = "{namespace}";
+          insecure_loopback = true; }}''' if hooks else ''
+        upstream = f'hosts = "127.0.0.1:{backend}";' if backend else 'self_scan = true;'
+        worker = f'''worker "rspamd_proxy" {{ bind_socket = "127.0.0.1:{p}"; count = 4;
+          milter = false; allow_file_and_shm_inputs = false; {hooks_config}
+          upstream {{ name = "local"; default = true; {upstream} }} }}''' if hooks else f'''
+          worker "normal" {{ bind_socket = "127.0.0.1:{p}"; count = 2; }}'''
+        cfg.write_text(f'''
+options {{ filters = []; url_tld = "{ROOT}/test/lua/unit/test_tld.dat";
+  lua_path = "{ROOT}/lualib/?.lua"; task_timeout = 10s;
+  hs_cache_dir = "{cache}"; maps_cache_dir = "{cache}"; temp_dir = "{work}"; }}
+logging {{ type = "console"; level = "info"; }}
+actions {{ reject = 100; discard {{ flags = ["no_threshold"]; }}
+  quarantine {{ flags = ["no_threshold"]; }} }}
+lua = "{ROOT}/test/functional/lua/mta_hooks.lua";
+{worker}
+''')
+        process = launch(name, [args.rspamd, '-f', '-c', str(cfg), '--var', f'DBDIR={cache}'])
+        wait_port(p, process)
+        return process
+
+    try:
+        rp, normal, self_port, upstream_port = port(), port(), port(), port()
+        namespace = 'mta-hooks-test:' + uuid.uuid4().hex + ':'
+        redis = launch('redis', [args.redis, '--bind', '127.0.0.1', '--port', str(rp),
+                                '--save', '', '--appendonly', 'no', '--dir', str(work)])
+        wait_port(rp, redis)
+        scanner('backend', normal)
+        scanner('self', self_port, hooks=True)
+        scanner('upstream', upstream_port, backend=normal, hooks=True)
+        check(self_port)
+        print('PASS self-scan (four workers)', flush=True)
+        r = check(upstream_port)
+        print('PASS upstream scan (four proxy workers, two backend workers)', flush=True)
+        # A registration created on one frontend is usable on another instance.
+        assert invoke(self_port, r)[0] == 204
+        for p in [self_port, upstream_port]:
+            short = registration(p, timeout=1000)
+            data = payload('slow')
+            raw = base64.b64decode(data['rawMessage']).replace(b'\r\n\r\n',
+                f'\r\nX-Hooks-Slow-Port: {slow.server_port}\r\n\r\n'.encode(), 1)
+            data['rawMessage'] = base64.b64encode(raw).decode()
+            started = time.monotonic()
+            status, result = invoke(p, short, data)
+            assert status == 503, (status, result)
+            assert time.monotonic() - started < 1.8, 'deadline extended into postfilters'
+            assert invoke(p, r)[0] == 204, 'worker did not recover after timeout'
+        print('PASS self/upstream hard deadlines and recovery', flush=True)
+        # Expire only a registration owned by this isolated test Redis instance.
+        key = namespace + hashlib.sha256(b':add-only-v1:').hexdigest() + ':registration:' + r['registrationId']
+        subprocess.run(['redis-cli', '-p', str(rp), 'EXPIRE', key, '0'], check=True, capture_output=True)
+        assert invoke(self_port, r)[0] == 404
+        r = registration(self_port)
+        redis.terminate(); redis.wait(timeout=5)
+        assert invoke(upstream_port, r)[0] == 503
+        print('PASS cross-instance registration and Redis outage fail-closed', flush=True)
+    finally:
+        slow.shutdown()
+        slow.server_close()
+        for process in reversed(processes):
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGTERM)
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=5)
+        for log in logs:
+            log.close()
+    for name in ['self', 'upstream', 'backend']:
+        text = (work / f'{name}.log').read_text(errors='replace')
+        assert 'ERROR: AddressSanitizer' not in text, f'sanitizer failure in {name}'
+    print('PASS all draft-01 integration checks', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/functional/util/mta_hooks_test.py
+++ b/test/functional/util/mta_hooks_test.py
@@ -13,9 +13,12 @@ from http.client import HTTPConnection
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
+import re
+import smtplib
 from pathlib import Path
 import signal
 import socket
+import struct
 import subprocess
 import tempfile
 import time
@@ -64,14 +67,14 @@ def http(p, path, body=None, method='POST', headers=None):
 def registration(p, timeout=20000):
     status, r = http(p, '/v1/hooks/register', {
         'name': 'interop-test', 'serialization': 'json', 'timeoutMs': timeout,
-        'inbound': {'stages': ['data'], 'properties': PROPERTIES}, 'outbound': None})
+        'inbound': {'stages': ['data'], 'properties': PROPERTIES + ['/tls', '/auth', '/server']}, 'outbound': None})
     assert status == 201, (status, r)
     assert r['negotiated']['inbound']['properties'] == PROPERTIES, r
     return r
 
 
 def payload(mode='accept'):
-    raw = f'From: sender@example.com\r\nTo: rcpt@example.com\r\nSubject: test\r\nX-Hooks-Test: {mode}\r\n\r\nhello\r\n'
+    raw = f'From: sender@example.com\r\nTo: rcpt@example.com\r\nSubject: test\r\nX-Old: one\r\nX-Old: two\r\nX-Hooks-Test: {mode}\r\n\r\nhello\r\n'
     return {'stage': 'data', 'action': 'accept', 'timestamp': '2026-09-05T12:00:00Z',
             'protocol': {'version': '1.0'}, 'rawMessage': base64.b64encode(raw.encode()).decode(),
             'envelope': {'from': {'address': None, 'parameters': {'SIZE': str(len(raw))}},
@@ -88,6 +91,10 @@ def invoke(p, r, data=None, request_id=None, extra=None):
 
 
 def check(p):
+    for properties in [PROPERTIES[:-1], PROPERTIES + ['/client'], PROPERTIES + [42]]:
+        assert http(p, '/v1/hooks/register', {
+            'name': 'invalid-properties', 'serialization': 'json',
+            'inbound': {'stages': ['data'], 'properties': properties}})[0] == 400
     r = registration(p)
     assert http(p, '/.well-known/mta-hooks', method='GET')[0] == 200
     assert http(p, '/checkv2', payload())[0] == 404
@@ -114,7 +121,7 @@ def check(p):
     status, response = invoke(p, r, missing)
     assert status == 200, (status, response)
     assert json.loads(response['add'][0]['value']['value'])['ip'] == 'none', response
-    status, response = invoke(p, r, payload('remove'))
+    status, response = invoke(p, r, payload('invalid'))
     assert status == 503 and 'add' not in response, response
     bad = payload(); bad['rawMessage'] = '!!!!'
     assert invoke(p, r, bad)[0] == 400
@@ -145,13 +152,158 @@ def check(p):
     return renewed
 
 
+def check_milter(p):
+    def send(sock, command, data=b''):
+        sock.sendall(struct.pack('!I', len(data) + 1) + command + data)
+
+    def receive(sock):
+        def exact(n):
+            data = b''
+            while len(data) < n:
+                chunk = sock.recv(n - len(data))
+                assert chunk, 'bridge closed connection'
+                data += chunk
+            return data
+        return exact(struct.unpack('!I', exact(4))[0])
+
+    for mode, verdict in [('accept', b'c'), ('headers', b'c'), ('reject', b'y'),
+                          ('soft reject', b'y'), ('discard', b'd'),
+                          ('quarantine', b'c'), ('remove', b'c'), ('invalid', b't'),
+                          ('subject', b'c'), ('spam', b'c'), ('body', b'c'),
+                          ('empty-body', b'c'), ('large-body', b'c'), ('dkim', b'c'), ('body-dkim', b'c')]:
+        with socket.create_connection(('127.0.0.1', p), timeout=25) as sock:
+            send(sock, b'O', struct.pack('!III', 6, 0x1ff, 0))
+            assert receive(sock)[:1] == b'O'
+            for command, data in [(b'C', b'mx.example.com\0' + b'4' + struct.pack('!H', 34567) + b'192.0.2.42\0'),
+                                  (b'H', b'mx.example.com\0'), (b'M', b'<>\0SIZE=100\0'),
+                                  (b'R', b'<rcpt@example.com>\0'), (b'T', b''),
+                                  (b'L', b'Subject\0test\0'),
+                                  (b'L', b'From\0sender@example.com\0'),
+                                  (b'L', b'To\0rcpt@example.com\0'),
+                                  (b'L', b'X-Old\0one\0'), (b'L', b'X-Old\0two\0'),
+                                  (b'L', b'X-Hooks-Test\0' + mode.encode() + b'\0'),
+                                  (b'N', b''), (b'B', b'hello\r\n')]:
+                send(sock, command, data)
+                assert receive(sock) == b'c', (mode, command)
+            send(sock, b'D', b'Ei\0TESTQ\0')
+            send(sock, b'E')
+            edits = []
+            while True:
+                frame = receive(sock)
+                if frame[:1] in [b'c', b'a', b'r', b't', b'd', b'y']:
+                    assert frame[:1] == verdict, (mode, frame)
+                    if mode in ['reject', 'soft reject']:
+                        assert frame[1:4] == (b'550' if mode == 'reject' else b'451'), frame
+                    break
+                edits.append(frame)
+            if mode == 'headers':
+                header = next(x for x in edits if x.startswith(b'hX-Hooks-Metadata\0'))
+                metadata = json.loads(header.split(b'\0')[1])
+                assert metadata['ip'] == '192.0.2.42' and metadata['queue'] == 'TESTQ', metadata
+                assert metadata['from'] == '' and metadata['rcpt'] == 'rcpt@example.com', metadata
+            elif mode == 'quarantine':
+                assert any(x[:1] == b'q' for x in edits), edits
+            elif mode == 'invalid':
+                assert not edits, edits
+            elif mode == 'subject':
+                assert any(b'Subject\0[SPAM] test\0' in x for x in edits), edits
+            elif mode == 'spam':
+                assert any(b'X-Spam\0Yes\0' in x for x in edits), edits
+            elif mode == 'remove':
+                removals = [x for x in edits if x[:1] == b'm']
+                assert [struct.unpack('!I', x[1:5])[0] for x in removals] == [2, 1], removals
+                assert any(b'X-Good\0yes\0' in x for x in edits), edits
+            elif mode in ['body', 'empty-body', 'large-body', 'body-dkim']:
+                assert any(x[:1] == b'b' for x in edits), (mode, 'missing explicit body replacement')
+                replacement = b''.join(x[1:] for x in edits if x[:1] == b'b')
+                expected = b'' if mode == 'empty-body' else b'x' * 1500000 + b'\r\n' if mode == 'large-body' else b'replacement\r\n'
+                assert replacement == expected, (mode, len(replacement))
+                assert any(b'X-Rewritten\0' in x for x in edits), edits
+            if mode in ['dkim', 'body-dkim']:
+                assert sum(b'DKIM-Signature\0' in x for x in edits) == 2, edits
+            send(sock, b'Q')
+
+
+def check_postfix(mp):
+    import dkim
+    from email.parser import BytesParser
+    if not Path('/.dockerenv').exists():
+        raise RuntimeError('--postfix is restricted to the disposable test container')
+    for setting in ['myhostname=postfix.interop.test', 'mydestination=localhost',
+                    'inet_interfaces=127.0.0.1', 'inet_protocols=ipv4', 'local_recipient_maps=',
+                    'mynetworks=127.0.0.0/8', 'smtpd_relay_restrictions=permit_mynetworks,reject',
+                    f'smtpd_milters=inet:127.0.0.1:{mp}', 'milter_protocol=6',
+                    'milter_default_action=tempfail', 'milter_content_timeout=25s',
+                    'defer_transports=smtp,local,relay']:
+        subprocess.run(['postconf', '-e', setting], check=True)
+    subprocess.run(['postconf', '-M', '2525/inet=2525 inet n - n - - smtpd'], check=True)
+    subprocess.run(['postfix', 'start'], check=True)
+    public = subprocess.check_output(['openssl', 'rsa', '-in', os.environ['RSPAMD_HOOKS_TEST_KEY'],
+                                      '-pubout', '-outform', 'DER'], stderr=subprocess.DEVNULL)
+    dns = b'v=DKIM1; k=rsa; p=' + base64.b64encode(public)
+    try:
+        for mode in ['accept', 'remove', 'presigned', 'subject', 'spam', 'body', 'empty-body', 'large-body',
+                     'dkim', 'body-dkim', 'reject', 'soft reject', 'invalid', 'discard', 'quarantine']:
+            with smtplib.SMTP('127.0.0.1', 2525, timeout=30) as smtp:
+                smtp.ehlo('client.example.com')
+                assert smtp.mail('sender@example.com')[0] == 250
+                assert smtp.rcpt('rcpt@localhost')[0] == 250
+                raw = base64.b64decode(payload('remove' if mode == 'presigned' else mode)['rawMessage'])
+                if mode == 'presigned':
+                    raw = dkim.sign(raw, b'input', b'example.com', Path(os.environ['RSPAMD_HOOKS_TEST_KEY']).read_bytes(),
+                                    canonicalize=(b'simple', b'simple'), include_headers=[b'from', b'to', b'subject', b'x-hooks-test']) + raw
+                code, response = smtp.data(raw)
+                expected = 550 if mode == 'reject' else 451 if mode in ['soft reject', 'invalid'] else 250
+                assert code == expected, (mode, code, response)
+                if code != 250 or mode == 'discard':
+                    print('PASS Postfix SMTP', mode, code, flush=True)
+                    continue
+                queue = re.search(rb'queued as ([A-Za-z0-9]+)', response)
+                assert queue, response
+                queued = subprocess.check_output(['postcat', '-qbh', queue[1].decode()])
+                # postcat emits diagnostic delimiters around the RFC 5322 content.
+                lines = queued.splitlines(keepends=True)
+                start = next((i for i, line in enumerate(lines) if line.startswith(b'*** MESSAGE CONTENTS')), -1) + 1
+                end = next((i for i in range(start, len(lines)) if lines[i].startswith(b'*** ')), len(lines))
+                message = b''.join(lines[start:end]).replace(b'\r\n', b'\n').replace(b'\n', b'\r\n')
+                parsed = BytesParser().parsebytes(message)
+                if mode in ['remove', 'presigned']:
+                    assert parsed.get_all('X-Old') is None and parsed['X-Good'] == 'yes', message
+                elif mode == 'subject': assert parsed['Subject'] == '[SPAM] test', message
+                elif mode == 'spam': assert parsed['X-Spam'] == 'Yes', message
+                if mode in ['body', 'empty-body', 'large-body', 'body-dkim']:
+                    actual = message.split(b'\r\n\r\n', 1)[1]
+                    expected_body = b'' if mode == 'empty-body' else b'x' * 1500000 + b'\r\n' if mode == 'large-body' else b'replacement\r\n'
+                    assert actual == expected_body, (mode, len(actual), len(expected_body))
+                    assert parsed['X-Rewritten'] == 'yes'
+                if mode in ['dkim', 'body-dkim']:
+                    verifier = dkim.DKIM(message)
+                    assert len(parsed.get_all('DKIM-Signature')) == 2
+                    for index in range(2): assert verifier.verify(idx=index, dnsfunc=lambda *a, **kw: dns), mode
+                    assert not dkim.verify(message + b'tampered\r\n', dnsfunc=lambda *a, **kw: dns)
+                    assert not dkim.verify(message.replace(b'Subject: test', b'Subject: changed'), dnsfunc=lambda *a, **kw: dns)
+                if mode == 'presigned':
+                    assert dkim.verify(message, dnsfunc=lambda *a, **kw: dns), 'simple signature was damaged by header edits'
+                if mode == 'quarantine':
+                    assert list(Path('/var/spool/postfix/hold').rglob(queue[1].decode())), 'message was not held'
+                subprocess.run(['postsuper', '-d', queue[1].decode()], check=True, capture_output=True)
+            print('PASS Postfix queue', mode, flush=True)
+    finally:
+        subprocess.run(['postfix', 'stop'], check=True)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--rspamd', required=True)
     ap.add_argument('--redis', default='redis-server')
+    ap.add_argument('--milter', help='Path to the real mta-hooks-milter executable')
+    ap.add_argument('--postfix', action='store_true', help='Verify synthetic Postfix queues inside Docker')
     args = ap.parse_args()
+    if args.postfix and not args.milter:
+        ap.error('--postfix requires --milter')
     work = Path(tempfile.mkdtemp(prefix='rspamd-mta-hooks-test-'))
     print(f'Logs: {work}', flush=True)
+    os.environ['RSPAMD_HOOKS_TEST_KEY'] = str(ROOT / 'test/functional/configs/dkim.key')
     processes = []
     logs = []
     class SlowHandler(BaseHTTPRequestHandler):
@@ -189,16 +341,19 @@ def main():
           upstream {{ name = "local"; default = true; {upstream} }} }}''' if hooks else f'''
           worker "normal" {{ bind_socket = "127.0.0.1:{p}"; count = 2; }}'''
         cfg.write_text(f'''
-options {{ filters = []; url_tld = "{ROOT}/test/lua/unit/test_tld.dat";
+options {{ filters = ["dkim"]; url_tld = "{ROOT}/test/lua/unit/test_tld.dat";
   lua_path = "{ROOT}/lualib/?.lua"; task_timeout = 10s;
   hs_cache_dir = "{cache}"; maps_cache_dir = "{cache}"; temp_dir = "{work}"; }}
 logging {{ type = "console"; level = "info"; }}
-actions {{ reject = 100; discard {{ flags = ["no_threshold"]; }}
+actions {{ reject = 100; subject = "[SPAM] %s"; discard {{ flags = ["no_threshold"]; }}
   quarantine {{ flags = ["no_threshold"]; }} }}
 lua = "{ROOT}/test/functional/lua/mta_hooks.lua";
 {worker}
 ''')
-        process = launch(name, [args.rspamd, '-f', '-c', str(cfg), '--var', f'DBDIR={cache}'])
+        command = [args.rspamd, '-f', '-c', str(cfg), '--var', f'DBDIR={cache}']
+        if os.geteuid() == 0 and Path('/.dockerenv').exists():
+            command.append('--insecure')  # Disposable container, no host mounts or network.
+        process = launch(name, command)
         wait_port(p, process)
         return process
 
@@ -215,6 +370,21 @@ lua = "{ROOT}/test/functional/lua/mta_hooks.lua";
         print('PASS self-scan (four workers)', flush=True)
         r = check(upstream_port)
         print('PASS upstream scan (four proxy workers, two backend workers)', flush=True)
+        if args.milter:
+            for frontend in [self_port, upstream_port]:
+                mp, hp = port(), port()
+                bridge = launch(f'bridge-{frontend}', [args.milter,
+                    '--milter-listen', f'127.0.0.1:{mp}', '--http-listen', f'127.0.0.1:{hp}',
+                    '--scanner', f'http://127.0.0.1:{frontend}/v1/hooks/register',
+                    '--scanner-token', TOKEN, '--insecure-loopback', '--scanner-no-proxy',
+                    '--no-request-macros'])
+                wait_port(mp, bridge)
+                check_milter(mp)
+                if args.postfix:
+                    check_postfix(mp)
+                bridge.terminate()
+                bridge.wait(timeout=10)
+            print('PASS real mta-hooks-milter to self/upstream frontends', flush=True)
         # A registration created on one frontend is usable on another instance.
         assert invoke(self_port, r)[0] == 204
         for p in [self_port, upstream_port]:
@@ -230,7 +400,7 @@ lua = "{ROOT}/test/functional/lua/mta_hooks.lua";
             assert invoke(p, r)[0] == 204, 'worker did not recover after timeout'
         print('PASS self/upstream hard deadlines and recovery', flush=True)
         # Expire only a registration owned by this isolated test Redis instance.
-        key = namespace + hashlib.sha256(b':add-only-v1:').hexdigest() + ':registration:' + r['registrationId']
+        key = namespace + hashlib.sha256(b':data-edits-v2:X-Spam').hexdigest() + ':registration:' + r['registrationId']
         subprocess.run(['redis-cli', '-p', str(rp), 'EXPIRE', key, '0'], check=True, capture_output=True)
         assert invoke(self_port, r)[0] == 404
         r = registration(self_port)

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -39,6 +39,7 @@
 #include "rspamd_cxx_unit_upstream_latency.hxx"
 #include "rspamd_cxx_unit_upstream_srv.hxx"
 #include "rspamd_cxx_unit_multipart.hxx"
+#include "rspamd_cxx_unit_mta_hooks.hxx"
 #include "rspamd_cxx_unit_content_type.hxx"
 #include "rspamd_cxx_unit_content_negotiation.hxx"
 #include "rspamd_cxx_unit_charset.hxx"

--- a/test/rspamd_cxx_unit_mta_hooks.hxx
+++ b/test/rspamd_cxx_unit_mta_hooks.hxx
@@ -1,0 +1,245 @@
+/* Copyright 2026 Vsevolod Stakhov. SPDX-License-Identifier: Apache-2.0 */
+#ifndef RSPAMD_CXX_UNIT_MTA_HOOKS_HXX
+#define RSPAMD_CXX_UNIT_MTA_HOOKS_HXX
+#include "libserver/mta_hooks.h"
+#include "libserver/cfg_file.h"
+#include "libserver/http/http_private.h"
+#include "libutil/str_util.h"
+#include <memory>
+#include <string>
+
+namespace hooks_test {
+using msg_ptr = std::unique_ptr<rspamd_http_message, decltype(&rspamd_http_message_unref)>;
+static std::string request()
+{
+	return R"({"stage":"data","action":"accept","timestamp":"2026-09-05T12:00:00Z","protocol":{"version":"1.0"},"rawMessage":"U3ViamVjdDogdGVzdA0KDQpoZWxsbw0K","envelope":{"from":{"address":null,"parameters":{"SIZE":"24"}},"to":[{"address":"rcpt@example.com","parameters":{"ORCPT":"rfc822;rcpt@example.com"}}]},"client":{"ip":"192.0.2.1","ehlo":"mx.example.com"},"queue":{"id":"Q123"}})";
+}
+static msg_ptr decode(const std::string &s, size_t limit = 1024)
+{
+	GError *err = nullptr;
+	msg_ptr m{rspamd_mta_hooks_decode(s.data(), s.size(), limit, &err), rspamd_http_message_unref};
+	if (err) g_error_free(err);
+	return m;
+}
+static msg_ptr encode(const char *s, bool rewritten = false)
+{
+	auto *p = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
+	REQUIRE(ucl_parser_add_chunk(p, reinterpret_cast<const unsigned char *>(s), strlen(s)));
+	auto *o = ucl_parser_get_object(p);
+	ucl_parser_free(p);
+	msg_ptr m{rspamd_mta_hooks_encode(o, rewritten), rspamd_http_message_unref};
+	ucl_object_unref(o);
+	return m;
+}
+static std::string body(rspamd_http_message *m)
+{
+	gsize n;
+	auto *s = rspamd_http_message_get_body(m, &n);
+	return {s ? s : "", n};
+}
+}// namespace hooks_test
+
+TEST_SUITE("mta_hooks")
+{
+	TEST_CASE("DATA conversion preserves message and approved metadata")
+	{
+		auto m = hooks_test::decode(hooks_test::request());
+		REQUIRE(m);
+		CHECK(hooks_test::body(m.get()) == "Subject: test\r\n\r\nhello\r\n");
+		CHECK(std::string(m->url->str, m->url->len) == "/checkv2");
+		auto *from = rspamd_http_message_find_header(m.get(), "From");
+		REQUIRE(from);
+		CHECK(std::string(from->begin, from->len) == "<>");
+		CHECK(rspamd_http_message_find_header(m.get(), "X-Rspamd-Rcpt-Esmtp-Args") != nullptr);
+		CHECK(rspamd_http_message_find_header(m.get(), "Authorization") == nullptr);
+		CHECK(rspamd_http_message_find_header(m.get(), "Settings") == nullptr);
+	}
+	TEST_CASE("untrusted UCL and bounded message")
+	{
+		CHECK_FALSE(hooks_test::decode(hooks_test::request(), 4));
+		auto s = hooks_test::request();
+		s.insert(1, "\"stage\":\"data\",");
+		CHECK_FALSE(hooks_test::decode(s));
+		s = hooks_test::request();
+		s.insert(1, "\"st\\u0061ge\":\"data\",");
+		CHECK_FALSE(hooks_test::decode(s));
+
+		// No separate JSON grammar: safe UCL syntax is deliberately accepted.
+		s = hooks_test::request();
+		s.replace(s.find("\"stage\":\"data\""), strlen("\"stage\":\"data\""), "stage = \"data\"");
+		CHECK(hooks_test::decode(s));
+		s = hooks_test::request();
+		s.insert(s.size() - 1, ",");
+		CHECK(hooks_test::decode(s));
+		s = hooks_test::request();
+		s.insert(1, "\n.include \"/mta-hooks-does-not-exist\"\n");
+		CHECK_FALSE(hooks_test::decode(s));// macros disabled, not executed
+
+		s = hooks_test::request();
+		s.insert(1, "\"extra\":" + std::string(20, '[') + "null" + std::string(20, ']') + ",");
+		CHECK_FALSE(hooks_test::decode(s));// parser nesting budget
+		s = hooks_test::request();
+		s.insert(1, "\"" + std::string(257, 'k') + "\":0,");
+		CHECK_FALSE(hooks_test::decode(s));// parser key budget
+		std::string nodes = "\"extra\":[";
+		for (int i = 0; i < 20001; ++i) {
+			nodes += "0,";
+		}
+		nodes += "0],";
+		s = hooks_test::request();
+		s.insert(1, nodes);
+		CHECK_FALSE(hooks_test::decode(s));// parser node budget, below HTTP size limit
+		s = hooks_test::request();
+		s.replace(s.find("U3Viam"), 1, "!");
+		CHECK_FALSE(hooks_test::decode(s));
+	}
+	TEST_CASE("codec owns output but borrows length-delimited input")
+	{
+		const std::string bytes{"a\0b\xff\r\n", 6};
+		gsize len;
+		auto encoded = std::unique_ptr<char, decltype(&g_free)>{
+			rspamd_encode_base64(reinterpret_cast<const unsigned char *>(bytes.data()), bytes.size(), 0, &len), g_free};
+		auto source = hooks_test::request();
+		source.replace(source.find("U3ViamVjdDogdGVzdA0KDQpoZWxsbw0K"), 32, encoded.get(), len);
+		const auto request_len = source.size();
+		source += "not part of the request";
+		GError *error = nullptr;
+		auto m = hooks_test::msg_ptr{
+			rspamd_mta_hooks_decode(source.data(), request_len, 1024, &error), rspamd_http_message_unref};
+		REQUIRE(error == nullptr);
+		REQUIRE(m);
+		source.assign(source.size(), '!');
+		CHECK(hooks_test::body(m.get()) == bytes);
+		auto *helo = rspamd_http_message_find_header(m.get(), "Helo");
+		REQUIRE(helo);
+		CHECK(std::string(helo->begin, helo->len) == "mx.example.com");
+	}
+	TEST_CASE("canonical base64 accepts padding and rejects junk")
+	{
+		for (auto raw: {"YQ==", "YWI=", "YWJj"}) {
+			auto s = hooks_test::request();
+			s.replace(s.find("U3ViamVjdDogdGVzdA0KDQpoZWxsbw0K"), 32, raw);
+			CHECK(hooks_test::decode(s));
+		}
+		for (auto raw: {"YR==", "YWJ=", "YQ= ", "YQ==AAAA", "====", ""}) {
+			auto s = hooks_test::request();
+			s.replace(s.find("U3ViamVjdDogdGVzdA0KDQpoZWxsbw0K"), 32, raw);
+			CHECK_FALSE(hooks_test::decode(s));
+		}
+	}
+	TEST_CASE("typed decoding errors propagate through the C API")
+	{
+		for (auto pair: {std::pair{"\"stage\":\"data\"", "\"stage\":true"},
+						 std::pair{"\"rawMessage\":\"U3ViamVjdDogdGVzdA0KDQpoZWxsbw0K\"", "\"rawMessage\":[]"},
+						 std::pair{"\"address\":null", "\"address\":3"},
+						 std::pair{"\"SIZE\":\"24\"", "\"SIZE\":24"},
+						 std::pair{"\"ip\":\"192.0.2.1\"", "\"ip\":false"},
+						 std::pair{"\"ehlo\":\"mx.example.com\"", "\"ehlo\":{}"},
+						 std::pair{"\"id\":\"Q123\"", "\"id\":[]"}}) {
+			auto s = hooks_test::request();
+			s.replace(s.find(pair.first), strlen(pair.first), pair.second);
+			GError *error = nullptr;
+			auto m = hooks_test::msg_ptr{
+				rspamd_mta_hooks_decode(s.data(), s.size(), 1024, &error), rspamd_http_message_unref};
+			CHECK_FALSE(m);
+			REQUIRE(error);
+			CHECK(error->code == 400);
+			CHECK(strlen(error->message) > 0);
+			g_error_free(error);
+		}
+	}
+	TEST_CASE("fast UTF-8 validation and UTC timestamps")
+	{
+		for (auto date: {"2026-02-30T12:00:00Z", "xxxx-09-05T12:00:00Z", "2026-09-05T24:00:00Z",
+						 "2026-09-05T12:60:00Z", "2026-09-05T12:00:00.Z", "2026-09-05T12:00:00+01:00"}) {
+			auto s = hooks_test::request();
+			s.replace(s.find("2026-09-05T12:00:00Z"), 20, date);
+			CHECK_FALSE(hooks_test::decode(s));
+		}
+		auto s = hooks_test::request();
+		s.replace(s.find("2026-09-05T12:00:00Z"), 20, "2024-02-29T12:00:00.123Z");
+		CHECK(hooks_test::decode(s));
+		s = hooks_test::request();
+		s.replace(s.find("mx.example.com"), 14, "m\xc3\xa9.example.com");
+		CHECK(hooks_test::decode(s));
+		s = hooks_test::request();
+		s.replace(s.find("mx.example.com"), 14, "\xff");
+		CHECK_FALSE(hooks_test::decode(s));
+		CHECK(hooks_test::encode("{\"action\":\"no action\",\"milter\":{\"add_headers\":{\"X-Test\":\"m\xc3\xa9\"}}}")->code == 200);
+		CHECK(hooks_test::encode("{\"action\":\"no action\",\"milter\":{\"add_headers\":{\"X-Test\":\"\xff\"}}}")->code == 503);
+	}
+	TEST_CASE("reject metadata injection and null recipients")
+	{
+		auto s = hooks_test::request();
+		s.replace(s.find("mx.example.com"), strlen("mx.example.com"), "mx\\r\\nSettings: evil");
+		CHECK_FALSE(hooks_test::decode(s));
+		s = hooks_test::request();
+		s.replace(s.find("\"rcpt@example.com\""), strlen("\"rcpt@example.com\""), "null");
+		CHECK_FALSE(hooks_test::decode(s));
+	}
+	TEST_CASE("no action preserves previous decision")
+	{
+		auto m = hooks_test::encode(R"({"action":"no action"})");
+		CHECK(m->code == 204);
+		CHECK(hooks_test::body(m.get()).empty());
+	}
+	TEST_CASE("verdict and additive headers")
+	{
+		for (auto pair: {std::pair{"reject", "550"}, std::pair{"soft reject", "451"}}) {
+			std::string s = "{\"action\":\"" + std::string(pair.first) + "\",\"messages\":{\"smtp_message\":\"Policy\"}}";
+			auto m = hooks_test::encode(s.c_str());
+			CHECK(m->code == 200);
+			CHECK(hooks_test::body(m.get()).find(pair.second) != std::string::npos);
+		}
+		auto m = hooks_test::encode(R"({"action":"no action","milter":{"add_headers":{"X-Test":{"value":"yes","order":0}}}})");
+		CHECK(m->code == 200);
+		CHECK(hooks_test::body(m.get()).find("/message/headers") != std::string::npos);
+	}
+	TEST_CASE("unsupported changes fail atomically")
+	{
+		for (auto s: {R"({"action":"rewrite subject","subject":"spam"})",
+					  R"({"action":"add header"})", R"({"action":"no action","dkim-signature":"sig"})",
+					  R"({"action":"no action","milter":{"add_headers":{"X-Test":"yes"},"remove_headers":{"X-Test":0}}})",
+					  R"({"action":"no action","milter":{"add_headers":{"X-Test":"a\r\nb"}}})"}) {
+			auto m = hooks_test::encode(s);
+			CHECK(m->code == 503);
+			CHECK(hooks_test::body(m.get()).find("\"add\"") == std::string::npos);
+		}
+		CHECK(hooks_test::encode(R"({"action":"no action"})", true)->code == 503);
+	}
+	TEST_CASE("dedicated frontend requires TLS and bearer authentication")
+	{
+		rspamd_config cfg{};
+		cfg.max_message = 1024 * 1024;
+		auto *o = ucl_object_typed_new(UCL_OBJECT);
+		ucl_object_insert_key(o, ucl_object_frombool(true), "enabled", 0, false);
+		ucl_object_insert_key(o, ucl_object_fromstring("01234567890123456789012345678901"), "token", 0, false);
+		ucl_object_insert_key(o, ucl_object_fromstring("127.0.0.1"), "redis_host", 0, false);
+		GError *error = nullptr;
+		auto c = std::unique_ptr<rspamd_mta_hooks_config, decltype(&rspamd_mta_hooks_config_free)>(
+			rspamd_mta_hooks_config_new(o, &cfg, &error), rspamd_mta_hooks_config_free);
+		ucl_object_unref(o);
+		REQUIRE(error == nullptr);
+		REQUIRE(c);
+		auto request = hooks_test::msg_ptr{rspamd_http_new_message(HTTP_REQUEST), rspamd_http_message_unref};
+		request->method = HTTP_GET;
+		request->url = rspamd_fstring_append(request->url, "/checkv2", 8);
+		auto run = [&](bool tls) {
+			auto *r = rspamd_mta_hooks_request_new(c.get(), request.get(), tls, true);
+			rspamd_http_message *response = nullptr;
+			rspamd_mta_hooks_begin(r, [](rspamd_http_message *m, gboolean scan, gpointer ud) {
+				CHECK_FALSE(scan);
+				*static_cast<rspamd_http_message **>(ud) = m; }, &response);
+			rspamd_mta_hooks_request_free(r);
+			REQUIRE(response);
+			return hooks_test::msg_ptr{response, rspamd_http_message_unref};
+		};
+		CHECK(run(false)->code == 403);// loopback alone does not bypass TLS
+		CHECK(run(true)->code == 401);
+		rspamd_http_message_add_header(request.get(), "Authorization", "Bearer 01234567890123456789012345678901");
+		CHECK(run(true)->code == 404);// native scan interface is not exposed
+		rspamd_http_message_add_header(request.get(), "Authorization", "Bearer second");
+		CHECK(run(true)->code == 400);// ambiguous credentials are rejected
+	}
+}
+#endif

--- a/test/rspamd_cxx_unit_mta_hooks.hxx
+++ b/test/rspamd_cxx_unit_mta_hooks.hxx
@@ -21,13 +21,16 @@ static msg_ptr decode(const std::string &s, size_t limit = 1024)
 	if (err) g_error_free(err);
 	return m;
 }
-static msg_ptr encode(const char *s, bool rewritten = false)
+static msg_ptr encode(const char *s, bool rewritten = false,
+					  const std::string &original = "Subject: test\r\nX-Old: one\r\nX-Old: two\r\n\r\nhello\r\n")
 {
 	auto *p = ucl_parser_new(UCL_PARSER_SAFE_FLAGS);
 	REQUIRE(ucl_parser_add_chunk(p, reinterpret_cast<const unsigned char *>(s), strlen(s)));
 	auto *o = ucl_parser_get_object(p);
 	ucl_parser_free(p);
-	msg_ptr m{rspamd_mta_hooks_encode(o, rewritten), rspamd_http_message_unref};
+	msg_ptr m{rspamd_mta_hooks_encode(o, original.data(), original.size(), rewritten ? "new body\r\n" : nullptr,
+									  rewritten ? 10 : 0, "X-Spam", 1024 * 1024),
+			  rspamd_http_message_unref};
 	ucl_object_unref(o);
 	return m;
 }
@@ -150,7 +153,9 @@ TEST_SUITE("mta_hooks")
 	}
 	TEST_CASE("fast UTF-8 validation and UTC timestamps")
 	{
-		for (auto date: {"2026-02-30T12:00:00Z", "xxxx-09-05T12:00:00Z", "2026-09-05T24:00:00Z",
+		for (auto date: {"2026-02-30T12:00:00Z", "1900-02-29T12:00:00Z", "2026-00-05T12:00:00Z",
+						 "2026-13-05T12:00:00Z", "2026-09-00T12:00:00Z", "0000-09-05T12:00:00Z",
+						 "xxxx-09-05T12:00:00Z", "2026-09-05T24:00:00Z",
 						 "2026-09-05T12:60:00Z", "2026-09-05T12:00:00.Z", "2026-09-05T12:00:00+01:00"}) {
 			auto s = hooks_test::request();
 			s.replace(s.find("2026-09-05T12:00:00Z"), 20, date);
@@ -158,6 +163,9 @@ TEST_SUITE("mta_hooks")
 		}
 		auto s = hooks_test::request();
 		s.replace(s.find("2026-09-05T12:00:00Z"), 20, "2024-02-29T12:00:00.123Z");
+		CHECK(hooks_test::decode(s));
+		s = hooks_test::request();
+		s.replace(s.find("2026-09-05T12:00:00Z"), 20, "2000-02-29T12:00:00Z");
 		CHECK(hooks_test::decode(s));
 		s = hooks_test::request();
 		s.replace(s.find("mx.example.com"), 14, "m\xc3\xa9.example.com");
@@ -197,15 +205,28 @@ TEST_SUITE("mta_hooks")
 	}
 	TEST_CASE("unsupported changes fail atomically")
 	{
-		for (auto s: {R"({"action":"rewrite subject","subject":"spam"})",
-					  R"({"action":"add header"})", R"({"action":"no action","dkim-signature":"sig"})",
-					  R"({"action":"no action","milter":{"add_headers":{"X-Test":"yes"},"remove_headers":{"X-Test":0}}})",
+		for (auto s: {R"({"action":"rewrite subject","subject":"spam\r\nEvil: yes"})",
+					  R"({"action":"no action","dkim-signature":42})",
+					  R"({"action":"no action","milter":{"add_headers":{"X-Test":"yes"},"remove_headers":{"X-Test":-1}}})",
 					  R"({"action":"no action","milter":{"add_headers":{"X-Test":"a\r\nb"}}})"}) {
 			auto m = hooks_test::encode(s);
 			CHECK(m->code == 503);
 			CHECK(hooks_test::body(m.get()).find("\"add\"") == std::string::npos);
 		}
-		CHECK(hooks_test::encode(R"({"action":"no action"})", true)->code == 503);
+		CHECK(hooks_test::encode(R"({"action":"no action"})", true)->code == 200);
+	}
+	TEST_CASE("header actions and folded signatures")
+	{
+		for (auto s: {R"({"action":"rewrite subject","subject":"spam"})",
+					  R"({"action":"add header"})",
+					  R"({"action":"no action","dkim-signature":["v=1;\r\n\tb=one", "v=1; b=two"]})",
+					  R"({"action":"no action","milter":{"remove_headers":{"x-old":[1,2]},"add_headers":{"X-Old":"new"}}})"}) {
+			CHECK(hooks_test::encode(s)->code == 200);
+		}
+		auto m = hooks_test::encode(R"({"action":"no action","milter":{"remove_headers":{"x-old":2},"add_headers":{"X-New":{"value":"new","order":0}}}})");
+		CHECK(hooks_test::body(m.get()).find("/message/headers/3") != std::string::npos);
+		m = hooks_test::encode(R"({"action":"rewrite subject","subject":"spam"})");
+		CHECK(hooks_test::body(m.get()).find("/message/headers/0/value") != std::string::npos);
 	}
 	TEST_CASE("dedicated frontend requires TLS and bearer authentication")
 	{


### PR DESCRIPTION
## Summary

Add an opt-in MTA Hooks frontend to the proxy worker for an inbound DATA / JSON / add-only profile of draft-degennaro-mta-hooks-01. It is intended to work with rspamd/mta-hooks-milter and can scan locally or forward clean native requests to existing scan workers.

- Terminate discovery, bearer authentication, registration and invocation in a dedicated HTTP proxy listener.
- Share registration, revocation and bounded retry deduplication state through Redis.
- Translate supported verdicts and additive headers, with input limits, metadata isolation and hard scan deadlines.
- Use tl::expected, untrusted UCL parsing and borrowed views with owned buffers across asynchronous boundaries.

Nothing is enabled in the stock configuration.

## Validation

- Staged build and all pre-commit hooks passed.
- 416 C++ tests passed, including 11 Hooks cases with 118 assertions.
- Lua suite: 1,261 passed, three unassertive, no failures or errors.
- Multi-worker integration passed for self-scan and native upstreams, including registration/replay, metadata isolation, deadlines, recovery and Redis outage.
- Adapter compiles with -fno-exceptions.

## Draft scope

This is not full draft compliance or production milter parity. Header deletion/replacement, body/envelope rewriting, DKIM-signing output and unsupported delivery actions fail closed. Early SMTP stages, outbound events and CBOR are deferred.

Full Postfix -> mta-hooks-milter -> Rspamd delivery verification remains a separate interoperability gate.