### PR TITLE
[Feature] Lazy per-source stats for fuzzy keys

### DIFF
--- a/lualib/rspamadm/fuzzy_stat.lua
+++ b/lualib/rspamadm/fuzzy_stat.lua
@@ -32,6 +32,9 @@ local function add_data(target, src)
       else
         target[k] = v
       end
+    elseif k == 'ips_overflow' then
+      -- Sticky across workers: one worker giving up is enough to report it
+      target.ips_overflow = target.ips_overflow or v
     elseif k == 'ips' then
       if not target['ips'] then
         target['ips'] = {}
@@ -335,6 +338,11 @@ return function(args, res)
         end
 
         print_stat(key_stat, '\t')
+
+        if key_stat.ips_overflow then
+          print('')
+          print('\tIPs stat: disabled, too many distinct sources for the per-key table')
+        end
 
         if key_stat['ips'] and not opts['no_ips'] then
           print('')

--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -1324,7 +1324,6 @@ rspamd_fuzzy_process_command(struct fuzzy_session *session)
 	struct fuzzy_peer_request *up_req;
 	struct fuzzy_key_stat *ip_stat = NULL;
 	char hexbuf[rspamd_cryptobox_HASHBYTES * 2 + 1];
-	rspamd_inet_addr_t *naddr;
 	gpointer ptr;
 	gsize up_len = 0;
 	int send_flags = 0;
@@ -1469,19 +1468,14 @@ rspamd_fuzzy_process_command(struct fuzzy_session *session)
 	}
 
 	if (session->key && session->addr) {
-		ip_stat = rspamd_lru_hash_lookup(session->key->stat->last_ips,
-										 session->addr, -1);
+		ip_stat = fuzzy_key_stat_get_ip(session->key->stat,
+										fuzzy_key_max_ips(session->ctx, session->key),
+										session->addr, session->timestamp);
 
-		if (ip_stat == NULL) {
-			naddr = rspamd_inet_address_copy(session->addr, NULL);
-			ip_stat = g_malloc0(sizeof(*ip_stat));
-			REF_INIT_RETAIN(ip_stat, fuzzy_key_stat_dtor);
-			rspamd_lru_hash_insert(session->key->stat->last_ips,
-								   naddr, ip_stat, -1, 0);
+		if (ip_stat) {
+			REF_RETAIN(ip_stat);
+			session->ip_stat = ip_stat;
 		}
-
-		REF_RETAIN(ip_stat);
-		session->ip_stat = ip_stat;
 	}
 	else if (session->addr) {
 		/*
@@ -1492,27 +1486,17 @@ rspamd_fuzzy_process_command(struct fuzzy_session *session)
 			struct fuzzy_key_stat *unkeyed = g_malloc0(sizeof(*unkeyed));
 
 			REF_INIT_RETAIN(unkeyed, fuzzy_key_stat_dtor);
-			unkeyed->last_ips = rspamd_lru_hash_new_full(1024,
-														 (GDestroyNotify) rspamd_inet_address_free,
-														 fuzzy_key_stat_unref,
-														 rspamd_inet_address_hash,
-														 rspamd_inet_address_equal);
 			session->ctx->unkeyed_stat = unkeyed;
 		}
 
-		ip_stat = rspamd_lru_hash_lookup(session->ctx->unkeyed_stat->last_ips,
-										 session->addr, -1);
+		ip_stat = fuzzy_key_stat_get_ip(session->ctx->unkeyed_stat,
+										session->ctx->max_ips_per_key, session->addr,
+										session->timestamp);
 
-		if (ip_stat == NULL) {
-			naddr = rspamd_inet_address_copy(session->addr, NULL);
-			ip_stat = g_malloc0(sizeof(*ip_stat));
-			REF_INIT_RETAIN(ip_stat, fuzzy_key_stat_dtor);
-			rspamd_lru_hash_insert(session->ctx->unkeyed_stat->last_ips,
-								   naddr, ip_stat, -1, 0);
+		if (ip_stat) {
+			REF_RETAIN(ip_stat);
+			session->ip_stat = ip_stat;
 		}
-
-		REF_RETAIN(ip_stat);
-		session->ip_stat = ip_stat;
 	}
 
 	/*
@@ -3010,6 +2994,7 @@ init_fuzzy(struct rspamd_config *cfg)
 	ctx->magic = rspamd_fuzzy_storage_magic;
 	ctx->sync_timeout = DEFAULT_SYNC_TIMEOUT;
 	ctx->keypair_cache_size = DEFAULT_KEYPAIR_CACHE_SIZE;
+	ctx->max_ips_per_key = FUZZY_KEY_DEFAULT_MAX_IPS;
 	ctx->keys = kh_init(rspamd_fuzzy_keys_hash);
 	rspamd_mempool_add_destructor(cfg->cfg_pool,
 								  (rspamd_mempool_destruct_t) fuzzy_hash_table_dtor, ctx->keys);
@@ -3148,6 +3133,16 @@ init_fuzzy(struct rspamd_config *cfg)
 													  keypair_cache_size),
 									  RSPAMD_CL_FLAG_UINT,
 									  "Size of keypairs cache, default: " G_STRINGIFY(DEFAULT_KEYPAIR_CACHE_SIZE));
+
+	rspamd_rcl_register_worker_option(cfg,
+									  type,
+									  "max_ips_per_key",
+									  rspamd_rcl_parse_struct_integer,
+									  ctx,
+									  G_STRUCT_OFFSET(struct rspamd_fuzzy_storage_ctx,
+													  max_ips_per_key),
+									  RSPAMD_CL_FLAG_UINT,
+									  "Per-source stats kept for each key except the default one, which tracks none unless its max_ips extension says otherwise (0 disables), default: " G_STRINGIFY(FUZZY_KEY_DEFAULT_MAX_IPS));
 
 	rspamd_rcl_register_worker_option(cfg,
 									  type,

--- a/src/fuzzy_storage.c
+++ b/src/fuzzy_storage.c
@@ -600,8 +600,12 @@ rspamd_fuzzy_update_stats(struct rspamd_fuzzy_storage_ctx *ctx,
 		ctx->stat.delayed_hashes++;
 	}
 
-	if (key == NULL && ip_stat != NULL && ctx->unkeyed_stat != NULL) {
-		/* Unkeyed client: update the aggregate bucket */
+	if (key == NULL && ctx->unkeyed_stat != NULL) {
+		/*
+		 * Unkeyed client: update the aggregate bucket. This must not depend
+		 * on ip_stat, which is NULL whenever per-source tracking is off for
+		 * the bucket (max_ips_per_key = 0 or after an overflow)
+		 */
 		rspamd_fuzzy_update_key_stat(matched, ctx->unkeyed_stat, cmd, res, timestamp);
 	}
 

--- a/src/libserver/fuzzy_storage_internal.h
+++ b/src/libserver/fuzzy_storage_internal.h
@@ -81,10 +81,39 @@ struct fuzzy_key_stat {
 	uint64_t last_checked_count;
 	uint64_t last_matched_count;
 	struct rspamd_cryptobox_keypair *keypair;
+	/*
+	 * Per-source breakdown, keyed by client address. Allocated on the first
+	 * request that uses the owning key and grown from a handful of buckets,
+	 * since most keys only ever see one or two addresses; NULL when the key
+	 * has per-IP stats disabled or has not been used yet
+	 */
 	rspamd_lru_hash_t *last_ips;
+	/*
+	 * Overflow guard for last_ips: a table that keeps evicting means the
+	 * key has far more sources than the cap can represent, so the per-IP
+	 * breakdown is noise and every request pays allocations for it. Once
+	 * ips_inserted_window passes the overflow threshold inside one window
+	 * the table is dropped and ips_overflow stays set for the key's lifetime
+	 */
+	uint64_t ips_inserted;        /* sources inserted in total */
+	uint64_t ips_inserted_window; /* sources inserted while full, current window */
+	double ips_window_start;
+	bool ips_overflow;
 
 	ref_entry_t ref;
 };
+
+/* Default cap on the per-source stats kept for one key */
+#define FUZZY_KEY_DEFAULT_MAX_IPS 1024
+/* Buckets to start a per-source table with; grows on demand */
+#define FUZZY_KEY_IPS_INITIAL_SIZE 4
+/*
+ * A full table that takes more than FACTOR * cap new sources within one
+ * WINDOW seconds cannot represent its population; per-IP stats are then
+ * disabled for that key
+ */
+#define FUZZY_KEY_IPS_OVERFLOW_FACTOR 8
+#define FUZZY_KEY_IPS_OVERFLOW_WINDOW 3600.0
 
 struct rspamd_leaky_bucket_elt {
 	rspamd_inet_addr_t *addr;
@@ -110,7 +139,8 @@ fuzzy_kp_hash(const unsigned char *p)
 static inline bool
 fuzzy_kp_equal(gconstpointer a, gconstpointer b)
 {
-	const unsigned char *pa = a, *pb = b;
+	const unsigned char *pa = (const unsigned char *) a,
+						*pb = (const unsigned char *) b;
 
 	return (memcmp(pa, pb, RSPAMD_FUZZY_KEYLEN) == 0);
 }
@@ -139,6 +169,8 @@ struct fuzzy_key {
 	ev_tstamp expire;
 	bool expired;
 	int flags; /* enum fuzzy_key_op */
+	/* Cap on per-source stats for this key; -1 = worker default, 0 = off */
+	int max_ips;
 	ref_entry_t ref;
 };
 
@@ -178,6 +210,7 @@ struct rspamd_fuzzy_storage_ctx {
 	const ucl_object_t *dynamic_keys_map;
 
 	unsigned int keypair_cache_size;
+	unsigned int max_ips_per_key;
 	ev_timer stat_ev;
 	ev_io peer_ev;
 
@@ -306,6 +339,24 @@ void ucl_keymap_dtor_cb(struct map_cb_data *data);
 
 void fuzzy_key_stat_dtor(gpointer p);
 void fuzzy_key_stat_unref(gpointer p);
+/*
+ * Find or create the per-source stats for `addr` under `st`, creating the
+ * address table itself on first use. Returns NULL (and allocates nothing)
+ * when max_ips is 0. The result is owned by the table; callers that keep
+ * it must retain it.
+ */
+struct fuzzy_key_stat *fuzzy_key_stat_get_ip(struct fuzzy_key_stat *st,
+											 unsigned int max_ips,
+											 const rspamd_inet_addr_t *addr,
+											 double now);
+/*
+ * Effective per-source cap for a key: its own max_ips extension when set,
+ * otherwise 0 for the default key (it is the one key that can see a
+ * practically unbounded set of sources, where a bounded table is noise)
+ * and the worker default for everything else
+ */
+unsigned int fuzzy_key_max_ips(const struct rspamd_fuzzy_storage_ctx *ctx,
+							   const struct fuzzy_key *key);
 void fuzzy_key_dtor(gpointer p);
 void fuzzy_hash_table_dtor(khash_t(rspamd_fuzzy_keys_hash) * hash);
 

--- a/src/libserver/fuzzy_storage_keys.c
+++ b/src/libserver/fuzzy_storage_keys.c
@@ -166,6 +166,86 @@ void ucl_keymap_dtor_cb(struct map_cb_data *data)
 	}
 }
 
+unsigned int
+fuzzy_key_max_ips(const struct rspamd_fuzzy_storage_ctx *ctx,
+				  const struct fuzzy_key *key)
+{
+	if (key->max_ips >= 0) {
+		return (unsigned int) key->max_ips;
+	}
+
+	if (key == ctx->default_key) {
+		return 0;
+	}
+
+	return ctx->max_ips_per_key;
+}
+
+struct fuzzy_key_stat *
+fuzzy_key_stat_get_ip(struct fuzzy_key_stat *st,
+					  unsigned int max_ips,
+					  const rspamd_inet_addr_t *addr,
+					  double now)
+{
+	struct fuzzy_key_stat *ip_stat;
+
+	if (st->last_ips == NULL) {
+		if (max_ips == 0 || st->ips_overflow) {
+			/* Per-source stats are disabled for this key */
+			return NULL;
+		}
+
+		st->last_ips = rspamd_lru_hash_new_sized(max_ips,
+												 FUZZY_KEY_IPS_INITIAL_SIZE,
+												 (GDestroyNotify) rspamd_inet_address_free,
+												 fuzzy_key_stat_unref,
+												 rspamd_inet_address_hash,
+												 rspamd_inet_address_equal);
+	}
+
+	ip_stat = rspamd_lru_hash_lookup(st->last_ips, addr, -1);
+
+	if (ip_stat != NULL) {
+		return ip_stat;
+	}
+
+	/*
+	 * New source. The LRU evicts as soon as an insertion reaches its cap, so
+	 * a table holding cap - 1 entries is effectively full and this insertion
+	 * will push another source out; count those per window and give up on
+	 * the table when the churn shows it cannot hold the key's population
+	 */
+	if (rspamd_lru_hash_size(st->last_ips) + 1 >= rspamd_lru_hash_capacity(st->last_ips)) {
+		if (st->ips_window_start == 0.0 ||
+			now > st->ips_window_start + FUZZY_KEY_IPS_OVERFLOW_WINDOW) {
+			st->ips_window_start = now;
+			st->ips_inserted_window = 0;
+		}
+
+		st->ips_inserted_window++;
+
+		if (st->ips_inserted_window >
+			(uint64_t) FUZZY_KEY_IPS_OVERFLOW_FACTOR * rspamd_lru_hash_capacity(st->last_ips)) {
+			/* Sessions in flight hold their own references to the values */
+			rspamd_lru_hash_destroy(st->last_ips);
+			st->last_ips = NULL;
+			st->ips_overflow = true;
+			st->ips_inserted++;
+
+			return NULL;
+		}
+	}
+
+	rspamd_inet_addr_t *naddr = rspamd_inet_address_copy(addr, NULL);
+
+	ip_stat = g_malloc0(sizeof(*ip_stat));
+	REF_INIT_RETAIN(ip_stat, fuzzy_key_stat_dtor);
+	rspamd_lru_hash_insert(st->last_ips, naddr, ip_stat, -1, 0);
+	st->ips_inserted++;
+
+	return ip_stat;
+}
+
 void fuzzy_key_stat_dtor(gpointer p)
 {
 	struct fuzzy_key_stat *st = p;
@@ -296,17 +376,15 @@ fuzzy_add_keypair_from_ucl(struct rspamd_config *cfg,
 	key->key = kp;
 	struct fuzzy_key_stat *keystat = g_malloc0(sizeof(*keystat));
 	REF_INIT_RETAIN(keystat, fuzzy_key_stat_dtor);
-	/* Hash of ip -> fuzzy_key_stat */
-	keystat->last_ips = rspamd_lru_hash_new_full(1024,
-												 (GDestroyNotify) rspamd_inet_address_free,
-												 fuzzy_key_stat_unref,
-												 rspamd_inet_address_hash, rspamd_inet_address_equal);
+	/* ip -> fuzzy_key_stat table is created lazily by fuzzy_key_stat_get_ip */
+	keystat->last_ips = NULL;
 	key->stat = keystat;
 	key->flags_stat = kh_init(fuzzy_key_flag_stat);
 	key->burst = NAN;
 	key->rate = NAN;
 	key->expire = NAN;
 	key->rl_bucket = NULL;
+	key->max_ips = -1;
 	/* Allow read by default */
 	key->flags = FUZZY_KEY_READ;
 	/* Preallocate some space for flags */
@@ -417,6 +495,18 @@ fuzzy_add_keypair_from_ucl(struct rspamd_config *cfg,
 		const ucl_object_t *name = ucl_object_lookup(extensions, "name");
 		if (name && ucl_object_type(name) == UCL_STRING) {
 			key->name = g_strdup(ucl_object_tostring(name));
+		}
+
+		const ucl_object_t *max_ips = ucl_object_lookup(extensions, "max_ips");
+		if (max_ips) {
+			if ((ucl_object_type(max_ips) == UCL_INT || ucl_object_type(max_ips) == UCL_FLOAT) &&
+				ucl_object_toint(max_ips) >= 0) {
+				key->max_ips = ucl_object_toint(max_ips);
+			}
+			else {
+				msg_warn_config("invalid max_ips for keypair %*bs: must be a non-negative integer",
+								(int) crypto_box_publickeybytes(), pk);
+			}
 		}
 
 		/* Check permissions */

--- a/src/libserver/fuzzy_storage_stat.c
+++ b/src/libserver/fuzzy_storage_stat.c
@@ -56,6 +56,16 @@ rspamd_fuzzy_storage_stat_key(const struct fuzzy_key_stat *key_stat)
 	ucl_object_insert_key(res, ucl_object_fromint(key_stat->errors),
 						  "errors", 0, false);
 
+	if (key_stat->ips_inserted > 0) {
+		ucl_object_insert_key(res, ucl_object_fromint(key_stat->ips_inserted),
+							  "ips_inserted", 0, false);
+	}
+
+	if (key_stat->ips_overflow) {
+		ucl_object_insert_key(res, ucl_object_frombool(true),
+							  "ips_overflow", 0, false);
+	}
+
 	return res;
 }
 

--- a/src/libutil/hash.c
+++ b/src/libutil/hash.c
@@ -503,11 +503,12 @@ rspamd_lru_hash_evict(rspamd_lru_hash_t *hash, time_t now)
 }
 
 rspamd_lru_hash_t *
-rspamd_lru_hash_new_full(int maxsize,
-						 GDestroyNotify key_destroy,
-						 GDestroyNotify value_destroy,
-						 GHashFunc hf,
-						 GEqualFunc cmpf)
+rspamd_lru_hash_new_sized(int maxsize,
+						  int initial_size,
+						  GDestroyNotify key_destroy,
+						  GDestroyNotify value_destroy,
+						  GHashFunc hf,
+						  GEqualFunc cmpf)
 {
 	rspamd_lru_hash_t *h;
 
@@ -525,10 +526,28 @@ rspamd_lru_hash_new_full(int maxsize,
 	h->key_destroy = key_destroy;
 	h->eviction_min_prio = G_MAXUINT;
 
-	/* Preallocate some elements */
-	rspamd_lru_hash_resize(h, MIN(h->maxsize, 128));
+	/*
+	 * Preallocate buckets only when asked to: an empty table grows on the
+	 * first insertion, so tables that will mostly stay tiny cost nothing
+	 * beyond the header until they are actually used
+	 */
+	if (initial_size > 0) {
+		rspamd_lru_hash_resize(h, MIN((khint_t) initial_size, h->maxsize));
+	}
 
 	return h;
+}
+
+rspamd_lru_hash_t *
+rspamd_lru_hash_new_full(int maxsize,
+						 GDestroyNotify key_destroy,
+						 GDestroyNotify value_destroy,
+						 GHashFunc hf,
+						 GEqualFunc cmpf)
+{
+	return rspamd_lru_hash_new_sized(maxsize, 128,
+									 key_destroy, value_destroy,
+									 hf, cmpf);
 }
 
 rspamd_lru_hash_t *

--- a/src/libutil/hash.h
+++ b/src/libutil/hash.h
@@ -47,6 +47,23 @@ rspamd_lru_hash_t *rspamd_lru_hash_new_full(int maxsize,
 											GEqualFunc eqfunc);
 
 /**
+ * Create new lru hash with an explicit initial bucket count
+ * @param maxsize maximum elements in a hash
+ * @param initial_size buckets to preallocate; 0 allocates nothing until the
+ * first insertion, which is the right choice for tables that usually stay
+ * tiny (the plain constructors preallocate 128 buckets)
+ * @param hash_func pointer to hash function
+ * @param key_equal_func pointer to function for comparing keys
+ * @return new rspamd_hash object
+ */
+rspamd_lru_hash_t *rspamd_lru_hash_new_sized(int maxsize,
+											 int initial_size,
+											 GDestroyNotify key_destroy,
+											 GDestroyNotify value_destroy,
+											 GHashFunc hfunc,
+											 GEqualFunc eqfunc);
+
+/**
  * Lookup item from hash
  * @param hash hash object
  * @param key key to find

--- a/test/functional/configs/maps/fuzzy_keymap.map
+++ b/test/functional/configs/maps/fuzzy_keymap.map
@@ -13,4 +13,7 @@
     type = "kex";
     algorithm = "curve25519";
     encoding = "base32";
+    extensions = {
+        max_ips = 0;
+    }
 }]

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -56,6 +56,7 @@
 #include "rspamd_cxx_unit_task_input.hxx"
 #include "rspamd_cxx_unit_ucl_limits.hxx"
 #include "rspamd_cxx_unit_tld_lookup.hxx"
+#include "rspamd_cxx_unit_lru_hash.hxx"
 
 static gboolean verbose = false;
 static const GOptionEntry entries[] =

--- a/test/rspamd_cxx_unit.cxx
+++ b/test/rspamd_cxx_unit.cxx
@@ -57,6 +57,7 @@
 #include "rspamd_cxx_unit_ucl_limits.hxx"
 #include "rspamd_cxx_unit_tld_lookup.hxx"
 #include "rspamd_cxx_unit_lru_hash.hxx"
+#include "rspamd_cxx_unit_fuzzy_key_ips.hxx"
 
 static gboolean verbose = false;
 static const GOptionEntry entries[] =

--- a/test/rspamd_cxx_unit_fuzzy_key_ips.hxx
+++ b/test/rspamd_cxx_unit_fuzzy_key_ips.hxx
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Per-source stat tables of fuzzy storage keys: lazy growth and overflow */
+
+#ifndef RSPAMD_RSPAMD_CXX_UNIT_FUZZY_KEY_IPS_HXX
+#define RSPAMD_RSPAMD_CXX_UNIT_FUZZY_KEY_IPS_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+extern "C" {
+#include "libserver/fuzzy_storage_internal.h"
+#include "libutil/addr.h"
+}
+
+#include <memory>
+#include <string>
+
+TEST_SUITE("fuzzy_key_ips")
+{
+	using addr_ptr = std::unique_ptr<rspamd_inet_addr_t, decltype(&rspamd_inet_address_free)>;
+
+	static auto make_addr(unsigned int n) -> addr_ptr
+	{
+		/* 10.a.b.c, distinct for every n below 2^24 */
+		auto s = "10." + std::to_string((n >> 16) & 0xff) + "." +
+				 std::to_string((n >> 8) & 0xff) + "." + std::to_string(n & 0xff);
+		rspamd_inet_addr_t *a = nullptr;
+		REQUIRE(rspamd_parse_inet_address(&a, s.c_str(), s.size(),
+										  RSPAMD_INET_ADDRESS_PARSE_DEFAULT));
+		return addr_ptr{a, rspamd_inet_address_free};
+	}
+
+	struct stat_holder {
+		struct fuzzy_key_stat *st;
+		stat_holder()
+		{
+			st = (struct fuzzy_key_stat *) g_malloc0(sizeof(*st));
+			REF_INIT_RETAIN(st, fuzzy_key_stat_dtor);
+		}
+		~stat_holder()
+		{
+			REF_RELEASE(st);
+		}
+	};
+
+	TEST_CASE("table is created on first use and not at all when disabled")
+	{
+		stat_holder h;
+		auto a = make_addr(1);
+
+		CHECK(h.st->last_ips == nullptr);
+		CHECK(fuzzy_key_stat_get_ip(h.st, 0, a.get(), 100.0) == nullptr);
+		CHECK(h.st->last_ips == nullptr);
+		CHECK(h.st->ips_inserted == 0);
+
+		auto *ip1 = fuzzy_key_stat_get_ip(h.st, 64, a.get(), 100.0);
+		REQUIRE(ip1 != nullptr);
+		REQUIRE(h.st->last_ips != nullptr);
+		CHECK(rspamd_lru_hash_size(h.st->last_ips) == 1);
+		CHECK(h.st->ips_inserted == 1);
+
+		/* Same source comes back as the same record and is not re-counted */
+		CHECK(fuzzy_key_stat_get_ip(h.st, 64, a.get(), 101.0) == ip1);
+		CHECK(h.st->ips_inserted == 1);
+	}
+
+	TEST_CASE("a small population never trips the overflow guard")
+	{
+		stat_holder h;
+		/* 32 is the smallest cap the LRU accepts */
+		const unsigned int cap = 32;
+
+		for (int round = 0; round < 50; round++) {
+			for (unsigned int i = 0; i < cap / 2; i++) {
+				auto a = make_addr(i);
+				CHECK(fuzzy_key_stat_get_ip(h.st, cap, a.get(), 100.0 + round) != nullptr);
+			}
+		}
+
+		CHECK_FALSE(h.st->ips_overflow);
+		CHECK(h.st->last_ips != nullptr);
+		CHECK(h.st->ips_inserted == cap / 2);
+	}
+
+	TEST_CASE("churn past the cap drops the table and sticks")
+	{
+		stat_holder h;
+		const unsigned int cap = 32;
+		const unsigned int limit = FUZZY_KEY_IPS_OVERFLOW_FACTOR * cap;
+		unsigned int n = 0;
+
+		/*
+		 * Fill up to the point where the next insertion evicts: the LRU
+		 * evicts on reaching its cap, so that is cap - 1 entries. None of
+		 * these count as churn
+		 */
+		for (; n < cap - 1; n++) {
+			auto a = make_addr(n);
+			REQUIRE(fuzzy_key_stat_get_ip(h.st, cap, a.get(), 100.0) != nullptr);
+		}
+		CHECK_FALSE(h.st->ips_overflow);
+		CHECK(h.st->ips_inserted_window == 0);
+
+		/* Up to the threshold the table still serves new sources */
+		for (; n < cap - 1 + limit; n++) {
+			auto a = make_addr(n);
+			REQUIRE(fuzzy_key_stat_get_ip(h.st, cap, a.get(), 100.0) != nullptr);
+		}
+		CHECK_FALSE(h.st->ips_overflow);
+		CHECK(h.st->ips_inserted_window == limit);
+
+		/* One more new source inside the window trips it */
+		auto a = make_addr(n++);
+		CHECK(fuzzy_key_stat_get_ip(h.st, cap, a.get(), 100.0) == nullptr);
+		CHECK(h.st->ips_overflow);
+		CHECK(h.st->last_ips == nullptr);
+		CHECK(h.st->ips_inserted == n);
+
+		/* And it stays off, even for sources that were tracked before */
+		auto first = make_addr(0);
+		CHECK(fuzzy_key_stat_get_ip(h.st, cap, first.get(), 5000.0) == nullptr);
+		CHECK(h.st->last_ips == nullptr);
+	}
+
+	TEST_CASE("slow churn spread over windows does not trip")
+	{
+		stat_holder h;
+		const unsigned int cap = 32;
+		const unsigned int limit = FUZZY_KEY_IPS_OVERFLOW_FACTOR * cap;
+		unsigned int n = 0;
+		double now = 100.0;
+
+		for (; n < cap - 1; n++) {
+			auto a = make_addr(n);
+			REQUIRE(fuzzy_key_stat_get_ip(h.st, cap, a.get(), now) != nullptr);
+		}
+
+		/* Half the threshold per window, over four windows */
+		for (int w = 0; w < 4; w++) {
+			now += FUZZY_KEY_IPS_OVERFLOW_WINDOW + 1.0;
+			for (unsigned int i = 0; i < limit / 2; i++, n++) {
+				auto a = make_addr(n);
+				REQUIRE(fuzzy_key_stat_get_ip(h.st, cap, a.get(), now) != nullptr);
+			}
+		}
+
+		CHECK_FALSE(h.st->ips_overflow);
+		CHECK(h.st->last_ips != nullptr);
+		CHECK(h.st->ips_inserted == n);
+	}
+
+	TEST_CASE("effective cap: explicit extension, default key, worker default")
+	{
+		struct rspamd_fuzzy_storage_ctx ctx;
+		struct fuzzy_key def, other;
+
+		memset(&ctx, 0, sizeof(ctx));
+		memset(&def, 0, sizeof(def));
+		memset(&other, 0, sizeof(other));
+		ctx.max_ips_per_key = 1024;
+		ctx.default_key = &def;
+		def.max_ips = -1;
+		other.max_ips = -1;
+
+		CHECK(fuzzy_key_max_ips(&ctx, &def) == 0);
+		CHECK(fuzzy_key_max_ips(&ctx, &other) == 1024);
+
+		def.max_ips = 256;
+		other.max_ips = 0;
+		CHECK(fuzzy_key_max_ips(&ctx, &def) == 256);
+		CHECK(fuzzy_key_max_ips(&ctx, &other) == 0);
+	}
+}
+
+#endif

--- a/test/rspamd_cxx_unit_lru_hash.hxx
+++ b/test/rspamd_cxx_unit_lru_hash.hxx
@@ -86,11 +86,13 @@ TEST_SUITE("lru_hash")
 		}
 
 		/*
-		 * The cap is soft: eviction is probabilistic and the candidate pool
-		 * is rebuilt after every rehash, so the table can sit a few entries
-		 * above maxsize. It must stay in that neighbourhood though
+		 * The cap is soft in both directions: eviction fires as soon as an
+		 * insertion reaches maxsize, so the steady state is maxsize - 1, and
+		 * it is probabilistic with the candidate pool rebuilt after every
+		 * rehash, so the table can also sit a few entries above maxsize. It
+		 * must stay in that neighbourhood though
 		 */
-		CHECK(rspamd_lru_hash_size(h) >= 32);
+		CHECK(rspamd_lru_hash_size(h) >= 32 - 1);
 		CHECK(rspamd_lru_hash_size(h) < 32 + 16);
 		CHECK(destroyed_values == 200 - (int) rspamd_lru_hash_size(h));
 
@@ -113,7 +115,7 @@ TEST_SUITE("lru_hash")
 			rspamd_lru_hash_insert(h, (gpointer) keys[i].c_str(), (gpointer) keys[i].c_str(), -1, 0);
 		}
 		/* Same soft cap semantics as the sized constructor */
-		CHECK(rspamd_lru_hash_size(h) >= 64);
+		CHECK(rspamd_lru_hash_size(h) >= 64 - 1);
 		CHECK(rspamd_lru_hash_size(h) < 64 + 16);
 		rspamd_lru_hash_destroy(h);
 	}

--- a/test/rspamd_cxx_unit_lru_hash.hxx
+++ b/test/rspamd_cxx_unit_lru_hash.hxx
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Vsevolod Stakhov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RSPAMD_RSPAMD_CXX_UNIT_LRU_HASH_HXX
+#define RSPAMD_RSPAMD_CXX_UNIT_LRU_HASH_HXX
+
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include "doctest/doctest.h"
+
+extern "C" {
+#include "libutil/hash.h"
+#include "libutil/str_util.h"
+}
+
+#include <string>
+#include <vector>
+
+TEST_SUITE("lru_hash")
+{
+	static int destroyed_values = 0;
+
+	static void count_value_destroy(gpointer)
+	{
+		destroyed_values++;
+	}
+
+	static auto make_keys(int n) -> std::vector<std::string>
+	{
+		std::vector<std::string> keys;
+		keys.reserve(n);
+		for (int i = 0; i < n; i++) {
+			keys.emplace_back("key" + std::to_string(i));
+		}
+		return keys;
+	}
+
+	TEST_CASE("sized constructor starts empty and grows on demand")
+	{
+		auto *h = rspamd_lru_hash_new_sized(64, 0, nullptr, nullptr,
+											rspamd_strcase_hash, rspamd_strcase_equal);
+		REQUIRE(h != nullptr);
+		CHECK(rspamd_lru_hash_size(h) == 0);
+		CHECK(rspamd_lru_hash_capacity(h) == 64);
+		/* Lookup on a table with no buckets must not touch memory */
+		CHECK(rspamd_lru_hash_lookup(h, "missing", -1) == nullptr);
+
+		auto keys = make_keys(40);
+		for (auto &k: keys) {
+			rspamd_lru_hash_insert(h, (gpointer) k.c_str(), (gpointer) k.c_str(), -1, 0);
+		}
+
+		CHECK(rspamd_lru_hash_size(h) == 40);
+		for (auto &k: keys) {
+			auto *v = rspamd_lru_hash_lookup(h, k.c_str(), -1);
+			REQUIRE(v != nullptr);
+			CHECK(std::string((const char *) v) == k);
+		}
+
+		rspamd_lru_hash_destroy(h);
+	}
+
+	TEST_CASE("sized constructor keeps the element cap")
+	{
+		/* Under the eviction floor of 32 the cap is raised to that floor */
+		auto *h = rspamd_lru_hash_new_sized(8, 0, nullptr, count_value_destroy,
+											rspamd_strcase_hash, rspamd_strcase_equal);
+		CHECK(rspamd_lru_hash_capacity(h) == 32);
+
+		destroyed_values = 0;
+		auto keys = make_keys(200);
+		for (auto &k: keys) {
+			rspamd_lru_hash_insert(h, (gpointer) k.c_str(), (gpointer) k.c_str(), -1, 0);
+		}
+
+		/*
+		 * The cap is soft: eviction is probabilistic and the candidate pool
+		 * is rebuilt after every rehash, so the table can sit a few entries
+		 * above maxsize. It must stay in that neighbourhood though
+		 */
+		CHECK(rspamd_lru_hash_size(h) >= 32);
+		CHECK(rspamd_lru_hash_size(h) < 32 + 16);
+		CHECK(destroyed_values == 200 - (int) rspamd_lru_hash_size(h));
+
+		rspamd_lru_hash_destroy(h);
+		CHECK(destroyed_values == 200);
+	}
+
+	TEST_CASE("plain constructor still preallocates and behaves the same")
+	{
+		auto *h = rspamd_lru_hash_new_full(64, nullptr, nullptr,
+										   rspamd_strcase_hash, rspamd_strcase_equal);
+		auto keys = make_keys(200);
+		for (int i = 0; i < 40; i++) {
+			rspamd_lru_hash_insert(h, (gpointer) keys[i].c_str(), (gpointer) keys[i].c_str(), -1, 0);
+		}
+		CHECK(rspamd_lru_hash_size(h) == 40);
+		CHECK(rspamd_lru_hash_lookup(h, "key7", -1) != nullptr);
+
+		for (int i = 40; i < 200; i++) {
+			rspamd_lru_hash_insert(h, (gpointer) keys[i].c_str(), (gpointer) keys[i].c_str(), -1, 0);
+		}
+		/* Same soft cap semantics as the sized constructor */
+		CHECK(rspamd_lru_hash_size(h) >= 64);
+		CHECK(rspamd_lru_hash_size(h) < 64 + 16);
+		rspamd_lru_hash_destroy(h);
+	}
+}
+
+#endif


### PR DESCRIPTION
## Problem

Every fuzzy storage key gets a 1024-entry per-source (per-IP) stats table at creation, preallocated at 128 buckets. Two things go wrong at scale:

- **Thousands of keys**: several MB of idle memory per fuzzy worker for tables that mostly hold one or two addresses, since a typical customer key is used from a handful of hosts.
- **The default key**: it is the one key that can see a practically unbounded source population (100k+ hosts on a public storage). A 1024-slot table cannot represent that, so nearly every request misses: copy the address, allocate a stat block, evict another entry, free both. Four heap operations per request on the busiest key, for a breakdown that is noise anyway. Per-source stats feed nothing but `rspamadm fuzzystat`; they play no role in rate limiting or blocking.

## Changes

**Sized LRU constructor** (`rspamd_lru_hash_new_sized`): takes an initial bucket count, zero allocates nothing until the first insertion. The existing constructors keep preallocating 128 buckets, so nothing else changes behaviour.

**Lazy per-key tables**: a key's table is created on the first request that uses the key, starting at 4 buckets and growing on demand. Idle cost per key drops from ~6 KB to the stat block itself. The keyed and unkeyed paths share one helper.

**Configurable cap**:
- worker option `max_ips_per_key` sets the default (still 1024);
- a key can override it with a `max_ips` extension, `0` disables per-source tracking for that key;
- the default key tracks nothing unless it has an explicit `max_ips`.

**Overflow guard**: any key can still turn out to have more sources than its cap. Insertions that evict another source are counted per hour; once they exceed 8× the cap the table is dropped and the key is flagged for the rest of its life. Sessions in flight hold their own references, so a drop under load is safe. A key with a few hundred rotating addresses never gets near the threshold; one that behaves like the public key trips it within its first few thousand requests regardless of its position in the config.

**Stats**: the per-key stats object gains `ips_inserted` and `ips_overflow`; `rspamadm fuzzystat` prints a line saying per-IP stats were disabled for that key instead of an empty table.

Note that the LRU evicts as soon as an insertion reaches `maxsize`, so its steady state is one entry below the cap. The fullness check accounts for that; the unit test documents it.

## Tests

- `lru_hash` unit suite: growth from empty, lookups, the (soft) element cap, destructor accounting.
- `fuzzy_key_ips` unit suite: table created on first use and never when disabled; a population under the cap never trips the guard; churn past the threshold drops the table and stays off; the same churn spread over several windows does not trip; effective cap resolution for explicit / default-key / worker-default cases.
- The second dynamic key in the functional keymap fixture carries `max_ips = 0`, so the `120_fuzzy` Encrypted-Dyn suites exercise the disabled path. All fuzzy functional suites pass locally.

Left for follow-ups: the synchronous stats dump in the control handler (still serialises every key and IP with the event loop blocked) and the counter reset on dynamic keymap reload.
