### PR TITLE
[Fix] Drop a grouped selector that cannot be evaluated

### DIFF
--- a/src/libserver/css/css_selector.cxx
+++ b/src/libserver/css/css_selector.cxx
@@ -113,30 +113,40 @@ auto process_selector_tokens(rspamd_mempool_t *pool,
 				}
 			}
 			else if (state == selector_process_state::selector_ident_consumed) {
-				if (parser_tok.type == css_parser_token::token_type::comma_token && cur_selector) {
+				if (parser_tok.type == css_parser_token::token_type::comma_token) {
 					/* Got full selector, attach it to the vector and go further */
-					msg_debug_css("attached selector: %s", cur_selector->debug_str().c_str());
-					ret.push_back(std::move(cur_selector));
+					if (cur_selector) {
+						msg_debug_css("attached selector: %s", cur_selector->debug_str().c_str());
+						ret.push_back(std::move(cur_selector));
+					}
 					state = selector_process_state::selector_parse_start;
 				}
 				else if (parser_tok.type == css_parser_token::token_type::semicolon_token) {
 					/* TODO: implement adjustments */
 					state = selector_process_state::selector_ignore_function;
+					cur_selector.reset();
 				}
 				else if (parser_tok.type == css_parser_token::token_type::osqbrace_token) {
 					/* TODO: implement attributes checks */
 					state = selector_process_state::selector_ignore_attribute;
+					cur_selector.reset();
 				}
 				else {
 					/* TODO: implement selectors combinations */
 					state = selector_process_state::selector_ignore_combination;
+					/*
+					 * What follows narrows the selector down and we cannot
+					 * evaluate it, so the simple selector parsed so far no
+					 * longer describes the rule. Drop it: attaching it would
+					 * apply the declarations to every element of that name
+					 */
+					cur_selector.reset();
 				}
 			}
 			else {
 				/* Ignore state; ignore all till ',' token or eof token */
-				if (parser_tok.type == css_parser_token::token_type::comma_token && cur_selector) {
-					/* Got full selector, attach it to the vector and go further */
-					ret.push_back(std::move(cur_selector));
+				if (parser_tok.type == css_parser_token::token_type::comma_token) {
+					/* The ignored selector ends here, start the next one */
 					state = selector_process_state::selector_parse_start;
 				}
 				else {
@@ -217,6 +227,43 @@ TEST_SUITE("css")
 			for (auto i = 0; i < c.second.size(); i++) {
 				CHECK(res[i]->type == c.second[i]);
 			}
+		}
+
+		rspamd_mempool_delete(pool);
+	}
+
+	TEST_CASE("a narrowed selector is not registered by its first part")
+	{
+		/*
+		 * Compounds and combinators are not evaluated. A selector that uses
+		 * them must be dropped whole: keeping its first simple selector would
+		 * apply the declarations to every element of that name.
+		 * Attribute selectors are not covered: the tokeniser folds them into
+		 * a block, so `a[href]` still reaches us as a bare `a`
+		 */
+		const std::vector<std::pair<const char *, std::size_t>> cases{
+			/* Nothing of these can be evaluated */
+			{"div.mainbox ul li.spacer", 0},
+			{"div.mainbox ul li.spacer, div.mainbox ol li.spacer", 0},
+			{"p.intro span.note, td.cell span.note", 0},
+			{"div.a, div.b", 0},
+			{"div > p, div > span", 0},
+			/* Plain selector lists keep working */
+			{"p, span", 2},
+			{"em,.class,#id", 3},
+			{"*", 1},
+			/* A list that mixes both keeps only what it can evaluate */
+			{"div.mainbox li.spacer, p", 1},
+			{"p, div.mainbox li.spacer", 1},
+		};
+
+		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(),
+										"css", 0);
+
+		for (const auto &c: cases) {
+			auto res = process_selector_tokens(pool,
+											   get_selectors_parser_functor(pool, c.first));
+			CHECK_MESSAGE(res.size() == c.second, c.first);
 		}
 
 		rspamd_mempool_delete(pool);

--- a/test/functional/cases/001_merged/100_general.robot
+++ b/test/functional/cases/001_merged/100_general.robot
@@ -98,6 +98,7 @@ HTML VISIBILITY - No significant hidden content
   visible
   font_shorthand
   relative_font
+  grouped_selector
 
 HTML ONLY - TRUE POSITIVE
   Scan File  ${RSPAMD_TESTDIR}/messages/zerofont.eml

--- a/test/functional/messages/html_hidden_grouped_selector.eml
+++ b/test/functional/messages/html_hidden_grouped_selector.eml
@@ -1,0 +1,8 @@
+From: sender@example.com
+To: recipient@example.net
+Subject: Hidden content amount
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 8bit
+
+<html><head><style>div.mainbox ul li.spacer, div.mainbox ol li.spacer { font-size: 0; color: transparent; opacity: 0 }</style></head><body><div class="mainbox"><p>Visible text.</p><div>Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. </div></div></body></html>

--- a/test/lua/unit/html.lua
+++ b/test/lua/unit/html.lua
@@ -229,6 +229,24 @@ context("HTML processing", function()
     assert_equal(checked, 3)
   end)
 
+  -- A grouped selector list used to be truncated to the first simple selector
+  -- of its first part, so a rule meant for a spacer blanked every such element
+  test("A grouped selector that cannot be evaluated is not applied", function()
+    local html = parse_html_message(
+        '<html><head><style>div.mainbox ul li.spacer, div.mainbox ol li.spacer ' ..
+        '{ font-size: 0; color: transparent; opacity: 0 }</style></head>' ..
+        '<body><div class="mainbox"><div>kept visible</div></div></body></html>')
+    assert_not_nil(html, 'html part not parsed')
+    assert_equal('', tostring(html:get_invisible()))
+
+    -- The same declarations on a selector we can evaluate still hide
+    local hidden = parse_html_message(
+        '<html><head><style>.spacer { font-size: 0 }</style></head>' ..
+        '<body><div class="spacer">gone</div></body></html>')
+    assert_not_nil(hidden, 'html part not parsed')
+    assert_equal('gone', tostring(hidden:get_invisible()))
+  end)
+
   test("HTML tag get_all_attributes basic test", function()
     local rspamd_mempool = require("rspamd_mempool")
     local pool = rspamd_mempool.create()


### PR DESCRIPTION
## What breaks today

A selector list drops each of its parts down to the first simple selector that part starts with, and applies the declarations to that.

```css
div.mainbox ul li.spacer, div.mainbox ol li.spacer { font-size: 0 }
```

registers `div`. Every `<div>` in the document gets `font-size: 0`, and no class has to match anything. Without the comma the same rule is correctly ignored, which is why this only shows up in grouped rules.

Confirmed against a document where no class matches anything:

| rule | what disappears |
|---|---|
| `p.nomatch span.nomatch { font-size: 0 }` | nothing |
| `p.nomatch span.nomatch, x.other y.other { font-size: 0 }` | every `<p>` |
| `span.nomatch a.nomatch, q.other r.other { font-size: 0 }` | every `<span>` |
| `div.nomatch i.nomatch, q.other r.other { font-size: 0 }` | every `<div>` |
| `.onlyclass .other, .a .b { font-size: 0 }` | nothing (first part starts with a class) |

## Why it matters

Grouped descendant rules are everywhere in mail templates, and the ones carrying `font-size: 0`, `opacity: 0`, `color: transparent` or `display: none` are the spacer, preheader and mobile-only rules. When one of them collapses to a bare `div` or `td`, the whole body becomes invisible.

A real double opt-in confirmation, DKIM signed, hit this: its `div.mainbox ul li.spacer, div.mainbox ol li.spacer { font-size: 0; color: transparent; opacity: 0 }` became `div { font-size: 0 }`. The HTML part went from 81 words to 0, which is worth about 9 points:

* `HIDDEN_TEXT` 4.06 on 411 invisible characters
* `R_SUSPICIOUS_IMAGES` 5.0, since with zero words a single logo makes the image to text ratio 1.0

## The fix

`cur_selector` survived the transition into the ignore states, so a comma attached it as if it were complete. Reset it there, and let a comma restart parsing whether or not anything was attached.

## Scope and what is left

Nothing that used to match stops matching: plain selector lists (`p, span`, `em,.class,#id`) are unaffected, and a list that mixes both keeps the parts it can evaluate. What goes away is matching that was never asked for.

This does not lose hiding detection either: an ungrouped `div.x span.y { display: none }` is already ignored today, so grouped and ungrouped now behave the same.

Attribute selectors are untouched and still over-broad: the tokeniser folds `[...]` into a block, so the bracket never reaches this state machine and `a[href]` is registered as a bare `a`. Fixing that means changing how the block is consumed, which felt like a separate change. Say the word if you would rather have both in one go.

## Verified

* 410/410 C++ unit cases, 1344 Lua unit tests, no failures
* new `css` selector case covering grouped, compound, combinator and mixed lists
* a Lua unit case asserting the grouped rule no longer blanks the document while `.spacer { font-size: 0 }` still hides
* a functional fixture added to the existing `HTML VISIBILITY - No significant hidden content` template
