### PR TITLE
[Feature] Evaluate compound selectors and combinators in CSS

### DIFF
--- a/src/libserver/css/css.cxx
+++ b/src/libserver/css/css.cxx
@@ -20,6 +20,8 @@
 #include "libserver/html/html_tag.hxx"
 #include "libserver/html/html_block.hxx"
 
+#include <algorithm>
+
 /* Keep unit tests implementation here (it'll possibly be moved outside one day) */
 #define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 #define DOCTEST_CONFIG_IMPLEMENT
@@ -31,16 +33,27 @@ INIT_LOG_MODULE_PUBLIC(css);
 
 class css_style_sheet::impl {
 public:
-	using sel_shared_hash = smart_ptr_hash<css_selector>;
-	using sel_shared_eq = smart_ptr_equal<css_selector>;
-	using selector_ptr = std::unique_ptr<css_selector>;
-	using selectors_hash = ankerl::unordered_dense::map<selector_ptr, css_declarations_block_ptr,
-														sel_shared_hash, sel_shared_eq>;
-	using universal_selector_t = std::pair<selector_ptr, css_declarations_block_ptr>;
-	selectors_hash tags_selector;
+	struct selector_entry {
+		std::unique_ptr<css_selector> selector;
+		css_declarations_block_ptr decls;
+		/* Source order: at equal specificity a later rule wins */
+		unsigned order;
+	};
+	using selectors_bucket = std::vector<selector_entry>;
+	/*
+	 * Selectors are indexed by the most specific simple selector of their
+	 * subject compound; the rest of the selector (other parts of the
+	 * compound, ancestors and siblings) is evaluated against the tag tree
+	 * on lookup
+	 */
+	using selectors_hash = ankerl::unordered_dense::map<css_simple_selector, selectors_bucket>;
+	selectors_hash tags_selectors;
 	selectors_hash class_selectors;
 	selectors_hash id_selectors;
-	std::optional<universal_selector_t> universal_selector;
+	selectors_bucket universal_selectors;
+	unsigned next_order = 0;
+	/* Scratch space for the lookup, kept to avoid an allocation per tag */
+	std::vector<const selector_entry *> matched;
 };
 
 css_style_sheet::css_style_sheet(rspamd_mempool_t *pool)
@@ -54,89 +67,94 @@ css_style_sheet::~css_style_sheet()
 auto css_style_sheet::add_selector_rule(std::unique_ptr<css_selector> &&selector,
 										css_declarations_block_ptr decls) -> void
 {
-	impl::selectors_hash *target_hash = nullptr;
+	const auto &key = selector->key();
+	impl::selectors_bucket *bucket = nullptr;
 
-	switch (selector->type) {
-	case css_selector::selector_type::SELECTOR_ALL:
-		if (pimpl->universal_selector) {
-			/* Another universal selector */
-			msg_debug_css("redefined universal selector, merging rules");
-			pimpl->universal_selector->second->merge_block(*decls);
-		}
-		else {
-			msg_debug_css("added universal selector");
-			pimpl->universal_selector = std::make_pair(std::move(selector),
-													   decls);
-		}
+	switch (key.type) {
+	case css_simple_selector::selector_type::SELECTOR_ALL:
+		bucket = &pimpl->universal_selectors;
 		break;
-	case css_selector::selector_type::SELECTOR_CLASS:
-		target_hash = &pimpl->class_selectors;
+	case css_simple_selector::selector_type::SELECTOR_CLASS:
+		bucket = &pimpl->class_selectors[key];
 		break;
-	case css_selector::selector_type::SELECTOR_ID:
-		target_hash = &pimpl->id_selectors;
+	case css_simple_selector::selector_type::SELECTOR_ID:
+		bucket = &pimpl->id_selectors[key];
 		break;
-	case css_selector::selector_type::SELECTOR_TAG:
-		target_hash = &pimpl->tags_selector;
+	case css_simple_selector::selector_type::SELECTOR_TAG:
+		bucket = &pimpl->tags_selectors[key];
 		break;
 	}
 
-	if (target_hash) {
-		auto found_it = target_hash->find(selector);
-
-		if (found_it == target_hash->end()) {
-			/* Easy case, new element */
-			target_hash->insert({std::move(selector), decls});
-		}
-		else {
-			/* The problem with merging is actually in how to handle selectors chains
-			 * For example, we have 2 selectors:
-			 * 1. class id tag -> meaning that we first match class, then we ensure that
-			 * id is also the same and finally we check the tag
-			 * 2. tag class id -> it means that we check first tag, then class and then id
-			 * So we have somehow equal path in the xpath terms.
-			 * I suppose now, that we merely check parent stuff and handle duplicates
-			 * merging when finally resolving paths.
+	for (auto &entry: *bucket) {
+		if (*entry.selector == *selector) {
+			/*
+			 * The same selector again: merge the declarations, later ones
+			 * override, and the rule moves to the end of the cascade
 			 */
-			auto sel_str = selector->to_string().value_or("unknown");
-			msg_debug_css("found duplicate selector: %*s", (int) sel_str.size(),
-						  sel_str.data());
-			found_it->second->merge_block(*decls);
+			msg_debug_css("found duplicate selector: %s, merging rules",
+						  selector->debug_str().c_str());
+			entry.decls->merge_block(*decls);
+			entry.order = pimpl->next_order++;
+
+			return;
 		}
 	}
+
+	msg_debug_css("added selector: %s", selector->debug_str().c_str());
+	bucket->push_back(impl::selector_entry{std::move(selector), std::move(decls),
+										   pimpl->next_order++});
 }
 
 auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspamd::html::html_block *
 {
-	rspamd::html::html_block *res = nullptr;
-
 	if (!tag) {
 		return nullptr;
 	}
 
-	/* First, find id in a tag and a class */
-	auto id_comp = tag->find_id();
-	auto class_comp = tag->find_class();
+	auto &matched = pimpl->matched;
+	matched.clear();
+
+	auto collect = [&](const impl::selectors_bucket &bucket) {
+		for (const auto &entry: bucket) {
+			if (entry.selector->matches(tag)) {
+				matched.push_back(&entry);
+			}
+		}
+	};
+	auto collect_hash = [&](const impl::selectors_hash &hash, const css_simple_selector &key) {
+		auto found = hash.find(key);
+
+		if (found != hash.end()) {
+			collect(found->second);
+		}
+	};
 
 	/* ID part */
-	if (id_comp && !pimpl->id_selectors.empty()) {
-		auto found_id_sel = pimpl->id_selectors.find(css_selector{id_comp.value()});
+	if (!pimpl->id_selectors.empty()) {
+		auto id_comp = tag->find_id();
 
-		if (found_id_sel != pimpl->id_selectors.end()) {
-			const auto &decl = *(found_id_sel->second);
-			res = decl.compile_to_block(pool);
+		if (id_comp) {
+			collect_hash(pimpl->id_selectors,
+						 css_simple_selector{id_comp.value(),
+											 css_simple_selector::selector_type::SELECTOR_ID});
 		}
 	}
 
 	/* Class part */
-	if (class_comp && !pimpl->class_selectors.empty()) {
-		auto sv_split = [](auto strv, std::string_view delims = " ") -> std::vector<std::string_view> {
-			std::vector<decltype(strv)> ret;
+	if (!pimpl->class_selectors.empty()) {
+		auto class_comp = tag->find_class();
+
+		if (class_comp) {
+			auto strv = class_comp.value();
 			std::size_t start = 0;
 
 			while (start < strv.size()) {
-				const auto last = strv.find_first_of(delims, start);
+				const auto last = strv.find_first_of(" \t\r\n", start);
+
 				if (start != last) {
-					ret.emplace_back(strv.substr(start, last - start));
+					collect_hash(pimpl->class_selectors,
+								 css_simple_selector{strv.substr(start, last - start),
+													 css_simple_selector::selector_type::SELECTOR_CLASS});
 				}
 
 				if (last == std::string_view::npos) {
@@ -145,51 +163,42 @@ auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspa
 
 				start = last + 1;
 			}
-
-			return ret;
-		};
-
-		auto elts = sv_split(class_comp.value());
-
-		for (const auto &e: elts) {
-			auto found_class_sel = pimpl->class_selectors.find(
-				css_selector{e, css_selector::selector_type::SELECTOR_CLASS});
-
-			if (found_class_sel != pimpl->class_selectors.end()) {
-				const auto &decl = *(found_class_sel->second);
-				auto *tmp = decl.compile_to_block(pool);
-
-				if (res == nullptr) {
-					res = tmp;
-				}
-				else {
-					res->propagate_block(*tmp);
-				}
-			}
 		}
 	}
 
 	/* Tags part */
-	if (!pimpl->tags_selector.empty()) {
-		auto found_tag_sel = pimpl->tags_selector.find(
-			css_selector{static_cast<tag_id_t>(tag->id)});
-
-		if (found_tag_sel != pimpl->tags_selector.end()) {
-			const auto &decl = *(found_tag_sel->second);
-			auto *tmp = decl.compile_to_block(pool);
-
-			if (res == nullptr) {
-				res = tmp;
-			}
-			else {
-				res->propagate_block(*tmp);
-			}
-		}
+	if (!pimpl->tags_selectors.empty()) {
+		collect_hash(pimpl->tags_selectors,
+					 css_simple_selector{static_cast<tag_id_t>(tag->id)});
 	}
 
 	/* Finally, universal selector */
-	if (pimpl->universal_selector) {
-		auto *tmp = pimpl->universal_selector->second->compile_to_block(pool);
+	collect(pimpl->universal_selectors);
+
+	if (matched.empty()) {
+		return nullptr;
+	}
+
+	/*
+	 * Cascade: the most specific selector wins, source order breaks ties.
+	 * The winner is compiled first and the others only fill in what it
+	 * leaves undefined
+	 */
+	std::stable_sort(matched.begin(), matched.end(),
+					 [](const impl::selector_entry *a, const impl::selector_entry *b) {
+						 auto sa = a->selector->specificity(), sb = b->selector->specificity();
+
+						 if (sa != sb) {
+							 return sa > sb;
+						 }
+
+						 return a->order > b->order;
+					 });
+
+	rspamd::html::html_block *res = nullptr;
+
+	for (const auto *entry: matched) {
+		auto *tmp = entry->decls->compile_to_block(pool);
 
 		if (res == nullptr) {
 			res = tmp;

--- a/src/libserver/css/css.cxx
+++ b/src/libserver/css/css.cxx
@@ -54,6 +54,14 @@ public:
 	unsigned next_order = 0;
 	/* Scratch space for the lookup, kept to avoid an allocation per tag */
 	std::vector<const selector_entry *> matched;
+
+	/*
+	 * Every matching selector is evaluated for every element, so the
+	 * number of rules is capped: legitimate mail styles are far below
+	 * this and a crafted one must not turn the lookup into a quadratic
+	 * scan
+	 */
+	static constexpr unsigned max_selectors = 4096;
 };
 
 css_style_sheet::css_style_sheet(rspamd_mempool_t *pool)
@@ -85,21 +93,19 @@ auto css_style_sheet::add_selector_rule(std::unique_ptr<css_selector> &&selector
 		break;
 	}
 
-	for (auto &entry: *bucket) {
-		if (*entry.selector == *selector) {
-			/*
-			 * The same selector again: merge the declarations, later ones
-			 * override, and the rule moves to the end of the cascade
-			 */
-			msg_debug_css("found duplicate selector: %s, merging rules",
-						  selector->debug_str().c_str());
-			entry.decls->merge_block(*decls);
-			entry.order = pimpl->next_order++;
+	if (pimpl->next_order >= impl::max_selectors) {
+		msg_debug_css("too many selectors (%d), ignore selector %s",
+					  (int) pimpl->next_order, selector->debug_str().c_str());
 
-			return;
-		}
+		return;
 	}
 
+	/*
+	 * A repeated selector is not merged with the earlier one: it is a new
+	 * rule in the cascade, so only its own declarations move forward.
+	 * Merging would also drag the earlier declarations past rules that
+	 * were written in between
+	 */
 	msg_debug_css("added selector: %s", selector->debug_str().c_str());
 	bucket->push_back(impl::selector_entry{std::move(selector), std::move(decls),
 										   pimpl->next_order++});
@@ -181,8 +187,10 @@ auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspa
 
 	/*
 	 * Cascade: the most specific selector wins, source order breaks ties.
-	 * The winner is compiled first and the others only fill in what it
-	 * leaves undefined
+	 * The winner is compiled into the block returned to the caller; the
+	 * others are compiled into a temporary and only fill in what the
+	 * block leaves undefined, so a tag costs one pool allocation however
+	 * many rules match it
 	 */
 	std::stable_sort(matched.begin(), matched.end(),
 					 [](const impl::selector_entry *a, const impl::selector_entry *b) {
@@ -195,17 +203,13 @@ auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspa
 						 return a->order > b->order;
 					 });
 
-	rspamd::html::html_block *res = nullptr;
+	auto *res = matched.front()->decls->compile_to_block(pool);
 
-	for (const auto *entry: matched) {
-		auto *tmp = entry->decls->compile_to_block(pool);
+	for (auto it = matched.begin() + 1; it != matched.end(); ++it) {
+		rspamd::html::html_block tmp{};
 
-		if (res == nullptr) {
-			res = tmp;
-		}
-		else {
-			res->propagate_block(*tmp);
-		}
+		(*it)->decls->compile_into(tmp);
+		res->set_block(tmp);
 	}
 
 	return res;

--- a/src/libserver/css/css.cxx
+++ b/src/libserver/css/css.cxx
@@ -38,6 +38,7 @@ public:
 		css_declarations_block_ptr decls;
 		/* Source order: at equal specificity a later rule wins */
 		unsigned order;
+		unsigned specificity;
 	};
 	using selectors_bucket = std::vector<selector_entry>;
 	/*
@@ -54,12 +55,12 @@ public:
 	unsigned next_order = 0;
 	/* Scratch space for the lookup, kept to avoid an allocation per tag */
 	std::vector<const selector_entry *> matched;
+	ankerl::unordered_dense::set<const selectors_bucket *> visited_classes;
+	css_match_budget match_budget;
 
 	/*
-	 * Every matching selector is evaluated for every element, so the
-	 * number of rules is capped: legitimate mail styles are far below
-	 * this and a crafted one must not turn the lookup into a quadratic
-	 * scan
+	 * Bound index storage and per-element cascade scratch space. The
+	 * shared work budget separately bounds matching across all elements.
 	 */
 	static constexpr unsigned max_selectors = 4096;
 };
@@ -75,6 +76,10 @@ css_style_sheet::~css_style_sheet()
 auto css_style_sheet::add_selector_rule(std::unique_ptr<css_selector> &&selector,
 										css_declarations_block_ptr decls) -> void
 {
+	if (pimpl->next_order >= impl::max_selectors) {
+		return;
+	}
+
 	const auto &key = selector->key();
 	impl::selectors_bucket *bucket = nullptr;
 
@@ -93,13 +98,6 @@ auto css_style_sheet::add_selector_rule(std::unique_ptr<css_selector> &&selector
 		break;
 	}
 
-	if (pimpl->next_order >= impl::max_selectors) {
-		msg_debug_css("too many selectors (%d), ignore selector %s",
-					  (int) pimpl->next_order, selector->debug_str().c_str());
-
-		return;
-	}
-
 	/*
 	 * A repeated selector is not merged with the earlier one: it is a new
 	 * rule in the cascade, so only its own declarations move forward.
@@ -107,30 +105,40 @@ auto css_style_sheet::add_selector_rule(std::unique_ptr<css_selector> &&selector
 	 * were written in between
 	 */
 	msg_debug_css("added selector: %s", selector->debug_str().c_str());
+	auto specificity = selector->specificity();
 	bucket->push_back(impl::selector_entry{std::move(selector), std::move(decls),
-										   pimpl->next_order++});
+										   pimpl->next_order++, specificity});
 }
 
 auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspamd::html::html_block *
 {
-	if (!tag) {
+	auto &budget = pimpl->match_budget;
+	if (!tag || !budget.consume(1 + tag->components.size())) {
 		return nullptr;
 	}
 
 	auto &matched = pimpl->matched;
 	matched.clear();
+	pimpl->visited_classes.clear();
 
 	auto collect = [&](const impl::selectors_bucket &bucket) {
 		for (const auto &entry: bucket) {
-			if (entry.selector->matches(tag)) {
+			if (!budget.consume()) {
+				return;
+			}
+			if (entry.selector->matches(tag, budget)) {
 				matched.push_back(&entry);
 			}
 		}
 	};
-	auto collect_hash = [&](const impl::selectors_hash &hash, const css_simple_selector &key) {
+	auto collect_hash = [&](const impl::selectors_hash &hash, const css_simple_selector &key,
+							bool is_class = false) {
 		auto found = hash.find(key);
 
 		if (found != hash.end()) {
+			if (is_class && !pimpl->visited_classes.insert(&found->second).second) {
+				return;
+			}
 			collect(found->second);
 		}
 	};
@@ -140,6 +148,9 @@ auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspa
 		auto id_comp = tag->find_id();
 
 		if (id_comp) {
+			if (!budget.consume(id_comp->size())) {
+				return nullptr;
+			}
 			collect_hash(pimpl->id_selectors,
 						 css_simple_selector{id_comp.value(),
 											 css_simple_selector::selector_type::SELECTOR_ID});
@@ -152,15 +163,22 @@ auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspa
 
 		if (class_comp) {
 			auto strv = class_comp.value();
+			if (!budget.consume(strv.size())) {
+				return nullptr;
+			}
 			std::size_t start = 0;
 
 			while (start < strv.size()) {
+				if (!budget.consume()) {
+					return nullptr;
+				}
 				const auto last = strv.find_first_of(" \t\r\n", start);
 
 				if (start != last) {
 					collect_hash(pimpl->class_selectors,
 								 css_simple_selector{strv.substr(start, last - start),
-													 css_simple_selector::selector_type::SELECTOR_CLASS});
+													 css_simple_selector::selector_type::SELECTOR_CLASS},
+								 true);
 				}
 
 				if (last == std::string_view::npos) {
@@ -181,7 +199,8 @@ auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspa
 	/* Finally, universal selector */
 	collect(pimpl->universal_selectors);
 
-	if (matched.empty()) {
+	/* Do not apply a partial cascade when the document budget runs out. */
+	if (budget.remaining == 0 || matched.empty()) {
 		return nullptr;
 	}
 
@@ -194,7 +213,7 @@ auto css_style_sheet::check_tag_block(const rspamd::html::html_tag *tag) -> rspa
 	 */
 	std::stable_sort(matched.begin(), matched.end(),
 					 [](const impl::selector_entry *a, const impl::selector_entry *b) {
-						 auto sa = a->selector->specificity(), sb = b->selector->specificity();
+						 auto sa = a->specificity, sb = b->specificity;
 
 						 if (sa != sb) {
 							 return sa > sb;
@@ -228,6 +247,63 @@ auto css_parse_style(rspamd_mempool_t *pool,
 	}
 
 	return std::make_pair(nullptr, parse_res.error());
+}
+
+TEST_SUITE("css")
+{
+	TEST_CASE("budget exhaustion discards an incomplete cascade")
+	{
+		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(), "css", 0);
+		{
+			std::string css = ".x { font-size: 0 } ";
+			for (auto i = 0; i < css_compound_selector::max_parts; i++) {
+				css += ".x";
+			}
+			css += " { font-size: 14px }";
+			auto parsed = css_parse_style(pool, css, nullptr);
+			REQUIRE(parsed.first != nullptr);
+			html::html_tag tag;
+			tag.id = Tag_SPAN;
+			std::string classes(65536, 'q');
+			classes += " x";
+			tag.components.emplace_back(html::html_component_class{classes});
+			/* The first rule matches, but the overriding compound runs out. */
+			CHECK(parsed.first->check_tag_block(&tag) == nullptr);
+			auto control = css_parse_style(pool, ".x { font-size: 0 }", nullptr);
+			REQUIRE(control.first != nullptr);
+			CHECK(control.first->check_tag_block(&tag) != nullptr);
+		}
+		rspamd_mempool_delete(pool);
+	}
+
+	TEST_CASE("stylesheet matching budget persists across elements and style blocks")
+	{
+		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(), "css", 0);
+		{
+			auto parsed = css_parse_style(pool, ".x { color: red }", nullptr);
+			REQUIRE(parsed.first != nullptr);
+			html::html_tag tag;
+			tag.id = Tag_SPAN;
+			std::string classes(65536, ' ');
+			classes += "x";
+			tag.components.emplace_back(html::html_component_class{classes});
+			CHECK(parsed.first->check_tag_block(&tag) != nullptr);
+			/* Each lookup scans the attribute both for indexing and matching. */
+			for (auto i = 0; i < css_match_budget::max_work / classes.size() + 1; i++) {
+				parsed.first->check_tag_block(&tag);
+			}
+			tag.components.clear();
+			tag.components.emplace_back(html::html_component_class{"x"});
+			CHECK(parsed.first->check_tag_block(&tag) == nullptr);
+			parsed = css_parse_style(pool, "span { color: blue }", std::move(parsed.first));
+			REQUIRE(parsed.first != nullptr);
+			CHECK(parsed.first->check_tag_block(&tag) == nullptr);
+			auto fresh = css_parse_style(pool, ".x { color: red }", nullptr);
+			REQUIRE(fresh.first != nullptr);
+			CHECK(fresh.first->check_tag_block(&tag) != nullptr);
+		}
+		rspamd_mempool_delete(pool);
+	}
 }
 
 }// namespace rspamd::css

--- a/src/libserver/css/css_parser.cxx
+++ b/src/libserver/css/css_parser.cxx
@@ -381,7 +381,17 @@ auto css_parser::qualified_rule_consumer(std::unique_ptr<css_consumed_block> &to
 			want_more = false;
 			break;
 		case css_parser_token::token_type::whitespace_token:
-			/* Ignore whitespaces */
+			/*
+			 * Whitespace between the components of a prelude is significant:
+			 * it is the descendant combinator in a selector, so `div .x` and
+			 * `div.x` must reach the selectors parser as different streams.
+			 * Leading whitespace carries no information and is dropped
+			 */
+			if (block->size() > 0) {
+				block->attach_block(std::make_unique<css_consumed_block>(
+					css_consumed_block::parser_tag_type::css_component,
+					std::move(next_token)));
+			}
 			break;
 		default:
 			tokeniser->pushback_token(next_token);
@@ -635,10 +645,20 @@ css_parser::consume_input(const std::string_view &sv)
 
 		if (children.size() > 1 &&
 			children[0]->tag == css_consumed_block::parser_tag_type::css_component) {
-			auto simple_block = std::find_if(children.begin(), children.end(),
-											 [](auto &bl) {
-												 return bl->tag == css_consumed_block::parser_tag_type::css_simple_block;
-											 });
+			/*
+			 * The declarations live in the last nested block: the prelude
+			 * may contain nested blocks of its own, e.g. attribute selectors
+			 * like `a[href]`, which the selectors parser has to see
+			 */
+			auto simple_block = children.end();
+			auto simple_block_rit = std::find_if(children.rbegin(), children.rend(),
+												 [](auto &bl) {
+													 return bl->tag == css_consumed_block::parser_tag_type::css_simple_block;
+												 });
+
+			if (simple_block_rit != children.rend()) {
+				simple_block = std::prev(simple_block_rit.base());
+			}
 
 			if (simple_block != children.end()) {
 				/*
@@ -716,6 +736,13 @@ auto get_selectors_parser_functor(rspamd_mempool_t *pool,
 
 	auto &&consumed_blocks = parser.consume_css_blocks(st);
 	const auto &rules = consumed_blocks->get_blocks_or_empty();
+
+	if (rules.empty()) {
+		/* Nothing to consume, e.g. an empty input */
+		return [](void) -> const css_consumed_block & {
+			return css_parser_eof_block;
+		};
+	}
 
 	auto rules_it = rules.begin();
 	auto &&children = (*rules_it)->get_blocks_or_empty();

--- a/src/libserver/css/css_rule.cxx
+++ b/src/libserver/css/css_rule.cxx
@@ -512,6 +512,15 @@ auto css_declarations_block::merge_block(const css_declarations_block &other, me
 auto css_declarations_block::compile_to_block(rspamd_mempool_t *pool) const -> rspamd::html::html_block *
 {
 	auto *block = rspamd_mempool_alloc0_type(pool, rspamd::html::html_block);
+
+	compile_into(*block);
+
+	return block;
+}
+
+auto css_declarations_block::compile_into(rspamd::html::html_block &out) const -> void
+{
+	auto *block = &out;
 	auto opacity = -1.0f;
 	std::optional<css_dimension> height, width, max_height, max_width;
 	std::optional<css_dimension> left, top, text_indent;
@@ -711,8 +720,6 @@ auto css_declarations_block::compile_to_block(rspamd_mempool_t *pool) const -> r
 			}
 		}
 	}
-
-	return block;
 }
 
 void css_rule::add_value(const css_value &value)

--- a/src/libserver/css/css_rule.hxx
+++ b/src/libserver/css/css_rule.hxx
@@ -138,6 +138,13 @@ public:
 	 */
 	auto compile_to_block(rspamd_mempool_t *pool) const -> rspamd::html::html_block *;
 
+	/**
+	 * Compile CSS declaration into an existing zero initialised html block,
+	 * for callers that do not need the block to outlive them
+	 * @param block block to fill
+	 */
+	auto compile_into(rspamd::html::html_block &block) const -> void;
+
 private:
 	ankerl::unordered_dense::set<rule_shared_ptr, rule_shared_hash, rule_shared_eq> rules;
 };

--- a/src/libserver/css/css_selector.cxx
+++ b/src/libserver/css/css_selector.cxx
@@ -307,14 +307,24 @@ auto css_compound_selector::matches(const html::html_tag *tag) const -> bool
 
 /*
  * Match the chain from the link `idx` on, starting from `elt` (the element
- * matched by the previous link or the subject). Descendant and subsequent
- * sibling combinators backtrack over all candidates, so `a b c` still
- * matches when the nearest `b` ancestor has no `a` above it but a farther
- * one has.
+ * matched by the previous link or the subject).
+ *
+ * Descendant and subsequent sibling combinators backtrack over all
+ * candidates, so `a > b c` still matches when the nearest `b` ancestor has
+ * no `a` parent but a farther one has. Backtracking is only needed while
+ * a child or next sibling link is still ahead: when the rest of the chain
+ * is descendant links only, the nearest matching ancestor is always a
+ * valid choice (any farther one is also above it), so the walk is greedy
+ * and linear. The same holds for a rest made of subsequent sibling links.
+ *
+ * `budget` bounds the compound evaluations of a single match: the
+ * backtracking cases revisit elements and a crafted document with a deep
+ * nesting and a long chain would otherwise take seconds
  */
 static auto match_chain(const std::vector<css_selector::link> &chain,
 						std::size_t idx,
-						const html::html_tag *elt) -> bool
+						const html::html_tag *elt,
+						unsigned &budget) -> bool
 {
 	if (idx == chain.size()) {
 		return true;
@@ -322,18 +332,44 @@ static auto match_chain(const std::vector<css_selector::link> &chain,
 
 	const auto &lnk = chain[idx];
 
+	auto rest_is_only = [&](css_selector::combinator_type comb) -> bool {
+		for (auto i = idx + 1; i < chain.size(); i++) {
+			if (chain[i].combinator != comb) {
+				return false;
+			}
+		}
+		return true;
+	};
+
+	auto try_target = [&](const html::html_tag *cand) -> bool {
+		if (budget == 0) {
+			return false;
+		}
+		budget--;
+
+		return lnk.target.matches(cand);
+	};
+
 	switch (lnk.combinator) {
 	case css_selector::combinator_type::child: {
 		const auto *p = elt->parent;
-		return p && lnk.target.matches(p) && match_chain(chain, idx + 1, p);
+		return p && try_target(p) && match_chain(chain, idx + 1, p, budget);
 	}
-	case css_selector::combinator_type::descendant:
-		for (const auto *p = elt->parent; p != nullptr; p = p->parent) {
-			if (lnk.target.matches(p) && match_chain(chain, idx + 1, p)) {
-				return true;
+	case css_selector::combinator_type::descendant: {
+		auto greedy = rest_is_only(css_selector::combinator_type::descendant);
+
+		for (const auto *p = elt->parent; p != nullptr && budget > 0; p = p->parent) {
+			if (try_target(p)) {
+				if (greedy) {
+					return match_chain(chain, idx + 1, p, budget);
+				}
+				if (match_chain(chain, idx + 1, p, budget)) {
+					return true;
+				}
 			}
 		}
 		return false;
+	}
 	case css_selector::combinator_type::next_sibling: {
 		const auto *p = elt->parent;
 
@@ -352,7 +388,7 @@ static auto match_chain(const std::vector<css_selector::link> &chain,
 			prev = s;
 		}
 
-		return found && prev && lnk.target.matches(prev) && match_chain(chain, idx + 1, prev);
+		return found && prev && try_target(prev) && match_chain(chain, idx + 1, prev, budget);
 	}
 	case css_selector::combinator_type::subsequent_sibling: {
 		const auto *p = elt->parent;
@@ -361,12 +397,22 @@ static auto match_chain(const std::vector<css_selector::link> &chain,
 			return false;
 		}
 
-		for (const auto *s: p->children) {
-			if (s == elt) {
-				break;
-			}
-			if (lnk.target.matches(s) && match_chain(chain, idx + 1, s)) {
-				return true;
+		auto greedy = rest_is_only(css_selector::combinator_type::subsequent_sibling);
+		/* Walk the preceding siblings from the nearest one */
+		auto self = std::find(p->children.begin(), p->children.end(), elt);
+
+		if (self == p->children.end()) {
+			return false;
+		}
+
+		for (auto it = std::make_reverse_iterator(self); it != p->children.rend() && budget > 0; ++it) {
+			if (try_target(*it)) {
+				if (greedy) {
+					return match_chain(chain, idx + 1, *it, budget);
+				}
+				if (match_chain(chain, idx + 1, *it, budget)) {
+					return true;
+				}
 			}
 		}
 
@@ -383,7 +429,9 @@ auto css_selector::matches(const html::html_tag *tag) const -> bool
 		return false;
 	}
 
-	return match_chain(chain, 0, tag);
+	auto budget = max_match_steps;
+
+	return match_chain(chain, 0, tag, budget);
 }
 
 /*

--- a/src/libserver/css/css_selector.cxx
+++ b/src/libserver/css/css_selector.cxx
@@ -70,6 +70,10 @@ auto process_selector_tokens(rspamd_mempool_t *pool,
 
 	auto add_part = [&](css_simple_selector &&part) {
 		if (ws_pending && !cur.parts.empty()) {
+			if (combinators.size() >= css_selector::max_chain_length) {
+				broken = true;
+				return;
+			}
 			/* Whitespace between two compounds */
 			compounds.push_back(std::move(cur));
 			cur.parts.clear();
@@ -77,10 +81,18 @@ auto process_selector_tokens(rspamd_mempool_t *pool,
 		}
 
 		ws_pending = false;
+		if (cur.parts.size() >= css_compound_selector::max_parts) {
+			broken = true;
+			return;
+		}
 		cur.parts.push_back(std::move(part));
 	};
 
 	auto add_combinator = [&](css_selector::combinator_type comb) {
+		if (combinators.size() >= css_selector::max_chain_length) {
+			broken = true;
+			return;
+		}
 		if (cur.parts.empty()) {
 			/* Leading or doubled combinator */
 			msg_debug_css("combinator without a preceding compound, drop selector");
@@ -243,7 +255,8 @@ auto process_selector_tokens(rspamd_mempool_t *pool,
  * Matching
  */
 
-static auto tag_has_class(const html::html_tag *tag, std::string_view cls) -> bool
+static auto tag_has_class(const html::html_tag *tag, std::string_view cls,
+						  css_match_budget &budget) -> bool
 {
 	auto class_comp = tag->find_class();
 
@@ -252,6 +265,10 @@ static auto tag_has_class(const html::html_tag *tag, std::string_view cls) -> bo
 	}
 
 	auto strv = class_comp.value();
+	/* Charge the entire scan before touching an arbitrarily long attribute. */
+	if (!budget.consume(strv.size())) {
+		return false;
+	}
 	std::size_t start = 0;
 
 	while (start < strv.size()) {
@@ -272,8 +289,15 @@ static auto tag_has_class(const html::html_tag *tag, std::string_view cls) -> bo
 	return false;
 }
 
-auto css_simple_selector::matches(const html::html_tag *tag) const -> bool
+auto css_simple_selector::matches(const html::html_tag *tag, css_match_budget &budget) const -> bool
 {
+	if (!budget.consume()) {
+		return false;
+	}
+	if ((type == selector_type::SELECTOR_ID || type == selector_type::SELECTOR_CLASS) &&
+		!budget.consume(tag->components.size())) {
+		return false;
+	}
 	switch (type) {
 	case selector_type::SELECTOR_ALL:
 		return true;
@@ -281,10 +305,11 @@ auto css_simple_selector::matches(const html::html_tag *tag) const -> bool
 		return static_cast<tag_id_t>(tag->id) == std::get<tag_id_t>(value);
 	case selector_type::SELECTOR_ID: {
 		auto id_comp = tag->find_id();
-		return id_comp && id_comp.value() == std::get<std::string_view>(value);
+		return id_comp && budget.consume(id_comp->size()) &&
+			   id_comp.value() == std::get<std::string_view>(value);
 	}
 	case selector_type::SELECTOR_CLASS:
-		return tag_has_class(tag, std::get<std::string_view>(value));
+		return tag_has_class(tag, std::get<std::string_view>(value), budget);
 	}
 
 	return false;
@@ -299,10 +324,10 @@ auto css_compound_selector::key() const -> const css_simple_selector &
 							 });
 }
 
-auto css_compound_selector::matches(const html::html_tag *tag) const -> bool
+auto css_compound_selector::matches(const html::html_tag *tag, css_match_budget &budget) const -> bool
 {
 	return std::all_of(parts.begin(), parts.end(),
-					   [tag](const auto &p) { return p.matches(tag); });
+					   [tag, &budget](const auto &p) { return p.matches(tag, budget); });
 }
 
 /*
@@ -320,12 +345,17 @@ auto css_compound_selector::matches(const html::html_tag *tag) const -> bool
  * `budget` bounds the compound evaluations of a single match: the
  * backtracking cases revisit elements and a crafted document with a deep
  * nesting and a long chain would otherwise take seconds
+ * `work` additionally charges attribute scans and sibling traversal to the
+ * document-wide allowance, including the subject evaluated by the caller.
  */
 static auto match_chain(const std::vector<css_selector::link> &chain,
 						std::size_t idx,
 						const html::html_tag *elt,
-						unsigned &budget) -> bool
+						unsigned &budget, css_match_budget &work) -> bool
 {
+	if (!work.consume()) {
+		return false;
+	}
 	if (idx == chain.size()) {
 		return true;
 	}
@@ -347,23 +377,23 @@ static auto match_chain(const std::vector<css_selector::link> &chain,
 		}
 		budget--;
 
-		return lnk.target.matches(cand);
+		return lnk.target.matches(cand, work);
 	};
 
 	switch (lnk.combinator) {
 	case css_selector::combinator_type::child: {
 		const auto *p = elt->parent;
-		return p && try_target(p) && match_chain(chain, idx + 1, p, budget);
+		return p && try_target(p) && match_chain(chain, idx + 1, p, budget, work);
 	}
 	case css_selector::combinator_type::descendant: {
 		auto greedy = rest_is_only(css_selector::combinator_type::descendant);
 
-		for (const auto *p = elt->parent; p != nullptr && budget > 0; p = p->parent) {
+		for (const auto *p = elt->parent; p != nullptr && budget > 0 && work.remaining > 0; p = p->parent) {
 			if (try_target(p)) {
 				if (greedy) {
-					return match_chain(chain, idx + 1, p, budget);
+					return match_chain(chain, idx + 1, p, budget, work);
 				}
-				if (match_chain(chain, idx + 1, p, budget)) {
+				if (match_chain(chain, idx + 1, p, budget, work)) {
 					return true;
 				}
 			}
@@ -381,6 +411,9 @@ static auto match_chain(const std::vector<css_selector::link> &chain,
 		bool found = false;
 
 		for (const auto *s: p->children) {
+			if (!work.consume()) {
+				return false;
+			}
 			if (s == elt) {
 				found = true;
 				break;
@@ -388,7 +421,7 @@ static auto match_chain(const std::vector<css_selector::link> &chain,
 			prev = s;
 		}
 
-		return found && prev && try_target(prev) && match_chain(chain, idx + 1, prev, budget);
+		return found && prev && try_target(prev) && match_chain(chain, idx + 1, prev, budget, work);
 	}
 	case css_selector::combinator_type::subsequent_sibling: {
 		const auto *p = elt->parent;
@@ -399,18 +432,26 @@ static auto match_chain(const std::vector<css_selector::link> &chain,
 
 		auto greedy = rest_is_only(css_selector::combinator_type::subsequent_sibling);
 		/* Walk the preceding siblings from the nearest one */
-		auto self = std::find(p->children.begin(), p->children.end(), elt);
+		auto self = p->children.begin();
+		for (; self != p->children.end(); ++self) {
+			if (!work.consume()) {
+				return false;
+			}
+			if (*self == elt) {
+				break;
+			}
+		}
 
 		if (self == p->children.end()) {
 			return false;
 		}
 
-		for (auto it = std::make_reverse_iterator(self); it != p->children.rend() && budget > 0; ++it) {
+		for (auto it = std::make_reverse_iterator(self); it != p->children.rend() && budget > 0 && work.remaining > 0; ++it) {
 			if (try_target(*it)) {
 				if (greedy) {
-					return match_chain(chain, idx + 1, *it, budget);
+					return match_chain(chain, idx + 1, *it, budget, work);
 				}
-				if (match_chain(chain, idx + 1, *it, budget)) {
+				if (match_chain(chain, idx + 1, *it, budget, work)) {
 					return true;
 				}
 			}
@@ -423,15 +464,15 @@ static auto match_chain(const std::vector<css_selector::link> &chain,
 	return false;
 }
 
-auto css_selector::matches(const html::html_tag *tag) const -> bool
+auto css_selector::matches(const html::html_tag *tag, css_match_budget &work) const -> bool
 {
-	if (!tag || !subject.matches(tag)) {
+	if (!tag || !subject.matches(tag, work)) {
 		return false;
 	}
 
 	auto budget = max_match_steps;
 
-	return match_chain(chain, 0, tag, budget);
+	return match_chain(chain, 0, tag, budget, work);
 }
 
 /*
@@ -511,6 +552,85 @@ auto css_selector::debug_str() const -> std::string
 
 TEST_SUITE("css")
 {
+	TEST_CASE("selector work budget includes subjects and attribute scans")
+	{
+		css_match_budget exhausted{2};
+		CHECK(exhausted.consume(2));
+		CHECK_FALSE(exhausted.consume());
+		CHECK(exhausted.remaining == 0);
+
+		html::html_tag tag;
+		tag.id = Tag_SPAN;
+		std::string classes(128, ' ');
+		classes += "x";
+		tag.components.emplace_back(html::html_component_class{classes});
+		css_selector sel{"x", css_selector::selector_type::SELECTOR_CLASS};
+		css_match_budget small{64};
+		CHECK_FALSE(sel.matches(&tag, small));
+		CHECK(small.remaining == 0);
+		css_match_budget enough{512};
+		CHECK(sel.matches(&tag, enough));
+		CHECK(enough.remaining < 512 - classes.size());
+
+		/* The same scan is charged for every part of a compound. */
+		sel.subject.parts.push_back(sel.subject.parts.front());
+		css_match_budget compound{200};
+		CHECK_FALSE(sel.matches(&tag, compound));
+		CHECK(compound.remaining == 0);
+
+		tag.components.clear();
+		tag.components.emplace_back(html::html_component_id{classes});
+		css_selector id{classes};
+		css_match_budget id_budget{64};
+		CHECK_FALSE(id.matches(&tag, id_budget));
+		CHECK(id_budget.remaining == 0);
+	}
+
+	TEST_CASE("sibling searches charge forward traversal to the shared budget")
+	{
+		html::html_tag parent;
+		std::vector<html::html_tag> siblings(32);
+		for (auto &sibling: siblings) {
+			sibling.id = Tag_DIV;
+			sibling.parent = &parent;
+			parent.children.push_back(&sibling);
+		}
+		siblings.back().id = Tag_SPAN;
+		for (auto comb: {css_selector::combinator_type::next_sibling,
+						 css_selector::combinator_type::subsequent_sibling}) {
+			css_selector sel{Tag_SPAN};
+			sel.chain.push_back({comb, {{css_simple_selector{Tag_DIV}}}});
+			css_match_budget small{16};
+			CHECK_FALSE(sel.matches(&siblings.back(), small));
+			CHECK(small.remaining == 0);
+			css_match_budget enough{128};
+			CHECK(sel.matches(&siblings.back(), enough));
+			CHECK(enough.remaining < 128 - siblings.size());
+		}
+	}
+
+	TEST_CASE("compound length is bounded and parsing resumes at the next selector")
+	{
+		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(), "css", 0);
+		std::string compound;
+		for (auto i = 0; i < css_compound_selector::max_parts; i++) {
+			compound += ".x";
+		}
+		auto res = process_selector_tokens(pool, get_selectors_parser_functor(pool, compound));
+		REQUIRE(res.size() == 1);
+		CHECK(res[0]->subject.parts.size() == css_compound_selector::max_parts);
+		compound += ".x";
+		for (const auto &input: {compound, compound + " > span", "div > " + compound}) {
+			res = process_selector_tokens(pool, get_selectors_parser_functor(pool, input));
+			CHECK(res.empty());
+			auto with_valid = input + ", p";
+			res = process_selector_tokens(pool, get_selectors_parser_functor(pool, with_valid));
+			REQUIRE(res.size() == 1);
+			CHECK(res[0]->key().to_tag() == Tag_P);
+		}
+		rspamd_mempool_delete(pool);
+	}
+
 	TEST_CASE("simple css selectors")
 	{
 		using st = css_simple_selector::selector_type;

--- a/src/libserver/css/css_selector.cxx
+++ b/src/libserver/css/css_selector.cxx
@@ -17,162 +17,380 @@
 #include "css_selector.hxx"
 #include "css.hxx"
 #include "libserver/html/html.hxx"
+#include "libserver/html/html_tag.hxx"
 #include "contrib/fmt/include/fmt/base.h"
 #define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 #include "doctest/doctest.h"
 
+#include <algorithm>
+
 namespace rspamd::css {
 
+/*
+ * Parsing
+ *
+ * The token stream is the preamble of a qualified rule: components (with
+ * whitespace preserved, as it is the descendant combinator) and, for the
+ * attribute selectors, nested blocks. We build compounds left to right,
+ * remember the combinator between each pair, and turn the list into a
+ * subject plus a right-to-left chain when the selector ends (comma or eof).
+ *
+ * Anything we cannot evaluate (pseudo classes, attributes, unknown tags,
+ * dangling combinators) poisons the current selector: it is skipped up to
+ * the next comma, as attaching a prefix of it would apply the declarations
+ * to elements the author never targeted.
+ */
 auto process_selector_tokens(rspamd_mempool_t *pool,
 							 blocks_gen_functor &&next_token_functor)
 	-> selectors_vec
 {
 	selectors_vec ret;
-	bool can_continue = true;
-	enum class selector_process_state {
-		selector_parse_start = 0,
-		selector_expect_ident,
-		selector_ident_consumed,
-		selector_ignore_attribute,
-		selector_ignore_function,
-		selector_ignore_combination
-	} state = selector_process_state::selector_parse_start;
-	std::unique_ptr<css_selector> cur_selector;
+	/* Compounds of the selector being parsed, left to right */
+	std::vector<css_compound_selector> compounds;
+	/* combinators[i] sits between compounds[i] and compounds[i + 1] */
+	std::vector<css_selector::combinator_type> combinators;
+	/* Compound being accumulated */
+	css_compound_selector cur;
+	/* Whitespace after the current compound: a descendant combinator unless an explicit one follows */
+	bool ws_pending = false;
+	/* After '.' or '#' we need an ident to complete the part */
+	bool expect_ident = false;
+	auto expect_type = css_simple_selector::selector_type::SELECTOR_CLASS;
+	/* The selector cannot be evaluated: skip up to the next comma */
+	bool broken = false;
 
+	auto reset = [&]() {
+		compounds.clear();
+		combinators.clear();
+		cur.parts.clear();
+		ws_pending = false;
+		expect_ident = false;
+		broken = false;
+	};
 
-	while (can_continue) {
-		const auto &next_tok = next_token_functor();
+	auto add_part = [&](css_simple_selector &&part) {
+		if (ws_pending && !cur.parts.empty()) {
+			/* Whitespace between two compounds */
+			compounds.push_back(std::move(cur));
+			cur.parts.clear();
+			combinators.push_back(css_selector::combinator_type::descendant);
+		}
 
-		if (next_tok.tag == css_consumed_block::parser_tag_type::css_component) {
-			const auto &parser_tok = next_tok.get_token_or_empty();
+		ws_pending = false;
+		cur.parts.push_back(std::move(part));
+	};
 
-			if (state == selector_process_state::selector_parse_start) {
-				/*
-				 * At the beginning of the parsing we can expect either
-				 * delim or an ident, everything else is discarded for now
-				 */
-				msg_debug_css("start consume selector");
+	auto add_combinator = [&](css_selector::combinator_type comb) {
+		if (cur.parts.empty()) {
+			/* Leading or doubled combinator */
+			msg_debug_css("combinator without a preceding compound, drop selector");
+			broken = true;
+			return;
+		}
 
-				switch (parser_tok.type) {
-				case css_parser_token::token_type::delim_token: {
-					auto delim_c = parser_tok.get_delim();
+		compounds.push_back(std::move(cur));
+		cur.parts.clear();
+		combinators.push_back(comb);
+		ws_pending = false;
+	};
 
-					if (delim_c == '.') {
-						cur_selector = std::make_unique<css_selector>(
-							css_selector::selector_type::SELECTOR_CLASS);
-						state = selector_process_state::selector_expect_ident;
-					}
-					else if (delim_c == '#') {
-						cur_selector = std::make_unique<css_selector>(
-							css_selector::selector_type::SELECTOR_ID);
-						state = selector_process_state::selector_expect_ident;
-					}
-					else if (delim_c == '*') {
-						cur_selector = std::make_unique<css_selector>(
-							css_selector::selector_type::SELECTOR_ALL);
-						state = selector_process_state::selector_ident_consumed;
-					}
-					break;
-				}
-				case css_parser_token::token_type::ident_token: {
-					auto tag_id = html::html_tag_by_name(parser_tok.get_string_or_default(""));
+	auto finish = [&]() {
+		if (!broken && !expect_ident && !cur.parts.empty()) {
+			compounds.push_back(std::move(cur));
+			cur.parts.clear();
 
-					if (tag_id) {
-						cur_selector = std::make_unique<css_selector>(tag_id.value());
-					}
-					state = selector_process_state::selector_ident_consumed;
-					break;
-				}
-				case css_parser_token::token_type::hash_token:
-					cur_selector = std::make_unique<css_selector>(
-						css_selector::selector_type::SELECTOR_ID);
-					cur_selector->value =
-						parser_tok.get_string_or_default("");
-					state = selector_process_state::selector_ident_consumed;
-					break;
-				default:
-					msg_debug_css("cannot consume more of a selector, invalid parser token: %s; expected start",
-								  next_tok.token_type_str());
-					can_continue = false;
-					break;
-				}
+			auto sel = std::make_unique<css_selector>();
+			sel->subject = std::move(compounds.back());
+
+			for (auto i = compounds.size() - 1; i > 0; i--) {
+				sel->chain.push_back(css_selector::link{combinators[i - 1],
+														std::move(compounds[i - 1])});
 			}
-			else if (state == selector_process_state::selector_expect_ident) {
-				/*
-				 * We got something like a selector start, so we expect
-				 * a plain ident
-				 */
-				if (parser_tok.type == css_parser_token::token_type::ident_token && cur_selector) {
-					cur_selector->value = parser_tok.get_string_or_default("");
-					state = selector_process_state::selector_ident_consumed;
-				}
-				else {
-					msg_debug_css("cannot consume more of a selector, invalid parser token: %s; expected ident",
-								  next_tok.token_type_str());
-					can_continue = false;
-				}
-			}
-			else if (state == selector_process_state::selector_ident_consumed) {
-				if (parser_tok.type == css_parser_token::token_type::comma_token) {
-					/* Got full selector, attach it to the vector and go further */
-					if (cur_selector) {
-						msg_debug_css("attached selector: %s", cur_selector->debug_str().c_str());
-						ret.push_back(std::move(cur_selector));
-					}
-					state = selector_process_state::selector_parse_start;
-				}
-				else if (parser_tok.type == css_parser_token::token_type::semicolon_token) {
-					/* TODO: implement adjustments */
-					state = selector_process_state::selector_ignore_function;
-					cur_selector.reset();
-				}
-				else if (parser_tok.type == css_parser_token::token_type::osqbrace_token) {
-					/* TODO: implement attributes checks */
-					state = selector_process_state::selector_ignore_attribute;
-					cur_selector.reset();
-				}
-				else {
-					/* TODO: implement selectors combinations */
-					state = selector_process_state::selector_ignore_combination;
-					/*
-					 * What follows narrows the selector down and we cannot
-					 * evaluate it, so the simple selector parsed so far no
-					 * longer describes the rule. Drop it: attaching it would
-					 * apply the declarations to every element of that name
-					 */
-					cur_selector.reset();
-				}
+
+			if (sel->chain.size() <= css_selector::max_chain_length) {
+				msg_debug_css("attached selector: %s", sel->debug_str().c_str());
+				ret.push_back(std::move(sel));
 			}
 			else {
-				/* Ignore state; ignore all till ',' token or eof token */
-				if (parser_tok.type == css_parser_token::token_type::comma_token) {
-					/* The ignored selector ends here, start the next one */
-					state = selector_process_state::selector_parse_start;
-				}
-				else {
-					auto debug_str = parser_tok.get_string_or_default("");
-					msg_debug_css("ignore token %*s", (int) debug_str.size(),
-								  debug_str.data());
-				}
+				msg_debug_css("selector chain is too long: %d links, drop selector",
+							  (int) sel->chain.size());
 			}
 		}
 		else {
-			/* End of parsing */
-			if (state == selector_process_state::selector_ident_consumed && cur_selector) {
-				msg_debug_css("attached selector: %s", cur_selector->debug_str().c_str());
-				ret.push_back(std::move(cur_selector));
+			msg_debug_css("not attached selector: broken=%d, expect_ident=%d, empty=%d",
+						  (int) broken, (int) expect_ident, (int) cur.parts.empty());
+		}
+
+		reset();
+	};
+
+	for (;;) {
+		const auto &next_tok = next_token_functor();
+
+		if (next_tok.tag == css_consumed_block::parser_tag_type::css_eof_block) {
+			finish();
+			break;
+		}
+
+		if (next_tok.tag != css_consumed_block::parser_tag_type::css_component) {
+			/*
+			 * A nested block: an attribute selector `[...]` or a functional
+			 * pseudo class argument; neither is evaluated
+			 */
+			msg_debug_css("cannot evaluate nested block %s in a selector, drop selector",
+						  next_tok.token_type_str());
+			broken = true;
+			continue;
+		}
+
+		const auto &parser_tok = next_tok.get_token_or_empty();
+
+		if (parser_tok.type == css_parser_token::token_type::comma_token) {
+			finish();
+			continue;
+		}
+
+		if (broken) {
+			auto debug_str = parser_tok.get_string_or_default("");
+			msg_debug_css("ignore token %*s", (int) debug_str.size(),
+						  debug_str.data());
+			continue;
+		}
+
+		if (expect_ident) {
+			if (parser_tok.type == css_parser_token::token_type::ident_token) {
+				add_part(css_simple_selector{parser_tok.get_string_or_default(""),
+											 expect_type});
+				expect_ident = false;
 			}
 			else {
-				msg_debug_css("not attached selector, state: %d", static_cast<int>(state));
+				msg_debug_css("invalid parser token: %s; expected ident, drop selector",
+							  next_tok.token_type_str());
+				broken = true;
 			}
-			can_continue = false;
+			continue;
+		}
+
+		switch (parser_tok.type) {
+		case css_parser_token::token_type::whitespace_token:
+			if (!cur.parts.empty()) {
+				ws_pending = true;
+			}
+			break;
+		case css_parser_token::token_type::ident_token: {
+			auto name = parser_tok.get_string_or_default("");
+			auto tag_id = html::html_tag_by_name(name);
+
+			if (tag_id) {
+				add_part(css_simple_selector{tag_id.value()});
+			}
+			else {
+				/* Such an element can never be matched */
+				msg_debug_css("unknown tag %*s in a selector, drop selector",
+							  (int) name.size(), name.data());
+				broken = true;
+			}
+			break;
+		}
+		case css_parser_token::token_type::hash_token:
+			add_part(css_simple_selector{parser_tok.get_string_or_default(""),
+										 css_simple_selector::selector_type::SELECTOR_ID});
+			break;
+		case css_parser_token::token_type::delim_token: {
+			auto delim_c = parser_tok.get_delim();
+
+			switch (delim_c) {
+			case '.':
+				expect_ident = true;
+				expect_type = css_simple_selector::selector_type::SELECTOR_CLASS;
+				break;
+			case '#':
+				expect_ident = true;
+				expect_type = css_simple_selector::selector_type::SELECTOR_ID;
+				break;
+			case '*':
+				add_part(css_simple_selector{css_simple_selector::selector_type::SELECTOR_ALL});
+				break;
+			case '>':
+				add_combinator(css_selector::combinator_type::child);
+				break;
+			case '+':
+				add_combinator(css_selector::combinator_type::next_sibling);
+				break;
+			case '~':
+				add_combinator(css_selector::combinator_type::subsequent_sibling);
+				break;
+			default:
+				msg_debug_css("unexpected delimiter %c in a selector, drop selector", delim_c);
+				broken = true;
+				break;
+			}
+			break;
+		}
+		default:
+			/* Pseudo classes and elements, numbers, strings and so on */
+			msg_debug_css("cannot consume selector token: %s; drop selector",
+						  next_tok.token_type_str());
+			broken = true;
+			break;
 		}
 	}
 
 	return ret; /* copy elision */
 }
 
-auto css_selector::debug_str() const -> std::string
+/*
+ * Matching
+ */
+
+static auto tag_has_class(const html::html_tag *tag, std::string_view cls) -> bool
+{
+	auto class_comp = tag->find_class();
+
+	if (!class_comp) {
+		return false;
+	}
+
+	auto strv = class_comp.value();
+	std::size_t start = 0;
+
+	while (start < strv.size()) {
+		const auto last = strv.find_first_of(" \t\r\n", start);
+		const auto elt = strv.substr(start, last - start);
+
+		if (elt == cls) {
+			return true;
+		}
+
+		if (last == std::string_view::npos) {
+			break;
+		}
+
+		start = last + 1;
+	}
+
+	return false;
+}
+
+auto css_simple_selector::matches(const html::html_tag *tag) const -> bool
+{
+	switch (type) {
+	case selector_type::SELECTOR_ALL:
+		return true;
+	case selector_type::SELECTOR_TAG:
+		return static_cast<tag_id_t>(tag->id) == std::get<tag_id_t>(value);
+	case selector_type::SELECTOR_ID: {
+		auto id_comp = tag->find_id();
+		return id_comp && id_comp.value() == std::get<std::string_view>(value);
+	}
+	case selector_type::SELECTOR_CLASS:
+		return tag_has_class(tag, std::get<std::string_view>(value));
+	}
+
+	return false;
+}
+
+auto css_compound_selector::key() const -> const css_simple_selector &
+{
+	/* Parts are never empty for a parsed selector */
+	return *std::max_element(parts.begin(), parts.end(),
+							 [](const auto &a, const auto &b) {
+								 return a.specificity() < b.specificity();
+							 });
+}
+
+auto css_compound_selector::matches(const html::html_tag *tag) const -> bool
+{
+	return std::all_of(parts.begin(), parts.end(),
+					   [tag](const auto &p) { return p.matches(tag); });
+}
+
+/*
+ * Match the chain from the link `idx` on, starting from `elt` (the element
+ * matched by the previous link or the subject). Descendant and subsequent
+ * sibling combinators backtrack over all candidates, so `a b c` still
+ * matches when the nearest `b` ancestor has no `a` above it but a farther
+ * one has.
+ */
+static auto match_chain(const std::vector<css_selector::link> &chain,
+						std::size_t idx,
+						const html::html_tag *elt) -> bool
+{
+	if (idx == chain.size()) {
+		return true;
+	}
+
+	const auto &lnk = chain[idx];
+
+	switch (lnk.combinator) {
+	case css_selector::combinator_type::child: {
+		const auto *p = elt->parent;
+		return p && lnk.target.matches(p) && match_chain(chain, idx + 1, p);
+	}
+	case css_selector::combinator_type::descendant:
+		for (const auto *p = elt->parent; p != nullptr; p = p->parent) {
+			if (lnk.target.matches(p) && match_chain(chain, idx + 1, p)) {
+				return true;
+			}
+		}
+		return false;
+	case css_selector::combinator_type::next_sibling: {
+		const auto *p = elt->parent;
+
+		if (!p) {
+			return false;
+		}
+
+		const html::html_tag *prev = nullptr;
+		bool found = false;
+
+		for (const auto *s: p->children) {
+			if (s == elt) {
+				found = true;
+				break;
+			}
+			prev = s;
+		}
+
+		return found && prev && lnk.target.matches(prev) && match_chain(chain, idx + 1, prev);
+	}
+	case css_selector::combinator_type::subsequent_sibling: {
+		const auto *p = elt->parent;
+
+		if (!p) {
+			return false;
+		}
+
+		for (const auto *s: p->children) {
+			if (s == elt) {
+				break;
+			}
+			if (lnk.target.matches(s) && match_chain(chain, idx + 1, s)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+	}
+
+	return false;
+}
+
+auto css_selector::matches(const html::html_tag *tag) const -> bool
+{
+	if (!tag || !subject.matches(tag)) {
+		return false;
+	}
+
+	return match_chain(chain, 0, tag);
+}
+
+/*
+ * Debug output
+ */
+
+auto css_simple_selector::debug_str() const -> std::string
 {
 	std::string ret;
 
@@ -203,16 +421,58 @@ auto css_selector::debug_str() const -> std::string
 	return ret;
 }
 
+auto css_compound_selector::debug_str() const -> std::string
+{
+	std::string ret;
+
+	for (const auto &p: parts) {
+		ret += p.debug_str();
+	}
+
+	return ret;
+}
+
+auto css_selector::debug_str() const -> std::string
+{
+	/* Print left to right, as written */
+	std::string ret;
+
+	for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
+		ret += it->target.debug_str();
+
+		switch (it->combinator) {
+		case combinator_type::descendant:
+			ret += " ";
+			break;
+		case combinator_type::child:
+			ret += " > ";
+			break;
+		case combinator_type::next_sibling:
+			ret += " + ";
+			break;
+		case combinator_type::subsequent_sibling:
+			ret += " ~ ";
+			break;
+		}
+	}
+
+	ret += subject.debug_str();
+
+	return ret;
+}
+
 TEST_SUITE("css")
 {
 	TEST_CASE("simple css selectors")
 	{
-		const std::vector<std::pair<const char *, std::vector<css_selector::selector_type>>> cases{
-			{"em", {css_selector::selector_type::SELECTOR_TAG}},
-			{"*", {css_selector::selector_type::SELECTOR_ALL}},
-			{".class", {css_selector::selector_type::SELECTOR_CLASS}},
-			{"#id", {css_selector::selector_type::SELECTOR_ID}},
-			{"em,.class,#id", {css_selector::selector_type::SELECTOR_TAG, css_selector::selector_type::SELECTOR_CLASS, css_selector::selector_type::SELECTOR_ID}},
+		using st = css_simple_selector::selector_type;
+		const std::vector<std::pair<const char *, std::vector<st>>> cases{
+			{"em", {st::SELECTOR_TAG}},
+			{"*", {st::SELECTOR_ALL}},
+			{".class", {st::SELECTOR_CLASS}},
+			{"#id", {st::SELECTOR_ID}},
+			{"em,.class,#id", {st::SELECTOR_TAG, st::SELECTOR_CLASS, st::SELECTOR_ID}},
+			{"em , .class ,#id ", {st::SELECTOR_TAG, st::SELECTOR_CLASS, st::SELECTOR_ID}},
 		};
 
 		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(),
@@ -225,36 +485,114 @@ TEST_SUITE("css")
 			CHECK(c.second.size() == res.size());
 
 			for (auto i = 0; i < c.second.size(); i++) {
-				CHECK(res[i]->type == c.second[i]);
+				CHECK(res[i]->is_simple());
+				CHECK(res[i]->key().type == c.second[i]);
 			}
 		}
 
 		rspamd_mempool_delete(pool);
 	}
 
-	TEST_CASE("a narrowed selector is not registered by its first part")
+	TEST_CASE("compound and complex css selectors")
+	{
+		using st = css_simple_selector::selector_type;
+		using ct = css_selector::combinator_type;
+		struct expected {
+			std::vector<st> subject;
+			std::vector<std::pair<ct, std::vector<st>>> chain; /* right to left */
+			st key;
+		};
+		const std::vector<std::pair<const char *, expected>> cases{
+			{"div.mainbox", {{st::SELECTOR_TAG, st::SELECTOR_CLASS}, {}, st::SELECTOR_CLASS}},
+			{"*.spacer#top", {{st::SELECTOR_ALL, st::SELECTOR_CLASS, st::SELECTOR_ID}, {}, st::SELECTOR_ID}},
+			{".a.b", {{st::SELECTOR_CLASS, st::SELECTOR_CLASS}, {}, st::SELECTOR_CLASS}},
+			{"div p", {{st::SELECTOR_TAG}, {{ct::descendant, {st::SELECTOR_TAG}}}, st::SELECTOR_TAG}},
+			{".a .b", {{st::SELECTOR_CLASS}, {{ct::descendant, {st::SELECTOR_CLASS}}}, st::SELECTOR_CLASS}},
+			{"div > p", {{st::SELECTOR_TAG}, {{ct::child, {st::SELECTOR_TAG}}}, st::SELECTOR_TAG}},
+			{"div>p", {{st::SELECTOR_TAG}, {{ct::child, {st::SELECTOR_TAG}}}, st::SELECTOR_TAG}},
+			{"h1 + p", {{st::SELECTOR_TAG}, {{ct::next_sibling, {st::SELECTOR_TAG}}}, st::SELECTOR_TAG}},
+			{"h1 ~ p", {{st::SELECTOR_TAG}, {{ct::subsequent_sibling, {st::SELECTOR_TAG}}}, st::SELECTOR_TAG}},
+			{"div.mainbox ul li.spacer",
+			 {{st::SELECTOR_TAG, st::SELECTOR_CLASS},
+			  {{ct::descendant, {st::SELECTOR_TAG}}, {ct::descendant, {st::SELECTOR_TAG, st::SELECTOR_CLASS}}},
+			  st::SELECTOR_CLASS}},
+			{"#top > div span",
+			 {{st::SELECTOR_TAG},
+			  {{ct::descendant, {st::SELECTOR_TAG}}, {ct::child, {st::SELECTOR_ID}}},
+			  st::SELECTOR_TAG}},
+			{"div * ", {{st::SELECTOR_ALL}, {{ct::descendant, {st::SELECTOR_TAG}}}, st::SELECTOR_ALL}},
+		};
+
+		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(),
+										"css", 0);
+
+		for (const auto &c: cases) {
+			auto res = process_selector_tokens(pool,
+											   get_selectors_parser_functor(pool, c.first));
+
+			REQUIRE_MESSAGE(res.size() == 1, c.first);
+			const auto &sel = *res[0];
+			const auto &exp = c.second;
+
+			REQUIRE_MESSAGE(sel.subject.parts.size() == exp.subject.size(), c.first);
+			for (auto i = 0; i < exp.subject.size(); i++) {
+				CHECK_MESSAGE(sel.subject.parts[i].type == exp.subject[i], c.first);
+			}
+
+			REQUIRE_MESSAGE(sel.chain.size() == exp.chain.size(), c.first);
+			for (auto i = 0; i < exp.chain.size(); i++) {
+				CHECK_MESSAGE(sel.chain[i].combinator == exp.chain[i].first, c.first);
+				REQUIRE_MESSAGE(sel.chain[i].target.parts.size() == exp.chain[i].second.size(), c.first);
+				for (auto j = 0; j < exp.chain[i].second.size(); j++) {
+					CHECK_MESSAGE(sel.chain[i].target.parts[j].type == exp.chain[i].second[j], c.first);
+				}
+			}
+
+			CHECK_MESSAGE(sel.key().type == exp.key, c.first);
+		}
+
+		rspamd_mempool_delete(pool);
+	}
+
+	TEST_CASE("selectors that cannot be evaluated are dropped whole")
 	{
 		/*
-		 * Compounds and combinators are not evaluated. A selector that uses
-		 * them must be dropped whole: keeping its first simple selector would
-		 * apply the declarations to every element of that name.
-		 * Attribute selectors are not covered: the tokeniser folds them into
-		 * a block, so `a[href]` still reaches us as a bare `a`
+		 * A selector we cannot evaluate must be dropped as a whole: keeping
+		 * a prefix of it would apply the declarations to every element that
+		 * prefix names. Other members of the list are kept
 		 */
 		const std::vector<std::pair<const char *, std::size_t>> cases{
-			/* Nothing of these can be evaluated */
-			{"div.mainbox ul li.spacer", 0},
-			{"div.mainbox ul li.spacer, div.mainbox ol li.spacer", 0},
-			{"p.intro span.note, td.cell span.note", 0},
-			{"div.a, div.b", 0},
-			{"div > p, div > span", 0},
-			/* Plain selector lists keep working */
-			{"p, span", 2},
+			/* Pseudo classes and elements */
+			{"a:hover", 0},
+			{"p::first-line", 0},
+			{"a:not(.x)", 0},
+			{"a:hover, p", 1},
+			{"p, a:hover", 1},
+			{"a:not(.x), p", 1},
+			/* Attribute selectors are tokenised as a nested block */
+			{"a[href]", 0},
+			{"a[href], p", 1},
+			{"p, a[href]", 1},
+			{"td[class=\"x\"] p", 0},
+			/* Unknown element names never match */
+			{"blink", 0},
+			{"blink, p", 1},
+			{"div blink", 0},
+			/* Dangling and doubled combinators */
+			{"> p", 0},
+			{"div >", 0},
+			{"div > > p", 0},
+			{"div + , p", 1},
+			{"div .", 0},
+			{".class.", 0},
+			/* Mixed lists */
+			{"div.mainbox li.spacer, p", 2},
+			{"p, div.mainbox li.spacer", 2},
+			{"div.mainbox ul li.spacer, div.mainbox ol li.spacer", 2},
 			{"em,.class,#id", 3},
 			{"*", 1},
-			/* A list that mixes both keeps only what it can evaluate */
-			{"div.mainbox li.spacer, p", 1},
-			{"p, div.mainbox li.spacer", 1},
+			{"", 0},
+			{" , ", 0},
 		};
 
 		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(),
@@ -265,6 +603,34 @@ TEST_SUITE("css")
 											   get_selectors_parser_functor(pool, c.first));
 			CHECK_MESSAGE(res.size() == c.second, c.first);
 		}
+
+		rspamd_mempool_delete(pool);
+	}
+
+	TEST_CASE("selector chain length is bounded")
+	{
+		std::string too_long = "p";
+
+		for (auto i = 0; i < css_selector::max_chain_length + 1; i++) {
+			too_long += " > p";
+		}
+
+		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(),
+										"css", 0);
+		auto res = process_selector_tokens(pool,
+										   get_selectors_parser_functor(pool, too_long));
+		CHECK(res.empty());
+
+		std::string just_fits = "p";
+
+		for (auto i = 0; i < css_selector::max_chain_length; i++) {
+			just_fits += " > p";
+		}
+
+		res = process_selector_tokens(pool,
+									  get_selectors_parser_functor(pool, just_fits));
+		REQUIRE(res.size() == 1);
+		CHECK(res[0]->chain.size() == css_selector::max_chain_length);
 
 		rspamd_mempool_delete(pool);
 	}

--- a/src/libserver/css/css_selector.cxx
+++ b/src/libserver/css/css_selector.cxx
@@ -113,30 +113,40 @@ auto process_selector_tokens(rspamd_mempool_t *pool,
 				}
 			}
 			else if (state == selector_process_state::selector_ident_consumed) {
-				if (parser_tok.type == css_parser_token::token_type::comma_token && cur_selector) {
+				if (parser_tok.type == css_parser_token::token_type::comma_token) {
 					/* Got full selector, attach it to the vector and go further */
-					msg_debug_css("attached selector: %s", cur_selector->debug_str().c_str());
-					ret.push_back(std::move(cur_selector));
+					if (cur_selector) {
+						msg_debug_css("attached selector: %s", cur_selector->debug_str().c_str());
+						ret.push_back(std::move(cur_selector));
+					}
 					state = selector_process_state::selector_parse_start;
 				}
 				else if (parser_tok.type == css_parser_token::token_type::semicolon_token) {
 					/* TODO: implement adjustments */
 					state = selector_process_state::selector_ignore_function;
+					cur_selector.reset();
 				}
 				else if (parser_tok.type == css_parser_token::token_type::osqbrace_token) {
 					/* TODO: implement attributes checks */
 					state = selector_process_state::selector_ignore_attribute;
+					cur_selector.reset();
 				}
 				else {
 					/* TODO: implement selectors combinations */
 					state = selector_process_state::selector_ignore_combination;
+					/*
+					 * What follows narrows the selector down and we cannot
+					 * evaluate it, so the simple selector parsed so far no
+					 * longer describes the rule. Drop it: attaching it would
+					 * apply the declarations to every element of that name
+					 */
+					cur_selector.reset();
 				}
 			}
 			else {
 				/* Ignore state; ignore all till ',' token or eof token */
-				if (parser_tok.type == css_parser_token::token_type::comma_token && cur_selector) {
-					/* Got full selector, attach it to the vector and go further */
-					ret.push_back(std::move(cur_selector));
+				if (parser_tok.type == css_parser_token::token_type::comma_token) {
+					/* The ignored selector ends here, start the next one */
 					state = selector_process_state::selector_parse_start;
 				}
 				else {
@@ -217,6 +227,43 @@ TEST_SUITE("css")
 			for (auto i = 0; i < c.second.size(); i++) {
 				CHECK(res[i]->type == c.second[i]);
 			}
+		}
+
+		rspamd_mempool_delete(pool);
+	}
+
+	TEST_CASE("a narrowed selector is not registered by its first part")
+	{
+		/*
+		 * Compounds and combinators are not evaluated. A selector that uses
+		 * them must be dropped whole: keeping its first simple selector would
+		 * apply the declarations to every element of that name.
+		 * Attribute selectors are not covered: the tokeniser folds them into
+		 * a block, so `a[href]` still reaches us as a bare `a`
+		 */
+		const std::vector<std::pair<const char *, std::size_t>> cases{
+			/* Nothing of these can be evaluated */
+			{"div.mainbox ul li.spacer", 0},
+			{"div.mainbox ul li.spacer, div.mainbox ol li.spacer", 0},
+			{"p.intro span.note, td.cell span.note", 0},
+			{"div.a, div.b", 0},
+			{"div > p, div > span", 0},
+			/* Plain selector lists keep working */
+			{"p, span", 2},
+			{"em,.class,#id", 3},
+			{"*", 1},
+			/* A list that mixes both keeps only what it can evaluate */
+			{"div.mainbox li.spacer, p", 1},
+			{"p, div.mainbox li.spacer", 1},
+		};
+
+		auto *pool = rspamd_mempool_new(rspamd_mempool_suggest_size(),
+										"css", 0);
+
+		for (const auto &c: cases) {
+			auto res = process_selector_tokens(pool,
+											   get_selectors_parser_functor(pool, c.first));
+			CHECK_MESSAGE(res.size() == c.second, c.first);
 		}
 
 		rspamd_mempool_delete(pool);

--- a/src/libserver/css/css_selector.hxx
+++ b/src/libserver/css/css_selector.hxx
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2021 Vsevolod Stakhov
+ * Copyright 2025 Vsevolod Stakhov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 #include <optional>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 #include "function2/function2.hpp"
 #include "parse_error.hxx"
@@ -31,13 +32,17 @@
 #include "libserver/html/html_tags.h"
 #include "libcryptobox/cryptobox.h"
 
+namespace rspamd::html {
+struct html_tag;
+}
+
 namespace rspamd::css {
 
 /*
- * Holds a value for css selector, internal is handled by variant
+ * A simple selector: a single tag name, class, id or the universal selector
  */
-struct css_selector {
-	enum class selector_type {
+struct css_simple_selector {
+	enum class selector_type : std::uint8_t {
 		SELECTOR_TAG,   /* e.g. tr, for this value we use tag_id_t */
 		SELECTOR_CLASS, /* generic class, e.g. .class */
 		SELECTOR_ID,    /* e.g. #id */
@@ -47,20 +52,23 @@ struct css_selector {
 	selector_type type;
 	std::variant<tag_id_t, std::string_view> value;
 
-	/* Conditions for the css selector */
-	/* Dependency on attributes */
-	struct css_attribute_condition {
-		std::string_view attribute;
-		std::string_view op = "";
-		std::string_view value = "";
-	};
+	explicit css_simple_selector(selector_type t)
+		: type(t)
+	{
+	}
+	explicit css_simple_selector(tag_id_t t)
+		: type(selector_type::SELECTOR_TAG)
+	{
+		value = t;
+	}
+	explicit css_simple_selector(const std::string_view &st,
+								 selector_type t = selector_type::SELECTOR_ID)
+		: type(t)
+	{
+		value = st;
+	}
 
-	/* General dependency chain */
-	using css_selector_ptr = std::unique_ptr<css_selector>;
-	using css_selector_dep = std::variant<css_attribute_condition, css_selector_ptr>;
-	std::vector<css_selector_dep> dependencies;
-
-	auto to_tag(void) const -> std::optional<tag_id_t>
+	auto to_tag() const -> std::optional<tag_id_t>
 	{
 		if (type == selector_type::SELECTOR_TAG) {
 			return std::get<tag_id_t>(value);
@@ -68,35 +76,163 @@ struct css_selector {
 		return std::nullopt;
 	}
 
-	auto to_string(void) const -> std::optional<const std::string_view>
+	auto to_string() const -> std::optional<const std::string_view>
 	{
 		if (type != selector_type::SELECTOR_TAG) {
 			return std::string_view(std::get<std::string_view>(value));
 		}
 		return std::nullopt;
-	};
-
-	explicit css_selector(selector_type t)
-		: type(t)
-	{
-	}
-	explicit css_selector(tag_id_t t)
-		: type(selector_type::SELECTOR_TAG)
-	{
-		value = t;
-	}
-	explicit css_selector(const std::string_view &st, selector_type t = selector_type::SELECTOR_ID)
-		: type(t)
-	{
-		value = st;
 	}
 
-	auto operator==(const css_selector &other) const -> bool
+	/*
+	 * Specificity weight of a single simple selector, following the CSS
+	 * (id, class, type) triple flattened to one number
+	 */
+	auto specificity() const -> unsigned
+	{
+		switch (type) {
+		case selector_type::SELECTOR_ID:
+			return 100;
+		case selector_type::SELECTOR_CLASS:
+			return 10;
+		case selector_type::SELECTOR_TAG:
+			return 1;
+		case selector_type::SELECTOR_ALL:
+			break;
+		}
+		return 0;
+	}
+
+	auto operator==(const css_simple_selector &other) const -> bool
 	{
 		return type == other.type && value == other.value;
 	}
 
-	auto debug_str(void) const -> std::string;
+	/* Check whether this simple selector matches the element itself */
+	auto matches(const rspamd::html::html_tag *tag) const -> bool;
+
+	auto debug_str() const -> std::string;
+};
+
+/*
+ * A compound selector: simple selectors that must all match the same
+ * element, e.g. `div.mainbox` or `*.spacer#top`
+ */
+struct css_compound_selector {
+	std::vector<css_simple_selector> parts;
+
+	auto specificity() const -> unsigned
+	{
+		unsigned ret = 0;
+
+		for (const auto &p: parts) {
+			ret += p.specificity();
+		}
+
+		return ret;
+	}
+
+	/*
+	 * The most specific part; a style sheet indexes the selector by this
+	 * part and evaluates the rest on lookup
+	 */
+	auto key() const -> const css_simple_selector &;
+
+	auto operator==(const css_compound_selector &other) const -> bool
+	{
+		return parts == other.parts;
+	}
+
+	auto matches(const rspamd::html::html_tag *tag) const -> bool;
+	auto debug_str() const -> std::string;
+};
+
+/*
+ * A complex selector: the subject compound (the element the declarations
+ * apply to) plus the chain of compounds that must match its ancestors or
+ * preceding siblings.
+ *
+ * The chain is stored right to left, so `a > b c` has subject `c` and
+ * chain [{descendant, b}, {child, a}]: each link relates the compound of
+ * the previous link (or the subject for the first one) to its target.
+ */
+struct css_selector {
+	using selector_type = css_simple_selector::selector_type;
+
+	enum class combinator_type : std::uint8_t {
+		descendant,         /* a b */
+		child,              /* a > b */
+		next_sibling,       /* a + b */
+		subsequent_sibling, /* a ~ b */
+	};
+
+	struct link {
+		combinator_type combinator;
+		css_compound_selector target;
+
+		auto operator==(const link &other) const -> bool
+		{
+			return combinator == other.combinator && target == other.target;
+		}
+	};
+
+	/*
+	 * Longer chains are dropped when parsing: matching recurses over the
+	 * chain and nothing sane needs more levels than this
+	 */
+	static constexpr std::size_t max_chain_length = 16;
+
+	css_compound_selector subject;
+	std::vector<link> chain;
+
+	css_selector() = default;
+	explicit css_selector(css_simple_selector &&simple)
+	{
+		subject.parts.push_back(std::move(simple));
+	}
+	explicit css_selector(selector_type t)
+		: css_selector(css_simple_selector{t})
+	{
+	}
+	explicit css_selector(tag_id_t t)
+		: css_selector(css_simple_selector{t})
+	{
+	}
+	explicit css_selector(const std::string_view &st, selector_type t = selector_type::SELECTOR_ID)
+		: css_selector(css_simple_selector{st, t})
+	{
+	}
+
+	auto is_simple() const -> bool
+	{
+		return chain.empty() && subject.parts.size() == 1;
+	}
+
+	auto key() const -> const css_simple_selector &
+	{
+		return subject.key();
+	}
+
+	auto specificity() const -> unsigned
+	{
+		auto ret = subject.specificity();
+
+		for (const auto &l: chain) {
+			ret += l.target.specificity();
+		}
+
+		return ret;
+	}
+
+	auto operator==(const css_selector &other) const -> bool
+	{
+		return subject == other.subject && chain == other.chain;
+	}
+
+	/* Check whether the selector matches the element (walks the tag tree) */
+	auto matches(const rspamd::html::html_tag *tag) const -> bool;
+
+	auto debug_str() const -> std::string;
 };
 
 
@@ -114,12 +250,12 @@ auto process_selector_tokens(rspamd_mempool_t *pool,
 /* Selectors hashing */
 namespace std {
 template<>
-class hash<rspamd::css::css_selector> {
+class hash<rspamd::css::css_simple_selector> {
 public:
 	using is_avalanching = void;
-	auto operator()(const rspamd::css::css_selector &sel) const -> std::size_t
+	auto operator()(const rspamd::css::css_simple_selector &sel) const -> std::size_t
 	{
-		if (sel.type == rspamd::css::css_selector::selector_type::SELECTOR_TAG) {
+		if (sel.type == rspamd::css::css_simple_selector::selector_type::SELECTOR_TAG) {
 			return static_cast<std::size_t>(std::get<tag_id_t>(sel.value));
 		}
 		else {

--- a/src/libserver/css/css_selector.hxx
+++ b/src/libserver/css/css_selector.hxx
@@ -39,6 +39,26 @@ struct html_tag;
 namespace rspamd::css {
 
 /*
+ * Shared by every selector and element of an HTML document. Work counts
+ * selector/DOM steps and bytes scanned in attributes; exhaustion disables
+ * further stylesheet matching, not HTML parsing or inline styles.
+ */
+struct css_match_budget {
+	static constexpr std::size_t max_work = 4 * 1024 * 1024;
+	std::size_t remaining = max_work;
+
+	auto consume(std::size_t work = 1) -> bool
+	{
+		if (work > remaining) {
+			remaining = 0;
+			return false;
+		}
+		remaining -= work;
+		return true;
+	}
+};
+
+/*
  * A simple selector: a single tag name, class, id or the universal selector
  */
 struct css_simple_selector {
@@ -109,7 +129,7 @@ struct css_simple_selector {
 	}
 
 	/* Check whether this simple selector matches the element itself */
-	auto matches(const rspamd::html::html_tag *tag) const -> bool;
+	auto matches(const rspamd::html::html_tag *tag, css_match_budget &budget) const -> bool;
 
 	auto debug_str() const -> std::string;
 };
@@ -119,6 +139,7 @@ struct css_simple_selector {
  * element, e.g. `div.mainbox` or `*.spacer#top`
  */
 struct css_compound_selector {
+	static constexpr std::size_t max_parts = 64;
 	std::vector<css_simple_selector> parts;
 
 	auto specificity() const -> unsigned
@@ -143,7 +164,7 @@ struct css_compound_selector {
 		return parts == other.parts;
 	}
 
-	auto matches(const rspamd::html::html_tag *tag) const -> bool;
+	auto matches(const rspamd::html::html_tag *tag, css_match_budget &budget) const -> bool;
 	auto debug_str() const -> std::string;
 };
 
@@ -237,7 +258,7 @@ struct css_selector {
 	}
 
 	/* Check whether the selector matches the element (walks the tag tree) */
-	auto matches(const rspamd::html::html_tag *tag) const -> bool;
+	auto matches(const rspamd::html::html_tag *tag, css_match_budget &budget) const -> bool;
 
 	auto debug_str() const -> std::string;
 };

--- a/src/libserver/css/css_selector.hxx
+++ b/src/libserver/css/css_selector.hxx
@@ -181,6 +181,13 @@ struct css_selector {
 	 * chain and nothing sane needs more levels than this
 	 */
 	static constexpr std::size_t max_chain_length = 16;
+	/*
+	 * Descendant and subsequent sibling links backtrack over their
+	 * candidates, so a chain of them can revisit the same elements many
+	 * times. The number of compound evaluations per match is bounded and
+	 * a match that exhausts the budget fails
+	 */
+	static constexpr unsigned max_match_steps = 1024;
 
 	css_compound_selector subject;
 	std::vector<link> chain;

--- a/test/functional/cases/001_merged/100_general.robot
+++ b/test/functional/cases/001_merged/100_general.robot
@@ -98,6 +98,7 @@ HTML VISIBILITY - No significant hidden content
   visible
   font_shorthand
   relative_font
+  grouped_selector
 
 HTML ONLY - TRUE POSITIVE
   Scan File  ${RSPAMD_TESTDIR}/messages/zerofont.eml

--- a/test/functional/messages/html_hidden_grouped_selector.eml
+++ b/test/functional/messages/html_hidden_grouped_selector.eml
@@ -1,0 +1,8 @@
+From: sender@example.com
+To: recipient@example.net
+Subject: Hidden content amount
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 8bit
+
+<html><head><style>div.mainbox ul li.spacer, div.mainbox ol li.spacer { font-size: 0; color: transparent; opacity: 0 }</style></head><body><div class="mainbox"><p>Visible text.</p><div>Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. Visible content. </div></div></body></html>

--- a/test/lua/unit/html.lua
+++ b/test/lua/unit/html.lua
@@ -231,7 +231,7 @@ context("HTML processing", function()
 
   -- A grouped selector list used to be truncated to the first simple selector
   -- of its first part, so a rule meant for a spacer blanked every such element
-  test("A grouped selector that cannot be evaluated is not applied", function()
+  test("A grouped descendant selector is not applied by its first part", function()
     local html = parse_html_message(
         '<html><head><style>div.mainbox ul li.spacer, div.mainbox ol li.spacer ' ..
         '{ font-size: 0; color: transparent; opacity: 0 }</style></head>' ..
@@ -245,6 +245,82 @@ context("HTML processing", function()
         '<body><div class="spacer">gone</div></body></html>')
     assert_not_nil(hidden, 'html part not parsed')
     assert_equal('gone', tostring(hidden:get_invisible()))
+  end)
+
+  local function invisible_of(css, body)
+    local html = parse_html_message(
+        '<html><head><style>' .. css .. '</style></head><body>' .. body .. '</body></html>')
+    if not html then
+      return nil
+    end
+    return tostring(html:get_invisible())
+  end
+
+  test("Compound selectors match all parts on the same element", function()
+    local css = 'p.x { display: none }'
+    assert_equal('gone', invisible_of(css,
+        '<p class="x">gone</p><p class="y">kept</p><div class="x">kept</div>'))
+    assert_equal('gone', invisible_of('.a.b { display: none }',
+        '<p class="b a">gone</p><p class="a">kept</p><p class="b">kept</p>'))
+    assert_equal('gone', invisible_of('div#top.x { display: none }',
+        '<div id="top" class="x">gone</div><div id="top">kept</div><div class="x">kept</div>'))
+  end)
+
+  test("Descendant combinator matches any ancestor", function()
+    local css = 'div.mainbox li.spacer { font-size: 0 }'
+    assert_equal('gone', invisible_of(css,
+        '<div class="mainbox"><ul><li class="spacer">gone</li><li>kept</li></ul></div>' ..
+        '<div class="other"><ul><li class="spacer">kept</li></ul></div>' ..
+        '<ul><li class="spacer">kept</li></ul>'))
+    -- The nearest matching ancestor is not the only candidate
+    assert_equal('gone', invisible_of('.a .b .c { display: none }',
+        '<div class="a"><div class="b"><div class="b"><span class="c">gone</span></div></div></div>' ..
+        '<div class="b"><div class="a"><span class="c">kept</span></div></div>'))
+  end)
+
+  test("Child combinator matches the parent only", function()
+    local css = 'div > p { display: none }'
+    assert_equal('gone', invisible_of(css,
+        '<div><p>gone</p><span><p>kept</p></span></div><p>kept</p>'))
+  end)
+
+  test("Sibling combinators match preceding siblings", function()
+    assert_equal('gone', invisible_of('h1 + p { display: none }',
+        '<div><h1>title</h1><p>gone</p><p>kept</p></div><div><p>kept</p><h1>title</h1></div>'))
+    assert_equal('gonegone', invisible_of('h1 ~ p { display: none }',
+        '<div><p>kept</p><h1>title</h1><p>gone</p><span>x</span><p>gone</p></div>' ..
+        '<div><p>kept</p></div>'))
+  end)
+
+  test("Grouped complex selectors are applied to every member", function()
+    local css = 'div.mainbox ul li.spacer, div.mainbox ol li.spacer { font-size: 0 }'
+    assert_equal('gonegone', invisible_of(css,
+        '<div class="mainbox"><ul><li class="spacer">gone</li></ul>' ..
+        '<ol><li class="spacer">gone</li></ol><p>Visible content.</p></div>'))
+  end)
+
+  test("Selectors that cannot be evaluated do not hide anything", function()
+    assert_equal('', invisible_of('a:hover { display: none }', '<a href="http://example.com/">kept</a>'))
+    assert_equal('', invisible_of('a[href] { display: none }', '<a href="http://example.com/">kept</a>'))
+    -- But the members of the list that can be evaluated still apply
+    assert_equal('gone', invisible_of('a:hover, p.x { display: none }',
+        '<a href="http://example.com/">kept</a><p class="x">gone</p>'))
+  end)
+
+  test("A more specific selector wins regardless of the order", function()
+    assert_equal('gone', invisible_of(
+        'div.mainbox .spacer { font-size: 0 } .spacer { font-size: 14px }',
+        '<div class="mainbox"><span class="spacer">gone</span></div><span class="spacer">kept</span>'))
+    assert_equal('gone', invisible_of(
+        '.spacer { font-size: 14px } div.mainbox .spacer { font-size: 0 }',
+        '<div class="mainbox"><span class="spacer">gone</span></div><span class="spacer">kept</span>'))
+    -- At equal specificity the later rule wins
+    assert_equal('gone', invisible_of(
+        '.a { font-size: 14px } .b { font-size: 0 }',
+        '<span class="a b">gone</span>'))
+    assert_equal('', invisible_of(
+        '.b { font-size: 0 } .a { font-size: 14px }',
+        '<span class="a b">kept</span>'))
   end)
 
   test("HTML tag get_all_attributes basic test", function()

--- a/test/lua/unit/html.lua
+++ b/test/lua/unit/html.lua
@@ -345,10 +345,34 @@ context("HTML processing", function()
     local chain = string.rep('.a ', 16) .. '.b'
     assert_equal('text', invisible_of(chain .. ' { display: none }', nested))
     -- A mismatch at the far end of the chain fails fast as well
-    assert_equal('', invisible_of('.z ' .. chain .. ' { display: none }', nested))
+    assert_equal('', invisible_of('.z ' .. string.rep('.a ', 15) .. '.b { display: none }', nested))
     -- Alternating child/descendant links need backtracking; the budget bounds it
     local mixed = '#nope > ' .. string.rep('.a > .a ', 7) .. '.a .b'
     assert_equal('', invisible_of(mixed .. ' { display: none }', nested))
+  end)
+
+  test("Repeated class names do not multiply the cascade", function()
+    local css = string.rep('.x { font-size: 0 }', 512)
+    assert_equal('gone', invisible_of(css,
+        '<span class="' .. string.rep('x ', 1024) .. '">gone</span>'))
+    assert_equal('gone', invisible_of(css, '<span class="x">gone</span>'))
+  end)
+
+  test("Oversized compounds are dropped whole", function()
+    local compound = string.rep('.x', 65)
+    assert_equal('', invisible_of(compound .. ' { display: none }',
+        '<span class="x">kept</span>'))
+    assert_equal('gone', invisible_of(compound .. ', .y { display: none }',
+        '<span class="x">kept</span><span class="y">gone</span>'))
+  end)
+
+  test("Matching work is bounded across rules and elements", function()
+    local rule = '#missing > ' .. string.rep('div ', 8) .. 'span { color: red }'
+    local body = string.rep('<div>', 28) .. string.rep('<span>kept</span>', 256) ..
+        string.rep('</div>', 28) .. '<p class="end">tail</p>'
+    -- Once exhausted, later elements must not receive stylesheet declarations.
+    assert_equal('', invisible_of(string.rep(rule, 128) .. '.end { display: none }', body))
+    assert_equal('tail', invisible_of(rule .. '.end { display: none }', body))
   end)
 
   test("HTML tag get_all_attributes basic test", function()

--- a/test/lua/unit/html.lua
+++ b/test/lua/unit/html.lua
@@ -321,6 +321,34 @@ context("HTML processing", function()
     assert_equal('', invisible_of(
         '.b { font-size: 0 } .a { font-size: 14px }',
         '<span class="a b">kept</span>'))
+    -- A less specific display:none does not leak through a more specific display:block
+    assert_equal('', invisible_of(
+        'p { display: none } .show { display: block }',
+        '<p class="show">kept</p>'))
+  end)
+
+  -- A repeated selector is a new rule in the cascade: only the declarations
+  -- of the later rule move past the rules written in between
+  test("A repeated selector does not carry its earlier declarations forward", function()
+    assert_equal('', invisible_of(
+        '.a { font-size: 0 } .b { font-size: 14px } .a { color: red }',
+        '<span class="b a">kept</span>'))
+    assert_equal('gone', invisible_of(
+        '.a { color: red } .b { font-size: 14px } .a { font-size: 0 }',
+        '<span class="b a">gone</span>'))
+  end)
+
+  test("Deep nesting with long chains is matched in bounded time", function()
+    local nested = string.rep('<div class="a">', 28) .. '<span class="b">text</span>' ..
+        string.rep('</div>', 28)
+    -- Descendant-only chains are matched greedily, no backtracking
+    local chain = string.rep('.a ', 16) .. '.b'
+    assert_equal('text', invisible_of(chain .. ' { display: none }', nested))
+    -- A mismatch at the far end of the chain fails fast as well
+    assert_equal('', invisible_of('.z ' .. chain .. ' { display: none }', nested))
+    -- Alternating child/descendant links need backtracking; the budget bounds it
+    local mixed = '#nope > ' .. string.rep('.a > .a ', 7) .. '.a .b'
+    assert_equal('', invisible_of(mixed .. ' { display: none }', nested))
   end)
 
   test("HTML tag get_all_attributes basic test", function()

--- a/test/lua/unit/html.lua
+++ b/test/lua/unit/html.lua
@@ -229,6 +229,24 @@ context("HTML processing", function()
     assert_equal(checked, 3)
   end)
 
+  -- A grouped selector list used to be truncated to the first simple selector
+  -- of its first part, so a rule meant for a spacer blanked every such element
+  test("A grouped selector that cannot be evaluated is not applied", function()
+    local html = parse_html_message(
+        '<html><head><style>div.mainbox ul li.spacer, div.mainbox ol li.spacer ' ..
+        '{ font-size: 0; color: transparent; opacity: 0 }</style></head>' ..
+        '<body><div class="mainbox"><div>kept visible</div></div></body></html>')
+    assert_not_nil(html, 'html part not parsed')
+    assert_equal('', tostring(html:get_invisible()))
+
+    -- The same declarations on a selector we can evaluate still hide
+    local hidden = parse_html_message(
+        '<html><head><style>.spacer { font-size: 0 }</style></head>' ..
+        '<body><div class="spacer">gone</div></body></html>')
+    assert_not_nil(hidden, 'html part not parsed')
+    assert_equal('gone', tostring(hidden:get_invisible()))
+  end)
+
   test("HTML tag get_all_attributes basic test", function()
     local rspamd_mempool = require("rspamd_mempool")
     local pool = rspamd_mempool.create()


### PR DESCRIPTION
Builds on #6250 (its commit is included here until it lands; only the last commit is new).

## Problem

The selectors parser reduced every selector to one simple selector. A compound (`div.mainbox`) or anything with a combinator (`div p`, `div > p`, `h1 + p`, `h1 ~ p`) was ignored, and before #6250 a grouped list of those was applied by its first part. Mail templates hide spacers, preheaders and mobile-only blocks with exactly these rules, so hidden text detection could not see them.

## What changes

**Selector model** (`css_selector.hxx`): a selector is now a subject compound plus a right-to-left chain of `{combinator, compound}` links. `a > b c` is subject `c`, chain `[{descendant, b}, {child, a}]`. Simple selectors keep their type/value and gain `matches(tag)`.

**Parser** (`css_selector.cxx`): builds compounds left to right and remembers the combinator between them. A selector that cannot be evaluated (pseudo class or element, attribute selector, unknown element, dangling or doubled combinator) is dropped whole up to the next comma, so the other members of the list still apply. Chains longer than 16 links are dropped since matching recurses over the chain.

**Prelude whitespace** (`css_parser.cxx`): the qualified rule prelude keeps its whitespace tokens, since `div .x` and `div.x` were indistinguishable once it was thrown away. The declarations block is taken as the last nested block, so an attribute selector like `a[href]` reaches the selectors parser instead of being mistaken for the declarations.

**Style sheet** (`css.cxx`): each selector is indexed by the most specific part of its subject (id > class > tag > `*`) and the rest is evaluated against the tag tree on lookup, walking `parent` for descendant/child and the parent's `children` for the sibling combinators, with backtracking for the `descendant` and `~` cases. Rules matching a tag are applied by specificity, source order breaking ties, in place of the fixed id, class, tag, universal order.

## Behaviour

```css
div.mainbox ul li.spacer, div.mainbox ol li.spacer { font-size: 0 }
```

now hides the `li.spacer` under a `div.mainbox` list and nothing else. `div.mainbox .spacer { font-size: 0 } .spacer { font-size: 14px }` hides the spacer inside the mainbox regardless of the order of the two rules.

Still dropped (never applied): `a:hover`, `p::first-line`, `a:not(.x)`, `a[href]`, unknown element names.

## Tests

* `css` doctest suite: structural cases for compounds and every combinator, the drop list, chain length bound
* `test/lua/unit/html.lua`: end-to-end hiding through the HTML parser for compound, descendant (including the backtracking case), child, `+`, `~`, grouped lists, unevaluable selectors, and the specificity cascade
* Local run: full `rspamd-test-cxx`, Lua unit suite, and the `HTML*` cases of `100_general` all pass


## Bounds and cascade (second commit)

* **Matching is linear for the common shapes and bounded otherwise.** When the rest of a chain is descendant-only (or `~`-only) the nearest candidate is always a valid choice, so the walk is greedy. Mixed chains (`.a > .a .a > .a ...`) still backtrack but under a budget of 1024 compound evaluations per match; a match that spends it fails. A 28-deep nesting with a 16-link chain is matched in microseconds either way.
* **Repeated selectors are separate cascade entries**, not merged into the earlier one. Merging was a quadratic scan per insertion and moved the earlier declarations past the rules written in between (`.a {font-size:0} .b {font-size:14px} .a {color:red}` hid `<span class="b a">`). Parsing 1000/2000/4000 rules now takes 0.22/0.23/0.45 s on the debug+ASan build. A sheet keeps at most 4096 selectors.
* **One pool allocation per matched element.** The cascade winner is compiled into the returned block; the other matching rules compile into a stack temporary and fill only what the winner leaves undefined. That uses the `set` merge semantics rather than parent propagation, so a less specific `display:none` no longer overrides a more specific `display:block`.
