### PR TITLE
[Fix] rspamadm: wrong description in help of fuzzy_ping command for `-n` options

### DIFF
--- a/lualib/rspamadm/fuzzy_ping.lua
+++ b/lualib/rspamadm/fuzzy_ping.lua
@@ -47,7 +47,7 @@ parser:option "-s --server"
       :description "Override server to ping"
       :argname("<name>")
 parser:option "-n --number"
-      :description "Timeout for requests"
+      :description "Number of requests"
       :argname("<number>")
       :convert(tonumber)
       :default(5)


### PR DESCRIPTION
With `rspamadm fuzzyping -h`, the following help message is shown:

```
...
          -t <timeout>,       Timeout for requests
   --timeout <timeout>
         -s <name>,           Override server to ping
   --server <name>
         -n <number>,         Timeout for requests
   --number <number>
...
```

The `-n` option should specify the number of ping requests, instead of timeout for requests (`-t`).