### PR TITLE
[Feature] WebUI: Bayes learns balance bar and min_learns status in the Status tab

### DIFF
--- a/interface/css/rspamd.css
+++ b/interface/css/rspamd.css
@@ -641,6 +641,12 @@ input.action-scores {
     background-color: var(--rspamd-balance-special);
 }
 
+/* Class row marker: the class has not reached the classifier min_learns yet;
+   same warning tint as the cluster drift badge */
+#bayesTable .bayes-below-min {
+    color: var(--rspamd-text-warning);
+}
+
 /* Cluster (servers) table: details toggle, last-seen line, details row */
 #clusterTable td.cluster-toggle {
     width: 1%;

--- a/interface/css/rspamd.css
+++ b/interface/css/rspamd.css
@@ -35,6 +35,12 @@
     --rspamd-symbol-positive-hover-bg: #fbd6d1;
     --rspamd-symbol-special-hover-bg: #cddbff;
 
+    /* Bayes balance bar segment fills (stronger than the row tints to keep
+       the thin stacked segments distinguishable) */
+    --rspamd-balance-positive: rgb(var(--bs-danger-rgb));
+    --rspamd-balance-negative: rgb(var(--bs-success-rgb));
+    --rspamd-balance-special: #3a6fe8;
+
     /* Light mode logo display rules */
     --rspamd-display-logo-light: inline;
     --rspamd-display-logo-dark: none;
@@ -63,6 +69,11 @@
     --rspamd-symbol-negative-hover-bg: #274f27;
     --rspamd-symbol-positive-hover-bg: #4b2b2b;
     --rspamd-symbol-special-hover-bg: #41426a;
+
+    /* Bayes balance bar segment fills (dark theme) */
+    --rspamd-balance-positive: #c93737;
+    --rspamd-balance-negative: #35a862;
+    --rspamd-balance-special: #5a7bd6;
 
     /* Dark mode logo display rules */
     --rspamd-display-logo-light: none;
@@ -600,6 +611,34 @@ input.action-scores {
 .status-table tbody td.table-hover-cell {
     --bs-table-color-state: var(--bs-table-hover-color);
     --bs-table-bg-state: var(--bs-table-hover-bg);
+}
+
+/* Bayes learns balance bar in the classifier cell of #bayesTable: stacked
+   segments sized by flex-grow, 2px gaps between fills, rounded outer ends */
+#bayesTable .bayes-balance {
+    border-radius: 4px;
+    display: flex;
+    gap: 2px;
+    height: 6px;
+    margin-top: 0.25rem;
+    min-width: 8em;
+    overflow: hidden;
+}
+
+#bayesTable .bayes-balance-segment {
+    flex-basis: 0;
+}
+
+#bayesTable .bayes-balance-segment.balance-positive {
+    background-color: var(--rspamd-balance-positive);
+}
+
+#bayesTable .bayes-balance-segment.balance-negative {
+    background-color: var(--rspamd-balance-negative);
+}
+
+#bayesTable .bayes-balance-segment.balance-special {
+    background-color: var(--rspamd-balance-special);
 }
 
 /* Cluster (servers) table: details toggle, last-seen line, details row */

--- a/interface/index.html
+++ b/interface/index.html
@@ -233,13 +233,13 @@
 									<table class="table status-table table-sm table-bordered text-nowrap mb-0" id="bayesTable">
 										<thead class="text-secondary">
 											<tr>
-												<th>Server name</th>
-												<th>Classifier name</th>
-												<th>Class</th>
-												<th>Symbol</th>
-												<th>Type</th>
-												<th>Learns</th>
-												<th>Users</th>
+												<th title="rspamd instance that reported this row">Server name</th>
+												<th title="Bayes classifier; rows are grouped per classifier">Classifier name</th>
+												<th title="Learn class of the statfile (e.g. spam or ham)">Class</th>
+												<th title="Symbol inserted when this class wins classification">Symbol</th>
+												<th title="Statfile backend (e.g. redis, sqlite, mmap)">Type</th>
+												<th title="Messages learned for this class, summed across per-user tracks">Learns</th>
+												<th title="Per-user tracks that have learns for this class">Users</th>
 											</tr>
 										</thead>
 										<tbody>

--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -769,6 +769,7 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             function addStatfiles(server, statfiles) {
                 const safeStatfiles = Array.isArray(statfiles) ? statfiles : [];
                 const classToSymbolClass = {spam: "symbol-positive", ham: "symbol-negative"};
+                const classToBalanceClass = {spam: "balance-positive", ham: "balance-negative"};
                 const rowsCount = safeStatfiles.length;
                 const bayesTbody = document.querySelector("#bayesTable tbody");
 
@@ -784,7 +785,76 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                     return "-";
                 }
 
-                function formatClassifierLabel(statfile) {
+                function statfileClass(statfile) {
+                    return statfile.class ?? guessClassFromSymbol(statfile.symbol ?? "-");
+                }
+
+                /*
+                 * Pre-pass: split statfiles into consecutive runs of the same
+                 * classifier name and sum learns per class, so the classifier
+                 * cell can render the balance bar when the first row of the
+                 * group is emitted. Revisions of the redis backend are
+                 * refreshed asynchronously (roughly every 30 seconds), so the
+                 * sums may slightly lag behind the actual learns.
+                 */
+                function statfileGroups() {
+                    const groupEnd = [];
+                    const groupSums = [];
+                    let start = 0;
+
+                    function groupName(idx) {
+                        return safeStatfiles[idx].classifier?.name ?? "-";
+                    }
+
+                    while (start < safeStatfiles.length) {
+                        let end = start + 1;
+                        const sums = new Map();
+
+                        while (end < safeStatfiles.length && groupName(end) === groupName(start)) {
+                            end++;
+                        }
+                        for (let k = start; k < end; k++) {
+                            const cls = statfileClass(safeStatfiles[k]);
+                            const revision = coerceNumber(safeStatfiles[k].revision);
+
+                            sums.set(cls, (sums.get(cls) ?? 0) + revision);
+                            groupEnd[k] = end;
+                            groupSums[k] = sums;
+                        }
+                        start = end;
+                    }
+
+                    return {groupEnd, groupSums};
+                }
+
+                /*
+                 * Stacked bar of the learns share between the classes of one
+                 * classifier. The table rows of the group carry the class
+                 * names and counts, and tooltips spell every segment out, so
+                 * segment colors are never the only encoding.
+                 */
+                function renderBalanceBar(classSums) {
+                    const entries = Array.from(classSums).filter(([, count]) => count > 0);
+                    const total = entries.reduce((sum, [, count]) => sum + count, 0);
+
+                    if (total <= 0) return "";
+
+                    const parts = entries.map(([cls, count]) => `${cls}: ${count} (${Math.round(count * 100 / total)}%)`);
+                    const segments = [];
+
+                    for (let idx = 0; idx < entries.length; idx++) {
+                        const [cls, count] = entries[idx];
+
+                        segments.push(`<span class="bayes-balance-segment ${classToBalanceClass[cls] ?? "balance-special"}"` +
+                            ` style="flex-grow:${count}" title="${common.escapeHTML(parts[idx])}"></span>`);
+                    }
+                    const label = `Learns balance: ${parts.join("; ")}`;
+
+                    return `<div class="bayes-balance" role="img" title="${common.escapeHTML(label)}"` +
+                        ` aria-label="${common.escapeHTML(label)}">${segments.join("")}</div>`;
+                }
+
+                function formatClassifierLabel(statfile, classSums) {
                     const classifier = statfile.classifier ?? {};
                     const badges = [];
                     function badge(cls, text) { return ` <span class="badge ${cls} ms-1">${text}</span>`; }
@@ -792,7 +862,8 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                     if (classifier.type === "multi-class") badges.push(badge("bg-secondary", "multi-class"));
                     if (classifier.per_user) badges.push(badge("bg-info", "per-user"));
 
-                    return common.escapeHTML(classifier.name ?? "-") + badges.join("");
+                    return common.escapeHTML(classifier.name ?? "-") + badges.join("") +
+                        renderBalanceBar(classSums);
                 }
 
                 function renderCell(value, className) {
@@ -800,9 +871,11 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                     return cls ? `<td class="${cls}">${value}</td>` : `<td>${value}</td>`;
                 }
 
+                const {groupEnd, groupSums} = statfileGroups();
+
                 safeStatfiles.forEach((statfile, i) => {
                     const symbol = statfile.symbol ?? "-";
-                    const classValue = statfile.class ?? guessClassFromSymbol(symbol);
+                    const classValue = statfileClass(statfile);
                     const cls = classToSymbolClass[classValue] || "";
                     const clName = statfile.classifier?.name ?? "-";
                     const prevClName = i > 0 ? (safeStatfiles[i - 1].classifier?.name ?? "-") : null;
@@ -811,13 +884,8 @@ define(["app/common", "app/libft", "d3pie", "d3"],
 
                     let classifierCell = "";
                     if (clName !== prevClName) {
-                        let groupSize = 1;
-                        for (let k = i + 1; k < safeStatfiles.length; k++) {
-                            if ((safeStatfiles[k].classifier?.name ?? "-") === clName) {
-                                groupSize++;
-                            } else break;
-                        }
-                        classifierCell = `<td rowspan="${groupSize}">${formatClassifierLabel(statfile)}</td>`;
+                        const groupSize = groupEnd[i] - i;
+                        classifierCell = `<td rowspan="${groupSize}">${formatClassifierLabel(statfile, groupSums[i])}</td>`;
                     }
 
                     bayesTbody.insertAdjacentHTML("beforeend", `<tr>${serverCell}${classifierCell}${[

--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -816,7 +816,6 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                         for (let k = start; k < end; k++) {
                             const cls = statfileClass(safeStatfiles[k]);
                             const revision = coerceNumber(safeStatfiles[k].revision);
-
                             sums.set(cls, (sums.get(cls) ?? 0) + revision);
                             groupEnd[k] = end;
                             groupSums[k] = sums;
@@ -841,10 +840,8 @@ define(["app/common", "app/libft", "d3pie", "d3"],
 
                     const parts = entries.map(([cls, count]) => `${cls}: ${count} (${Math.round(count * 100 / total)}%)`);
                     const segments = [];
-
                     for (let idx = 0; idx < entries.length; idx++) {
                         const [cls, count] = entries[idx];
-
                         segments.push(`<span class="bayes-balance-segment ${classToBalanceClass[cls] ?? "balance-special"}"` +
                             ` style="flex-grow:${count}" title="${common.escapeHTML(parts[idx])}"></span>`);
                     }
@@ -854,13 +851,70 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                         ` aria-label="${common.escapeHTML(label)}">${segments.join("")}</div>`;
                 }
 
+                function badge(cls, text, title) {
+                    const titleAttr = title ? ` title="${common.escapeHTML(title)}"` : "";
+                    return ` <span class="badge ${cls} ms-1"${titleAttr}>${text}</span>`;
+                }
+
+                function normalizeMinLearns(value) {
+                    return (Number.isFinite(value) && value > 0) ? value : 0;
+                }
+
+                /*
+                 * min_learns gate badge. A binary classifier classifies nothing
+                 * when any class is below the threshold; a multi-class one
+                 * drops the classes below it and stops classifying only when
+                 * all of them are below. Servers that predate the field in
+                 * /stat render no badge.
+                 */
+                function renderMinLearnsBadge(classifier, classSums) {
+                    const minLearns = normalizeMinLearns(classifier.min_learns);
+
+                    if (minLearns <= 0) return "";
+
+                    const below = Array.from(classSums).filter(([, count]) => count < minLearns);
+
+                    if (!below.length) return "";
+
+                    const parts = [];
+                    for (let idx = 0; idx < below.length; idx++) {
+                        const [cls, count] = below[idx];
+                        parts.push(`class ${cls} has ${count} learns, min_learns ${minLearns}`);
+                    }
+                    const details = parts.join("; ");
+
+                    if (classifier.type !== "multi-class" || below.length === classSums.size) {
+                        return badge("text-bg-warning", "not classifying", `Not classifying: ${details}`);
+                    }
+
+                    return badge("text-bg-secondary", "classes excluded", `Excluded from classification: ${details}`);
+                }
+
+                /*
+                 * Row-level marker of a class that has not reached min_learns
+                 * yet, pointing at the exact class that holds the classifier
+                 * back (binary) or is excluded from classification (multi-class).
+                 */
+                function belowMinLearnsMark(statfile, classValue, classSums) {
+                    const minLearns = normalizeMinLearns(statfile.classifier?.min_learns);
+                    const count = classSums.get(classValue) ?? 0;
+
+                    if (minLearns <= 0 || count >= minLearns) return "";
+
+                    const text = `${count} learns < min_learns ${minLearns}`;
+                    const escaped = common.escapeHTML(text);
+
+                    return ` <span class="bayes-below-min" title="${escaped}">` +
+                        '<i class="fas fa-exclamation-triangle"></i></span>';
+                }
+
                 function formatClassifierLabel(statfile, classSums) {
                     const classifier = statfile.classifier ?? {};
                     const badges = [];
-                    function badge(cls, text) { return ` <span class="badge ${cls} ms-1">${text}</span>`; }
 
                     if (classifier.type === "multi-class") badges.push(badge("bg-secondary", "multi-class"));
                     if (classifier.per_user) badges.push(badge("bg-info", "per-user"));
+                    badges.push(renderMinLearnsBadge(classifier, classSums));
 
                     return common.escapeHTML(classifier.name ?? "-") + badges.join("") +
                         renderBalanceBar(classSums);
@@ -879,6 +933,7 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                     const cls = classToSymbolClass[classValue] || "";
                     const clName = statfile.classifier?.name ?? "-";
                     const prevClName = i > 0 ? (safeStatfiles[i - 1].classifier?.name ?? "-") : null;
+                    const belowMark = belowMinLearnsMark(statfile, classValue, groupSums[i]);
 
                     const serverCell = i === 0 ? `<td rowspan="${rowsCount}">${common.escapeHTML(server)}</td>` : "";
 
@@ -889,7 +944,7 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                     }
 
                     bayesTbody.insertAdjacentHTML("beforeend", `<tr>${serverCell}${classifierCell}${[
-                        renderCell(common.escapeHTML(classValue), cls),
+                        renderCell(common.escapeHTML(classValue) + belowMark, cls),
                         renderCell(common.escapeHTML(symbol), cls),
                         renderCell(common.escapeHTML(statfile.type ?? "-"), cls),
                         renderCell(coerceNumber(statfile.revision), `text-end ${cls}`),

--- a/src/libstat/stat_process.c
+++ b/src/libstat/stat_process.c
@@ -1928,6 +1928,7 @@ rspamd_stat_statistics(struct rspamd_task *task,
 	const char *classifier_name;
 	const char *classifier_type;
 	gboolean classifier_per_user;
+	unsigned int classifier_min_learns;
 	unsigned int i, j;
 	int id;
 
@@ -1946,6 +1947,7 @@ rspamd_stat_statistics(struct rspamd_task *task,
 		classifier_name = cl->cfg->name;
 		classifier_type = rspamd_classifier_type(cl->cfg);
 		classifier_per_user = rspamd_classifier_is_per_user(cl->cfg);
+		classifier_min_learns = cl->cfg->min_learns;
 
 		for (j = 0; j < cl->statfiles_ids->len; j++) {
 			id = g_array_index(cl->statfiles_ids, int, j);
@@ -1987,6 +1989,9 @@ rspamd_stat_statistics(struct rspamd_task *task,
 				ucl_object_insert_key(classifier_obj,
 						ucl_object_frombool(classifier_per_user),
 						"per_user", 0, false);
+				ucl_object_insert_key(classifier_obj,
+						ucl_object_fromint(classifier_min_learns),
+						"min_learns", 0, false);
 
 				ucl_object_insert_key(elt, classifier_obj, "classifier", 0, false);
 


### PR DESCRIPTION
## Motivation

The Bayesian statistics table on the Status tab showed raw learn counts but did
not answer two questions an admin actually asks:

- how balanced the training between the classes is (spam vs ham);
- whether the classifier classifies at all: below the `min_learns` threshold a
  class stops participating, and a binary classifier stops classifying
  entirely — with no indication in the UI.

## Changes

1. **WebUI: Bayes learns balance bar** (frontend only, works against an
   unmodified server)
   - Stacked balance bar of the per-class learns share in the classifier cell,
     computed client-side from statfile revisions (the redis backend refreshes
     them asynchronously, ~30 s, so the bar may lag slightly).
   - Segment colors follow the spam/ham row semantics via dedicated
     `--rspamd-balance-*` variables, validated for contrast and CVD separation
     in both light and dark themes; identity is never color-alone — tooltips
     and the neighbouring table rows spell the numbers out.
   - Native `title` tooltips on all table column headers.

2. **WebUI: Bayes min_learns status badge** (backend + frontend)
   - `/stat`: expose `classifier.min_learns` in each statfile entry.
   - Classifier-cell badge reflecting the actual gating in `bayes.c`: a binary
     classifier classifies nothing while any class is below the threshold
     ("not classifying"); a multi-class one excludes the classes below it and
     stops only when all of them are below ("classes excluded").
   - Row-level warning triangle next to a class that has not reached
     `min_learns` yet, with the exact numbers in a tooltip.

## Compatibility

- Both features degrade gracefully on servers that do not send the new
  `classifier.min_learns` field (or predate classifier metadata entirely):
  no badge or marker; the balance bar keeps working off revisions.
- The badge and marker stay inert until the server is rebuilt.
- Gating semantics verified against `src/libstat/classifiers/bayes.c`
  (binary gate and multi-class viable/winner selection).