### PR TITLE
Remove unused license from replxx

### DIFF
--- a/contrib/replxx/LICENSE.md
+++ b/contrib/replxx/LICENSE.md
@@ -37,27 +37,3 @@ Markus Kuhn -- 2007-05-26 (Unicode 5.0)
 Permission to use, copy, modify, and distribute this software
 for any purpose and without fee is hereby granted. The author
 disclaims all warranties with regard to this software.
-
-
-ConvertUTF.cpp
-==============
-
-Copyright 2001-2004 Unicode, Inc.
-
-Disclaimer
-
-This source code is provided as is by Unicode, Inc. No claims are
-made as to fitness for any particular purpose. No warranties of any
-kind are expressed or implied. The recipient agrees to determine
-applicability of information provided. If this file has been
-purchased on magnetic or optical media from Unicode, Inc., the
-sole remedy for any claim will be exchange of defective media
-within 90 days of receipt.
-
-Limitations on Rights to Redistribute This Code
-
-Unicode, Inc. hereby grants the right to freely use the information
-supplied in this file in the creation of products supporting the
-Unicode Standard, and to make copies of this file in any form
-for internal or external distribution as long as this notice
-remains attached.


### PR DESCRIPTION
This removes `ConvertUTF.cpp` license since it is no longer included in rspamd.