### PR TITLE
[Fix] Font size follow-ups: unitless zero in the shorthand, uniform block propagation

### DIFF
--- a/src/libserver/css/css_rule.cxx
+++ b/src/libserver/css/css_rule.cxx
@@ -240,9 +240,16 @@ allowed_property_value(const css_property &prop, const css_consumed_block &parse
 								   css_parser_token::number_percent))) {
 					/*
 					 * In the `font` shorthand a unitless number is the weight
-					 * or the line-height, never the size
+					 * or the line-height, never the size. Zero is the
+					 * exception: it is a valid length in every mode, cannot
+					 * be a weight, and `font: 0 ...` renders text invisible
 					 */
-					return std::nullopt;
+					auto is_zero = std::holds_alternative<float>(tok.value) &&
+								   std::get<float>(tok.value) == 0.0f;
+
+					if (!is_zero) {
+						return std::nullopt;
+					}
 				}
 
 				return css_value::maybe_dimension_from_number(tok);
@@ -767,6 +774,9 @@ TEST_SUITE("css")
 			"clip-path:circle(0)",
 			/* visibility:collapse */
 			"visibility:collapse",
+			/* unitless zero size in the font shorthand */
+			"font:0 Arial",
+			"font:400 0/1.5 Arial",
 			/* Tiny font */
 			"font-size:1px",
 			"font-size:2px",
@@ -839,6 +849,11 @@ TEST_SUITE("css")
 			{"font:italic 400 12pt/2 Arial", 16},
 			{"font:1px/1.5 Arial", 1},
 			{"font:400 0px/1.5 Arial", 0},
+			/* A unitless zero is the one unitless size the shorthand allows */
+			{"font:0 Arial", 0},
+			{"font:400 0/1.5 Arial", 0},
+			{"font:bold 0/16px Arial", 0},
+			{"font:16px/0 Arial", 16},
 		};
 
 		for (const auto &c: cases) {

--- a/src/libserver/html/html.cxx
+++ b/src/libserver/html/html.cxx
@@ -3192,13 +3192,19 @@ auto html_process_input(struct rspamd_task *task,
 
 			for (const auto *cld_tag: tag->children) {
 
-				if (cld_tag->block) {
-					cld_tag->block->propagate_block(*tag->block);
-				}
-				else {
+				if (!cld_tag->block) {
+					/*
+					 * Tags normally get a block while parsing (from the style
+					 * attribute or an empty one). Should one arrive here
+					 * without it, inherit through propagation rather than a
+					 * copy: a copy would carry the parent's `set` masks, and a
+					 * stylesheet rule merged into the child later could not
+					 * override what the parent set inline
+					 */
 					cld_tag->block = rspamd_mempool_alloc0_type(pool, html_block);
-					*cld_tag->block = *tag->block;
 				}
+
+				cld_tag->block->propagate_block(*tag->block);
 			}
 		}
 		return true;

--- a/test/functional/cases/001_merged/100_general.robot
+++ b/test/functional/cases/001_merged/100_general.robot
@@ -89,6 +89,7 @@ HTML VISIBILITY - Significant hidden content
   boundary  2  200
   intermediate  3  300
   multipart  2  200
+  stylesheet_over_inline  5  500
 
 HTML VISIBILITY - No significant hidden content
   [Template]  Check No Significant Hidden Content

--- a/test/functional/messages/html_hidden_stylesheet_over_inline.eml
+++ b/test/functional/messages/html_hidden_stylesheet_over_inline.eml
@@ -1,0 +1,8 @@
+From: sender@example.com
+To: recipient@example.net
+Subject: Hidden content amount
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 8bit
+
+<html><head><style>.fine { font-size: 0 }</style></head><body style="font-size:12px"><p>Visible text.</p><span class="fine">Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. Hidden content. </span></body></html>

--- a/test/lua/unit/html.lua
+++ b/test/lua/unit/html.lua
@@ -154,6 +154,81 @@ context("HTML processing", function()
     pool:destroy()
   end)
 
+  -- The standalone parser never applies stylesheets, so cases that need a
+  -- <style> block go through a real task, where the CSS parser is enabled
+  local function parse_html_message(body)
+    local rspamd_task = require("rspamd_task")
+    local msg = "From: test@example.com\r\nTo: nobody@example.com\r\nSubject: test\r\n" ..
+        "Content-Type: text/html\r\n\r\n" .. body
+    -- no assertions here: telescope only exposes them inside test bodies
+    local res, task = rspamd_task.load_from_string(msg, rspamd_config)
+    if not res then return nil end
+    task:process_message()
+    local html = task:get_text_parts()[1]:get_html()
+    if not html then return nil end
+    local tags = {}
+    html:foreach_tag("any", function(tag)
+      table.insert(tags, tag)
+      return false
+    end)
+    return html, tags, task
+  end
+
+  -- Block-level tags get their own block while parsing; inline tags without
+  -- a style attribute only receive the parent's block on propagation, which
+  -- is the path where a copied `set` mask used to shadow stylesheet rules
+  test("A stylesheet rule overrides a size the parent set inline", function()
+    local html, tags = parse_html_message(
+        '<html><head><style>.fine { font-size: 0 }</style></head>' ..
+        '<body style="font-size:12px"><p><span class="fine">hidden</span>' ..
+        '<span>shown</span></p></body></html>')
+    assert_not_nil(html, 'html part not parsed')
+
+    assert_equal('hidden', tostring(html:get_invisible()))
+    local checked = 0
+    for _, tag in ipairs(tags) do
+      if tag:get_type() == 'span' then
+        local style = tag:get_style()
+        if tag:get_attribute('class') == 'fine' then
+          assert_false(style.visible)
+        else
+          assert_true(style.visible)
+          assert_equal(style.font_size, 12)
+        end
+        checked = checked + 1
+      end
+    end
+    assert_equal(checked, 2)
+  end)
+
+  test("Inherited values keep their inherited mask on children", function()
+    local html, tags = parse_html_message(
+        '<html><head><style>.tiny { font-size: 1px } .big { font-size: 200% }</style></head>' ..
+        '<body style="font-size:12px"><p><span class="tiny">hidden</span>' ..
+        '<span class="big">large</span><span>plain</span></p></body></html>')
+    assert_not_nil(html, 'html part not parsed')
+
+    assert_equal('hidden', tostring(html:get_invisible()))
+    local checked = 0
+    for _, tag in ipairs(tags) do
+      if tag:get_type() == 'span' then
+        local class = tag:get_attribute('class')
+        local style = tag:get_style()
+        if class == 'tiny' then
+          assert_false(style.visible)
+        elseif class == 'big' then
+          assert_true(style.visible)
+          assert_equal(style.font_size, 24)
+        else
+          assert_true(style.visible)
+          assert_equal(style.font_size, 12)
+        end
+        checked = checked + 1
+      end
+    end
+    assert_equal(checked, 3)
+  end)
+
   test("HTML tag get_all_attributes basic test", function()
     local rspamd_mempool = require("rspamd_mempool")
     local pool = rspamd_mempool.create()


### PR DESCRIPTION
## Summary

Two follow-ups from the review of #6245, rebased on master now that #6245 has landed.

## Changes

**`[Fix]` Accept a unitless zero as the font shorthand size.** #6245 rejects unitless numbers in the `font` shorthand because there they are the weight or the line-height. Zero is the one exception: it is never a valid weight, it is a valid length in every rendering mode, and `font: 0 Arial` renders text invisible. A zero now passes, so that hiding trick is still caught; the first-length rule keeps `font: 16px/0 Arial` at 16. Covered by four shorthand cases in the css doctest table and two entries in the invisible-block list.

**`[Minor]` Propagate parent blocks instead of copying them.** The review flagged that a child without a block received a verbatim copy of the parent's block, `set` masks included, which would stop a later stylesheet rule from overriding an inline parent value. On closer inspection every tag already gets a block while parsing (from its style attribute, or an empty one), so that branch is not reached in practice and the issue does not manifest. The branch is kept consistent anyway: allocate an empty block and propagate, which marks inherited values as inherited.

**`[Test]` Cover stylesheet rules overriding sizes a parent set inline.** Two Lua unit cases through a real task (the standalone HTML parser never applies stylesheets), and a functional fixture that hides the `large_zero` block through a class rule inside an inline element under an inline-sized body, expecting `HIDDEN_TEXT` at full weight.

## Verification

- css doctest suite: 15 cases, 356 assertions; full C++ suite green
- Lua unit suite: 1293 passed
- Functional `100_general`: 23/23, including #6245's fixtures and the new one
- Full merged functional suite: 436/436
- clang-format, luacheck and pre-commit hooks clean
