### PR TITLE
clickhouse: data-skipping indexes for point lookups (schema 12)

### DIFF
--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -206,7 +206,7 @@ CREATE TABLE IF NOT EXISTS rspamd
     INDEX idx_ip IP TYPE bloom_filter(0.01) GRANULARITY 4,
     INDEX idx_urls_tld `Urls.Tld` TYPE bloom_filter(0.01) GRANULARITY 4,
     INDEX idx_attachments_digest `Attachments.Digest` TYPE bloom_filter(0.01) GRANULARITY 4,
-    INDEX idx_subject Subject TYPE tokenbf_v1(8192, 3, 0) GRANULARITY 4
+    INDEX idx_subject Subject TYPE bloom_filter(0.01) GRANULARITY 4
 ) ENGINE = MergeTree()
 PARTITION BY toMonday(Date)
 ORDER BY TS
@@ -333,7 +333,7 @@ local migrations = {
   [11] = {
     -- Data-skipping indexes for point lookups: the table is ordered by TS
     -- only, so a lookup by Message-ID, sender domain, client IP, URL eSLD,
-    -- attachment digest or subject word reads every row in the time window
+    -- attachment digest or exact subject reads every row in the time window
     -- (measured: 303M rows / 15.5 GB / 1.6 s for one Message-ID on a 20M
     -- messages/day install). Bloom filters over 4 granules cut that to a
     -- few granules. ADD INDEX is a metadata-only change: parts written from
@@ -348,7 +348,7 @@ local migrations = {
       ADD INDEX IF NOT EXISTS idx_ip IP TYPE bloom_filter(0.01) GRANULARITY 4,
       ADD INDEX IF NOT EXISTS idx_urls_tld `Urls.Tld` TYPE bloom_filter(0.01) GRANULARITY 4,
       ADD INDEX IF NOT EXISTS idx_attachments_digest `Attachments.Digest` TYPE bloom_filter(0.01) GRANULARITY 4,
-      ADD INDEX IF NOT EXISTS idx_subject Subject TYPE tokenbf_v1(8192, 3, 0) GRANULARITY 4
+      ADD INDEX IF NOT EXISTS idx_subject Subject TYPE bloom_filter(0.01) GRANULARITY 4
     ]],
     -- New version
     [[INSERT INTO rspamd_version (Version) Values (12)]],

--- a/src/plugins/lua/clickhouse.lua
+++ b/src/plugins/lua/clickhouse.lua
@@ -33,7 +33,7 @@ local nrows = 0
 local used_memory = 0
 local last_collection = 0
 local final_call = false -- If the final collection has been started
-local schema_version = 11 -- Current schema version
+local schema_version = 12 -- Current schema version
 
 local extra_tables = {}
 local extra_table_rows = {}
@@ -199,7 +199,14 @@ CREATE TABLE IF NOT EXISTS rspamd
     SMTPFrom ALIAS if(From = '', '', concat(FromUser, '@', From)) COMMENT 'Return address (RFC5321.MailFrom)',
     SMTPRcpt ALIAS SMTPRecipients[1] COMMENT 'The first envelope recipient (RFC5321.RcptTo)',
     MIMEFrom ALIAS if(MimeFrom = '', '', concat(MimeUser, '@', MimeFrom)) COMMENT 'Address in From: header (RFC5322.From)',
-    MIMERcpt ALIAS MimeRecipients[1] COMMENT 'The first recipient from headers (RFC5322.To/.CC/.BCC)'
+    MIMERcpt ALIAS MimeRecipients[1] COMMENT 'The first recipient from headers (RFC5322.To/.CC/.BCC)',
+    INDEX idx_message_id MessageId TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_from From TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_mime_from MimeFrom TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_ip IP TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_urls_tld `Urls.Tld` TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_attachments_digest `Attachments.Digest` TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_subject Subject TYPE tokenbf_v1(8192, 3, 0) GRANULARITY 4
 ) ENGINE = MergeTree()
 PARTITION BY toMonday(Date)
 ORDER BY TS
@@ -322,6 +329,29 @@ local migrations = {
     ]],
     -- New version
     [[INSERT INTO rspamd_version (Version) Values (11)]],
+  },
+  [11] = {
+    -- Data-skipping indexes for point lookups: the table is ordered by TS
+    -- only, so a lookup by Message-ID, sender domain, client IP, URL eSLD,
+    -- attachment digest or subject word reads every row in the time window
+    -- (measured: 303M rows / 15.5 GB / 1.6 s for one Message-ID on a 20M
+    -- messages/day install). Bloom filters over 4 granules cut that to a
+    -- few granules. ADD INDEX is a metadata-only change: parts written from
+    -- now on carry the index, and existing parts get it as they are merged
+    -- or expire. To backfill old parts explicitly run
+    --   ALTER TABLE rspamd MATERIALIZE INDEX <name>
+    -- for each index (a background mutation that rereads the column).
+    [[ALTER TABLE rspamd
+      ADD INDEX IF NOT EXISTS idx_message_id MessageId TYPE bloom_filter(0.01) GRANULARITY 4,
+      ADD INDEX IF NOT EXISTS idx_from From TYPE bloom_filter(0.01) GRANULARITY 4,
+      ADD INDEX IF NOT EXISTS idx_mime_from MimeFrom TYPE bloom_filter(0.01) GRANULARITY 4,
+      ADD INDEX IF NOT EXISTS idx_ip IP TYPE bloom_filter(0.01) GRANULARITY 4,
+      ADD INDEX IF NOT EXISTS idx_urls_tld `Urls.Tld` TYPE bloom_filter(0.01) GRANULARITY 4,
+      ADD INDEX IF NOT EXISTS idx_attachments_digest `Attachments.Digest` TYPE bloom_filter(0.01) GRANULARITY 4,
+      ADD INDEX IF NOT EXISTS idx_subject Subject TYPE tokenbf_v1(8192, 3, 0) GRANULARITY 4
+    ]],
+    -- New version
+    [[INSERT INTO rspamd_version (Version) Values (12)]],
   },
 }
 


### PR DESCRIPTION
The `rspamd` table is `ORDER BY TS` only, so every lookup that is not a time range reads the whole column for the window. Measured on a 20M messages/day install (303M rows in the table): one `MessageId = ?` over 30 days reads 303M rows / 15.5 GB in 1.6 s; a `Subject LIKE` over 7 days reads 6.9 GB in 0.5 s. Repeats look instant only because of the query-condition cache.

This adds bloom-filter data-skipping indexes (granularity 4) on `MessageId`, `From`, `MimeFrom`, `IP`, `Urls.Tld`, `Attachments.Digest`, and a `tokenbf_v1` on `Subject`:

- in the `CREATE TABLE` schema for new installs;
- as migration 11 → 12 with `ADD INDEX IF NOT EXISTS` for existing tables.

`ADD INDEX` is metadata-only: parts written from now on carry the index, and older parts get it when they are merged or expire under TTL. `MATERIALIZE INDEX` is deliberately not part of the automatic migration since it rereads the column as a background mutation; the migration comment documents it for operators who want to backfill.

Note for consumers: bloom-filter indexes apply to `=`, `IN` and `has(array, value)`; `arrayExists(lambda)` does not use them.