### PR TITLE
WebUI: fuzzy storage details and availability; fix empty storages missing from stat

### DIFF
--- a/interface/index.html
+++ b/interface/index.html
@@ -256,9 +256,9 @@
 									<table class="table status-table table-sm table-bordered text-nowrap mb-0" id="fuzzyTable">
 										<thead class="text-secondary">
 											<tr>
-												<th>Server name</th>
-												<th>Storage</th>
-												<th>Hashes</th>
+												<th title="rspamd instance that reported this row">Server name</th>
+												<th title="Fuzzy storage rule; hover a storage for its servers, symbols and flags">Storage</th>
+												<th title="Number of fuzzy hashes in this storage">Hashes</th>
 											</tr>
 										</thead>
 										<tbody>

--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -987,7 +987,15 @@ define(["app/common", "app/libft", "d3pie", "d3"],
             function addFuzzyStorage(server, storages, up) {
                 const fuzzyTbody = document.querySelector("#fuzzyTable tbody");
                 const entries = Object.entries(storages || {});
-                if (!entries.length) {
+                // Rules configured but absent from fuzzy_hashes: the storage
+                // selected for the statistics query did not answer in time —
+                // down, rate-limited or denied. Detectable only when the
+                // storages config is known; otherwise the row stays hidden.
+                const ruleInfo = fuzzyStorages.get(server);
+                const missing = ruleInfo
+                    ? Object.keys(ruleInfo).filter((rule) => !{}.hasOwnProperty.call(storages || {}, rule))
+                    : [];
+                if (!entries.length && !missing.length) {
                     // An up server without fuzzy storages stays visible in
                     // the group; a down one renders nothing, as in the bayes
                     // table
@@ -996,22 +1004,35 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                         '</td><td colspan="2" class="text-secondary">No fuzzy storages</td></tr>');
                     return;
                 }
+                const rowsCount = entries.length + missing.length;
+
+                function serverCellAt(i) {
+                    if (i !== 0) return "";
+                    return '<td rowspan="' + rowsCount + '">' + common.escapeHTML(server) + "</td>";
+                }
                 // Per-server join: fuzzy_hashes keys (rule names) are the
                 // storages keys
-                const ruleInfo = fuzzyStorages.get(server);
                 entries.forEach(([storage, hashes], i) => {
-                    const serverCell = (i === 0)
-                        ? '<td rowspan="' + entries.length + '">' + common.escapeHTML(server) + "</td>"
-                        : "";
                     const info = ruleInfo?.[storage];
                     const title = info ? fuzzyStorageTitle(info) : "";
                     const titleAttr = title ? ' title="' + common.escapeHTML(title) + '"' : "";
                     const roBadge = (info && info.read_only)
                         ? badge("text-bg-secondary", "read-only", "Storage is read-only: it cannot be learned to")
                         : "";
-                    fuzzyTbody.insertAdjacentHTML("beforeend", "<tr>" + serverCell +
+                    fuzzyTbody.insertAdjacentHTML("beforeend", "<tr>" + serverCellAt(i) +
                         "<td" + titleAttr + ">" + common.escapeHTML(storage) + roBadge + "</td>" +
                         '<td class="text-end">' + hashes + "</td></tr>");
+                });
+                missing.forEach((storage, i) => {
+                    const info = ruleInfo?.[storage];
+                    const title = info ? fuzzyStorageTitle(info) : "";
+                    const titleAttr = title ? ' title="' + common.escapeHTML(title) + '"' : "";
+                    fuzzyTbody.insertAdjacentHTML("beforeend", "<tr>" + serverCellAt(entries.length + i) +
+                        "<td" + titleAttr + ">" + common.escapeHTML(storage) +
+                        badge("text-bg-danger", "unavailable",
+                            "No reply to the statistics query; the storage may be down, rate-limited or access denied") +
+                        "</td>" +
+                        '<td class="text-end">-</td></tr>');
                 });
             }
 

--- a/interface/js/app/stats.js
+++ b/interface/js/app/stats.js
@@ -82,6 +82,17 @@ define(["app/common", "app/libft", "d3pie", "d3"],
         // overwrite the state written by a newer one
         let statCycleId = 0;
 
+        // Per-server fuzzy storages config from plugins/fuzzy/storages
+        // (rule name -> {read_only, servers|read_servers+write_servers,
+        // flags}). Fetched rarely — once per page load, refetched only on a
+        // configuration/neighbours or up-set change, never in the /stat
+        // cycle — since it changes only with the configuration. A failed
+        // probe is not an error: older rspamd or fuzzy_check disabled
+        // leaves the table plain.
+        const fuzzyStorages = new Map();
+        let fuzzyStoragesSig = null;
+        let fuzzyStoragesFetching = false;
+
         // @ ms to latency string
         function formatLatency(ms) {
             if (!Number.isFinite(ms)) return "-";
@@ -647,6 +658,13 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                     '"><i class="fas fa-exclamation-triangle"></i></span>';
             }
 
+            // @ small inline text badge with an optional tooltip (fuzzy
+            // read-only mark, bayes classifier flags)
+            function badge(cls, text, title) {
+                const titleAttr = title ? ` title="${common.escapeHTML(title)}"` : "";
+                return ` <span class="badge ${cls} ms-1"${titleAttr}>${text}</span>`;
+            }
+
             // The badge marks deviating servers and the aggregate row alike:
             // the majority value the latter shows is not cluster-wide
             function hasDriftBadge(drift, key) {
@@ -851,11 +869,6 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                         ` aria-label="${common.escapeHTML(label)}">${segments.join("")}</div>`;
                 }
 
-                function badge(cls, text, title) {
-                    const titleAttr = title ? ` title="${common.escapeHTML(title)}"` : "";
-                    return ` <span class="badge ${cls} ms-1"${titleAttr}>${text}</span>`;
-                }
-
                 function normalizeMinLearns(value) {
                     return (Number.isFinite(value) && value > 0) ? value : 0;
                 }
@@ -953,17 +966,52 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                 });
             }
 
-            function addFuzzyStorage(server, storages) {
-                let i = 0;
+            // Combined tooltip for a fuzzy storage cell: server addresses
+            // and the symbol/flag mapping, one item per line. Empty sections
+            // are omitted (an SRV-configured rule may report no addresses
+            // yet right after a configuration load).
+            function fuzzyStorageTitle(info) {
+                const lines = [];
+                const read = info.servers || info.read_servers;
+                const write = info.write_servers;
+                if (Array.isArray(read) && read.length) {
+                    lines.push((Array.isArray(write) ? "Read: " : "Servers: ") + read.join(", "));
+                }
+                if (Array.isArray(write) && write.length) lines.push("Write: " + write.join(", "));
+                const flags = Object.entries(info.flags || {})
+                    .map(([symbol, flag]) => `${symbol} (${flag})`);
+                if (flags.length) lines.push("Symbols:\n" + flags.join("\n"));
+                return lines.join("\n");
+            }
+
+            function addFuzzyStorage(server, storages, up) {
                 const fuzzyTbody = document.querySelector("#fuzzyTable tbody");
-                Object.entries(storages || {}).forEach(([storage, hashes]) => {
+                const entries = Object.entries(storages || {});
+                if (!entries.length) {
+                    // An up server without fuzzy storages stays visible in
+                    // the group; a down one renders nothing, as in the bayes
+                    // table
+                    if (!up) return;
+                    fuzzyTbody.insertAdjacentHTML("beforeend", "<tr><td>" + common.escapeHTML(server) +
+                        '</td><td colspan="2" class="text-secondary">No fuzzy storages</td></tr>');
+                    return;
+                }
+                // Per-server join: fuzzy_hashes keys (rule names) are the
+                // storages keys
+                const ruleInfo = fuzzyStorages.get(server);
+                entries.forEach(([storage, hashes], i) => {
                     const serverCell = (i === 0)
-                        ? '<td rowspan="' + Object.keys(storages || {}).length + '">' + common.escapeHTML(server) + "</td>"
+                        ? '<td rowspan="' + entries.length + '">' + common.escapeHTML(server) + "</td>"
+                        : "";
+                    const info = ruleInfo?.[storage];
+                    const title = info ? fuzzyStorageTitle(info) : "";
+                    const titleAttr = title ? ' title="' + common.escapeHTML(title) + '"' : "";
+                    const roBadge = (info && info.read_only)
+                        ? badge("text-bg-secondary", "read-only", "Storage is read-only: it cannot be learned to")
                         : "";
                     fuzzyTbody.insertAdjacentHTML("beforeend", "<tr>" + serverCell +
-                      "<td>" + common.escapeHTML(storage) + "</td>" +
-                      '<td class="text-end">' + hashes + "</td></tr>");
-                    i++;
+                        "<td" + titleAttr + ">" + common.escapeHTML(storage) + roBadge + "</td>" +
+                        '<td class="text-end">' + hashes + "</td></tr>");
                 });
             }
 
@@ -973,12 +1021,12 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                 Object.entries(servers).forEach(([server, val]) => {
                     if (server !== "All SERVERS") {
                         addStatfiles(server, val.data.statfiles);
-                        addFuzzyStorage(server, val.data.fuzzy_hashes);
+                        addFuzzyStorage(server, val.data.fuzzy_hashes, val.status);
                     }
                 });
             } else {
                 addStatfiles(checked_server, data.statfiles);
-                addFuzzyStorage(checked_server, data.fuzzy_hashes);
+                addFuzzyStorage(checked_server, data.fuzzy_hashes, servers[checked_server]?.status);
             }
 
             if (!rowspanHoverHandlersInitialized) {
@@ -986,6 +1034,58 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                 attachRowspanHoverHandlers("#fuzzyTable");
                 rowspanHoverHandlersInitialized = true;
             }
+        }
+
+        // Fetch the per-neighbour fuzzy storages config (read_only, server
+        // addresses, symbol/flag mapping) for the fuzzy table. A silent raw
+        // probe per up neighbour, probeHealth-style: a failure is data, not
+        // an error — older rspamd or fuzzy_check disabled just leaves the
+        // table plain. Cached by a name:config_id:up signature over all
+        // neighbours, so it is fetched once per page load and refetched only
+        // when the configuration or the set of up servers changes (a
+        // neighbour recovering after a page-load-time outage must not stay
+        // without its metadata), never in the /stat refresh cycle.
+        function fetchFuzzyStorages(neighbours_status, cycleId, checked_server) {
+            const sig = neighbours_status
+                .map((n) => `${n.name}:${n.data.config_id ?? ""}:${n.status ? 1 : 0}`)
+                .sort().join("|");
+            if (fuzzyStoragesFetching || sig === fuzzyStoragesSig) return;
+            // Commit the signature up front: an unavailable endpoint must
+            // not be retried on every refresh cycle
+            fuzzyStoragesFetching = true;
+            fuzzyStoragesSig = sig;
+
+            const up = neighbours_status.filter((neighbour) => neighbour.status);
+            let pending = up.length;
+            if (!pending) {
+                fuzzyStoragesFetching = false;
+                return;
+            }
+            function settled() {
+                if (--pending) return;
+                fuzzyStoragesFetching = false;
+                if (cycleId !== statCycleId) return;
+                if (document.getElementById("status").classList.contains("active")) {
+                    displayStatWidgets(checked_server);
+                }
+            }
+            up.forEach((neighbour) => {
+                const xhr = new XMLHttpRequest();
+                xhr.open("GET", neighbour.url + "plugins/fuzzy/storages", true);
+                xhr.setRequestHeader("Password", common.getPassword());
+                const timeout = Math.min(common.getAjaxTimeout() || Infinity, 10000);
+                if (timeout > 0) xhr.timeout = timeout;
+                xhr.onload = () => {
+                    if (xhr.status >= 200 && xhr.status < 300) {
+                        fuzzyStorages.set(neighbour.name,
+                            parseJsonOrEmpty(xhr.responseText).storages || {});
+                    }
+                    settled();
+                };
+                xhr.onerror = settled;
+                xhr.ontimeout = settled;
+                xhr.send();
+            });
         }
 
         function getChart(graphs, checked_server) {
@@ -1236,6 +1336,7 @@ define(["app/common", "app/libft", "d3pie", "d3"],
                                         sessionStorage.setItem("Credentials", JSON.stringify(to_Credentials));
                                         displayStatWidgets(checked_server);
                                         getChart(graphs, checked_server);
+                                        fetchFuzzyStorages(neighbours_status, cycleId, checked_server);
                                     }
                                     resolve();
                                 });

--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -1673,8 +1673,11 @@ rspamd_fuzzy_process_command(struct fuzzy_session *session)
 		}
 
 		if (cmd->cmd == FUZZY_STAT) {
-			/* Store approximation (if needed) */
-			result.v1.prob = session->ctx->stat.fuzzy_hashes;
+			/* prob merely signals success: the count is carried by value and
+			 * flag below. Encoding the count in prob made an empty storage
+			 * (count 0) indistinguishable from an error reply for
+			 * clients guarding on prob > 0.5 */
+			result.v1.prob = 1.0f;
 			/* Store high qword in value and low qword in flag */
 			result.v1.value = (int32_t) ((uint64_t) session->ctx->stat.fuzzy_hashes >> 32);
 			result.v1.flag = (uint32_t) (session->ctx->stat.fuzzy_hashes & G_MAXUINT32);

--- a/src/plugins/fuzzy_check.c
+++ b/src/plugins/fuzzy_check.c
@@ -1527,7 +1527,10 @@ fuzzy_tcp_process_reply(struct fuzzy_tcp_connection *conn,
 	struct rspamd_task *task = pending->task;
 
 	/* Process the reply - similar to UDP code in fuzzy_check_try_read */
-	if (rep->v1.prob > 0.5) {
+	/* See the UDP reply handler: a legacy empty-storage STAT reply comes
+	 * with prob = 0 and zero value/flag */
+	if (rep->v1.prob > 0.5 ||
+		(pending->io->cmd.cmd == FUZZY_STAT && rep->v1.value == 0 && rep->v1.flag == 0)) {
 		if (pending->io->cmd.cmd == FUZZY_CHECK) {
 			/* Insert result for primary flag */
 			fuzzy_insert_result(pending->session, rep, &pending->io->cmd,
@@ -5060,7 +5063,11 @@ fuzzy_check_try_read(struct fuzzy_client_session *session)
 			if (rep_v2) {
 				session->rule->server_supports_v2 = TRUE;
 			}
-			if (rep->v1.prob > 0.5) {
+			/* A legacy storage encodes an empty fuzzy storage (count 0) as
+			 * prob = 0 with both count qwords zero; error replies carry a
+			 * nonzero code in value, so accept that shape for STAT too */
+			if (rep->v1.prob > 0.5 ||
+				(cmd->cmd == FUZZY_STAT && rep->v1.value == 0 && rep->v1.flag == 0)) {
 				if (cmd->cmd == FUZZY_CHECK) {
 					fuzzy_insert_result(session, rep, cmd, io, rep->v1.flag);
 

--- a/test/playwright/tests/fuzzy.spec.mjs
+++ b/test/playwright/tests/fuzzy.spec.mjs
@@ -14,14 +14,20 @@ test("fuzzy table: per-server join, tooltips, read-only badge, raw numbers", asy
 
     // n1: a unified servers list and a read-only rule; "local<b>" is absent
     // from the storages reply — escaping canary and missing-rule fallback in
-    // one. n2: the same rule name with different addresses and flags — the
-    // join must not mix the two servers' configs.
+    // one; "down.example" is configured but absent from fuzzy_hashes — the
+    // unavailable row. n2: the same rule name with different addresses and
+    // flags — the join must not mix the two servers' configs.
     const fuzzyHashes = {
         n1: {"rspamd.com": 1234567, "local<b>": 7},
         n2: {"rspamd.com": 42},
     };
     const storages = {
         n1: {
+            "down.example": {
+                flags: {RW_BL_2: 2},
+                read_only: false,
+                servers: ["fuzzy9.example.com:11335"]
+            },
             "rspamd.com": {
                 flags: {FUZZY_DENIED: 1, FUZZY_PROB: 2},
                 read_only: true,
@@ -82,34 +88,45 @@ test("fuzzy table: per-server join, tooltips, read-only badge, raw numbers", asy
     ]);
 
     const rows = page.locator("#fuzzyTable tbody tr");
-    await expect(rows).toHaveCount(3);
+    await expect(rows).toHaveCount(4);
 
     // Rowspan server cell on the first row of each group only; the rule
     // missing from the storages reply renders as text (escaping) and keeps
     // its raw count without a tooltip
     await expect(rows.nth(0).locator("td").nth(0)).toHaveText("srv1");
+    await expect(rows.nth(0).locator("td").nth(0)).toHaveAttribute("rowspan", "3");
     await expect(rows.nth(1).locator("td").nth(0)).toHaveText("local<b>");
     await expect(rows.nth(1).locator("td").nth(0)).not.toHaveAttribute("title");
-    await expect(rows.nth(2).locator("td").nth(0)).toHaveText("srv2");
+    await expect(rows.nth(3).locator("td").nth(0)).toHaveText("srv2");
 
-    // Exactly one read-only badge, on n1's rspamd.com
-    await expect(page.locator("#fuzzyTable .badge")).toHaveCount(1);
+    // One read-only badge (n1's rspamd.com) and one unavailable badge
+    // (n1's down.example) — no badges for n2
+    await expect(page.locator("#fuzzyTable .badge")).toHaveCount(2);
     await expect(rows.nth(0).locator(".badge")).toHaveText("read-only");
     await expect(rows.nth(0).locator(".badge"))
         .toHaveAttribute("title", "Storage is read-only: it cannot be learned to");
+    await expect(rows.nth(2).locator(".badge")).toHaveText("unavailable");
+    await expect(rows.nth(2).locator(".badge")).toHaveAttribute("title",
+        "No reply to the statistics query; the storage may be down, rate-limited or access denied");
+
+    // The configured-but-unreported rule keeps its config tooltip and
+    // renders "-" instead of a count
+    await expect(rows.nth(2).locator("td").nth(0)).toHaveAttribute("title",
+        "Servers: fuzzy9.example.com:11335\nSymbols:\nRW_BL_2 (2)");
+    await expect(rows.nth(2).locator("td").nth(1)).toHaveText("-");
 
     // n1: unified servers list plus the symbol/flag mapping in the tooltip
     await expect(rows.nth(0).locator("td").nth(1)).toHaveAttribute("title",
         "Servers: fuzzy1.rspamd.com:11335\nSymbols:\nFUZZY_DENIED (1)\nFUZZY_PROB (2)");
 
     // n2: its own split read/write lists and flags — no cross-server mixing
-    await expect(rows.nth(2).locator("td").nth(1)).toHaveAttribute("title",
+    await expect(rows.nth(3).locator("td").nth(1)).toHaveAttribute("title",
         "Read: 127.0.0.1:11335\nWrite: 10.0.0.1:11335\nSymbols:\nFUZZY_DENIED (5)");
 
     // Raw, copyable counts — no locale formatting
     await expect(rows.nth(0).locator("td").nth(2)).toHaveText("1234567");
     await expect(rows.nth(1).locator("td").nth(1)).toHaveText("7");
-    await expect(rows.nth(2).locator("td").nth(2)).toHaveText("42");
+    await expect(rows.nth(3).locator("td").nth(2)).toHaveText("42");
 
     // Header tooltips, as in the bayes table
     const headers = page.locator("#fuzzyTable thead th");

--- a/test/playwright/tests/fuzzy.spec.mjs
+++ b/test/playwright/tests/fuzzy.spec.mjs
@@ -1,0 +1,290 @@
+import {expect, test} from "@playwright/test";
+import {login} from "../helpers/auth.mjs";
+
+// The fuzzy table joins /stat's fuzzy_hashes (rule name -> hash count)
+// with the plugins/fuzzy/storages config (read_only, server addresses,
+// symbol/flag map) fetched once per page load. The mocking follows
+// cluster.spec: the /neighbours map points at path prefixes on the same
+// origin (keeps the Password-header XHRs free of CORS), and every /n<N>/stat
+// reply is the real /stat body with fuzzy_hashes injected, so the schema
+// stays in sync with the backend.
+test("fuzzy table: per-server join, tooltips, read-only badge, raw numbers", async ({page, request}, testInfo) => {
+    const {enablePassword, readOnlyPassword} = testInfo.project.use.rspamdPasswords;
+    const baseStat = await (await request.get("/stat", {headers: {Password: readOnlyPassword}})).json();
+
+    // n1: a unified servers list and a read-only rule; "local<b>" is absent
+    // from the storages reply — escaping canary and missing-rule fallback in
+    // one. n2: the same rule name with different addresses and flags — the
+    // join must not mix the two servers' configs.
+    const fuzzyHashes = {
+        n1: {"rspamd.com": 1234567, "local<b>": 7},
+        n2: {"rspamd.com": 42},
+    };
+    const storages = {
+        n1: {
+            "rspamd.com": {
+                flags: {FUZZY_DENIED: 1, FUZZY_PROB: 2},
+                read_only: true,
+                servers: ["fuzzy1.rspamd.com:11335"]
+            }
+        },
+        n2: {
+            "rspamd.com": {
+                flags: {FUZZY_DENIED: 5},
+                read_only: false,
+                read_servers: ["127.0.0.1:11335"],
+                write_servers: ["10.0.0.1:11335"]
+            }
+        }
+    };
+
+    await page.route("**/neighbours", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            srv1: {host: "127.0.0.1", url: "http://localhost:11334/n1/"},
+            srv2: {host: "127.0.0.1", url: "http://localhost:11334/n2/"},
+        }),
+    }));
+    for (const n of ["n1", "n2"]) {
+        await page.route(`**/${n}/stat`, (route) => route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({...baseStat, fuzzy_hashes: fuzzyHashes[n]}),
+        }));
+        // The login-time auth fan-out and the health probes must not 404
+        for (const ep of ["auth", "healthy", "ready"]) {
+            await page.route(`**/${n}/${ep}`, (route) => route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify(ep === "auth"
+                    ? {auth: "ok", version: baseStat.version}
+                    : {}),
+            }));
+        }
+        await page.route(`**/${n}/plugins/fuzzy/storages`, (route) => route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({storages: storages[n], success: true}),
+        }));
+    }
+
+    // The login-time sticky-tabs activation of the status tab already runs
+    // the first /stat cycle, so the storages probe may answer before this
+    // test could observe the navBar — arm the listener before logging in
+    const n1Storages = page.waitForResponse((r) => r.url().includes("/n1/plugins/fuzzy/storages"));
+    await login(page, enablePassword);
+    await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    // The storages config lands after the /stat render (second pass)
+    await Promise.all([
+        n1Storages,
+        page.locator("#status_nav").click(),
+    ]);
+
+    const rows = page.locator("#fuzzyTable tbody tr");
+    await expect(rows).toHaveCount(3);
+
+    // Rowspan server cell on the first row of each group only; the rule
+    // missing from the storages reply renders as text (escaping) and keeps
+    // its raw count without a tooltip
+    await expect(rows.nth(0).locator("td").nth(0)).toHaveText("srv1");
+    await expect(rows.nth(1).locator("td").nth(0)).toHaveText("local<b>");
+    await expect(rows.nth(1).locator("td").nth(0)).not.toHaveAttribute("title");
+    await expect(rows.nth(2).locator("td").nth(0)).toHaveText("srv2");
+
+    // Exactly one read-only badge, on n1's rspamd.com
+    await expect(page.locator("#fuzzyTable .badge")).toHaveCount(1);
+    await expect(rows.nth(0).locator(".badge")).toHaveText("read-only");
+    await expect(rows.nth(0).locator(".badge"))
+        .toHaveAttribute("title", "Storage is read-only: it cannot be learned to");
+
+    // n1: unified servers list plus the symbol/flag mapping in the tooltip
+    await expect(rows.nth(0).locator("td").nth(1)).toHaveAttribute("title",
+        "Servers: fuzzy1.rspamd.com:11335\nSymbols:\nFUZZY_DENIED (1)\nFUZZY_PROB (2)");
+
+    // n2: its own split read/write lists and flags — no cross-server mixing
+    await expect(rows.nth(2).locator("td").nth(1)).toHaveAttribute("title",
+        "Read: 127.0.0.1:11335\nWrite: 10.0.0.1:11335\nSymbols:\nFUZZY_DENIED (5)");
+
+    // Raw, copyable counts — no locale formatting
+    await expect(rows.nth(0).locator("td").nth(2)).toHaveText("1234567");
+    await expect(rows.nth(1).locator("td").nth(1)).toHaveText("7");
+    await expect(rows.nth(2).locator("td").nth(2)).toHaveText("42");
+
+    // Header tooltips, as in the bayes table
+    const headers = page.locator("#fuzzyTable thead th");
+    await expect(headers).toHaveCount(3);
+    for (let i = 0; i < 3; i++) {
+        await expect(headers.nth(i)).toHaveAttribute("title", /.+/);
+    }
+});
+
+// An up server without fuzzy storages keeps its placeholder row, and a
+// missing storages endpoint (older rspamd, fuzzy_check disabled) degrades
+// silently: plain rows, no error-log badge.
+test("fuzzy table: empty state and storages endpoint degradation", async ({page, request}, testInfo) => {
+    const {enablePassword, readOnlyPassword} = testInfo.project.use.rspamdPasswords;
+    const baseStat = await (await request.get("/stat", {headers: {Password: readOnlyPassword}})).json();
+
+    const statNoFuzzy = {...baseStat};
+    delete statNoFuzzy.fuzzy_hashes;
+
+    await page.route("**/neighbours", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            srv1: {host: "127.0.0.1", url: "http://localhost:11334/n1/"},
+            srv2: {host: "127.0.0.1", url: "http://localhost:11334/n2/"},
+        }),
+    }));
+    await page.route("**/n1/stat", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(statNoFuzzy),
+    }));
+    await page.route("**/n2/stat", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({...baseStat, fuzzy_hashes: {"rspamd.com": 42}}),
+    }));
+    for (const n of ["n1", "n2"]) {
+        for (const ep of ["auth", "healthy", "ready"]) {
+            await page.route(`**/${n}/${ep}`, (route) => route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify(ep === "auth"
+                    ? {auth: "ok", version: baseStat.version}
+                    : {}),
+            }));
+        }
+        await page.route(`**/${n}/plugins/fuzzy/storages`, (route) => route.fulfill({
+            status: 404,
+            contentType: "application/json",
+            body: JSON.stringify({error: "fuzzy_check is not enabled"}),
+        }));
+    }
+
+    // Arm before logging in: the storages probe may answer during the
+    // login-time status activation (see the first test)
+    const n1Storages = page.waitForResponse((r) => r.url().includes("/n1/plugins/fuzzy/storages"));
+    await login(page, enablePassword);
+    await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    await Promise.all([
+        n1Storages,
+        page.locator("#status_nav").click(),
+    ]);
+
+    // The server without fuzzy hashes stays visible with a spanning
+    // placeholder; the other one renders its plain hash count
+    const rows = page.locator("#fuzzyTable tbody tr");
+    await expect(rows).toHaveCount(2);
+    await expect(rows.nth(0).locator("td").nth(0)).toHaveText("srv1");
+    await expect(rows.nth(0).locator('td[colspan="2"]')).toHaveText("No fuzzy storages");
+    await expect(rows.nth(1).locator("td").nth(1)).toHaveText("rspamd.com");
+    await expect(rows.nth(1).locator("td").nth(2)).toHaveText("42");
+
+    // Silent degradation: no badges, no tooltips, no error-log badge
+    await expect(page.locator("#fuzzyTable .badge")).toHaveCount(0);
+    await expect(rows.nth(1).locator("td").nth(1)).not.toHaveAttribute("title");
+    await expect(page.locator("#error-log-badge")).toHaveClass(/\bd-none\b/);
+});
+
+// A neighbour that was down at page load and recovers with the same
+// config_id must get its storages metadata on a later refresh cycle: the
+// cache signature tracks the up/down state, not just the configuration.
+test("fuzzy table: a recovered neighbour gets its storages", async ({page, request}, testInfo) => {
+    const {enablePassword, readOnlyPassword} = testInfo.project.use.rspamdPasswords;
+    const baseStat = await (await request.get("/stat", {headers: {Password: readOnlyPassword}})).json();
+
+    let n2Up = false;
+    await page.route("**/neighbours", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            srv1: {host: "127.0.0.1", url: "http://localhost:11334/n1/"},
+            srv2: {host: "127.0.0.1", url: "http://localhost:11334/n2/"},
+        }),
+    }));
+    await page.route("**/n1/stat", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({...baseStat, fuzzy_hashes: {"rspamd.com": 1234567}}),
+    }));
+    await page.route("**/n2/stat", (route) => {
+        if (!n2Up) return route.fulfill({status: 503, contentType: "application/json", body: "{}"});
+        return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({...baseStat, fuzzy_hashes: {"rspamd.com": 42}}),
+        });
+    });
+    for (const n of ["n1", "n2"]) {
+        for (const ep of ["auth", "healthy", "ready"]) {
+            await page.route(`**/${n}/${ep}`, (route) => route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify(ep === "auth"
+                    ? {auth: "ok", version: baseStat.version}
+                    : {}),
+            }));
+        }
+    }
+    await page.route("**/n1/plugins/fuzzy/storages", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            storages: {
+                "rspamd.com": {
+                    flags: {FUZZY_DENIED: 1},
+                    read_only: true,
+                    servers: ["fuzzy1.rspamd.com:11335"]
+                }
+            },
+            success: true
+        }),
+    }));
+    await page.route("**/n2/plugins/fuzzy/storages", (route) => route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+            storages: {
+                "rspamd.com": {
+                    flags: {FUZZY_DENIED: 5},
+                    read_only: true,
+                    read_servers: ["127.0.0.1:11335"],
+                    write_servers: ["10.0.0.1:11335"]
+                }
+            },
+            success: true
+        }),
+    }));
+
+    const n1Storages = page.waitForResponse((r) => r.url().includes("/n1/plugins/fuzzy/storages"));
+    await login(page, enablePassword);
+    await expect(page.locator("#navBar")).not.toHaveClass(/d-none/, {timeout: 30000});
+    await Promise.all([
+        n1Storages,
+        page.locator("#status_nav").click(),
+    ]);
+
+    // While n2 is down only n1 renders, with its storages metadata
+    const rows = page.locator("#fuzzyTable tbody tr");
+    await expect(rows).toHaveCount(1);
+    await expect(rows.nth(0).locator("td").nth(1))
+        .toHaveAttribute("title", "Servers: fuzzy1.rspamd.com:11335\nSymbols:\nFUZZY_DENIED (1)");
+    await expect(page.locator("#fuzzyTable .badge")).toHaveCount(1);
+
+    // n2 recovers with the same config_id; the manual refresh runs a new
+    // cycle whose changed up-set must refetch the storages config. Arm the
+    // listener before flipping the state so no fetch can slip past it
+    const n2Storages = page.waitForResponse((r) => r.url().includes("/n2/plugins/fuzzy/storages"));
+    n2Up = true;
+    await Promise.all([
+        n2Storages,
+        page.locator("#refresh").click(),
+    ]);
+    await expect(rows).toHaveCount(2);
+    await expect(rows.nth(1).locator("td").nth(1)).toHaveAttribute("title",
+        "Read: 127.0.0.1:11335\nWrite: 10.0.0.1:11335\nSymbols:\nFUZZY_DENIED (5)");
+    await expect(page.locator("#fuzzyTable .badge")).toHaveCount(2);
+});

--- a/test/playwright/tests/fuzzy.spec.mjs
+++ b/test/playwright/tests/fuzzy.spec.mjs
@@ -15,10 +15,11 @@ test("fuzzy table: per-server join, tooltips, read-only badge, raw numbers", asy
     // n1: a unified servers list and a read-only rule; "local<b>" is absent
     // from the storages reply — escaping canary and missing-rule fallback in
     // one; "down.example" is configured but absent from fuzzy_hashes — the
-    // unavailable row. n2: the same rule name with different addresses and
-    // flags — the join must not mix the two servers' configs.
+    // unavailable row; "empty.example" reports a zero count — must render as
+    // a plain 0, not unavailable. n2: the same rule name with different
+    // addresses and flags — the join must not mix the two servers' configs.
     const fuzzyHashes = {
-        n1: {"rspamd.com": 1234567, "local<b>": 7},
+        n1: {"rspamd.com": 1234567, "local<b>": 7, "empty.example": 0},
         n2: {"rspamd.com": 42},
     };
     const storages = {
@@ -27,6 +28,11 @@ test("fuzzy table: per-server join, tooltips, read-only badge, raw numbers", asy
                 flags: {RW_BL_2: 2},
                 read_only: false,
                 servers: ["fuzzy9.example.com:11335"]
+            },
+            "empty.example": {
+                flags: {RW_WL_1: 3},
+                read_only: false,
+                servers: ["fuzzy2.example.com:11335"]
             },
             "rspamd.com": {
                 flags: {FUZZY_DENIED: 1, FUZZY_PROB: 2},
@@ -88,16 +94,22 @@ test("fuzzy table: per-server join, tooltips, read-only badge, raw numbers", asy
     ]);
 
     const rows = page.locator("#fuzzyTable tbody tr");
-    await expect(rows).toHaveCount(4);
+    await expect(rows).toHaveCount(5);
 
     // Rowspan server cell on the first row of each group only; the rule
     // missing from the storages reply renders as text (escaping) and keeps
     // its raw count without a tooltip
     await expect(rows.nth(0).locator("td").nth(0)).toHaveText("srv1");
-    await expect(rows.nth(0).locator("td").nth(0)).toHaveAttribute("rowspan", "3");
+    await expect(rows.nth(0).locator("td").nth(0)).toHaveAttribute("rowspan", "4");
     await expect(rows.nth(1).locator("td").nth(0)).toHaveText("local<b>");
     await expect(rows.nth(1).locator("td").nth(0)).not.toHaveAttribute("title");
-    await expect(rows.nth(3).locator("td").nth(0)).toHaveText("srv2");
+    await expect(rows.nth(4).locator("td").nth(0)).toHaveText("srv2");
+
+    // A healthy storage with zero hashes renders a plain raw 0 — not an
+    // unavailable row
+    await expect(rows.nth(2).locator("td").nth(0)).toHaveText("empty.example");
+    await expect(rows.nth(2).locator("td").nth(1)).toHaveText("0");
+    await expect(rows.nth(2).locator(".badge")).toHaveCount(0);
 
     // One read-only badge (n1's rspamd.com) and one unavailable badge
     // (n1's down.example) — no badges for n2
@@ -105,28 +117,28 @@ test("fuzzy table: per-server join, tooltips, read-only badge, raw numbers", asy
     await expect(rows.nth(0).locator(".badge")).toHaveText("read-only");
     await expect(rows.nth(0).locator(".badge"))
         .toHaveAttribute("title", "Storage is read-only: it cannot be learned to");
-    await expect(rows.nth(2).locator(".badge")).toHaveText("unavailable");
-    await expect(rows.nth(2).locator(".badge")).toHaveAttribute("title",
+    await expect(rows.nth(3).locator(".badge")).toHaveText("unavailable");
+    await expect(rows.nth(3).locator(".badge")).toHaveAttribute("title",
         "No reply to the statistics query; the storage may be down, rate-limited or access denied");
 
     // The configured-but-unreported rule keeps its config tooltip and
     // renders "-" instead of a count
-    await expect(rows.nth(2).locator("td").nth(0)).toHaveAttribute("title",
+    await expect(rows.nth(3).locator("td").nth(0)).toHaveAttribute("title",
         "Servers: fuzzy9.example.com:11335\nSymbols:\nRW_BL_2 (2)");
-    await expect(rows.nth(2).locator("td").nth(1)).toHaveText("-");
+    await expect(rows.nth(3).locator("td").nth(1)).toHaveText("-");
 
     // n1: unified servers list plus the symbol/flag mapping in the tooltip
     await expect(rows.nth(0).locator("td").nth(1)).toHaveAttribute("title",
         "Servers: fuzzy1.rspamd.com:11335\nSymbols:\nFUZZY_DENIED (1)\nFUZZY_PROB (2)");
 
     // n2: its own split read/write lists and flags — no cross-server mixing
-    await expect(rows.nth(3).locator("td").nth(1)).toHaveAttribute("title",
+    await expect(rows.nth(4).locator("td").nth(1)).toHaveAttribute("title",
         "Read: 127.0.0.1:11335\nWrite: 10.0.0.1:11335\nSymbols:\nFUZZY_DENIED (5)");
 
     // Raw, copyable counts — no locale formatting
     await expect(rows.nth(0).locator("td").nth(2)).toHaveText("1234567");
     await expect(rows.nth(1).locator("td").nth(1)).toHaveText("7");
-    await expect(rows.nth(3).locator("td").nth(2)).toHaveText("42");
+    await expect(rows.nth(4).locator("td").nth(2)).toHaveText("42");
 
     // Header tooltips, as in the bayes table
     const headers = page.locator("#fuzzyTable thead th");


### PR DESCRIPTION
## What

The Status tab fuzzy table now shows each storage's configuration and
availability next to the hash count, and a long-standing protocol quirk
that hid empty storages from the statistics is fixed.

## WebUI

- `read-only` badge for storages that cannot be learned to
- combined tooltip on the storage name with server addresses (unified or
  split read/write) and the symbol → flag mapping, taken from the
  existing `plugins/fuzzy/storages` endpoint
- the storages config is fetched once per page load (and on a
  configuration or up-set change), never in the /stat refresh cycle; a
  missing endpoint (older rspamd, `fuzzy_check` disabled) degrades
  silently to the plain table
- rules configured but missing from `fuzzy_hashes` render as
  `unavailable` with "-" instead of a count: the selected storage did
  not answer FUZZY_STAT in time (down, rate-limited or denied). A
  neighbour that recovers gets its metadata on the next refresh cycle
- header tooltips and a "No fuzzy storages" empty-state row, matching
  the bayes table conventions; hash counts stay raw and copyable

## Protocol fix

An empty fuzzy storage (count 0) was indistinguishable from an error
reply: the storage encoded the hash count in `prob`, so a zero count
arrived as `prob = 0` and the client's `prob > 0.5` guard dropped it —
the rule silently disappeared from `/stat` (`fuzzy_hashes`) and from
`/metrics` (`rspamd_fuzzy_stat`).

- the storage now replies with `prob = 1.0`; the count already travels
  in `value` + `flag` (same semantics as FUZZY_PING)
- both client reply handlers (UDP and TCP) also accept the legacy
  zero-count encoding (`prob = 0` with zero `value`/`flag`), so
  mixed-version clusters upgrade cleanly; error replies always carry a
  nonzero code in `value` and are unaffected