### PR TITLE
docs: add the estate-wide Non-Negotiable Rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,124 @@
+## Non-Negotiable Rules
+
+Breaking one of these causes an incident. Each has already cost us something —
+the "Why this exists" lines are real events, not illustrations.
+
+1. **Security first, always**
+   Before any change, perform a full threat model: what new attack surface is
+   introduced, what data flows in and out, what privileges are required, and
+   what happens if this code is compromised or fed malicious input. If the
+   change touches auth, crypto, network, file system, or user-controlled data,
+   the threat model is written first. Specifically, and without exception:
+   - **Never introduce or move secrets.** No hardcoded credentials, API keys,
+     tokens or private keys. Never commit `.env` files, config carrying
+     secrets, or debug logs that could contain them. A secret comes from the
+     environment or a secret manager, and the code fails closed without it.
+   - **All external input is hostile until proven otherwise.** Anything
+     crossing a trust boundary — user input, API responses, file contents,
+     query params, headers, rows from an untrusted source — is validated or
+     typed before use. Prefer allow-lists over deny-lists. Never concatenate
+     untrusted data into queries, commands, paths or HTML.
+   - **Least privilege and explicit authorization.** Any new capability runs
+     with the minimum privilege required. Authorization is checked explicitly
+     and fails closed. Never assume the caller is authorized because they
+     reached this code path.
+   - **Prove the security properties still hold.** Confirm no new injection
+     point, no secret in logs or errors, and no weakening of an existing
+     control. If you cannot prove it is safe, do not ship it.
+
+   > **Why this exists.** A `grep -rn` on a `.env` printed a live database
+   > password into a transcript that cannot be un-leaked. Production database
+   > dumps sat unencrypted in a home directory for two weeks. Deployed images
+   > shipped the production IP and the full security architecture.
+
+2. **Understand the full impact before changing anything**
+   Map every place the change will touch or be affected by: callers, callees,
+   data flows, tests, configs, deployments, docs, monitoring, and existing
+   invariants. If you cannot clearly state what else is affected, do not
+   proceed. A change is not done until it is verified running on the target —
+   editing a file in a repository changes nothing on a server.
+
+   > **Why this exists.** Twice a safeguard was recorded as installed on both
+   > servers and existed on neither. Removing six variables from one `.env`
+   > would have broken disaster recovery, because the init script asserts them
+   > with `${VAR:?}` and aborts — discoverable only during a rebuild.
+
+3. **Prove it works — and make sure the check could have failed**
+   After the change, verify correctness and security with tests, manual checks,
+   or both. Never mark a task done without evidence it behaves correctly under
+   both normal and adversarial conditions. **A check that cannot report failure
+   is worse than no check**, because it converts ignorance into confidence:
+   prove it by making it fail once, or by including a known-positive control.
+   When a measurement and your expectation disagree, suspect the instrument
+   first.
+
+   > **Why this exists.** A restore test "succeeded" having restored 0 files.
+   > A capability check passed by parsing an empty list. A script rehearsal
+   > passed because the corruption it should have caught cancelled itself out
+   > in the test harness, and the same script then deleted 14 vault entries.
+
+4. **Errors and warnings must reach someone who reads them**
+   Every error path is deliberate. Never swallow an error silently. Prefer
+   explicit error types or results over generic exceptions. Failures are
+   logged with enough context to diagnose and without leaking sensitive data.
+   Detection is not delivery: a warning that is generated and then dropped on
+   the floor is indistinguishable from a check that never ran, so confirm it
+   arrives on a channel someone actually reads.
+
+   > **Why this exists.** The missing-database guard fired correctly on ~36
+   > consecutive backup runs over 12 days and every one of them was delivered
+   > as a green "Backup OK", because the warning reached only a channel that
+   > was skipped whenever the other succeeded.
+
+5. **Make the smallest change that leaves no rule half-applied**
+   Prefer the minimal, reversible, simplest change that achieves the goal.
+   Avoid drive-by refactors, speculative improvements, or expanding scope.
+   Leave the codebase cleaner than you found it. But a rule stated in one
+   place and not in its twin is not a smaller change — it is a broken one.
+
+   > **Why this exists.** `.gitignore` was widened to `.env.*` and
+   > `.dockerignore` was not; a later build copied two secrets backups into an
+   > image. `.dockerignore` excluded `docs/` and never gained `*.md`, so the
+   > two largest documents shipped from the repository root.
+
+---
+
+## Standards
+
+Expected on every change and reviewable, but not tripwires.
+
+6. **Plan first, then execute**
+   For any non-trivial change, write a short plan covering the goal, the
+   approach, the affected areas, and how you will verify it. Get agreement on
+   the plan before writing code. Non-trivial means: more than one repository,
+   anything on a production host, or anything a cheap rollback cannot undo.
+
+7. **Match existing patterns and conventions**
+   Follow the established style, architecture, naming, error-handling and
+   testing patterns already present in the codebase. Do not invent new
+   approaches unless the existing ones are clearly inadequate and you have
+   justified the deviation.
+
+8. **Handle errors explicitly and fail safely**
+   Every error path is deliberate and every failure mode is chosen. Prefer
+   failing closed to continuing in an unknown state.
+
+9. **Keep the change readable and self-documenting**
+   Code must be understandable by a future reader, including future you,
+   without tribal knowledge. Prefer clear names, small functions and obvious
+   control flow over cleverness. Comment the **why**, not the what, and only
+   where it is non-obvious.
+
+10. **Preserve testability, observability, and backwards compatibility**
+    New code is easy to test in isolation; add or update tests for the change.
+    Important behaviours produce useful logs or metrics so production problems
+    can be diagnosed without guessing. Do not break existing callers, public
+    APIs, data formats or configuration without an explicit migration plan —
+    prefer additive, reversible changes, and document the migration path when
+    a breaking change is unavoidable.
+
+---
+
 # Rspamd - Development Guide
 
 ## Build & Test

--- a/conf/scores.d/hfilter_group.conf
+++ b/conf/scores.d/hfilter_group.conf
@@ -82,6 +82,10 @@ symbols = {
         weight = 2.0;
         description = "Helo not FQDN";
     }
+    "HFILTER_HELO_DNSFAIL" {
+        weight = 0.0;
+        description = "Helo address lookup DNS error";
+    }
     "HFILTER_FROMHOST_NORESOLVE_MX" {
         weight = 0.5;
         description = "MX found in FROM host and no resolve";
@@ -93,6 +97,10 @@ symbols = {
     "HFILTER_FROMHOST_NOT_FQDN" {
         weight = 3.0;
         description = "FROM host not FQDN";
+    }
+    "HFILTER_FROMHOST_DNSFAIL" {
+        weight = 0.0;
+        description = "FROM host address lookup DNS error";
     }
     "HFILTER_FROM_BOUNCE" {
         weight = 0.0;
@@ -112,6 +120,10 @@ symbols = {
     "HFILTER_MID_NOT_FQDN" {
         weight = 0.5;
         description = "Message-id host not FQDN";
+    }
+    "HFILTER_MID_DNSFAIL" {
+        weight = 0.0;
+        description = "Message-id host address lookup DNS error";
     }
 */
     "HFILTER_HOSTNAME_UNKNOWN" {

--- a/conf/scores.d/hfilter_group.conf
+++ b/conf/scores.d/hfilter_group.conf
@@ -138,4 +138,12 @@ symbols = {
         weight = 0.0;
         description = "PTR verification DNS error";
     }
+    "RDNS_FCRDNS_FAIL" {
+        weight = 0.0;
+        description = "PTR name does not resolve back to the sender's IP";
+    }
+    "RDNS_FCRDNS_DNSFAIL" {
+        weight = 0.0;
+        description = "FCrDNS verification DNS error";
+    }
 }

--- a/rules/misc.lua
+++ b/rules/misc.lua
@@ -807,6 +807,74 @@ rspamd_config.COMPLETELY_EMPTY = {
 -- Preserve compatibility
 local rdns_auth_and_local_conf = lua_util.config_check_local_or_authed(rspamd_config, 'once_received',
   false, false)
+
+-- An MTA is expected to publish a client hostname only after forward
+-- confirmed reverse DNS: per the milter interface a name that fails that
+-- check is reported as the bare IP in square brackets instead, which
+-- `task:get_hostname()` deliberately reports as nil. When Rspamd resolves the
+-- PTR itself it has to perform the same verification, otherwise an
+-- unverified name silently replaces the MTA's verdict and
+-- HFILTER_HOSTNAME_UNKNOWN, documented as covering exactly this ("PTR or
+-- FCrDNS verification failed"), can never be inserted.
+local function rdns_verify_forward(task, task_ip, ptr_name)
+  local ip_str = task_ip:to_string()
+  local completed = 0
+  local matched = false
+  local tempfail = false
+
+  local function forward_dns_cb(_, to_resolve, results, err)
+    if err and (err ~= 'requested record is not found' and
+          err ~= 'no records with this name') then
+      rspamd_logger.infox(task, 'error verifying PTR name %s: %s', to_resolve, err)
+      tempfail = true
+    elseif results then
+      for _, addr in ipairs(results) do
+        -- Compare printed forms: `ip:equal()` compares ports as well, and
+        -- the client address carries one whereas a resolved address does not
+        if addr:to_string() == ip_str then
+          matched = true
+        end
+      end
+    end
+
+    -- The A and the AAAA lookups share this callback and complete in
+    -- arbitrary order, so judge only once both have returned: an address
+    -- published in the slower family is not visible yet and a host that does
+    -- confirm would be rejected depending on DNS timing
+    completed = completed + 1
+    if completed < 2 then
+      return
+    end
+
+    if matched then
+      rspamd_logger.infox(task, 'source hostname has not been passed to Rspamd from MTA, ' ..
+        'but we could resolve source IP address PTR as "%s"', ptr_name)
+      task:set_hostname(ptr_name)
+    elseif tempfail then
+      -- Verification could not be completed, which is not evidence against
+      -- the client, so keep trusting the PTR as before. The symbol lets a
+      -- deployment that enforces HFILTER_HOSTNAME_UNKNOWN soft reject these
+      -- rather than treat a resolver failure as a pass
+      task:insert_result('RDNS_FCRDNS_DNSFAIL', 1.0, ptr_name)
+      task:set_hostname(ptr_name)
+    else
+      -- The name provably does not belong to this client, so it is not set:
+      -- this is the same state the task would be in had the MTA done the
+      -- verification itself
+      task:insert_result('RDNS_FCRDNS_FAIL', 1.0, ptr_name)
+    end
+  end
+
+  for _, rr in ipairs({ 'a', 'aaaa' }) do
+    task:get_resolver():resolve(rr, {
+      task = task,
+      name = ptr_name,
+      callback = forward_dns_cb,
+      forced = true
+    })
+  end
+end
+
 -- Check for the hostname if it was not set
 local rnds_check_id = rspamd_config:register_symbol {
   name = 'RDNS_CHECK',
@@ -824,10 +892,7 @@ local rnds_check_id = rspamd_config:register_symbol {
           if not results then
             task:insert_result('RDNS_NONE', 1.0)
           else
-            rspamd_logger.infox(task, 'source hostname has not been passed to Rspamd from MTA, ' ..
-              'but we could resolve source IP address PTR %s as "%s"',
-              to_resolve, results[1])
-            task:set_hostname(results[1])
+            rdns_verify_forward(task, task_ip, results[1])
           end
         end
         task:get_resolver():resolve_ptr({
@@ -868,6 +933,25 @@ rspamd_config:register_symbol {
   name = 'RDNS_NONE',
   score = 2.0,
   description = 'DNS failure resolving RDNS',
+  group = 'hfilter',
+  parent = rnds_check_id,
+}
+-- Informational: the weight for an unverified client already comes from
+-- HFILTER_HOSTNAME_UNKNOWN, which now fires for these, so scoring here too
+-- would count the same fact twice
+rspamd_config:register_symbol {
+  type = 'virtual',
+  name = 'RDNS_FCRDNS_FAIL',
+  score = 0.0,
+  description = 'PTR name does not resolve back to the client IP (FCrDNS verification failed)',
+  group = 'hfilter',
+  parent = rnds_check_id,
+}
+rspamd_config:register_symbol {
+  type = 'virtual',
+  name = 'RDNS_FCRDNS_DNSFAIL',
+  score = 0.0,
+  description = 'DNS failure verifying that the PTR name resolves back to the client IP',
   group = 'hfilter',
   parent = rnds_check_id,
 }

--- a/src/plugins/lua/hfilter.lua
+++ b/src/plugins/lua/hfilter.lua
@@ -290,6 +290,16 @@ local function check_host(task, host, symbol_suffix, eq_ip, eq_host)
       return
     end
 
+    -- Every check below is suppressed when a lookup failed transiently,
+    -- which is correct but indistinguishable from a clean pass. Publish the
+    -- failure so that a deployment enforcing these symbols can soft reject
+    -- what it could not verify instead of letting it through as verified.
+    -- NXDOMAIN does not count: that is an answer, already reported as
+    -- HFILTER_<suffix>_NORES_A_OR_MX.
+    if address_lookup_failed then
+      task:insert_result('HFILTER_' .. symbol_suffix .. '_DNSFAIL', 1.0, host)
+    end
+
     if not address_lookup_failed and eq_ip and eq_ip ~= '' then
       local matched = false
       for _, result in pairs(resolved_address) do
@@ -554,7 +564,8 @@ local symbols_helo = {
   "HFILTER_HELO_NORESOLVE_MX",
   "HFILTER_HELO_NORES_A_OR_MX",
   "HFILTER_HELO_IP_A",
-  "HFILTER_HELO_NOT_FQDN"
+  "HFILTER_HELO_NOT_FQDN",
+  "HFILTER_HELO_DNSFAIL"
 }
 local symbols_hostname = {
   "HFILTER_HOSTNAME_1",
@@ -570,7 +581,8 @@ local symbols_rcpt = {
 local symbols_mid = {
   "HFILTER_MID_NORESOLVE_MX",
   "HFILTER_MID_NORES_A_OR_MX",
-  "HFILTER_MID_NOT_FQDN"
+  "HFILTER_MID_NOT_FQDN",
+  "HFILTER_MID_DNSFAIL"
 }
 local symbols_url = {
   "HFILTER_URL_ONLY",
@@ -580,6 +592,7 @@ local symbols_from = {
   "HFILTER_FROMHOST_NORESOLVE_MX",
   "HFILTER_FROMHOST_NORES_A_OR_MX",
   "HFILTER_FROMHOST_NOT_FQDN",
+  "HFILTER_FROMHOST_DNSFAIL",
   "HFILTER_FROM_BOUNCE"
 }
 

--- a/test/functional/cases/171_hfilter_helo.robot
+++ b/test/functional/cases/171_hfilter_helo.robot
@@ -10,7 +10,7 @@ ${CONFIG}          ${RSPAMD_TESTDIR}/configs/hfilter.conf
 ${MESSAGE}         ${RSPAMD_TESTDIR}/messages/spam_message.eml
 ${RSPAMD_SCOPE}    Suite
 ${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
-${SETTINGS}        {symbols_enabled = [HFILTER_CHECK, HFILTER_HELO_IP_A, HFILTER_HELO_NORES_A_OR_MX, HFILTER_HELO_NORESOLVE_MX, HFILTER_HELO_NOT_FQDN]}
+${SETTINGS}        {symbols_enabled = [HFILTER_CHECK, HFILTER_HELO_IP_A, HFILTER_HELO_NORES_A_OR_MX, HFILTER_HELO_NORESOLVE_MX, HFILTER_HELO_NOT_FQDN, HFILTER_HELO_DNSFAIL]}
 
 *** Test Cases ***
 # HFILTER_HELO_IP_A is documented as "Helo A IP != hostname IP", so a HELO
@@ -59,3 +59,31 @@ HELO with no address records keeps being flagged
 HELO with one transiently failed family is not flagged
   Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=partialfail.test  Settings=${SETTINGS}
   Do Not Expect Symbol  HFILTER_HELO_IP_A
+
+# Staying silent is right, but silence is indistinguishable from a clean
+# pass. A deployment that enforces HFILTER_HELO_IP_A needs to be able to tell
+# "verified, no mismatch" from "could not verify", so the transient failure
+# is published as its own symbol to soft reject on.
+HELO with a transiently failed family reports the DNS failure
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=partialfail.test  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HELO_DNSFAIL
+
+# Both families time out. The two lookups share one callback, so the symbol
+# must be inserted once rather than once per callback; a per-callback insert
+# scores 2.00.
+HELO with both families transiently failed reports the DNS failure once
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=bothfail.test  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HELO_DNSFAIL  1.00
+
+# Control: a HELO that resolves cleanly must not be reported as unverifiable.
+HELO that resolves cleanly reports no DNS failure
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=match.test  Settings=${SETTINGS}
+  Do Not Expect Symbol  HFILTER_HELO_DNSFAIL
+
+# Control: NXDOMAIN is an authoritative answer, not a failure to obtain one.
+# It is already reported as HFILTER_HELO_NORES_A_OR_MX and must not also be
+# reported as a DNS failure, or the soft-reject signal becomes useless.
+HELO with no address records reports no DNS failure
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Helo=noaddr.test  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HELO_NORES_A_OR_MX
+  Do Not Expect Symbol  HFILTER_HELO_DNSFAIL

--- a/test/functional/cases/172_rdns_fcrdns.robot
+++ b/test/functional/cases/172_rdns_fcrdns.robot
@@ -1,0 +1,91 @@
+*** Settings ***
+Suite Setup     Rspamd Setup
+Suite Teardown  Rspamd Teardown
+Library         ${RSPAMD_TESTDIR}/lib/rspamd.py
+Resource        ${RSPAMD_TESTDIR}/lib/rspamd.robot
+Variables       ${RSPAMD_TESTDIR}/lib/vars.py
+
+*** Variables ***
+${CONFIG}          ${RSPAMD_TESTDIR}/configs/rdns.conf
+${MESSAGE}         ${RSPAMD_TESTDIR}/messages/spam_message.eml
+${RSPAMD_SCOPE}    Suite
+${RSPAMD_URL_TLD}  ${RSPAMD_TESTDIR}/../lua/unit/test_tld.dat
+${SETTINGS}        {symbols_enabled = [RDNS_CHECK, RDNS_NONE, RDNS_DNSFAIL, RDNS_FCRDNS_FAIL, RDNS_FCRDNS_DNSFAIL, HFILTER_CHECK, HFILTER_HOSTNAME_UNKNOWN, HFILTER_HOSTNAME_1, HFILTER_HOSTNAME_2, HFILTER_HOSTNAME_3, HFILTER_HOSTNAME_4, HFILTER_HOSTNAME_5]}
+
+*** Test Cases ***
+# Harness control rather than a behaviour under test: RDNS_CHECK is a
+# prefilter, so if it did not run in this suite every other case here would
+# green for the wrong reason. A client with no PTR at all must reach the
+# pre-existing RDNS_NONE path and be reported as an unknown hostname.
+Client without a PTR record is reported unknown
+  Scan File  ${MESSAGE}  IP=23.45.67.89  Settings=${SETTINGS}
+  Expect Symbol  RDNS_NONE
+  Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# The bug. The PTR resolves, so the fallback in rules/misc.lua adopts the
+# name, but that name publishes a different address: forward-confirmed
+# reverse DNS fails. HFILTER_HOSTNAME_UNKNOWN documents itself as covering
+# exactly this ("PTR or FCrDNS verification failed") and must fire.
+Client whose PTR fails forward confirmation is reported unknown
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HOSTNAME_UNKNOWN  2.50
+  Expect Symbol  RDNS_FCRDNS_FAIL
+
+# The same client as seen from a real MTA. Per the milter interface a
+# hostname that failed the MTA's own FCrDNS check arrives as the bracketed
+# IP literal, which get_hostname() reports as nil; the fallback then runs and
+# must not overwrite that verdict with an unverified name.
+Bracketed IP literal from the MTA does not become a verified hostname
+  Scan File  ${MESSAGE}  IP=1.2.3.4  Hostname=[1.2.3.4]  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+  Expect Symbol  RDNS_FCRDNS_FAIL
+
+# Control: the PTR name publishes exactly the connecting address, so the
+# hostname is verified and neither symbol may be inserted. Guards against a
+# fix that simply stops trusting the fallback altogether.
+Client whose PTR forward-confirms is not reported unknown
+  Scan File  ${MESSAGE}  IP=5.6.7.8  Settings=${SETTINGS}
+  Do Not Expect Symbol  RDNS_FCRDNS_FAIL
+  Do Not Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# The A and AAAA lookups of the PTR name share one callback and complete in
+# arbitrary order. Here the connecting address is in the A reply while the
+# AAAA reply holds a different one, so a check that judges before both have
+# returned can reject a correctly configured host.
+Dual-stack PTR confirming on A is not reported unknown
+  Scan File  ${MESSAGE}  IP=34.56.78.90  Settings=${SETTINGS}
+  Do Not Expect Symbol  RDNS_FCRDNS_FAIL
+  Do Not Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# Authoritative absence of address records is a failed verification, not a
+# deferred one: the name provably does not confirm the client.
+Client whose PTR name has no address records is reported unknown
+  Scan File  ${MESSAGE}  IP=45.67.89.101  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+  Expect Symbol  RDNS_FCRDNS_FAIL
+
+# A resolver timeout proves nothing either way. The verification result is
+# unknown, so the default must not be to accuse the client; instead a
+# dedicated symbol is published so a deployment enforcing
+# HFILTER_HOSTNAME_UNKNOWN can soft-reject the temporary failures.
+Client whose forward lookup times out is reported as a temporary failure
+  Scan File  ${MESSAGE}  IP=9.9.9.9  Settings=${SETTINGS}
+  Expect Symbol  RDNS_FCRDNS_DNSFAIL
+  Do Not Expect Symbol  RDNS_FCRDNS_FAIL
+  Do Not Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# Hostname pattern scoring must keep working for clients that verify: a
+# generic/dynamic-looking PTR name still earns its weight.
+Generic PTR name that forward-confirms is still scored by pattern
+  Scan File  ${MESSAGE}  IP=67.89.101.23  Settings=${SETTINGS}
+  Expect Symbol With Score  HFILTER_HOSTNAME_5  3.00
+  Do Not Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+
+# The deliberate consequence of the fix, pinned so it cannot change by
+# accident: a name that fails verification is not used for pattern scoring
+# either. This matches what already happens when the MTA does the check
+# itself and passes the bracketed IP literal instead of the name.
+Generic PTR name that fails forward confirmation is not scored by pattern
+  Scan File  ${MESSAGE}  IP=56.78.90.12  Settings=${SETTINGS}
+  Expect Symbol  HFILTER_HOSTNAME_UNKNOWN
+  Do Not Expect Symbol  HFILTER_HOSTNAME_5

--- a/test/functional/configs/hfilter-dns.conf
+++ b/test/functional/configs/hfilter-dns.conf
@@ -77,6 +77,19 @@ options {
         name = "partialfail.test";
         type = "aaaa";
         replies = ["2001:db8::2"];
+      },
+      {
+        # Neither family answers. Both lookups share one callback, so a
+        # failure reported from inside that callback would be inserted
+        # twice; the score assertion is what catches that.
+        name = "bothfail.test";
+        type = "a";
+        rcode = 'timeout';
+      },
+      {
+        name = "bothfail.test";
+        type = "aaaa";
+        rcode = 'timeout';
       }
     ]
   }

--- a/test/functional/configs/hfilter.conf
+++ b/test/functional/configs/hfilter.conf
@@ -31,5 +31,10 @@ group "hfilter" {
     "HFILTER_HELO_NOT_FQDN" {
       weight = 2.0;
     }
+    # Shipped as informational (0.0); pinned here only so that a symbol
+    # inserted once per resolver callback shows as 2.0 rather than 1.0.
+    "HFILTER_HELO_DNSFAIL" {
+      weight = 1.0;
+    }
   }
 }

--- a/test/functional/configs/rdns-dns.conf
+++ b/test/functional/configs/rdns-dns.conf
@@ -1,0 +1,139 @@
+options {
+  dns {
+    fake_records = [
+      {
+        # The PTR resolves, but the name it yields publishes a different
+        # address: forward-confirmed reverse DNS fails. This is the case
+        # HFILTER_HOSTNAME_UNKNOWN is documented to cover ("PTR or FCrDNS
+        # verification failed") and the one an MTA reports as `[ip]`.
+        name = "4.3.2.1.in-addr.arpa";
+        type = "ptr";
+        replies = ["nofcrdns.test"];
+      },
+      {
+        name = "nofcrdns.test";
+        type = "a";
+        replies = ["99.99.99.99"];
+      },
+      {
+        name = "nofcrdns.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # Fully forward-confirmed: the PTR name publishes exactly the
+        # connecting address, so the hostname is trustworthy and no symbol
+        # may be inserted.
+        name = "8.7.6.5.in-addr.arpa";
+        type = "ptr";
+        replies = ["goodfcrdns.test"];
+      },
+      {
+        name = "goodfcrdns.test";
+        type = "a";
+        replies = ["5.6.7.8"];
+      },
+      {
+        name = "goodfcrdns.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # Both forward lookups time out. Absence of an answer is not proof
+        # of a mismatch, so this must be reported as a temporary failure
+        # rather than silently treated as either outcome.
+        name = "9.9.9.9.in-addr.arpa";
+        type = "ptr";
+        replies = ["tempfcrdns.test"];
+      },
+      {
+        name = "tempfcrdns.test";
+        type = "a";
+        rcode = 'timeout';
+      },
+      {
+        name = "tempfcrdns.test";
+        type = "aaaa";
+        rcode = 'timeout';
+      },
+      {
+        # No PTR at all: the pre-existing RDNS_NONE path, kept here as a
+        # harness control proving RDNS_CHECK actually runs in this suite.
+        name = "89.67.45.23.in-addr.arpa";
+        type = "ptr";
+        rcode = 'nxdomain';
+      },
+      {
+        # Dual-stack PTR name where the match lives in the A reply and the
+        # AAAA reply holds a different address. The two forward lookups
+        # share one callback and complete in arbitrary order, so a check
+        # that judges before both have returned can see only the AAAA
+        # answer and reject a correctly configured host.
+        name = "90.78.56.34.in-addr.arpa";
+        type = "ptr";
+        replies = ["dualfcrdns.test"];
+      },
+      {
+        name = "dualfcrdns.test";
+        type = "a";
+        replies = ["34.56.78.90"];
+      },
+      {
+        name = "dualfcrdns.test";
+        type = "aaaa";
+        replies = ["2001:db8::9"];
+      },
+      {
+        # PTR name with no address records at all. Authoritative absence,
+        # so verification fails rather than being deferred.
+        name = "101.89.67.45.in-addr.arpa";
+        type = "ptr";
+        replies = ["noaddrfcrdns.test"];
+      },
+      {
+        name = "noaddrfcrdns.test";
+        type = "a";
+        rcode = 'nxdomain';
+      },
+      {
+        name = "noaddrfcrdns.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # A generic/dynamic-looking PTR name (matches the `nat[.-][0-9]`
+        # pattern, weight 5) that does NOT forward-confirm.
+        name = "12.90.78.56.in-addr.arpa";
+        type = "ptr";
+        replies = ["nat-1.dyn.example.test"];
+      },
+      {
+        name = "nat-1.dyn.example.test";
+        type = "a";
+        replies = ["99.99.99.99"];
+      },
+      {
+        name = "nat-1.dyn.example.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      },
+      {
+        # The same generic name shape, but forward-confirmed. The pattern
+        # scoring must keep working for hosts that verify.
+        name = "23.101.89.67.in-addr.arpa";
+        type = "ptr";
+        replies = ["nat-2.dyn.example.test"];
+      },
+      {
+        name = "nat-2.dyn.example.test";
+        type = "a";
+        replies = ["67.89.101.23"];
+      },
+      {
+        name = "nat-2.dyn.example.test";
+        type = "aaaa";
+        rcode = 'nxdomain';
+      }
+    ]
+  }
+}

--- a/test/functional/configs/rdns.conf
+++ b/test/functional/configs/rdns.conf
@@ -1,0 +1,29 @@
+.include(duplicate=merge,priority=0) "{= env.TESTDIR =}/configs/plugins.conf"
+.include(duplicate=merge,priority=1) "{= env.TESTDIR =}/configs/rdns-dns.conf"
+
+hfilter {
+  enabled = true;
+  # Only the hostname checks are under test here; the other groups would
+  # add unrelated symbols and extra DNS traffic.
+  helo_enabled = false;
+  hostname_enabled = true;
+  from_enabled = false;
+  rcpt_enabled = false;
+  mid_enabled = false;
+  url_enabled = false;
+}
+
+# hfilter.lua registers its symbols with score 0.0 and relies on
+# conf/scores.d/hfilter_group.conf for the real weights; that file is not
+# part of the functional test configs, so mirror the ones asserted on here.
+# The RDNS_* symbols carry their scores in rules/misc.lua itself.
+group "hfilter" {
+  symbols = {
+    "HFILTER_HOSTNAME_UNKNOWN" {
+      weight = 2.5;
+    }
+    "HFILTER_HOSTNAME_5" {
+      weight = 3.0;
+    }
+  }
+}


### PR DESCRIPTION
Ten rules, identical in every repository — five non-negotiable (breaking them causes incidents) and five standards (expected, reviewable, not tripwires).

Each non-negotiable carries a **Why this exists** naming the real event behind it: the `.env` password in a transcript, the safeguard installed on neither server, the restore that "succeeded" having restored 0 files, the backup guard that fired correctly for 12 days and arrived green every time, the `.gitignore`/`.dockerignore` drift that baked two secrets backups into an image.

**Why identical text in every repo:** one set to learn, not one per app.

**Why the scars:** `server-ops/CLAUDE.md` is 337 lines with two rules at the top that name what they cost, and those are the rules that actually got followed today. The app CLAUDE.md files run to 1,300–2,400 lines and contained neither `a check must be able to fail` nor `not done until it is verified running on the target` — checked before writing, all zero.

Placed at the very top, above existing content, which is otherwise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzFzMxrnhaUrk4perzAJyo